### PR TITLE
[#9382] Remove unused items in Feedback*QuestionDetails and Feedback*ResponseDetails classes

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -612,7 +612,7 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
         if (!distributeToRecipients && numOfConstSumOptions < Const.FeedbackQuestion.CONST_SUM_MIN_NUM_OF_OPTIONS) {
             errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_NOT_ENOUGH_OPTIONS

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -632,13 +632,6 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        return new ArrayList<>();
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -11,10 +11,8 @@ import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -54,93 +52,6 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         this.points = points;
         this.forceUnevenDistribution = unevenDistribution;
         this.distributePointsFor = distributePointsFor;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(
-            Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-
-        String distributeToRecipientsString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS);
-        String pointsPerOptionString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSPEROPTION);
-        String totalPointsString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTS);
-        String pointsForEachOptionString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSFOREACHOPTION);
-        String pointsForEachRecipientString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSFOREACHRECIPIENT);
-
-        String forceUnevenDistributionString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMDISTRIBUTEUNEVENLY);
-        String distributePointsOption = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMDISTRIBUTEPOINTSOPTIONS);
-
-        boolean distributeToRecipients = "true".equals(distributeToRecipientsString);
-        boolean pointsPerOption = "true".equals(pointsPerOptionString);
-
-        int points = 0;
-        if (pointsPerOption) {
-            String pointsString = distributeToRecipients ? pointsForEachRecipientString : pointsForEachOptionString;
-            Assumption.assertNotNull("Null points for each recipient/option", pointsString);
-            points = Integer.parseInt(pointsString);
-        } else {
-            Assumption.assertNotNull("Null points in total", totalPointsString);
-            points = Integer.parseInt(totalPointsString);
-        }
-
-        boolean forceUnevenDistribution = "on".equals(forceUnevenDistributionString);
-
-        if (distributeToRecipients) {
-            this.setConstantSumQuestionDetails(pointsPerOption, points, forceUnevenDistribution,
-                    distributePointsOption);
-        } else {
-            String numConstSumOptionsCreatedString =
-                    HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                           Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED);
-            Assumption.assertNotNull("Null number of choice for ConstSum", numConstSumOptionsCreatedString);
-            int numConstSumOptionsCreated = Integer.parseInt(numConstSumOptionsCreatedString);
-
-            for (int i = 0; i < numConstSumOptionsCreated; i++) {
-                String constSumOption =
-                        HttpRequestHelper.getValueFromParamMap(
-                                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMOPTION + "-" + i);
-                if (constSumOption != null && !constSumOption.trim().isEmpty()) {
-                    constSumOptions.add(constSumOption);
-                    numOfConstSumOptions++;
-                }
-            }
-            this.setConstantSumQuestionDetails(constSumOptions, pointsPerOption, points, forceUnevenDistribution,
-                    distributePointsOption);
-        }
-        return true;
-    }
-
-    private void setConstantSumQuestionDetails(
-            List<String> constSumOptions, boolean pointsPerOption,
-            int points, boolean unevenDistribution, String distributePointsOption) {
-
-        this.numOfConstSumOptions = constSumOptions.size();
-        this.constSumOptions = constSumOptions;
-        this.distributeToRecipients = false;
-        this.pointsPerOption = pointsPerOption;
-        this.points = points;
-        this.forceUnevenDistribution = unevenDistribution;
-        this.distributePointsFor = distributePointsOption;
-
-    }
-
-    private void setConstantSumQuestionDetails(boolean pointsPerOption,
-            int points, boolean unevenDistribution, String distributePointsOption) {
-
-        this.numOfConstSumOptions = 0;
-        this.constSumOptions = new ArrayList<>();
-        this.distributeToRecipients = true;
-        this.pointsPerOption = pointsPerOption;
-        this.points = points;
-        this.forceUnevenDistribution = unevenDistribution;
-        this.distributePointsFor = distributePointsOption;
     }
 
     public void setNumOfConstSumOptions(int numOfConstSumOptions) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 
 public class FeedbackConstantSumResponseDetails extends
@@ -15,23 +14,6 @@ public class FeedbackConstantSumResponseDetails extends
 
     public FeedbackConstantSumResponseDetails() {
         super(FeedbackQuestionType.CONSTSUM);
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails, String[] answer) {
-        List<Integer> constSumAnswer = new ArrayList<>();
-        for (String answerPart : answer) {
-            try {
-                constSumAnswer.add(Integer.parseInt(answerPart));
-            } catch (NumberFormatException e) {
-                constSumAnswer.add(0);
-            }
-        }
-        FeedbackConstantSumQuestionDetails constSumQd = (FeedbackConstantSumQuestionDetails) questionDetails;
-        this.setConstantSumResponseDetails(constSumAnswer,
-                                           constSumQd.getConstSumOptions(),
-                                           constSumQd.isDistributeToRecipients());
     }
 
     /**
@@ -141,16 +123,6 @@ public class FeedbackConstantSumResponseDetails extends
         }
 
         return errors;
-    }
-
-    private void setConstantSumResponseDetails(List<Integer> answers, List<String> constSumOptions,
-                                               boolean distributeToRecipients) {
-        this.answers = answers;
-        if (!distributeToRecipients) {
-            Assumption.assertEquals("ConstSum num response does not match num of options. "
-                                            + answers.size() + "/" + constSumOptions.size(),
-                                    answers.size(), constSumOptions.size());
-        }
     }
 
     public void setAnswers(List<Integer> answers) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -16,7 +16,6 @@ import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.Logger;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.Templates;
@@ -45,22 +44,6 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
     public void setNotSureAllowed(boolean notSureAllowed) {
         isNotSureAllowed = notSureAllowed;
-    }
-
-    private void setContributionQuestionDetails(boolean isNotSureAllowed) {
-        this.isNotSureAllowed = isNotSureAllowed;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(
-            Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-        String isNotSureAllowedString = HttpRequestHelper.getValueFromParamMap(
-                requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_CONTRIBISNOTSUREALLOWED);
-        boolean isNotSureAllowed = "on".equals(isNotSureAllowedString);
-        this.setContributionQuestionDetails(isNotSureAllowed);
-        return true;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -825,19 +825,6 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         }
     }
 
-    @Override
-    public boolean isQuestionSkipped(String[] answer) {
-        if (answer == null) {
-            return true;
-        }
-        for (String ans : answer) {
-            if (!ans.trim().isEmpty() && Integer.parseInt(ans) != Const.POINTS_NOT_SUBMITTED) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     private String getEqualShareHelpLinkIfNeeded(int responseIdx) {
         return responseIdx == 0
                 ? "<span class=\"glyphicon glyphicon-info-sign\"></span>"

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -678,7 +678,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         return new ArrayList<>();
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -683,32 +683,6 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        List<String> errors = new ArrayList<>();
-        for (FeedbackResponseAttributes response : responses) {
-            boolean validAnswer = false;
-            FeedbackContributionResponseDetails frd = (FeedbackContributionResponseDetails) response.getResponseDetails();
-
-            // Valid answers: 0, 10, 20, .... 190, 200
-            boolean isValidRange = frd.getAnswer() >= 0 && frd.getAnswer() <= 200;
-            boolean isMultipleOf10 = frd.getAnswer() % 10 == 0;
-            if (isValidRange && isMultipleOf10) {
-                validAnswer = true;
-            }
-            if (frd.getAnswer() == Const.POINTS_NOT_SURE && isNotSureAllowed
-                    || frd.getAnswer() == Const.POINTS_NOT_SUBMITTED) {
-                validAnswer = true;
-            }
-            if (!validAnswer) {
-                errors.add(Const.FeedbackQuestion.CONTRIB_ERROR_INVALID_OPTION);
-            }
-        }
-        return errors;
-    }
-
-    @Override
     public String validateGiverRecipientVisibility(FeedbackQuestionAttributes feedbackQuestionAttributes) {
         String errorMsg = "";
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -33,18 +33,6 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
         this.answer = answer;
     }
 
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails, String[] answer) {
-        try {
-            int contribAnswer = Integer.parseInt(answer[0]);
-            setAnswer(contribAnswer);
-        } catch (NumberFormatException e) {
-            log.severe("Failed to parse contrib answer to integer - " + answer[0]);
-            throw e;
-        }
-    }
-
     /**
      * Gets answer in integer form.
      */
@@ -67,10 +55,6 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
     public String getAnswerCsv(FeedbackResponseAttributes response, FeedbackQuestionAttributes question,
                                FeedbackSessionResultsBundle feedbackSessionResultsBundle) {
         return getContributionQuestionResponseAnswerCsv(response, question, feedbackSessionResultsBundle);
-    }
-
-    private void setAnswer(int answer) {
-        this.answer = answer;
     }
 
     private String getContributionQuestionResponseAnswerCsv(
@@ -121,8 +105,7 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
         return responseAnswerCsv;
     }
 
