### PR TITLE
[#10107] Append email after participants' name for GRQ/RGQ/GQR/RQG view

### DIFF
--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -164,8 +164,8 @@ public class SessionResultsData extends ApiOutput {
 
             for (FeedbackResponseAttributes response : responsesForRecipient) {
                 String giverName = removeAnonymousHash(bundle.getGiverNameForResponse(response));
-                String giverEmail = bundle.getDisplayableEmailGiver(response);
-                String recipientEmail = bundle.getDisplayableEmailRecipient(response);
+                String giverEmail = bundle.isGiverVisible(response) ? response.giver : null;
+                String recipientEmail = bundle.isRecipientVisible(response) ? response.recipient : null;
                 Map<String, Set<String>> teamNameToMembersEmailTable = bundle.rosterTeamNameMembersTable;
                 String relatedGiverEmail = teamNameToMembersEmailTable.containsKey(response.giver)
                         ? teamNameToMembersEmailTable.get(response.giver).iterator().next() : response.giver;

--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -138,8 +138,9 @@ public class SessionResultsData extends ApiOutput {
                 Queue<CommentOutput> comments = buildComments(feedbackResponseComments, bundle);
 
                 // Student does not need to know the teams for giver and/or recipient
-                output.add(new ResponseOutput(response.getId(), displayedGiverName, null, null, response.giverSection,
-                        recipientName, null, response.recipientSection,
+                output.add(new ResponseOutput(response.getId(), displayedGiverName, null, null,
+                        null, response.giverSection,
+                        recipientName, null, null, response.recipientSection,
                         response.responseDetails, comments.poll(), new ArrayList<>(comments)));
             }
 
@@ -163,6 +164,8 @@ public class SessionResultsData extends ApiOutput {
 
             for (FeedbackResponseAttributes response : responsesForRecipient) {
                 String giverName = removeAnonymousHash(bundle.getGiverNameForResponse(response));
+                String giverEmail = bundle.getDisplayableEmailGiver(response);
+                String recipientEmail = bundle.getDisplayableEmailRecipient(response);
                 Map<String, Set<String>> teamNameToMembersEmailTable = bundle.rosterTeamNameMembersTable;
                 String relatedGiverEmail = teamNameToMembersEmailTable.containsKey(response.giver)
                         ? teamNameToMembersEmailTable.get(response.giver).iterator().next() : response.giver;
@@ -174,8 +177,8 @@ public class SessionResultsData extends ApiOutput {
                         bundle.getResponseComments().getOrDefault(response.getId(), Collections.emptyList());
                 Queue<CommentOutput> comments = buildComments(feedbackResponseComments, bundle);
 
-                output.add(new ResponseOutput(response.getId(), giverName, giverTeam, relatedGiverEmail,
-                        response.giverSection, recipientName, recipientTeam, response.recipientSection,
+                output.add(new ResponseOutput(response.getId(), giverName, giverTeam, giverEmail, relatedGiverEmail,
+                        response.giverSection, recipientName, recipientTeam, recipientEmail, response.recipientSection,
                         response.responseDetails, comments.poll(), new ArrayList<>(comments)));
             }
 
@@ -266,9 +269,13 @@ public class SessionResultsData extends ApiOutput {
          */
         private final String relatedGiverEmail; // TODO: security risk: relatedGiverEmail can expose giver email
         private final String giverTeam;
+        @Nullable
+        private final String giverEmail;
         private final String giverSection;
         private String recipient;
         private final String recipientTeam;
+        @Nullable
+        private final String recipientEmail;
         private final String recipientSection;
         private final FeedbackResponseDetails responseDetails;
 
@@ -277,17 +284,19 @@ public class SessionResultsData extends ApiOutput {
         private CommentOutput participantComment;
         private final List<CommentOutput> instructorComments;
 
-        ResponseOutput(String responseId, String giver, String giverTeam, String relatedGiverEmail,
-                       String giverSection, String recipient, String recipientTeam, String recipientSection,
-                       FeedbackResponseDetails responseDetails,
+        ResponseOutput(String responseId, String giver, String giverTeam, String giverEmail, String relatedGiverEmail,
+                       String giverSection, String recipient, String recipientTeam, String recipientEmail,
+                       String recipientSection, FeedbackResponseDetails responseDetails,
                        CommentOutput participantComment, List<CommentOutput> instructorComments) {
             this.responseId = responseId;
             this.giver = giver;
             this.relatedGiverEmail = relatedGiverEmail;
+            this.giverEmail = giverEmail;
             this.giverTeam = giverTeam;
             this.giverSection = giverSection;
             this.recipient = recipient;
             this.recipientTeam = recipientTeam;
+            this.recipientEmail = recipientEmail;
             this.recipientSection = recipientSection;
             this.responseDetails = responseDetails;
             this.participantComment = participantComment;
@@ -300,6 +309,10 @@ public class SessionResultsData extends ApiOutput {
 
         public String getGiver() {
             return giver;
+        }
+
+        public String getGiverEmail() {
+            return giverEmail;
         }
 
         public String getRelatedGiverEmail() {
@@ -320,6 +333,10 @@ public class SessionResultsData extends ApiOutput {
 
         public String getRecipientTeam() {
             return recipientTeam;
+        }
+
+        public String getRecipientEmail() {
+            return recipientEmail;
         }
 
         public String getRecipientSection() {

--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -164,8 +164,12 @@ public class SessionResultsData extends ApiOutput {
 
             for (FeedbackResponseAttributes response : responsesForRecipient) {
                 String giverName = removeAnonymousHash(bundle.getGiverNameForResponse(response));
-                String giverEmail = bundle.isGiverVisible(response) ? response.giver : null;
-                String recipientEmail = bundle.isRecipientVisible(response) ? response.recipient : null;
+                String giverEmail = bundle.isGiverVisible(response)
+                        ? (bundle.rosterTeamNameMembersTable.containsKey(response.giver) ? null : response.giver)
+                        : null;
+                String recipientEmail = bundle.isRecipientVisible(response)
+                        ? (bundle.rosterTeamNameMembersTable.containsKey(response.recipient) ? null : response.recipient)
+                        : null;
                 Map<String, Set<String>> teamNameToMembersEmailTable = bundle.rosterTeamNameMembersTable;
                 String relatedGiverEmail = teamNameToMembersEmailTable.containsKey(response.giver)
                         ? teamNameToMembersEmailTable.get(response.giver).iterator().next() : response.giver;

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -32,9 +32,9 @@
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
       {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
-      <span *ngIf="userToEmail[userInfo]">
+      <a *ngIf="userToEmail[userInfo]" [href]="'mailto:' + userToEmail[userInfo]" class="text-white" (click)="$event.stopPropagation()">
         [{{ userToEmail[userInfo] }}]
-      </span>
+      </a>
       <div class="float-right">
         <tm-response-moderation-button class="mr-md-3" *ngIf="isGqr" [session]="session" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -31,9 +31,12 @@
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
-      {{ isGqr ? 'From' : 'To' }}: {{ userInfo }} {{ userToEmail[userInfo] }}
+      {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
+      <span *ngIf="userToEmail[userInfo]">
+        [{{ userToEmail[userInfo] }}]
+      </span>
       <div class="float-right">
-        <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
+        <tm-response-moderation-button class="mr-md-3" *ngIf="isGqr" [session]="session" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>
         <i class="fas fa-chevron-up" *ngIf="userExpanded[userInfo]"></i>
       </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -31,7 +31,7 @@
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
-      {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
+      {{ isGqr ? 'From' : 'To' }}: {{ userInfo }} {{ userToEmail[userInfo] }}
       <div class="float-right">
         <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -86,7 +86,7 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
           }
           this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
-          if (this.userToEmail[response.giver].indexOf(response.giver) === -1 && response.giverEmail !== undefined) {
+          if (response.giverEmail) {
             this.userToEmail[response.giver] = response.giverEmail;
           }
           this.userExpanded[response.giver] = this.isExpandAll;
@@ -107,8 +107,7 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
           }
           this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
-          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1
-              && response.recipientEmail !== undefined) {
+          if (response.recipientEmail) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }
           this.userExpanded[response.recipient] = this.isExpandAll;

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -85,7 +85,6 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamsToUsers[response.giverTeam].push(response.giver);
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
           }
-          this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
           if (response.giverEmail) {
             this.userToEmail[response.giver] = response.giverEmail;
           }
@@ -106,7 +105,6 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamsToUsers[response.recipientTeam].push(response.recipient);
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
           }
-          this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
           if (response.recipientEmail) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -52,6 +52,7 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
   @Input() isGqr: boolean = true;
 
   teamsToUsers: Record<string, string[]> = {};
+  userToEmail: Record<string, string> = {};
 
   teamExpanded: Record<string, boolean> = {};
   userExpanded: Record<string, boolean> = {};
@@ -74,6 +75,7 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
     this.responsesToShow = {};
     this.teamsToUsers = {};
     this.teamExpanded = {};
+    this.userToEmail = {};
     this.userExpanded = {};
     for (const question of this.responses) {
       for (const response of question.allResponses) {
@@ -82,6 +84,10 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
           if (this.teamsToUsers[response.giverTeam].indexOf(response.giver) === -1) {
             this.teamsToUsers[response.giverTeam].push(response.giver);
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
+          }
+          this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
+          if (this.userToEmail[response.giver].indexOf(response.giver) === -1 && response.giverEmail !== undefined) {
+            this.userToEmail[response.giver] = response.giverEmail;
           }
           this.userExpanded[response.giver] = this.isExpandAll;
         } else {
@@ -99,6 +105,10 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
           if (this.teamsToUsers[response.recipientTeam].indexOf(response.recipient) === -1) {
             this.teamsToUsers[response.recipientTeam].push(response.recipient);
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
+          }
+          this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
+          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1 && response.recipientEmail !== undefined) {
+            this.userToEmail[response.recipient] = response.recipientEmail;
           }
           this.userExpanded[response.recipient] = this.isExpandAll;
         }

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -107,7 +107,8 @@ export class GqrRqgViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
           }
           this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
-          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1 && response.recipientEmail !== undefined) {
+          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1
+              && response.recipientEmail !== undefined) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }
           this.userExpanded[response.recipient] = this.isExpandAll;

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -33,7 +33,7 @@
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
-      {{ isGrq ? 'From' : 'To' }}: {{ userInfo }}
+      {{ isGrq ? 'From' : 'To' }}: {{ userInfo }} {{ userToEmail[userInfo] }}
       <div class="float-right">
         <tm-response-moderation-button *ngIf="isGrq" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -34,9 +34,9 @@
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
       {{ isGrq ? 'From' : 'To' }}: {{ userInfo }} {{ usersToTeams[userInfo] !== '' ? '(' + usersToTeams[userInfo] + ')' : ''}}
-      <span *ngIf="userToEmail[userInfo]">
+      <a *ngIf="userToEmail[userInfo]" [href]="'mailto:' + userToEmail[userInfo]" class="text-white" (click)="$event.stopPropagation()">
         [{{ userToEmail[userInfo] }}]
-      </span>
+      </a>
       <div class="float-right">
         <tm-response-moderation-button *ngIf="isGrq" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -33,7 +33,10 @@
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
     <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
-      {{ isGrq ? 'From' : 'To' }}: {{ userInfo }} {{ userToEmail[userInfo] }}
+      {{ isGrq ? 'From' : 'To' }}: {{ userInfo }}
+      <span *ngIf="userToEmail[userInfo]">
+        [{{ userToEmail[userInfo] }}]
+      </span>
       <div class="float-right">
         <tm-response-moderation-button *ngIf="isGrq" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
         <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -84,7 +84,6 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.usersToTeams[response.giver] = response.giverTeam;
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
           }
-          this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
           if (response.giverEmail) {
             this.userToEmail[response.giver] = response.giverEmail;
           }
@@ -107,7 +106,6 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
               this.teamExpanded[response.recipientTeam] = this.isExpandAll;
             }
           }
-          this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
           if (response.recipientEmail) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -46,6 +46,7 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
   @Input() isGrq: boolean = true;
 
   teamsToUsers: Record<string, string[]> = {};
+  userToEmail: Record<string, string> = {};
 
   teamExpanded: Record<string, boolean> = {};
   userExpanded: Record<string, boolean> = {};
@@ -67,6 +68,7 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
   private filterResponses(): void {
     this.responsesToShow = {};
     this.teamsToUsers = {};
+    this.userToEmail = {};
     this.teamExpanded = {};
     this.userExpanded = {};
     for (const question of this.responses) {
@@ -76,6 +78,10 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
           if (this.teamsToUsers[response.giverTeam].indexOf(response.giver) === -1) {
             this.teamsToUsers[response.giverTeam].push(response.giver);
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
+          }
+          this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
+          if (this.userToEmail[response.giver].indexOf(response.giver) === -1 && response.giverEmail !== undefined) {
+            this.userToEmail[response.giver] = response.giverEmail;
           }
           this.userExpanded[response.giver] = this.isExpandAll;
         } else {
@@ -94,7 +100,10 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamsToUsers[response.recipientTeam].push(response.recipient);
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
           }
-          this.userExpanded[response.recipient] = this.isExpandAll;
+          this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
+          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1 && response.recipientEmail !== undefined) {
+            this.userToEmail[response.recipient] = response.recipientEmail;
+          }
         }
       }
     }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -85,7 +85,7 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamExpanded[response.giverTeam] = this.isExpandAll;
           }
           this.userToEmail[response.giver] = this.userToEmail[response.giver] || '';
-          if (this.userToEmail[response.giver].indexOf(response.giver) === -1 && response.giverEmail !== undefined) {
+          if (response.giverEmail) {
             this.userToEmail[response.giver] = response.giverEmail;
           }
           this.userExpanded[response.giver] = this.isExpandAll;
@@ -108,8 +108,7 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
             }
           }
           this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
-          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1
-              && response.recipientEmail !== undefined) {
+          if (response.recipientEmail) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }
         }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -101,7 +101,8 @@ export class GrqRgqViewResponsesComponent extends ResponsesInstructorCommentsBas
             this.teamExpanded[response.recipientTeam] = this.isExpandAll;
           }
           this.userToEmail[response.recipient] = this.userToEmail[response.recipient] || '';
-          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1 && response.recipientEmail !== undefined) {
+          if (this.userToEmail[response.recipient].indexOf(response.recipient) === -1
+              && response.recipientEmail !== undefined) {
             this.userToEmail[response.recipient] = response.recipientEmail;
           }
         }


### PR DESCRIPTION
Fixes #10107

**Outline of Solution**
**GRQ**
![image](https://user-images.githubusercontent.com/28994607/82886124-a9177480-9f78-11ea-900a-ccabaf1a3cbf.png)

**RQG**
![image](https://user-images.githubusercontent.com/28994607/82886216-cc422400-9f78-11ea-9c23-3a4fe9a926b4.png)

- Add `recipientEmail` and `giverEmail` to backend output. The visibility is handled by the `getDisplayableEmailGiver/Recipient` method
- Made a map from user to email in the group by views and display them accordingly