### PR TITLE
[#10114] Fix UI of disabled delete button in instructor courses page

### DIFF
--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -329,7 +329,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                   
                   
                   <button
-                    class="btn btn-primary btn-sm disabled"
+                    class="btn btn-primary btn-sm dropdown-item disabled"
                   >
                      Delete 
                   </button>
@@ -846,7 +846,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                   
                   
                   <button
-                    class="btn btn-primary btn-sm disabled"
+                    class="btn btn-primary btn-sm dropdown-item disabled"
                   >
                      Delete 
                   </button>
@@ -1532,7 +1532,7 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                   
                   
                   <button
-                    class="btn btn-primary btn-sm disabled"
+                    class="btn btn-primary btn-sm dropdown-item disabled"
                   >
                      Delete 
                   </button>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -120,7 +120,7 @@
                     ngbTooltip="Delete the course and its corresponding students and sessions">
                     Delete
                   </button>
-                  <button class="btn btn-primary btn-sm disabled" *ngIf="!course.canModifyCourse">
+                  <button class="btn btn-primary btn-sm dropdown-item disabled" *ngIf="!course.canModifyCourse">
                     Delete
                   </button>
                 </div>


### PR DESCRIPTION
Fixes #10114 

**Before**:
<img width="1059" alt="Screenshot 2020-05-25 at 21 26 49" src="https://user-images.githubusercontent.com/32880438/82817147-0d7df980-9ecf-11ea-80a6-df649b197e15.png">

**After**:
<img width="1049" alt="Screenshot 2020-05-25 at 21 26 17" src="https://user-images.githubusercontent.com/32880438/82817174-18388e80-9ecf-11ea-9b46-a6251d12b0e2.png">


**Outline of Solution**
- add missing `dropdown-item` attribute to corresponding HTML element.