-    // TODO: check if this can be made non-static
-    public static Map<String, StudentResultSummary> getContribQnStudentResultSummary(FeedbackQuestionAttributes question,
+    private Map<String, StudentResultSummary> getContribQnStudentResultSummary(FeedbackQuestionAttributes question,
             FeedbackSessionResultsBundle feedbackSessionResultsBundle) {
 
         return feedbackSessionResultsBundle.contributionQuestionStudentResultSummary.computeIfAbsent(
@@ -141,7 +124,7 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
 
     }
 
-    public Map<String, TeamEvalResult> getContribQnTeamEvalResult(FeedbackQuestionAttributes question,
+    private Map<String, TeamEvalResult> getContribQnTeamEvalResult(FeedbackQuestionAttributes question,
             FeedbackSessionResultsBundle feedbackSessionResultsBundle) {
         Map<String, TeamEvalResult> contribQnStats =
                 feedbackSessionResultsBundle.contributionQuestionTeamEvalResults.get(question.getId());

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -454,23 +454,6 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        List<String> errors = new ArrayList<>();
-
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackMcqResponseDetails frd = (FeedbackMcqResponseDetails) response.getResponseDetails();
-
-            if (!otherEnabled && generateOptionsFor == FeedbackParticipantType.NONE
-                    && !mcqChoices.contains(frd.getAnswerString())) {
-                errors.add(frd.getAnswerString() + Const.FeedbackQuestion.MCQ_ERROR_INVALID_OPTION);
-            }
-        }
-        return errors;
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return true;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -392,7 +392,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
         if (generateOptionsFor == FeedbackParticipantType.NONE) {
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -430,16 +430,15 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
             // If weights are enabled, and any of the weights have negative value,
             // trigger this error.
             if (hasAssignedWeights && !mcqWeights.isEmpty()) {
-                for (double weight : mcqWeights) {
-                    if (weight < 0) {
-                        errors.add(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT);
-                    }
-                }
-                // If 'Other' option is enabled, and other weight has negative value,
-                // trigger this error.
-                if (otherEnabled && mcqOtherWeight < 0) {
-                    errors.add(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT);
-                }
+                mcqWeights.stream()
+                        .filter(weight -> weight < 0)
+                        .forEach(weight -> errors.add(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT));
+            }
+
+            // If 'Other' option is enabled, and other weight has negative value,
+            // trigger this error.
+            if (hasAssignedWeights && otherEnabled && mcqOtherWeight < 0) {
+                errors.add(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT);
             }
 
             //If there are duplicate mcq options trigger this error

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -15,15 +15,12 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
-import teammates.common.util.Logger;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.Templates;
 import teammates.common.util.Templates.FeedbackQuestion.FormTemplates;
 import teammates.common.util.Templates.FeedbackQuestion.Slots;
 
 public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
-    private static final Logger log = Logger.getLogger();
 
     private boolean hasAssignedWeights;
     private List<Double> mcqWeights;
@@ -66,63 +63,24 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
         return hasAssignedWeights;
     }
 
+    public void setHasAssignedWeights(boolean hasAssignedWeights) {
+        this.hasAssignedWeights = hasAssignedWeights;
+    }
+
     public List<Double> getMcqWeights() {
         return new ArrayList<>(mcqWeights);
     }
 
-    private List<Double> getMcqWeights(Map<String, String[]> requestParameters,
-            int numMcqChoicesCreated, boolean hasAssignedWeights) {
-        List<Double> mcqWeights = new ArrayList<>();
-
-        if (!hasAssignedWeights) {
-            return mcqWeights;
-        }
-
-        for (int i = 0; i < numMcqChoicesCreated; i++) {
-            String choice = HttpRequestHelper.getValueFromParamMap(
-                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-" + i);
-            String weight = HttpRequestHelper.getValueFromParamMap(
-                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-" + i);
-
-            if (choice != null && !choice.trim().isEmpty() && weight != null) {
-                try {
-                    // Do not add weight to mcqWeights if the weight cannot be parsed
-                    mcqWeights.add(Double.parseDouble(weight));
-                } catch (NumberFormatException e) {
-                    log.severe("Failed to parse weight for MCQ question: " + weight);
-                }
-            }
-        }
-
-        return mcqWeights;
+    public void setMcqWeights(List<Double> mcqWeights) {
+        this.mcqWeights = mcqWeights;
     }
 
     public double getMcqOtherWeight() {
         return mcqOtherWeight;
     }
 
-    private double getMcqOtherWeight(Map<String, String[]> requestParameters,
-            boolean mcqOtherEnabled, boolean hasAssignedWeights) {
-
-        double mcqOtherWeight = 0;
-
-        if (!hasAssignedWeights || !mcqOtherEnabled) {
-            return mcqOtherWeight;
-        }
-
-        String weightOther = HttpRequestHelper.getValueFromParamMap(
-                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT);
-
-        Assumption.assertNotNull("Null 'other' weight of MCQ question", weightOther);
-        Assumption.assertNotEmpty("Empty 'other' weight of MCQ question", weightOther);
-
-        try {
-            // Do not assign value to mcqOtherWeight if the weight can not be parsed.
-            mcqOtherWeight = Double.parseDouble(weightOther);
-        } catch (NumberFormatException e) {
-            log.severe("Failed to parse \"other\" weight of MCQ question: " + weightOther);
-        }
-        return mcqOtherWeight;
+    public void setMcqOtherWeight(double mcqOtherWeight) {
+        this.mcqOtherWeight = mcqOtherWeight;
     }
 
     public FeedbackParticipantType getGenerateOptionsFor() {
@@ -138,85 +96,16 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public boolean extractQuestionDetails(
-            Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-
-        int numOfMcqChoices = 0;
-        List<String> mcqChoices = new LinkedList<>();
-        boolean mcqOtherEnabled = false; // TODO change this when implementing "other, please specify" field
-
-        if ("on".equals(HttpRequestHelper.getValueFromParamMap(
-                                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG))) {
-            mcqOtherEnabled = true;
-        }
-
-        String generatedMcqOptions =
-                HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                       Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS);
-
-        if (generatedMcqOptions.equals(FeedbackParticipantType.NONE.toString())) {
-            String numMcqChoicesCreatedString =
-                    HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                           Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED);
-            Assumption.assertNotNull("Null number of choice for MCQ", numMcqChoicesCreatedString);
-            int numMcqChoicesCreated = Integer.parseInt(numMcqChoicesCreatedString);
-
-            for (int i = 0; i < numMcqChoicesCreated; i++) {
-                String paramName = Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-" + i;
-                String mcqChoice = HttpRequestHelper.getValueFromParamMap(requestParameters, paramName);
-                if (mcqChoice != null && !mcqChoice.trim().isEmpty()) {
-                    mcqChoices.add(mcqChoice);
-                    numOfMcqChoices++;
-                }
-            }
-
-            String hasAssignedWeightsString = HttpRequestHelper.getValueFromParamMap(
-                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED);
-            boolean hasAssignedWeights = "on".equals(hasAssignedWeightsString);
-            List<Double> mcqWeights = getMcqWeights(
-                    requestParameters, numMcqChoicesCreated, hasAssignedWeights);
-            double mcqOtherWeight = getMcqOtherWeight(requestParameters, mcqOtherEnabled, hasAssignedWeights);
-            setMcqQuestionDetails(
-                    numOfMcqChoices, mcqChoices, mcqOtherEnabled, hasAssignedWeights, mcqWeights, mcqOtherWeight);
-        } else {
-            setMcqQuestionDetails(FeedbackParticipantType.valueOf(generatedMcqOptions));
-        }
-        return true;
-    }
-
-    private void setMcqQuestionDetails(int numOfMcqChoices, List<String> mcqChoices, boolean otherEnabled,
-            boolean hasAssignedWeights, List<Double> mcqWeights, double mcqOtherWeight) {
-        this.numOfMcqChoices = numOfMcqChoices;
-        this.mcqChoices = mcqChoices;
-        this.otherEnabled = otherEnabled;
-        this.hasAssignedWeights = hasAssignedWeights;
-        this.mcqWeights = mcqWeights;
-        this.mcqOtherWeight = mcqOtherWeight;
-        this.generateOptionsFor = FeedbackParticipantType.NONE;
-    }
-
-    private void setMcqQuestionDetails(FeedbackParticipantType generateOptionsFor) {
-        this.numOfMcqChoices = 0;
-        this.mcqChoices = new ArrayList<>();
-        this.otherEnabled = false;
-        this.generateOptionsFor = generateOptionsFor;
-        Assumption.assertTrue(
-                "Can only generate students, students (excluding self), teams, teams (excluding self) or instructors",
-                generateOptionsFor == FeedbackParticipantType.STUDENTS
-                || generateOptionsFor == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF
-                || generateOptionsFor == FeedbackParticipantType.TEAMS
-                || generateOptionsFor == FeedbackParticipantType.TEAMS_EXCLUDING_SELF
-                || generateOptionsFor == FeedbackParticipantType.INSTRUCTORS);
-    }
-
-    @Override
     public String getQuestionTypeDisplayName() {
         return Const.FeedbackQuestionTypeNames.MCQ;
     }
 
     public boolean getOtherEnabled() {
         return otherEnabled;
+    }
+
+    public void setOtherEnabled(boolean otherEnabled) {
+        this.otherEnabled = otherEnabled;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
@@ -2,11 +2,9 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 
 public class FeedbackMcqResponseDetails extends FeedbackResponseDetails {
@@ -19,47 +17,6 @@ public class FeedbackMcqResponseDetails extends FeedbackResponseDetails {
         answer = "";
         isOther = false;
         otherFieldContent = "";
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-            FeedbackQuestionDetails questionDetails, String[] answer) {
-        /*
-         * answer[0] contains the answer given by the student, answer[1] is "1"
-         * if "other" is selected by the student, "0" if "other" is not
-         * selected, null if "other" is disabled by the instructor
-         */
-        isOther = answer.length >= 2 && "1".equals(answer[1]);
-
-        if (isOther) {
-            this.answer = "Other";
-            this.otherFieldContent = answer[0];
-        } else {
-            this.answer = answer[0];
-            this.otherFieldContent = "";
-        }
-    }
-
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                    FeedbackQuestionDetails questionDetails, String[] rawAnswer,
-                                    Map<String, String[]> requestParameters, int questionIndx,
-                                    int responseIndx) {
-
-        String[] answer = appendOtherOptionFlagToAnswer(rawAnswer, requestParameters, questionIndx, responseIndx);
-        /*
-         * answer[0] contains the answer given by the student, answer[1] is "1"
-         * if "other" is selected by the student, "0" if "other" is not
-         * selected, null if "other" is disabled by the instructor
-         */
-        isOther = answer.length >= 2 && "1".equals(answer[1]);
-
-        if (isOther) {
-            this.answer = "Other";
-            this.otherFieldContent = answer[0];
-        } else {
-            this.answer = answer[0];
-            this.otherFieldContent = "";
-        }
     }
 
     @Override
@@ -106,18 +63,4 @@ public class FeedbackMcqResponseDetails extends FeedbackResponseDetails {
         return otherFieldContent;
     }
 
-    private String[] appendOtherOptionFlagToAnswer(String[] answer, Map<String, String[]> requestParameters,
-                                    int questionIndx, int responseIndx) {
-        String isOtherOptionAnswer = HttpRequestHelper.getValueFromParamMap(
-                                        requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MCQ_ISOTHEROPTIONANSWER
-                                                           + "-" + questionIndx + "-" + responseIndx);
-        if (answer != null) {
-            String[] answerWithOtherOptionFlag = new String[answer.length + 1];
-
-            answerWithOtherOptionFlag[0] = answer[0]; // answer given by the student
-            answerWithOtherOptionFlag[1] = isOtherOptionAnswer; // "1" (other is selected) or "0" (other is not selected)
-            return answerWithOtherOptionFlag;
-        }
-        return answer;
-    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -504,16 +504,15 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
 
             // If weights are negative, trigger this error.
             if (hasAssignedWeights && !msqWeights.isEmpty()) {
-                for (double weight : msqWeights) {
-                    if (weight < 0) {
-                        errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT);
-                    }
-                }
-                // If 'Other' option is enabled, and other weight has negative value,
-                // trigger this error.
-                if (otherEnabled && msqOtherWeight < 0) {
-                    errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT);
-                }
+                msqWeights.stream()
+                        .filter(weight -> weight < 0)
+                        .forEach(weight -> errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT));
+            }
+
+            // If 'Other' option is enabled, and other weight has negative value,
+            // trigger this error.
+            if (hasAssignedWeights && otherEnabled && msqOtherWeight < 0) {
+                errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT);
             }
 
             //If there are duplicate mcq options trigger this error

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -589,29 +589,6 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        List<String> errors = new ArrayList<>();
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackMsqResponseDetails frd = (FeedbackMsqResponseDetails) response.getResponseDetails();
-            if (!otherEnabled) {
-                List<String> validChoices = msqChoices;
-                validChoices.add("");
-                if (!validChoices.containsAll(frd.answers) && generateOptionsFor == FeedbackParticipantType.NONE) {
-                    errors.add(frd.getAnswerString() + Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION);
-                }
-            }
-
-            if (maxSelectableChoices != Integer.MIN_VALUE && frd.answers.size() > maxSelectableChoices) {
-                errors.add(Const.FeedbackQuestion.MSQ_ERROR_MAX_SELECTABLE_EXCEEDED_TOTAL
-                        + maxSelectableChoices);
-            }
-        }
-        return errors;
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -611,15 +611,6 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
         return errors;
     }
 
-    /**
-     * Checks if the question has been skipped.
-     * MSQ allows a blank response, as that represents "None of the above"
-     */
-    @Override
-    public boolean isQuestionSkipped(String[] answer) {
-        return answer == null;
-    }
-
     @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
@@ -1,13 +1,10 @@
 package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 
@@ -21,34 +18,6 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
         this.answers = new ArrayList<>();
         isOther = false;
         otherFieldContent = "";
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails, String[] answer) {
-        this.answers = Arrays.asList(answer);
-    }
-
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                    FeedbackQuestionDetails questionDetails, String[] answer,
-                                    Map<String, String[]> requestParameters, int questionIndx,
-                                    int responseIndx) {
-
-        // "1" if other is selected, "0" if other is not selected, null if other is disabled by the instructor
-        String isOtherOptionAnswer = HttpRequestHelper.getValueFromParamMap(
-                                        requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_MSQ_ISOTHEROPTIONANSWER
-                                        + "-" + questionIndx + "-" + responseIndx);
-
-        if ("1".equals(isOtherOptionAnswer)) {
-            isOther = true;
-            try {
-                otherFieldContent = answer[answer.length - 1];
-            } catch (IndexOutOfBoundsException e) {
-                otherFieldContent = "";
-            }
-        }
-
-        extractResponseDetails(questionType, questionDetails, answer);
     }
 
     public boolean contains(String candidateAnswer) {
@@ -69,9 +38,7 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
         FeedbackMsqQuestionDetails msqDetails = (FeedbackMsqQuestionDetails) questionDetails;
         StringBuilder csvBuilder = new StringBuilder();
 
-        if (isAnswerBlank()) {
-            csvBuilder.append("");
-        } else {
+        if (!isAnswerBlank()) {
             for (String choice : msqDetails.getMsqChoices()) {
                 csvBuilder.append(',');
                 if (this.contains(choice)) {
@@ -138,7 +105,7 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
         return errors;
     }
 
-    protected boolean isAnswerBlank() {
+    private boolean isAnswerBlank() {
         return answers.size() == 1 && answers.get(0).isEmpty();
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -665,7 +665,7 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
         if (minScale >= maxScale) {
             errors.add(Const.FeedbackQuestion.NUMSCALE_ERROR_MIN_MAX);

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -13,9 +13,7 @@ import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -37,38 +35,6 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
     @Override
     public List<String> getInstructions() {
         return null;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(Map<String, String[]> requestParameters, FeedbackQuestionType questionType) {
-
-        String minScaleString =
-                HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                       Const.ParamsNames.FEEDBACK_QUESTION_NUMSCALE_MIN);
-        Assumption.assertNotNull("Null minimum scale", minScaleString);
-        int minScale = Integer.parseInt(minScaleString);
-
-        String maxScaleString =
-                HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                       Const.ParamsNames.FEEDBACK_QUESTION_NUMSCALE_MAX);
-        Assumption.assertNotNull("Null maximum scale", maxScaleString);
-        int maxScale = Integer.parseInt(maxScaleString);
-
-        String stepString =
-                HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                       Const.ParamsNames.FEEDBACK_QUESTION_NUMSCALE_STEP);
-        Assumption.assertNotNull("Null step", stepString);
-        Double step = Double.parseDouble(stepString);
-
-        setNumericalScaleQuestionDetails(minScale, maxScale, step);
-
-        return true;
-    }
-
-    private void setNumericalScaleQuestionDetails(int minScale, int maxScale, double step) {
-        this.minScale = minScale;
-        this.maxScale = maxScale;
-        this.step = step;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -677,23 +677,6 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        List<String> errors = new ArrayList<>();
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackNumericalScaleResponseDetails frd =
-                    (FeedbackNumericalScaleResponseDetails) response.getResponseDetails();
-            if (frd.getAnswer() < minScale || frd.getAnswer() > maxScale) {
-                errors.add(frd.getAnswerString() + Const.FeedbackQuestion.NUMSCALE_ERROR_OUT_OF_RANGE
-                           + "(min=" + minScale + ", max=" + maxScale + ")");
-            }
-            //TODO: strengthen check for step
-        }
-        return errors;
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
@@ -5,29 +5,14 @@ import java.util.List;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.Logger;
 import teammates.common.util.StringHelper;
 
 public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetails {
-
-    private static final Logger log = Logger.getLogger();
 
     private double answer;
 
     public FeedbackNumericalScaleResponseDetails() {
         super(FeedbackQuestionType.NUMSCALE);
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-            FeedbackQuestionDetails questionDetails, String[] answer) {
-        try {
-            double numscaleAnswer = Double.parseDouble(answer[0]);
-            setAnswer(numscaleAnswer);
-        } catch (NumberFormatException e) {
-            log.severe("Failed to parse numscale answer to double - " + answer[0]);
-            throw e;
-        }
     }
 
     /**
@@ -78,10 +63,6 @@ public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetai
                     + nextPossibleValueLessThanCurrent + " and " + nextPossibleValueGreaterThanCurrent + ".");
         }
         return errors;
-    }
-
-    private void setAnswer(double answer) {
-        this.answer = answer;
     }
 
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -159,11 +159,10 @@ public abstract class FeedbackQuestionDetails {
 
     /**
      * Validates the question details.
-     * @param courseId courseId of the question
      * @return A {@code List<String>} of error messages (to show as status message to user) if any, or an
      *         empty list if question details are valid.
      */
-    public abstract List<String> validateQuestionDetails(String courseId);
+    public abstract List<String> validateQuestionDetails();
 
     /**
      * Validates if giverType and recipientType are valid for the question type.

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -2,7 +2,6 @@ package teammates.common.datatransfer.questions;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -185,14 +184,6 @@ public abstract class FeedbackQuestionDetails {
      * @return error message detailing the error, or an empty string if valid.
      */
     public abstract String validateGiverRecipientVisibility(FeedbackQuestionAttributes feedbackQuestionAttributes);
-
-    /**
-     * Extract question details and sets details accordingly.
-     *
-     * @return true to indicate success in extracting the details, false otherwise.
-     */
-    public abstract boolean extractQuestionDetails(Map<String, String[]> requestParameters,
-                                                   FeedbackQuestionType questionType);
 
     // The following function handle the display of rows between possible givers
     // and recipients who did not respond to a question in feedback sessions

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -166,16 +166,6 @@ public abstract class FeedbackQuestionDetails {
     public abstract List<String> validateQuestionDetails(String courseId);
 
     /**
-     * Validates {@code List<FeedbackResponseAttributes>} for the question
-     * based on the current {@code Feedback*QuestionDetails}.
-     *
-     * @param responses - The {@code List<FeedbackResponseAttributes>} for the question to be validated
-     * @return A {@code List<String>} of error messages (to show as status message to user) if any, or an
-     *         empty list if question responses are valid.
-     */
-    public abstract List<String> validateResponseAttributes(List<FeedbackResponseAttributes> responses, int numRecipients);
-
-    /**
      * Validates if giverType and recipientType are valid for the question type.
      * Validates visibility options as well.
      *

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -1,6 +1,5 @@
 package teammates.common.datatransfer.questions;
 
-import java.util.Arrays;
 import java.util.List;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -224,14 +223,6 @@ public abstract class FeedbackQuestionDetails {
         Assumption.assertNotNull(questionType);
         String serializedDetails = getJsonString();
         return JsonUtils.fromJson(serializedDetails, questionType.getQuestionDetailsClass());
-    }
-
-    /** Checks if the question has been skipped. */
-    public boolean isQuestionSkipped(String[] answers) {
-        if (answers == null) {
-            return true;
-        }
-        return Arrays.stream(answers).noneMatch(answer -> answer != null && !answer.trim().isEmpty());
     }
 
     public FeedbackQuestionType getQuestionType() {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -7,17 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
-import com.google.common.primitives.Ints;
-
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -63,42 +58,6 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
         }
 
         return instructions;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(Map<String, String[]> requestParameters,
-                                          FeedbackQuestionType questionType) {
-        super.extractQuestionDetails(requestParameters, questionType);
-        List<String> options = new ArrayList<>();
-
-        String numOptionsCreatedString =
-                HttpRequestHelper.getValueFromParamMap(
-                        requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED);
-        Assumption.assertNotNull("Null number of choice for Rank", numOptionsCreatedString);
-        int numOptionsCreated = Integer.parseInt(numOptionsCreatedString);
-
-        for (int i = 0; i < numOptionsCreated; i++) {
-            String rankOption = HttpRequestHelper.getValueFromParamMap(
-                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANKOPTION + "-" + i);
-            if (rankOption != null && !rankOption.trim().isEmpty()) {
-                options.add(rankOption);
-            }
-        }
-
-        this.initialiseQuestionDetails(options);
-        String minOptionsToBeRankedParameter = Strings.nullToEmpty(HttpRequestHelper.getValueFromParamMap(
-                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANK_MIN_OPTIONS_TO_BE_RANKED));
-        String maxOptionsToBeRankedParameter = Strings.nullToEmpty(HttpRequestHelper.getValueFromParamMap(
-                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANK_MAX_OPTIONS_TO_BE_RANKED));
-
-        minOptionsToBeRanked = MoreObjects.firstNonNull(Ints.tryParse(minOptionsToBeRankedParameter), NO_VALUE);
-        maxOptionsToBeRanked = MoreObjects.firstNonNull(Ints.tryParse(maxOptionsToBeRankedParameter), NO_VALUE);
-
-        return true;
-    }
-
-    private void initialiseQuestionDetails(List<String> options) {
-        this.options = options;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -2,10 +2,8 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
@@ -410,34 +408,6 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
 
         if (options.size() < MIN_NUM_OF_OPTIONS) {
             errors.add(ERROR_NOT_ENOUGH_OPTIONS + MIN_NUM_OF_OPTIONS + ".");
-        }
-
-        return errors;
-    }
-
-    @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        if (responses.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        if (isAreDuplicatesAllowed()) {
-            return new ArrayList<>();
-        }
-        List<String> errors = new ArrayList<>();
-
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackRankOptionsResponseDetails frd = (FeedbackRankOptionsResponseDetails) response.getResponseDetails();
-            Set<Integer> responseRank = new HashSet<>();
-
-            for (int answer : frd.getFilteredSortedAnswerList()) {
-                if (responseRank.contains(answer)) {
-                    errors.add("Duplicate rank " + answer);
-                }
-                responseRank.add(answer);
-            }
         }
 
         return errors;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -372,7 +372,7 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
 
         boolean isEmptyRankOptionEntered = options.stream().anyMatch(optionText -> optionText.trim().equals(""));

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
@@ -8,7 +8,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
@@ -18,22 +17,6 @@ public class FeedbackRankOptionsResponseDetails extends FeedbackRankResponseDeta
 
     public FeedbackRankOptionsResponseDetails() {
         super(FeedbackQuestionType.RANK_OPTIONS);
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails,
-                                       String[] answer) {
-        List<Integer> rankAnswer = new ArrayList<>();
-        for (String answerPart : answer) {
-            try {
-                rankAnswer.add(Integer.parseInt(answerPart));
-            } catch (NumberFormatException e) {
-                rankAnswer.add(Const.POINTS_NOT_SUBMITTED);
-            }
-        }
-        FeedbackRankOptionsQuestionDetails rankQuestion = (FeedbackRankOptionsQuestionDetails) questionDetails;
-        this.setRankResponseDetails(rankAnswer, rankQuestion.options);
     }
 
     /**
@@ -134,15 +117,6 @@ public class FeedbackRankOptionsResponseDetails extends FeedbackRankResponseDeta
                           .add(option);
         }
         return orderedOptions;
-    }
-
-    private void setRankResponseDetails(List<Integer> answers, List<String> options) {
-        this.answers = answers;
-
-        Assumption.assertEquals("Rank question: number of responses does not match number of options. "
-                                        + answers.size() + "/" + options.size(),
-                                answers.size(), options.size());
-
     }
 
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -8,7 +8,6 @@ import java.util.TreeMap;
 
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 
 public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetails {
 
@@ -21,26 +20,6 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
         super(questionType);
         minOptionsToBeRanked = NO_VALUE;
         maxOptionsToBeRanked = NO_VALUE;
-    }
-
-    public FeedbackRankQuestionDetails(FeedbackQuestionType questionType, String questionText) {
-        super(questionType, questionText);
-        minOptionsToBeRanked = NO_VALUE;
-        maxOptionsToBeRanked = NO_VALUE;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(Map<String, String[]> requestParameters,
-                                          FeedbackQuestionType questionType) {
-
-        String areDuplicatesAllowedString =
-                HttpRequestHelper.getValueFromParamMap(
-                        requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANKISDUPLICATESALLOWED);
-        boolean areDuplicatesAllowed = "on".equals(areDuplicatesAllowedString);
-
-        this.areDuplicatesAllowed = areDuplicatesAllowed;
-
-        return true;
     }
 
     @Override
@@ -100,7 +79,7 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
         return pointsReceived.toString();
     }
 
-    protected double computeAverage(List<Integer> values) {
+    private double computeAverage(List<Integer> values) {
         double total = 0;
         for (double value : values) {
             total = total + value;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -2,10 +2,8 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -505,35 +503,6 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     @Override
     public List<String> validateQuestionDetails(String courseId) {
         return new ArrayList<>();
-    }
-
-    @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        if (responses.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        if (isAreDuplicatesAllowed()) {
-            return new ArrayList<>();
-        }
-        List<String> errors = new ArrayList<>();
-
-        Set<Integer> responseRank = new HashSet<>();
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackRankRecipientsResponseDetails frd =
-                    (FeedbackRankRecipientsResponseDetails) response.getResponseDetails();
-
-            if (responseRank.contains(frd.answer)) {
-                errors.add("Duplicate rank " + frd.answer + " in question");
-            } else if (frd.answer > numRecipients) {
-                errors.add("Invalid rank " + frd.answer + " in question");
-            }
-            responseRank.add(frd.answer);
-        }
-
-        return errors;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -7,17 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
-import com.google.common.primitives.Ints;
-
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -35,22 +30,6 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     @Override
     public String getQuestionTypeDisplayName() {
         return Const.FeedbackQuestionTypeNames.RANK_RECIPIENT;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-        super.extractQuestionDetails(requestParameters, questionType);
-
-        String minRecipientsToBeRanked = Strings.nullToEmpty(HttpRequestHelper.getValueFromParamMap(
-                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANK_MIN_RECIPIENTS_TO_BE_RANKED));
-        String maxRecipientsToBeRanked = Strings.nullToEmpty(HttpRequestHelper.getValueFromParamMap(
-                requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RANK_MAX_RECIPIENTS_TO_BE_RANKED));
-
-        minOptionsToBeRanked = MoreObjects.firstNonNull(Ints.tryParse(minRecipientsToBeRanked), NO_VALUE);
-        maxOptionsToBeRanked = MoreObjects.firstNonNull(Ints.tryParse(maxRecipientsToBeRanked), NO_VALUE);
-
-        return true;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -501,7 +501,7 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         return new ArrayList<>();
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
@@ -13,13 +13,6 @@ public class FeedbackRankRecipientsResponseDetails extends FeedbackRankResponseD
     }
 
     @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails,
-                                       String[] answer) {
-        this.setRankResponseDetails(Integer.parseInt(answer[0]));
-    }
-
-    @Override
     public String getAnswerString() {
         return Integer.toString(answer);
     }
@@ -32,10 +25,6 @@ public class FeedbackRankRecipientsResponseDetails extends FeedbackRankResponseD
     @Override
     public List<String> validateResponseDetails(FeedbackQuestionAttributes correspondingQuestion) {
         return new ArrayList<>();
-    }
-
-    private void setRankResponseDetails(int answer) {
-        this.answer = answer;
     }
 
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
@@ -27,14 +27,6 @@ public abstract class FeedbackResponseDetails {
         this.questionType = questionType;
     }
 
-    /**
-     * Extract response details and sets details accordingly.
-     */
-    public abstract void extractResponseDetails(
-            FeedbackQuestionType questionType,
-            FeedbackQuestionDetails questionDetails,
-            String[] answer);
-
     public abstract String getAnswerString();
 
     public String getJsonString() {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -839,7 +839,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         // For rubric questions,
         // 1) Description size should be valid
         // 2) At least 2 choices

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -891,13 +891,6 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        return new ArrayList<>();
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -16,8 +16,6 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
-import teammates.common.util.Logger;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -26,7 +24,6 @@ import teammates.common.util.Templates.FeedbackQuestion.Slots;
 
 public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
-    private static final Logger log = Logger.getLogger();
     private static final String STATISTICS_NO_VALUE_STRING = "-";
 
     private boolean hasAssignedWeights;
@@ -66,138 +63,8 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         return null;
     }
 
-    @Override
-    public boolean extractQuestionDetails(
-            Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-        String numOfRubricChoicesString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                                Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS);
-        String numOfRubricSubQuestionsString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                                     Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS);
-
-        if (numOfRubricChoicesString == null || numOfRubricSubQuestionsString == null) {
-            return false;
-        }
-
-        String hasAssignedWeightsString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                                Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED);
-
-        boolean hasAssignedWeights = "on".equals(hasAssignedWeightsString);
-        int numOfRubricChoices = Integer.parseInt(numOfRubricChoicesString);
-        int numOfRubricSubQuestions = Integer.parseInt(numOfRubricSubQuestionsString);
-        List<List<Double>> rubricWeightsForEachCell = getRubricWeightsForEachCell(
-                requestParameters, numOfRubricChoices, numOfRubricSubQuestions, hasAssignedWeights);
-        List<String> rubricChoices = getRubricChoices(requestParameters, numOfRubricChoices);
-        List<String> rubricSubQuestions = getSubQuestions(requestParameters, numOfRubricSubQuestions);
-        List<List<String>> rubricDescriptions = getRubricQuestionDescriptions(requestParameters,
-                                                                              numOfRubricChoices,
-                                                                              numOfRubricSubQuestions);
-
-        // Set details
-        setRubricQuestionDetails(hasAssignedWeights, rubricWeightsForEachCell,
-                rubricChoices, rubricSubQuestions, rubricDescriptions);
-
-        if (!isValidDescriptionSize()) {
-            // If description sizes are invalid, default to empty descriptions.
-            initializeRubricDescriptions();
-        }
-
-        return true;
-    }
-
-    /**
-     * Extracts Rubric weight values from request parameters map.
-     * @return Returns the list of rubric weights.
-     */
-    private List<List<Double>> getRubricWeightsForEachCell(Map<String, String[]> requestParameters,
-            int numOfRubricChoices, int numOfRubricSubQuestions, boolean hasAssignedWeights) {
-        List<List<Double>> rubricWeightsForEachCell = new ArrayList<>();
-
-        if (!hasAssignedWeights) {
-            return rubricWeightsForEachCell;
-        }
-
-        int weightRows = -1;
-        for (int i = 0; i < numOfRubricSubQuestions; i++) {
-            String subQn = HttpRequestHelper.getValueFromParamMap(
-                    requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-" + i);
-            if (subQn == null || subQn.trim().isEmpty()) {
-                // No weights should be parsed for a null or empty sub question.
-                continue;
-            }
-            boolean rowAdded = false;
-
-            for (int j = 0; j < numOfRubricChoices; j++) {
-                String choice = HttpRequestHelper.getValueFromParamMap(
-                        requestParameters, Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-" + j);
-                String paramName = Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-" + i + "-" + j;
-                String weight = HttpRequestHelper.getValueFromParamMap(requestParameters, paramName);
-                if (weight != null && choice != null) {
-                    if (!rowAdded) {
-                        weightRows++;
-                        rubricWeightsForEachCell.add(new ArrayList<>());
-                        rowAdded = true;
-                    }
-                    try {
-                        rubricWeightsForEachCell.get(weightRows).add(Double.parseDouble(weight));
-                    } catch (NumberFormatException e) {
-                        log.severe("Failed to parse weight for rubric question " + weight);
-                    }
-                }
-            }
-        }
-
-        return rubricWeightsForEachCell;
-    }
-
-    private List<String> getRubricChoices(Map<String, String[]> requestParameters, int numOfRubricChoices) {
-        List<String> rubricChoices = new ArrayList<>();
-        for (int i = 0; i < numOfRubricChoices; i++) {
-            String choice = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                  Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-" + i);
-            if (choice != null) {
-                rubricChoices.add(choice);
-            }
-        }
-        return rubricChoices;
-    }
-
     public List<String> getRubricChoices() {
         return rubricChoices;
-    }
-
-    private List<String> getSubQuestions(Map<String, String[]> requestParameters, int numOfRubricSubQuestions) {
-        List<String> rubricSubQuestions = new ArrayList<>();
-        for (int i = 0; i < numOfRubricSubQuestions; i++) {
-            String subQuestion = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                                                       Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-" + i);
-            if (subQuestion != null) {
-                rubricSubQuestions.add(subQuestion);
-            }
-        }
-        return rubricSubQuestions;
-    }
-
-    private List<List<String>> getRubricQuestionDescriptions(Map<String, String[]> requestParameters,
-                                                             int numOfRubricChoices, int numOfRubricSubQuestions) {
-        List<List<String>> rubricDescriptions = new ArrayList<>();
-        int descRows = -1;
-        for (int i = 0; i < numOfRubricSubQuestions; i++) {
-            boolean rowAdded = false;
-            for (int j = 0; j < numOfRubricChoices; j++) {
-                String paramName = Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_DESCRIPTION + "-" + i + "-" + j;
-                String description = HttpRequestHelper.getValueFromParamMap(requestParameters, paramName);
-                if (description != null) {
-                    if (!rowAdded) {
-                        descRows++;
-                        rubricDescriptions.add(new ArrayList<>());
-                        rowAdded = true;
-                    }
-                    rubricDescriptions.get(descRows).add(description);
-                }
-            }
-        }
-        return rubricDescriptions;
     }
 
     /**
@@ -225,20 +92,6 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
             return false;
         }
         return rubricWeightsForEachCell.stream().allMatch(x -> x.size() == numOfRubricChoices);
-    }
-
-    private void setRubricQuestionDetails(boolean hasAssignedWeights,
-                                          List<List<Double>> rubricWeightsForEachCell,
-                                          List<String> rubricChoices,
-                                          List<String> rubricSubQuestions,
-                                          List<List<String>> rubricDescriptions) {
-        this.hasAssignedWeights = hasAssignedWeights;
-        this.rubricWeightsForEachCell = rubricWeightsForEachCell;
-        this.numOfRubricChoices = rubricChoices.size();
-        this.rubricChoices = rubricChoices;
-        this.numOfRubricSubQuestions = rubricSubQuestions.size();
-        this.rubricSubQuestions = rubricSubQuestions;
-        this.rubricDescriptions = rubricDescriptions;
     }
 
     @Override
@@ -843,7 +696,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         return csv.toString();
     }
 
-    public List<Map.Entry<String, RubricRecipientStatistics>> getPerRecipientStatisticsSorted(
+    private List<Map.Entry<String, RubricRecipientStatistics>> getPerRecipientStatisticsSorted(
             List<FeedbackResponseAttributes> responses,
             FeedbackSessionResultsBundle bundle) {
         Map<String, RubricRecipientStatistics> recipientToRecipientStats = new HashMap<>();
@@ -865,7 +718,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         return recipientStatsList;
     }
 
-    public String getPerRecipientStatisticsCsv(List<FeedbackResponseAttributes> responses,
+    private String getPerRecipientStatisticsCsv(List<FeedbackResponseAttributes> responses,
             FeedbackSessionResultsBundle bundle) {
         StringBuilder csv = new StringBuilder(100);
         List<Map.Entry<String, RubricRecipientStatistics>> recipientStatsList =
@@ -891,18 +744,14 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         return "Choice Value";
     }
 
-    public String getPerRecipientStatisticsHeader() {
+    private String getPerRecipientStatisticsHeader() {
         StringBuilder header = new StringBuilder(100);
         String headerFragment = "Team,Recipient Name,Recipient's Email,Sub Question,";
 
         header.append(headerFragment);
 
         for (int i = 0; i < numOfRubricChoices; i++) {
-            StringBuilder rubricChoiceBuilder = new StringBuilder();
-
-            rubricChoiceBuilder.append(rubricChoices.get(i));
-
-            header.append(SanitizationHelper.sanitizeForCsv(rubricChoiceBuilder.toString())).append(',');
+            header.append(SanitizationHelper.sanitizeForCsv(rubricChoices.get(i))).append(',');
         }
 
         header.append("Total,Average").append(System.lineSeparator());

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -2,16 +2,11 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
-import teammates.common.exception.TeammatesException;
 import teammates.common.util.Const;
-import teammates.common.util.Logger;
 
 public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
-
-    private static final Logger log = Logger.getLogger();
 
     /**
      * List of integers, the size of the list corresponds to the number of sub-questions.
@@ -21,55 +16,6 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
 
     public FeedbackRubricResponseDetails() {
         super(FeedbackQuestionType.RUBRIC);
-    }
-
-    @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails, String[] answer) {
-
-        // Example: a response in the form: "0-1,1-0"
-        // means that for sub-question 0, choice 1 is chosen,
-        // and for sub-question 1, choice 0 is chosen.
-
-        String rawResponses = answer[0];
-        FeedbackRubricQuestionDetails fqd = (FeedbackRubricQuestionDetails) questionDetails;
-
-        initializeEmptyAnswerList(fqd.getNumOfRubricSubQuestions());
-
-        // Parse and extract answers
-        String[] subQuestionResponses = rawResponses.split(Pattern.quote(","));
-        for (String subQuestionResponse : subQuestionResponses) {
-            String[] subQuestionIndexAndChoice = subQuestionResponse.split(Pattern.quote("-"));
-
-            if (subQuestionIndexAndChoice.length != 2) {
-                // Expected length is 2.
-                // Failed to parse, ignore response.
-                continue;
-            }
-
-            try {
-                int subQuestionIndex = Integer.parseInt(subQuestionIndexAndChoice[0]);
-                int subQuestionChoice = Integer.parseInt(subQuestionIndexAndChoice[1]);
-                if (subQuestionIndex >= 0 && subQuestionIndex < fqd.getNumOfRubricSubQuestions()
-                        && subQuestionChoice >= 0 && subQuestionChoice < fqd.getNumOfRubricChoices()) {
-                    setAnswer(subQuestionIndex, subQuestionChoice);
-                } // else the indexes are invalid.
-            } catch (NumberFormatException e) {
-                // Failed to parse, ignore response.
-                log.warning(TeammatesException.toStringWithStackTrace(e));
-            }
-        }
-    }
-
-    /**
-     * Initializes the answer list to have empty responses.
-     */
-    private void initializeEmptyAnswerList(int numSubQuestions) {
-        answer = new ArrayList<>();
-        for (int i = 0; i < numSubQuestions; i++) {
-            // -1 indicates no choice chosen
-            answer.add(-1);
-        }
     }
 
     @Override
@@ -112,10 +58,6 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
 
     public int getAnswer(int subQuestionIndex) {
         return answer.get(subQuestionIndex);
-    }
-
-    public void setAnswer(int subQuestionIndex, int choice) {
-        this.answer.set(subQuestionIndex, choice);
     }
 
     public void setAnswer(List<Integer> answer) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -2,14 +2,12 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.Templates;
 import teammates.common.util.Templates.FeedbackQuestion.FormTemplates;
@@ -40,18 +38,6 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
     @Override
     public List<String> getInstructions() {
         return null;
-    }
-
-    @Override
-    public boolean extractQuestionDetails(
-            Map<String, String[]> requestParameters,
-            FeedbackQuestionType questionType) {
-        String recommendedLengthString = HttpRequestHelper.getValueFromParamMap(requestParameters,
-                Const.ParamsNames.FEEDBACK_QUESTION_TEXT_RECOMMENDEDLENGTH);
-
-        recommendedLength = recommendedLengthString == null || recommendedLengthString.isEmpty() ? 0
-                : Integer.parseInt(recommendedLengthString);
-        return true;
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -173,13 +173,6 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateResponseAttributes(
-            List<FeedbackResponseAttributes> responses,
-            int numRecipients) {
-        return new ArrayList<>();
-    }
-
-    @Override
     public boolean isFeedbackParticipantCommentsOnResponsesAllowed() {
         return false;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -164,7 +164,7 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
-    public List<String> validateQuestionDetails(String courseId) {
+    public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
         if (recommendedLength < 0) {
             errors.add(Const.FeedbackQuestion.TEXT_ERROR_INVALID_RECOMMENDED_LENGTH);

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
@@ -24,12 +24,6 @@ public class FeedbackTextResponseDetails extends FeedbackResponseDetails {
     }
 
     @Override
-    public void extractResponseDetails(FeedbackQuestionType questionType,
-                                       FeedbackQuestionDetails questionDetails, String[] answer) {
-        this.answer = SanitizationHelper.sanitizeForRichText(answer[0]);
-    }
-
-    @Override
     public String getAnswerString() {
         return SanitizationHelper.sanitizeForRichText(answer);
     }

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import teammates.common.datatransfer.CourseDetailsBundle;
 import teammates.common.datatransfer.CourseSummaryBundle;
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackResponseCommentSearchResultBundle;
 import teammates.common.datatransfer.FeedbackSessionDetailsBundle;
 import teammates.common.datatransfer.FeedbackSessionQuestionsBundle;
@@ -2030,6 +2031,12 @@ public class Logic {
      */
     public void putDocuments(DataBundle dataBundle) {
         dataBundleLogic.putDocuments(dataBundle);
+    }
+
+    public int getNumOfGeneratedChoicesForParticipantType(String courseId, FeedbackParticipantType generateOptionsFor) {
+        Assumption.assertNotNull(courseId);
+        Assumption.assertNotNull(generateOptionsFor);
+        return feedbackQuestionsLogic.getNumOfGeneratedChoicesForParticipantType(courseId, generateOptionsFor);
     }
 
 }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -757,4 +757,32 @@ public final class FeedbackQuestionsLogic {
         }
     }
 
+    /**
+     * Gets the number of generated options for MCQ-type and MSQ-type question.
+     */
+    public int getNumOfGeneratedChoicesForParticipantType(String courseId, FeedbackParticipantType participantType) {
+        if (participantType == FeedbackParticipantType.STUDENTS
+                || participantType == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF) {
+            List<StudentAttributes> studentList = studentsLogic.getStudentsForCourse(courseId);
+            return studentList.size() - (participantType == FeedbackParticipantType.STUDENTS ? 0 : 1);
+        }
+
+        if (participantType == FeedbackParticipantType.TEAMS
+                || participantType == FeedbackParticipantType.TEAMS_EXCLUDING_SELF) {
+            try {
+                List<TeamDetailsBundle> teamList = coursesLogic.getTeamsForCourse(courseId);
+                return teamList.size() - (participantType == FeedbackParticipantType.TEAMS ? 0 : 1);
+            } catch (EntityDoesNotExistException e) {
+                Assumption.fail("Course disappeared");
+            }
+        }
+
+        if (participantType == FeedbackParticipantType.INSTRUCTORS) {
+            List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForCourse(courseId);
+            return instructorList.size();
+        }
+
+        return 0;
+    }
+
 }

--- a/src/main/java/teammates/ui/webapi/action/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateFeedbackQuestionAction.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.questions.FeedbackMsqQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
@@ -57,8 +59,15 @@ public class CreateFeedbackQuestionAction extends Action {
             throw new InvalidHttpRequestBodyException(err);
         }
         // validate questions (question details)
-        List<String> questionDetailsErrors =
-                attributes.getQuestionDetails().validateQuestionDetails(attributes.getCourseId());
+        FeedbackQuestionDetails questionDetails = attributes.getQuestionDetails();
+        if (questionDetails instanceof FeedbackMsqQuestionDetails) {
+            FeedbackMsqQuestionDetails msqQuestionDetails = (FeedbackMsqQuestionDetails) questionDetails;
+            int numOfGeneratedMsqChoices = logic.getNumOfGeneratedChoicesForParticipantType(
+                    attributes.getCourseId(), msqQuestionDetails.getGenerateOptionsFor());
+            msqQuestionDetails.setNumOfGeneratedMsqChoices(numOfGeneratedMsqChoices);
+            questionDetails = msqQuestionDetails;
+        }
+        List<String> questionDetailsErrors = questionDetails.validateQuestionDetails();
         if (!questionDetailsErrors.isEmpty()) {
             throw new InvalidHttpRequestBodyException(questionDetailsErrors.toString());
         }

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.apache.http.HttpStatus;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.questions.FeedbackMsqQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpRequestBodyException;
@@ -65,8 +67,15 @@ public class UpdateFeedbackQuestionAction extends Action {
             throw new InvalidHttpRequestBodyException(err);
         }
         // validate questions (question details)
-        List<String> questionDetailsErrors =
-                oldQuestion.getQuestionDetails().validateQuestionDetails(oldQuestion.getCourseId());
+        FeedbackQuestionDetails questionDetails = oldQuestion.getQuestionDetails();
+        if (questionDetails instanceof FeedbackMsqQuestionDetails) {
+            FeedbackMsqQuestionDetails msqQuestionDetails = (FeedbackMsqQuestionDetails) questionDetails;
+            int numOfGeneratedMsqChoices = logic.getNumOfGeneratedChoicesForParticipantType(
+                    oldQuestion.getCourseId(), msqQuestionDetails.getGenerateOptionsFor());
+            msqQuestionDetails.setNumOfGeneratedMsqChoices(numOfGeneratedMsqChoices);
+            questionDetails = msqQuestionDetails;
+        }
+        List<String> questionDetailsErrors = questionDetails.validateQuestionDetails();
 
         if (!questionDetailsErrors.isEmpty()) {
             throw new InvalidHttpRequestBodyException(questionDetailsErrors.toString());

--- a/src/test/java/teammates/test/cases/architecture/ArchitectureTest.java
+++ b/src/test/java/teammates/test/cases/architecture/ArchitectureTest.java
@@ -96,8 +96,6 @@ public class ArchitectureTest {
     @Test
     public void testArchitecture_commonShouldNotTouchLogic() {
         noClasses().that().resideInAPackage(includeSubpackages(COMMON_PACKAGE))
-                // TODO fix these violations
-                .and().doNotHaveSimpleName("FeedbackMsqQuestionDetails")
                 .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_PACKAGE))
                 .check(forClasses(COMMON_PACKAGE, LOGIC_PACKAGE));
     }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
@@ -32,7 +32,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setNumOfMcqChoices(1);
         mcqDetails.setMcqChoices(Collections.singletonList("Choice 2"));
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_NOT_ENOUGH_CHOICES
                 + Const.FeedbackQuestion.MCQ_MIN_NUM_OF_CHOICES + ".", errors.get(0));
@@ -46,7 +46,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setMcqWeights(Collections.singletonList(1.22));
         mcqDetails.setHasAssignedWeights(true);
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -59,7 +59,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setHasAssignedWeights(true);
         mcqDetails.setMcqWeights(Arrays.asList(1.22, 1.55));
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(0, errors.size());
     }
 
@@ -70,7 +70,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setMcqChoices(Arrays.asList("Choice 1", "Choice 2"));
         mcqDetails.setMcqWeights(Arrays.asList(1.22, -1.55));
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -84,7 +84,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setHasAssignedWeights(true);
         mcqDetails.setMcqOtherWeight(-2);
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -96,13 +96,13 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         mcqDetails.setNumOfMcqChoices(2);
         mcqDetails.setMcqChoices(Arrays.asList("choice 1", "choice 1"));
 
-        List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_DUPLICATE_MCQ_OPTION, errors.get(0));
 
         //duplicate cases that has trailing and leading spaces
         mcqDetails.setMcqChoices(Arrays.asList("choice 1", " choice 1 "));
-        errors = mcqDetails.validateQuestionDetails(dummySessionToken);
+        errors = mcqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_DUPLICATE_MCQ_OPTION, errors.get(0));
     }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
@@ -1,9 +1,8 @@
 package teammates.test.cases.datatransfer;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -28,268 +27,11 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetMcqWeights_allChoicesNull_weightsListShouldBeEmpty() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "2.50" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertEquals(mcqDetails.getQuestionType(), FeedbackQuestionType.MCQ);
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertTrue(mcqDetails.getMcqChoices().isEmpty());
-        // getMcqWeight() returns empty list as there are no mcq choices set.
-        assertTrue(mcqDetails.getMcqWeights().isEmpty());
-        assertFalse(mcqDetails.getOtherEnabled());
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqWeights_emptyChoice_weightForInValidChoiceShouldNotBeParsed() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "        " });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        List<Double> weights = mcqDetails.getMcqWeights();
-        // As one weight can not be parsed, there will be only one weight in the list
-        assertEquals(1, weights.size());
-        assertEquals(1.55, weights.get(0));
-    }
-
-    @Test
-    public void testGetMcqWeights_allWeightsNull_weightsListShouldBeEmpty() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertEquals(2, mcqDetails.getMcqChoices().size());
-        assertEquals(0, mcqDetails.getMcqWeights().size());
-    }
-
-    @Test
-    public void testGetMcqWeights_invalidWeights_weightNotParsed() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "Invalid Weight" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        List<Double> weights = mcqDetails.getMcqWeights();
-        // As one weight can not be parsed, there will be only one weight in the list
-        assertEquals(1, weights.size());
-        assertEquals(1.55, weights.get(0));
-    }
-
-    @Test
-    public void testGetMcqWeights_weightsDisabledValidWeights_weightListShouldBeEmpty() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.55" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertFalse(mcqDetails.hasAssignedWeights());
-        // As weights are disabled, getMcqWeights should return an empty list.
-        assertTrue(mcqDetails.getMcqWeights().isEmpty());
-    }
-
-    @Test
-    public void testGetMcqWeights_weightsEnabledValidChoicesAndWeights_weightsShouldHaveCorrectValues() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "2.50" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertFalse(mcqDetails.getMcqChoices().isEmpty());
-        assertEquals(2, mcqDetails.getMcqChoices().size());
-        List<Double> weights = mcqDetails.getMcqWeights();
-        assertEquals(2, weights.size());
-        assertEquals(1.50, weights.get(0));
-        assertEquals(2.50, weights.get(1));
-        assertFalse(mcqDetails.getOtherEnabled());
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqOtherWeight_weightsEnabledOtherDisabledValidWeights_otherWeightShouldHaveDefaultValue() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertFalse(mcqDetails.getOtherEnabled());
-        // As 'other' option is disabled, 'otherWeight' will have default value of 0.0
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqOtherWeight_weightAndOtherEnabledValidWeights_fieldShouldHaveCorrectValue() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertTrue(mcqDetails.getOtherEnabled());
-        assertEquals(3.12, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqOtherWeight_weightsDisabledOtherEnabled_otherWeightShouldHaveDefaultValue() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertFalse(mcqDetails.hasAssignedWeights());
-        assertTrue(mcqDetails.getOtherEnabled());
-        // As weights is disabled, even though other is enabled, otherWeight will have it's default value.
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqOtherWeight_invalidOtherWeight_otherWeightNotParsed() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "aa" });
-
-        // Other weight value before editing the question
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
-        assertTrue(mcqDetails.getOtherEnabled());
-        // As 'aa' is not valid double value, other weight will keep the previous value
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
-
-    @Test
-    public void testGetMcqOtherWeight_nullOtherWeight_exceptionThrown() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        // Removed to send null as otherWeight parameter
-        // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "" });
-
-        assertThrows(AssertionError.class, () -> mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-    }
-
-    @Test
     public void testValidateQuestionDetails_choicesLessThanMinRequirement_errorReturned() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        mcqDetails.setNumOfMcqChoices(1);
