### PR TITLE
[#10102] Add participant comment to student session result

### DIFF
--- a/src/web/app/components/comment-box/comment-box.module.ts
+++ b/src/web/app/components/comment-box/comment-box.module.ts
@@ -16,6 +16,7 @@ import {
 import {
   ConfirmDeleteCommentModalComponent,
 } from './confirm-delete-comment-modal/confirm-delete-comment-modal.component';
+import { ParticipantCommentToCommandRowModelPipePipe } from './participant-comment-to-command-row-model-pipe.pipe';
 
 /**
  * Module for comments table
@@ -31,6 +32,7 @@ import {
     CommentVisibilityTypeDescriptionPipe,
     CommentVisibilityTypeNamePipe,
     CommentVisibilityTypesJointNamePipe,
+    ParticipantCommentToCommandRowModelPipePipe,
   ],
   imports: [
     TeammatesCommonModule,
@@ -44,6 +46,7 @@ import {
     CommentRowComponent,
     CommentTableComponent,
     CommentTableModalComponent,
+    ParticipantCommentToCommandRowModelPipePipe,
   ],
   entryComponents: [
     ConfirmDeleteCommentModalComponent,

--- a/src/web/app/components/comment-box/participant-comment-to-command-row-model-pipe.pipe.spec.ts
+++ b/src/web/app/components/comment-box/participant-comment-to-command-row-model-pipe.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ParticipantCommentToCommandRowModelPipePipe } from './participant-comment-to-command-row-model-pipe.pipe';
+
+describe('ParticipantCommentToCommandRowModelPipePipe', () => {
+  it('create an instance', () => {
+    const pipe: ParticipantCommentToCommandRowModelPipePipe = new ParticipantCommentToCommandRowModelPipePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/web/app/components/comment-box/participant-comment-to-command-row-model-pipe.pipe.ts
+++ b/src/web/app/components/comment-box/participant-comment-to-command-row-model-pipe.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CommentOutput } from '../../../types/api-output';
+import { CommentRowModel } from './comment-row/comment-row.component';
+
+/**
+ * Transforms participant comment to comment row model.
+ */
+@Pipe({
+  name: 'participantCommentToCommandRowModelPipe',
+})
+export class ParticipantCommentToCommandRowModelPipePipe implements PipeTransform {
+
+  transform(participantComment: CommentOutput, timezone?: string): CommentRowModel {
+    return {
+      timezone,
+      originalComment: participantComment,
+      commentGiverName: participantComment.commentGiverName,
+      lastEditorName: participantComment.lastEditorName,
+      commentEditFormModel: {
+        commentText: participantComment.commentText,
+        isUsingCustomVisibilities: false,
+        showCommentTo: [],
+        showGiverNameTo: [],
+      },
+      isEditing: false,
+    };
+  }
+
+}

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -20,7 +20,7 @@
         <div class="card-body">
           <tm-single-response [responseDetails]="response.allResponses[0].responseDetails" [questionDetails]="response.feedbackQuestion.questionDetails"></tm-single-response>
           <tm-comment-row *ngIf="response.allResponses[0].participantComment"
-                          [model]="transformParticipantCommentToCommandRowModel(response.allResponses[0].participantComment)"
+                          [model]="response.allResponses[0].participantComment | participantCommentToCommandRowModelPipe: session.timeZone"
                           [questionShowResponsesTo]="response.feedbackQuestion.showResponsesTo"
                           [isDisabled]="true" [isVisibilityOptionEnabled]="false"
                           [mode]="CommentRowMode.EDIT"

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -1,12 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import {
-  CommentOutput,
   FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
   QuestionOutput,
   ResponseVisibleSetting,
   SessionVisibleSetting,
 } from '../../../../types/api-output';
-import { CommentRowMode, CommentRowModel } from '../../comment-box/comment-row/comment-row.component';
+import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
 import { ResponsesInstructorCommentsBase } from '../responses-instructor-comments-base';
 
 /**
@@ -55,25 +54,6 @@ export class GroupedResponsesComponent extends ResponsesInstructorCommentsBase i
         `(${this.responses[0].allResponses[0].recipientTeam})` : '';
     team.giver = `(${this.responses[0].allResponses[0].giverTeam})`;
     return team;
-  }
-
-  /**
-   * Transforms participant comment to comment row model.
-   */
-  transformParticipantCommentToCommandRowModel(participantComment: CommentOutput): CommentRowModel {
-    return {
-      originalComment: participantComment,
-      timezone: this.session.timeZone,
-      commentGiverName: participantComment.commentGiverName,
-      lastEditorName: participantComment.lastEditorName,
-      commentEditFormModel: {
-        commentText: participantComment.commentText,
-        isUsingCustomVisibilities: false,
-        showCommentTo: [],
-        showGiverNameTo: [],
-      },
-      isEditing: false,
-    };
   }
 
 }

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -16,6 +16,35 @@
               <tm-single-response [responseDetails]="response.responseDetails" [questionDetails]="questionDetails" [isStudentPage]="true"></tm-single-response>
             </td>
           </tr>
+          <tr *ngIf="response.participantComment">
+            <td>
+              <tm-comment-row
+                              [mode]="CommentRowMode.EDIT"
+                              [isVisibilityOptionEnabled]="false"
+                              [isDisabled]="true"
+                              [shouldHideSavingButton]="true"
+                              [shouldHideClosingButton]="true"
+                              [shouldHideEditButton]="true"
+                              [shouldHideDeleteButton]="true"
+                              [isFeedbackParticipantComment]="true"
+                              [response]="response"
+                              [questionShowResponsesTo]="[]"
+                              [model]="
+                                {
+                                  commentEditFormModel: {
+                                    commentText: response.participantComment.commentText,
+                                    isUsingCustomVisibilities: false,
+                                    showCommentTo: response.participantComment.showCommentTo,
+                                    showGiverNameTo: response.participantComment.showGiverNameTo
+                                  },
+                                  originalComment: response.participantComment,
+                                  isEditing: false,
+                                  commentGiverName: response.participantComment.commentGiverName,
+                                  lastEditorName: response.participantComment.lastEditorName
+                                }"
+            ></tm-comment-row>
+            </td>
+          </tr>
         </ng-container>
       </tbody>
     </table>

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -13,7 +13,7 @@
           </tr>
           <tr>
             <td>
-              <tm-single-response [responseDetails]="response.responseDetails" [questionDetails]="questionDetails" [isStudentPage]="true"></tm-single-response>
+              <tm-single-response [responseDetails]="response.responseDetails" [questionDetails]="feedbackQuestion.questionDetails" [isStudentPage]="true"></tm-single-response>
             </td>
           </tr>
           <tr *ngIf="response.participantComment">
@@ -21,14 +21,14 @@
               <tm-comment-row
                               [mode]="CommentRowMode.EDIT"
                               [isVisibilityOptionEnabled]="false"
-                              [isDisabled]="true"
+                              [isDisabled]="false"
                               [shouldHideSavingButton]="true"
                               [shouldHideClosingButton]="true"
                               [shouldHideEditButton]="true"
                               [shouldHideDeleteButton]="true"
                               [isFeedbackParticipantComment]="true"
                               [response]="response"
-                              [questionShowResponsesTo]="[]"
+                              [questionShowResponsesTo]="feedbackQuestion.showResponsesTo"
                               [model]="response.participantComment | participantCommentToCommandRowModelPipe"
             ></tm-comment-row>
             </td>

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -21,7 +21,7 @@
               <tm-comment-row
                               [mode]="CommentRowMode.EDIT"
                               [isVisibilityOptionEnabled]="false"
-                              [isDisabled]="false"
+                              [isDisabled]="true"
                               [shouldHideSavingButton]="true"
                               [shouldHideClosingButton]="true"
                               [shouldHideEditButton]="true"

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -29,19 +29,7 @@
                               [isFeedbackParticipantComment]="true"
                               [response]="response"
                               [questionShowResponsesTo]="[]"
-                              [model]="
-                                {
-                                  commentEditFormModel: {
-                                    commentText: response.participantComment.commentText,
-                                    isUsingCustomVisibilities: false,
-                                    showCommentTo: response.participantComment.showCommentTo,
-                                    showGiverNameTo: response.participantComment.showGiverNameTo
-                                  },
-                                  originalComment: response.participantComment,
-                                  isEditing: false,
-                                  commentGiverName: response.participantComment.commentGiverName,
-                                  lastEditorName: response.participantComment.lastEditorName
-                                }"
+                              [model]="response.participantComment | participantCommentToCommandRowModelPipe"
             ></tm-comment-row>
             </td>
           </tr>

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { CommentBoxModule } from '../../comment-box/comment-box.module';
 import { SingleResponseModule } from '../single-response/single-response.module';
 import { StudentViewResponsesComponent } from './student-view-responses.component';
 
@@ -10,7 +11,7 @@ describe('StudentViewResponsesComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [StudentViewResponsesComponent],
-      imports: [SingleResponseModule],
+      imports: [SingleResponseModule, CommentBoxModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
@@ -2,9 +2,8 @@ import { Component, Input, OnInit } from '@angular/core';
 import {
   FeedbackParticipantType,
   FeedbackQuestion,
-  FeedbackQuestionDetails,
-  FeedbackQuestionType, FeedbackVisibilityType, NumberOfEntitiesToGiveFeedbackToSetting,
-  ResponseOutput
+  FeedbackQuestionType, NumberOfEntitiesToGiveFeedbackToSetting,
+  ResponseOutput,
 } from '../../../../types/api-output';
 import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
 

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FeedbackQuestion, ResponseOutput } from '../../../../types/api-output';
+import {
+  FeedbackParticipantType,
+  FeedbackQuestion,
+  FeedbackQuestionDetails,
+  FeedbackQuestionType, FeedbackVisibilityType, NumberOfEntitiesToGiveFeedbackToSetting,
+  ResponseOutput
+} from '../../../../types/api-output';
 import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
 
 /**
@@ -11,9 +17,27 @@ import { CommentRowMode } from '../../comment-box/comment-row/comment-row.compon
   styleUrls: ['./student-view-responses.component.scss'],
 })
 export class StudentViewResponsesComponent implements OnInit {
+  // enum
   CommentRowMode: typeof CommentRowMode = CommentRowMode;
 
-  @Input() feedbackQuestion!: FeedbackQuestion;
+  @Input() feedbackQuestion: FeedbackQuestion = {
+    feedbackQuestionId: '',
+    questionNumber: 1,
+    questionBrief: '',
+    questionDescription: '',
+    questionDetails: {
+      questionType: FeedbackQuestionType.MCQ,
+      questionText: '',
+    },
+    questionType: FeedbackQuestionType.MCQ,
+    giverType: FeedbackParticipantType.STUDENTS,
+    recipientType: FeedbackParticipantType.STUDENTS,
+    numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+    customNumberOfEntitiesToGiveFeedbackTo: 0,
+    showResponsesTo: [],
+    showGiverNameTo: [],
+    showRecipientNameTo: [],
+  };
   @Input() responses: ResponseOutput[] = [];
   @Input() isSelfResponses: boolean = false;
 

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FeedbackQuestionDetails, FeedbackQuestionType, ResponseOutput } from '../../../../types/api-output';
+import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
 
 /**
  * Feedback response in student results page view.
@@ -10,6 +11,7 @@ import { FeedbackQuestionDetails, FeedbackQuestionType, ResponseOutput } from '.
   styleUrls: ['./student-view-responses.component.scss'],
 })
 export class StudentViewResponsesComponent implements OnInit {
+  CommentRowMode: typeof CommentRowMode = CommentRowMode;
 
   @Input() questionDetails: FeedbackQuestionDetails = {
     questionType: FeedbackQuestionType.TEXT,

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FeedbackQuestionDetails, FeedbackQuestionType, ResponseOutput } from '../../../../types/api-output';
+import { FeedbackQuestion, ResponseOutput } from '../../../../types/api-output';
 import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
 
 /**
@@ -13,10 +13,7 @@ import { CommentRowMode } from '../../comment-box/comment-row/comment-row.compon
 export class StudentViewResponsesComponent implements OnInit {
   CommentRowMode: typeof CommentRowMode = CommentRowMode;
 
-  @Input() questionDetails: FeedbackQuestionDetails = {
-    questionType: FeedbackQuestionType.TEXT,
-    questionText: '',
-  };
+  @Input() feedbackQuestion!: FeedbackQuestion;
   @Input() responses: ResponseOutput[] = [];
   @Input() isSelfResponses: boolean = false;
 

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.module.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { CommentBoxModule } from '../../comment-box/comment-box.module';
 import { SingleResponseModule } from '../single-response/single-response.module';
 import { StudentViewResponsesComponent } from './student-view-responses.component';
 
@@ -12,6 +13,7 @@ import { StudentViewResponsesComponent } from './student-view-responses.componen
   imports: [
     CommonModule,
     SingleResponseModule,
+    CommentBoxModule,
   ],
 })
 export class StudentViewResponsesModule { }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -30,14 +30,14 @@
 <div class="card bg-light top-padded" *ngFor="let question of questions">
   <div class="card-body" style="padding: 20px;">
     <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" style="font-size: 20px;"></tm-question-text-with-info>
-    <tm-student-view-responses *ngIf="question.responsesToSelf.length" [responses]="question.responsesToSelf" [questionDetails]="question.feedbackQuestion.questionDetails"></tm-student-view-responses>
+    <tm-student-view-responses *ngIf="question.responsesToSelf.length" [responses]="question.responsesToSelf" [feedbackQuestion]="question.feedbackQuestion"></tm-student-view-responses>
     <div *ngFor="let responsesForOtherRecipient of question.otherResponses">
-      <tm-student-view-responses *ngIf="responsesForOtherRecipient.length" [responses]="responsesForOtherRecipient" [questionDetails]="question.feedbackQuestion.questionDetails"></tm-student-view-responses>
+      <tm-student-view-responses *ngIf="responsesForOtherRecipient.length" [responses]="responsesForOtherRecipient" [feedbackQuestion]="question.feedbackQuestion"></tm-student-view-responses>
     </div>
     <div *ngIf="question.responsesFromSelf.length" style="margin-top: 10px;">
       <strong>Your own responses:</strong>
       <div *ngFor="let responseFromSelf of question.responsesFromSelf">
-        <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [questionDetails]="question.feedbackQuestion.questionDetails"></tm-student-view-responses>
+        <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion"></tm-student-view-responses>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #10102 

![image](https://user-images.githubusercontent.com/32454748/82886083-99982b80-9f78-11ea-989a-e774d77cb1be.png)

**Outline of Solution**

Add `tm-comment-row` in `tm-student-view-responses`.

**Questions**

1. Not sure what visibility options to pass in for `questionShowResponsesTo`. Should the comment's visibility follow the question's visibility?

2. Is it correct to use `CommentRowMode.EDIT` for the mode? There isn't a `VIEW` mode as far as I can tell.