+        mcqDetails.setMcqChoices(Collections.singletonList("Choice 2"));
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
         List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_NOT_ENOUGH_CHOICES
@@ -299,21 +41,11 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_numberOfChoicesGreaterThanWeights_errorReturned() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        mcqDetails.setNumOfMcqChoices(2);
+        mcqDetails.setMcqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        mcqDetails.setMcqWeights(Collections.singletonList(1.22));
+        mcqDetails.setHasAssignedWeights(true);
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.22" });
-        // Remove this weight to make number of choices greater than number of weights
-        // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
         List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -322,20 +54,11 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_noValidationError_errorListShouldBeEmpty() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        mcqDetails.setNumOfMcqChoices(2);
+        mcqDetails.setMcqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        mcqDetails.setHasAssignedWeights(true);
+        mcqDetails.setMcqWeights(Arrays.asList(1.22, 1.55));
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        assertTrue(mcqDetails.hasAssignedWeights());
         List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(0, errors.size());
     }
@@ -343,20 +66,10 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_negativeWeights_errorsReturned() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        mcqDetails.setNumOfMcqChoices(2);
+        mcqDetails.setMcqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        mcqDetails.setMcqWeights(Arrays.asList(1.22, -1.55));
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.22" });
-        // Pass negative weight for choice 1 to check that negative weights are not allowed.
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "-1.55" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
         List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -365,22 +78,12 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_negativeOtherWeight_errorsReturned() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        mcqDetails.setNumOfMcqChoices(2);
+        mcqDetails.setMcqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        mcqDetails.setMcqWeights(Arrays.asList(1.22, 1.55));
+        mcqDetails.setHasAssignedWeights(true);
+        mcqDetails.setMcqOtherWeight(-2);
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.55" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        // Pass negative weight for 'Other' option to check that negative weights are not allowed.
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "-2" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
         List<String> errors = mcqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -404,29 +107,4 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         assertEquals(Const.FeedbackQuestion.MCQ_ERROR_DUPLICATE_MCQ_OPTION, errors.get(0));
     }
 
-    @Test
-    public void testExtractQuestionDetails_weightsEnabledForGenerateOptions_weightShouldRemainDisabled() {
-        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MCQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "mcq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_GENERATED_OPTIONS, new String[] { "STUDENTS" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
-        // As, weights does not support other generateOptionsFor options then 'NONE',
-        // here in this case, even though we assigned weights for 'Generate Options for Student'
-        // the weights will remain disabled, and the weights list will remain empty.
-        assertFalse(mcqDetails.hasAssignedWeights());
-        assertTrue(mcqDetails.getMcqWeights().isEmpty());
-        assertEquals(0.0, mcqDetails.getMcqOtherWeight());
-    }
 }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
@@ -34,7 +34,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
         msqDetails.setMsqChoices(Collections.singletonList("Choice 1"));
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_NOT_ENOUGH_CHOICES
                 + Const.FeedbackQuestion.MSQ_MIN_NUM_OF_CHOICES + ".", errors.get(0));
@@ -48,7 +48,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setMsqWeights(Collections.singletonList(1.22));
         msqDetails.setHasAssignedWeights(true);
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -61,7 +61,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setMsqWeights(Arrays.asList(1.22, 1.55));
         msqDetails.setHasAssignedWeights(true);
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(0, errors.size());
     }
 
@@ -73,7 +73,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setHasAssignedWeights(true);
         msqDetails.setMsqWeights(Arrays.asList(1.22, -1.55));
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -88,7 +88,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setHasAssignedWeights(true);
         msqDetails.setMsqOtherWeight(-2);
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -99,13 +99,13 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
 
         msqDetails.setMsqChoices(Arrays.asList("choice 1", "choice 1"));
 
-        List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_DUPLICATE_MSQ_OPTION, errors.get(0));
 
         //duplicate cases that has trailing and leading spaces
         msqDetails.setMsqChoices(Arrays.asList("choice 1", " choice 1 "));
-        errors = msqDetails.validateQuestionDetails(dummySessionToken);
+        errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_DUPLICATE_MSQ_OPTION, errors.get(0));
 
@@ -125,7 +125,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setMaxSelectableChoices(3);
         msqDetails.setMinSelectableChoices(Integer.MIN_VALUE);
 
-        List<String> errors = msqDetails.validateQuestionDetails("dummyCourse");
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         AssertHelper.assertContains(Const.FeedbackQuestion.MSQ_ERROR_MAX_SELECTABLE_EXCEEDED_TOTAL, errors.get(0));
     }
@@ -144,7 +144,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         msqDetails.setMaxSelectableChoices(3);
         msqDetails.setMinSelectableChoices(Integer.MIN_VALUE);
 
-        List<String> errors = msqDetails.validateQuestionDetails("dummyCourse");
+        List<String> errors = msqDetails.validateQuestionDetails();
         assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
@@ -2,9 +2,8 @@ package teammates.test.cases.datatransfer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -31,268 +30,10 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetMsqWeights_allChoicesNull_weightsListShouldBeEmpty() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "2.50" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertEquals(msqDetails.getQuestionType(), FeedbackQuestionType.MSQ);
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertTrue(msqDetails.getMsqChoices().isEmpty());
-        // getMsqWeight() returns empty list as there are no msq choices set.
-        assertTrue(msqDetails.getMsqWeights().isEmpty());
-        assertFalse(msqDetails.getOtherEnabled());
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqWeights_emptyChoice_weightForInValidChoiceShouldNotBeParsed() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "        " });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        List<Double> weights = msqDetails.getMsqWeights();
-        // As one weight can not be parsed, there will be only one weight in the list
-        assertEquals(1, weights.size());
-        assertEquals(1.55, weights.get(0));
-    }
-
-    @Test
-    public void testGetMsqWeights_allWeightsNull_weightsListShouldBeEmpty() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertEquals(2, msqDetails.getMsqChoices().size());
-        assertEquals(0, msqDetails.getMsqWeights().size());
-    }
-
-    @Test
-    public void testGetMsqWeights_invalidWeights_weightNotParsed() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "Invalid Weight" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        List<Double> weights = msqDetails.getMsqWeights();
-        // As one weight can not be parsed, there will be only one weight in the list
-        assertEquals(1, weights.size());
-        assertEquals(1.55, weights.get(0));
-    }
-
-    @Test
-    public void testGetMsqWeights_weightsDisabledValidWeights_weightListShouldBeEmpty() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.25" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertFalse(msqDetails.hasAssignedWeights());
-        // As weights are disabled, getMsqWeights should return an empty list.
-        assertTrue(msqDetails.getMsqWeights().isEmpty());
-    }
-
-    @Test
-    public void testGetMsqWeights_weightsEnabledValidChoicesAndWeights_weightsShouldHaveCorrectValues() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "2.50" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertFalse(msqDetails.getMsqChoices().isEmpty());
-        assertEquals(2, msqDetails.getMsqChoices().size());
-        List<Double> weights = msqDetails.getMsqWeights();
-        assertEquals(2, weights.size());
-        assertEquals(1.50, weights.get(0));
-        assertEquals(2.50, weights.get(1));
-        assertFalse(msqDetails.getOtherEnabled());
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqOtherWeight_weightsEnabledOtherDisabledValidWeights_otherWeightShouldHaveDefaultValue() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertFalse(msqDetails.getOtherEnabled());
-        // As 'other' option is disabled, 'otherWeight' will have default value of 0.0
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqOtherWeight_weightAndOtherEnabledValidWeights_fieldShouldHaveCorrectValue() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertTrue(msqDetails.getOtherEnabled());
-        assertEquals(3.12, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqOtherWeight_weightsDisabledOtherEnabled_otherWeightShouldHaveDefaultValue() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertFalse(msqDetails.hasAssignedWeights());
-        assertTrue(msqDetails.getOtherEnabled());
-        // As weights is disabled, even though other is enabled, otherWeight will have it's default value.
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqOtherWeight_invalidOtherWeight_otherWeightNotParsed() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "aa" });
-
-        // Other weight value before editing the question
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
-        assertTrue(msqDetails.getOtherEnabled());
-        // As 'aa' is not valid double value, other weight will keep the previous value
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
-    }
-
-    @Test
-    public void testGetMsqOtherWeight_nullOtherWeight_exceptionThrown() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        // The following line is commented out, so otherWeight parameter is missing from the requestParams.
-        // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "" });
-
-        assertThrows(AssertionError.class, () -> msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-    }
-
-    @Test
     public void testValidateQuestionDetails_choicesLessThanMinRequirement_errorReturned() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
+        msqDetails.setMsqChoices(Collections.singletonList("Choice 1"));
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
         List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_NOT_ENOUGH_CHOICES
@@ -302,21 +43,11 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_numberOfChoicesGreaterThanWeights_errorReturned() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.22" });
-        // The following msqWeight-1 is commented out, so the number of Weights can become 1 whereas numOfChoices is 2.
-        // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
+        msqDetails.setMsqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        msqDetails.setMsqWeights(Collections.singletonList(1.22));
+        msqDetails.setHasAssignedWeights(true);
 
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
         List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -325,20 +56,11 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_noValidationError_errorListShouldBeEmpty() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
+        msqDetails.setMsqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        msqDetails.setMsqWeights(Arrays.asList(1.22, 1.55));
+        msqDetails.setHasAssignedWeights(true);
 
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        assertTrue(msqDetails.hasAssignedWeights());
         List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(0, errors.size());
     }
@@ -346,20 +68,11 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_negativeWeights_errorsReturned() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.22" });
-        // Pass negative weight for choice 1 to check that negative weights are not allowed.
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "-1.55" });
+        msqDetails.setMsqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        msqDetails.setHasAssignedWeights(true);
+        msqDetails.setMsqWeights(Arrays.asList(1.22, -1.55));
 
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
         List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -368,22 +81,13 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_negativeOtherWeight_errorsReturned() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
 
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "NONE" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "1.22" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.55" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        // Pass negative weight for 'Other' option to check that negative weights are not allowed.
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "-2" });
+        msqDetails.setMsqChoices(Arrays.asList("Choice 1", "Choice 2"));
+        msqDetails.setMsqWeights(Arrays.asList(1.22, 1.55));
+        msqDetails.setOtherEnabled(true);
+        msqDetails.setHasAssignedWeights(true);
+        msqDetails.setMsqOtherWeight(-2);
 
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
         List<String> errors = msqDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -405,32 +109,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.MSQ_ERROR_DUPLICATE_MSQ_OPTION, errors.get(0));
 
-    }
-
-    @Test
-    public void testExtractQuestionDetails_weightsEnabledForGenerateOptions_weightShouldRemainDisabled() {
-        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "MSQ" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "msq question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_GENERATED_OPTIONS, new String[] { "STUDENTS" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-0", new String[] { "Choice 1" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQCHOICE + "-1", new String[] { "Choice 2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_HAS_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-0", new String[] { "2.57" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_WEIGHT + "-1", new String[] { "1.12" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQOTHEROPTIONFLAG, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "3.12" });
-
-        assertTrue(msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
-        // As, weights does not support other generateOptionsFor options then 'NONE',
-        // here in this case, even though we assigned weights for 'Generate Options for Student'
-        // the weights will remain disabled, and the weights list will remain empty.
-        assertFalse(msqDetails.hasAssignedWeights());
-        assertTrue(msqDetails.getMsqWeights().isEmpty());
-        assertEquals(0.0, msqDetails.getMsqOtherWeight());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackRubricQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackRubricQuestionDetailsTest.java
@@ -36,7 +36,7 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
         rubricDetails.setRubricChoices(Arrays.asList("Choice-1", "Choice-2"));
         rubricDetails.setRubricWeightsForEachCell(Arrays.asList(Arrays.asList(1.5, 2.5), Collections.singletonList(1.0)));
 
-        List<String> errors = rubricDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = rubricDetails.validateQuestionDetails();
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.RUBRIC_ERROR_INVALID_WEIGHT, errors.get(0));
     }
@@ -52,7 +52,7 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
         rubricDetails.setRubricChoices(Arrays.asList("Choice-1", "Choice-2"));
         rubricDetails.setRubricWeightsForEachCell(Arrays.asList(Arrays.asList(1.5, 2.5), Arrays.asList(1.0, 2.0)));
 
-        List<String> errors = rubricDetails.validateQuestionDetails(dummySessionToken);
+        List<String> errors = rubricDetails.validateQuestionDetails();
         assertEquals(0, errors.size());
     }
 }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackRubricQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackRubricQuestionDetailsTest.java
@@ -1,8 +1,8 @@
 package teammates.test.cases.datatransfer;
 
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -26,206 +26,16 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetRubricWeightsForEachCell_allChoicesNull_weightsListShouldBeEmpty() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        assertFalse(rubricDetails.getRubricSubQuestions().isEmpty());
-        assertTrue(rubricDetails.getRubricChoices().isEmpty());
-        // getRubricWeightForEachCell() returns empty list as there are no choices set.
-        assertTrue(rubricDetails.getRubricWeights().isEmpty());
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_allSubQuestionsNull_weightsListShouldBeEmpty() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {"Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        assertTrue(rubricDetails.getRubricSubQuestions().isEmpty());
-        assertFalse(rubricDetails.getRubricChoices().isEmpty());
-        // getRubricWeightForEachCell() returns empty list as there are no sub questions set.
-        assertTrue(rubricDetails.getRubricWeights().isEmpty());
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_emptySubQuestion_weightForInValidSubQestionShouldNotBeParsed() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"       "});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        // As SubQn-0 is empty, no weights for SubQn-0 should be parsed,
-        // So, weight list will contain 1 value (weights for SubQn-1).
-        assertEquals(1, rubricDetails.getRubricWeights().size());
-        // Check weights for SubQn-1 (for cell-1-0, cell 1-1).
-        assertEquals(1.00, rubricDetails.getRubricWeights().get(0).get(0));
-        assertEquals(2.00, rubricDetails.getRubricWeights().get(0).get(1));
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_allWeightsNull_weightListShouldBeEmpty() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        // As no weights have been passed, the weight list will be empty
-        assertEquals(0, rubricDetails.getRubricWeights().size());
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_invalidWeightPassed_invalidWeightShouldNotBeParsed() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] {"Invalid"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        assertEquals(2, rubricDetails.getRubricWeights().size());
-        // As invalid weight is passed for weight-0-0, there will be only one weight for SubQn-0.
-        assertEquals(1, rubricDetails.getRubricWeights().get(0).size());
-        // Check weights for SubQn-0 (for cell-0-1)
-        assertEquals(2.50, rubricDetails.getRubricWeights().get(0).get(0));
-        // Check weights for SubQn-1 (for cell-1-0, cell 1-1).
-        assertEquals(2, rubricDetails.getRubricWeights().get(1).size());
-        assertEquals(1.00, rubricDetails.getRubricWeights().get(1).get(0));
-        assertEquals(2.00, rubricDetails.getRubricWeights().get(1).get(1));
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_weightsDisabledValidWeights_weightListShouldBeEmpty() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "off" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertFalse(rubricDetails.hasAssignedWeights());
-        // As weights are disabled, weight list should be empty
-        assertTrue(rubricDetails.getRubricWeights().isEmpty());
-    }
-
-    @Test
-    public void testGetRubricWeightsForEachCell_weightsEnabledValidWeights_weightsListShouldHaveCorrectWeights() {
-        FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
-
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
-        // Check for the size of the weight list.
-        assertEquals(2, rubricDetails.getRubricWeights().size());
-        assertEquals(2, rubricDetails.getRubricWeights().get(0).size());
-        assertEquals(2, rubricDetails.getRubricWeights().get(1).size());
-        // Check weight list for correct values.
-        assertEquals(1.50, rubricDetails.getRubricWeights().get(0).get(0));
-        assertEquals(2.50, rubricDetails.getRubricWeights().get(0).get(1));
-        assertEquals(1.00, rubricDetails.getRubricWeights().get(1).get(0));
-        assertEquals(2.00, rubricDetails.getRubricWeights().get(1).get(1));
-    }
-
-    @Test
     public void testValidateQuestionDetails_invalidWeightListSize_errorReturned() {
         FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
+        rubricDetails.setNumOfRubricChoices(2);
+        rubricDetails.setNumOfRubricSubQuestions(2);
+        rubricDetails.setRubricDescriptions(Arrays.asList(Arrays.asList("", ""), Arrays.asList("", "")));
+        rubricDetails.setHasAssignedWeights(true);
+        rubricDetails.setRubricSubQuestions(Arrays.asList("SubQn-1", "SubQn-2"));
+        rubricDetails.setRubricChoices(Arrays.asList("Choice-1", "Choice-2"));
+        rubricDetails.setRubricWeightsForEachCell(Arrays.asList(Arrays.asList(1.5, 2.5), Collections.singletonList(1.0)));
 
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
         List<String> errors = rubricDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(1, errors.size());
         assertEquals(Const.FeedbackQuestion.RUBRIC_ERROR_INVALID_WEIGHT, errors.get(0));
@@ -234,23 +44,14 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
     @Test
     public void testValidateQuestionDetails_validWeightListSize_errorListShouldBeEmpty() {
         FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
-        Map<String, String[]> requestParams = new HashMap<>();
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, new String[] { "RUBRIC" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_TEXT, new String[] { "Rubric question text" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_COLS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_NUM_ROWS, new String[] { "2" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHTS_ASSIGNED, new String[] { "on" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-0", new String[] {"SubQn-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + "-1", new String[] {"SubQn-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-0", new String[] {" Choice-1"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_CHOICE + "-1", new String[] {"Choice-2"});
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-0", new String[] { "1.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-0-1", new String[] { "2.50" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-0", new String[] { "1.00" });
-        requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_WEIGHT + "-1-1", new String[] { "2.00" });
+        rubricDetails.setNumOfRubricChoices(2);
+        rubricDetails.setNumOfRubricSubQuestions(2);
+        rubricDetails.setRubricDescriptions(Arrays.asList(Arrays.asList("", ""), Arrays.asList("", "")));
+        rubricDetails.setHasAssignedWeights(true);
+        rubricDetails.setRubricSubQuestions(Arrays.asList("SubQn-1", "SubQn-2"));
+        rubricDetails.setRubricChoices(Arrays.asList("Choice-1", "Choice-2"));
+        rubricDetails.setRubricWeightsForEachCell(Arrays.asList(Arrays.asList(1.5, 2.5), Arrays.asList(1.0, 2.0)));
 
-        assertTrue(rubricDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.RUBRIC));
-        assertTrue(rubricDetails.hasAssignedWeights());
         List<String> errors = rubricDetails.validateQuestionDetails(dummySessionToken);
         assertEquals(0, errors.size());
     }


### PR DESCRIPTION
Part of #9382

This removes unused methods `extractQuestionDetails`, `extractResponseDetails` (the question/response construction logic is moved to the front-end and sent as request body), `isQuestionSkipped`, and `validateResponseAttributes` (not the right place), and adds a slight refactor to `FeedbackMsqQuestionDetails` such that it is no longer dependent to logic package. One more architecture violation is fixed.

The `Feedback*QuestionDetailsTest` cases that involve only extraction are no longer meaningful and thus removed; those that involve validation are still meaningful and should be improved after this.
