### PR TITLE
[#10146] Refactor get session result logic in the backend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,9 @@ task generateApiOutputFormat(type: cz.habarta.typescript.generator.gradle.Genera
     ]
     removeTypeNameSuffix = "Data"
     outputFile = "src/web/types/api-output.ts"
+    excludeClassPatterns = [
+        "teammates.ui.webapi.output.**Builder"
+    ]
 }
 
 task generateApiRequestFormat(type: cz.habarta.typescript.generator.gradle.GenerateTask) {

--- a/src/main/java/teammates/common/datatransfer/CourseRoster.java
+++ b/src/main/java/teammates/common/datatransfer/CourseRoster.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.Const;
 
 /**
  * Contains a list of students and instructors in a course. Useful for caching
@@ -15,12 +16,14 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
  */
 public class CourseRoster {
 
-    Map<String, StudentAttributes> studentListByEmail = new HashMap<>();
-    Map<String, InstructorAttributes> instructorListByEmail = new HashMap<>();
+    private final Map<String, StudentAttributes> studentListByEmail = new HashMap<>();
+    private final Map<String, InstructorAttributes> instructorListByEmail = new HashMap<>();
+    private final Map<String, List<StudentAttributes>> teamToMembersTable = new HashMap<>();
 
     public CourseRoster(List<StudentAttributes> students, List<InstructorAttributes> instructors) {
         populateStudentListByEmail(students);
         populateInstructorListByEmail(instructors);
+        buildTeamToMembersTable();
     }
 
     public List<StudentAttributes> getStudents() {
@@ -29,6 +32,10 @@ public class CourseRoster {
 
     public List<InstructorAttributes> getInstructors() {
         return new ArrayList<>(instructorListByEmail.values());
+    }
+
+    public Map<String, List<StudentAttributes>> getTeamToMembersTable() {
+        return teamToMembersTable;
     }
 
     /**
@@ -44,6 +51,13 @@ public class CourseRoster {
         return studentListByEmail.containsKey(studentEmail);
     }
 
+    /**
+     * Checks whether a team is in course.
+     */
+    public boolean isTeamInCourse(String teamName) {
+        return teamToMembersTable.containsKey(teamName);
+    }
+
     public boolean isStudentInTeam(String studentEmail, String targetTeamName) {
         StudentAttributes student = studentListByEmail.get(studentEmail);
         return student != null && student.team.equals(targetTeamName);
@@ -53,7 +67,7 @@ public class CourseRoster {
         StudentAttributes student1 = studentListByEmail.get(studentEmail1);
         StudentAttributes student2 = studentListByEmail.get(studentEmail2);
         return student1 != null && student2 != null
-               && student1.team != null && student1.team.equals(student2.team);
+                && student1.team != null && student1.team.equals(student2.team);
     }
 
     public StudentAttributes getStudentForEmail(String email) {
@@ -102,6 +116,78 @@ public class CourseRoster {
 
         for (InstructorAttributes i : instructors) {
             instructorListByEmail.put(i.email, i);
+        }
+    }
+
+    private void buildTeamToMembersTable() {
+        // group students by team
+        for (StudentAttributes studentAttributes : this.getStudents()) {
+            teamToMembersTable.computeIfAbsent(studentAttributes.getTeam(), key -> new ArrayList<>())
+                    .add(studentAttributes);
+        }
+    }
+
+    /**
+     * Gets info of a participant associated with an identifier in the course.
+     *
+     * @return an object {@link ParticipantInfo} containing the name, teamName and the sectionName.
+     */
+    public ParticipantInfo getInfoForIdentifier(String identifier) {
+        String name = Const.USER_NOBODY_TEXT;
+        String teamName = Const.USER_NOBODY_TEXT;
+        String sectionName = Const.DEFAULT_SECTION;
+
+        boolean isStudent = this.getStudentForEmail(identifier) != null;
+        boolean isInstructor = this.getInstructorForEmail(identifier) != null;
+        boolean isTeam = this.getTeamToMembersTable().containsKey(identifier);
+        if (isStudent) {
+            StudentAttributes student = this.getStudentForEmail(identifier);
+
+            name = student.getName();
+            teamName = student.getTeam();
+            sectionName = student.getSection();
+        } else if (isInstructor) {
+            InstructorAttributes instructor = this.getInstructorForEmail(identifier);
+
+            name = instructor.getName();
+            teamName = Const.USER_TEAM_FOR_INSTRUCTOR;
+            sectionName = Const.DEFAULT_SECTION;
+        } else if (isTeam) {
+            StudentAttributes teamMember = this.getTeamToMembersTable().get(identifier).iterator().next();
+
+            name = identifier;
+            teamName = identifier;
+            sectionName = teamMember.getSection();
+        }
+
+        return new ParticipantInfo(name, teamName, sectionName);
+    }
+
+    /**
+     * Simple data transfer object containing the information of a participant.
+     */
+    public static class ParticipantInfo {
+
+        private final String name;
+        private final String teamName;
+        private final String sectionName;
+
+        public ParticipantInfo(String name, String teamName, String sectionName) {
+            this.name = name;
+            this.teamName = teamName;
+            this.sectionName = sectionName;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getTeamName() {
+            return teamName;
+        }
+
+        public String getSectionName() {
+            return sectionName;
         }
     }
 }

--- a/src/main/java/teammates/common/datatransfer/CourseRoster.java
+++ b/src/main/java/teammates/common/datatransfer/CourseRoster.java
@@ -121,7 +121,7 @@ public class CourseRoster {
 
     private void buildTeamToMembersTable() {
         // group students by team
-        for (StudentAttributes studentAttributes : this.getStudents()) {
+        for (StudentAttributes studentAttributes : getStudents()) {
             teamToMembersTable.computeIfAbsent(studentAttributes.getTeam(), key -> new ArrayList<>())
                     .add(studentAttributes);
         }
@@ -137,23 +137,23 @@ public class CourseRoster {
         String teamName = Const.USER_NOBODY_TEXT;
         String sectionName = Const.DEFAULT_SECTION;
 
-        boolean isStudent = this.getStudentForEmail(identifier) != null;
-        boolean isInstructor = this.getInstructorForEmail(identifier) != null;
-        boolean isTeam = this.getTeamToMembersTable().containsKey(identifier);
+        boolean isStudent = getStudentForEmail(identifier) != null;
+        boolean isInstructor = getInstructorForEmail(identifier) != null;
+        boolean isTeam = getTeamToMembersTable().containsKey(identifier);
         if (isStudent) {
-            StudentAttributes student = this.getStudentForEmail(identifier);
+            StudentAttributes student = getStudentForEmail(identifier);
 
             name = student.getName();
             teamName = student.getTeam();
             sectionName = student.getSection();
         } else if (isInstructor) {
-            InstructorAttributes instructor = this.getInstructorForEmail(identifier);
+            InstructorAttributes instructor = getInstructorForEmail(identifier);
 
             name = instructor.getName();
             teamName = Const.USER_TEAM_FOR_INSTRUCTOR;
             sectionName = Const.DEFAULT_SECTION;
         } else if (isTeam) {
-            StudentAttributes teamMember = this.getTeamToMembersTable().get(identifier).iterator().next();
+            StudentAttributes teamMember = getTeamToMembersTable().get(identifier).iterator().next();
 
             name = identifier;
             teamName = identifier;

--- a/src/main/java/teammates/common/datatransfer/SessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/SessionResultsBundle.java
@@ -1,0 +1,151 @@
+package teammates.common.datatransfer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+
+/**
+ * Represents detailed results for a feedback session.
+ */
+public class SessionResultsBundle {
+
+    private final FeedbackSessionAttributes feedbackSession;
+    private final Map<String, FeedbackQuestionAttributes> questionsMap;
+    private Map<String, List<FeedbackResponseAttributes>> questionResponseMap;
+    private final Map<String, List<FeedbackResponseCommentAttributes>> responseCommentsMap;
+    private final Map<String, boolean[]> responseVisibilityTable;
+    private final Map<Long, boolean[]> commentVisibilityTable;
+    private final CourseRoster roster;
+
+    public SessionResultsBundle(FeedbackSessionAttributes feedbackSession,
+                                Map<String, FeedbackQuestionAttributes> questionsMap,
+                                List<FeedbackResponseAttributes> responses,
+                                Map<String, boolean[]> responseVisibilityTable,
+                                Map<String, List<FeedbackResponseCommentAttributes>> responseCommentsMap,
+                                Map<Long, boolean[]> commentVisibilityTable,
+                                CourseRoster roster) {
+
+        this.feedbackSession = feedbackSession;
+        this.questionsMap = questionsMap;
+        this.responseCommentsMap = responseCommentsMap;
+        this.responseVisibilityTable = responseVisibilityTable;
+        this.commentVisibilityTable = commentVisibilityTable;
+        this.roster = roster;
+        buildQuestionToResponseMap(responses);
+    }
+
+    private void buildQuestionToResponseMap(List<FeedbackResponseAttributes> responses) {
+        // build question to response map
+        questionResponseMap = new LinkedHashMap<>();
+        List<FeedbackQuestionAttributes> questions = new ArrayList<>(questionsMap.values());
+        for (FeedbackQuestionAttributes question : questions) {
+            questionResponseMap.put(question.getId(), new ArrayList<>());
+        }
+        for (FeedbackResponseAttributes response : responses) {
+            FeedbackQuestionAttributes question = questionsMap.get(response.getFeedbackQuestionId());
+            List<FeedbackResponseAttributes> responsesForQuestion = questionResponseMap.get(question.getId());
+            responsesForQuestion.add(response);
+        }
+    }
+
+    /**
+     * Returns true if the giver of a response is visible to the current user.
+     * Returns false otherwise.
+     */
+    public boolean isResponseGiverVisible(FeedbackResponseAttributes response) {
+        return isResponseParticipantVisible(true, response);
+    }
+
+    /**
+     * Returns true if the recipient of a response is visible to the current user.
+     * Returns false otherwise.
+     */
+    public boolean isResponseRecipientVisible(FeedbackResponseAttributes response) {
+        return isResponseParticipantVisible(false, response);
+    }
+
+    /**
+     * Checks if the giver/recipient for a response is visible/hidden from the current user.
+     */
+    private boolean isResponseParticipantVisible(boolean isGiver, FeedbackResponseAttributes response) {
+        FeedbackQuestionAttributes question = questionsMap.get(response.feedbackQuestionId);
+        FeedbackParticipantType participantType;
+        String responseId = response.getId();
+
+        boolean isVisible;
+        if (isGiver) {
+            isVisible = responseVisibilityTable.get(responseId)[Const.VISIBILITY_TABLE_GIVER];
+            participantType = question.giverType;
+        } else {
+            isVisible = responseVisibilityTable.get(responseId)[Const.VISIBILITY_TABLE_RECIPIENT];
+            participantType = question.recipientType;
+        }
+        boolean isTypeNone = participantType == FeedbackParticipantType.NONE;
+
+        return isVisible || isTypeNone;
+    }
+
+    /**
+     * Returns true if the giver of a comment is visible to the current user.
+     * Returns false otherwise.
+     */
+    public boolean isCommentGiverVisible(FeedbackResponseCommentAttributes comment) {
+        return commentVisibilityTable.get(comment.getId())[Const.VISIBILITY_TABLE_GIVER];
+    }
+
+    /**
+     * Gets the anonymous name for a given name.
+     *
+     * <p>The anonymous name will be deterministic based on {@code name}.
+     */
+    public static String getAnonName(FeedbackParticipantType type, String name) {
+        String hashedEncryptedName = getHashOfName(getEncryptedName(name));
+        String participantType = type.toSingularFormString();
+        return String.format(
+                Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT + " %s %s", participantType, hashedEncryptedName);
+    }
+
+    public Map<String, List<FeedbackResponseAttributes>> getQuestionResponseMap() {
+        return questionResponseMap;
+    }
+
+    private static String getEncryptedName(String name) {
+        return StringHelper.encrypt(name);
+    }
+
+    private static String getHashOfName(String name) {
+        return Long.toString(Math.abs((long) name.hashCode()));
+    }
+
+    public FeedbackSessionAttributes getFeedbackSession() {
+        return feedbackSession;
+    }
+
+    public Map<String, FeedbackQuestionAttributes> getQuestionsMap() {
+        return questionsMap;
+    }
+
+    public Map<String, List<FeedbackResponseCommentAttributes>> getResponseCommentsMap() {
+        return responseCommentsMap;
+    }
+
+    public CourseRoster getRoster() {
+        return roster;
+    }
+
+    public Map<String, boolean[]> getResponseVisibilityTable() {
+        return responseVisibilityTable;
+    }
+
+    public Map<Long, boolean[]> getCommentVisibilityTable() {
+        return commentVisibilityTable;
+    }
+}

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
+import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.util.Assumption;
@@ -36,8 +37,7 @@ public abstract class FeedbackQuestionDetails {
 
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     public String getQuestionResultStatisticsJson(
-            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
-            String userEmail, FeedbackSessionResultsBundle bundle) {
+            FeedbackQuestionAttributes question, String studentEmail, SessionResultsBundle bundle) {
         // Statistics are calculated in the front-end as it is dependent on the responses being filtered.
         // The only exception is contribution question, where there is only one statistics for the entire question.
         // It is also necessary to calculate contribution question statistics here

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.CourseDetailsBundle;
 import teammates.common.datatransfer.CourseSummaryBundle;
 import teammates.common.datatransfer.DataBundle;
@@ -18,8 +20,10 @@ import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.SectionDetail;
 import teammates.common.datatransfer.SectionDetailsBundle;
+import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.StudentSearchResultBundle;
 import teammates.common.datatransfer.TeamDetailsBundle;
+import teammates.common.datatransfer.UserRole;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
@@ -1675,6 +1679,23 @@ public class Logic {
         Assumption.assertNotNull(feedbackSessionName);
 
         return feedbackResponsesLogic.getGiverSetThatAnswerFeedbackSession(courseId, feedbackSessionName);
+    }
+
+    /**
+     * Gets the session result for a feedback session.
+     *
+     * @see FeedbackSessionsLogic#getSessionResultsForUser(String, String, String, UserRole, String, String)
+     */
+    public SessionResultsBundle getSessionResultsForUser(
+            String feedbackSessionName, String courseId, String userEmail, UserRole role,
+            @Nullable String questionId, @Nullable String section) {
+        Assumption.assertNotNull(feedbackSessionName);
+        Assumption.assertNotNull(courseId);
+        Assumption.assertNotNull(userEmail);
+        Assumption.assertNotNull(role);
+
+        return feedbackSessionsLogic.getSessionResultsForUser(
+                feedbackSessionName, courseId, userEmail, role, questionId, section);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -93,12 +95,35 @@ public final class FeedbackResponseCommentsLogic {
         return frcDb.getFeedbackResponseCommentsForSession(courseId, feedbackSessionName);
     }
 
-    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentForSessionInSection(String courseId,
-                                                           String feedbackSessionName, String section) {
+    /**
+     * Gets all feedback response comments for session in a section.
+     *
+     * @param courseId the course ID of the feedback session
+     * @param feedbackSessionName the feedback session name
+     * @param section if null, will retrieve all comments in the session
+     * @return a list of feedback response comments
+     */
+    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentForSessionInSection(
+            String courseId, String feedbackSessionName, @Nullable String section) {
         if (section == null) {
-            return getFeedbackResponseCommentForSession(courseId, feedbackSessionName);
+            return frcDb.getFeedbackResponseCommentsForSession(courseId, feedbackSessionName);
         }
         return frcDb.getFeedbackResponseCommentsForSessionInSection(courseId, feedbackSessionName, section);
+    }
+
+    /**
+     * Gets all feedback response comments for a question in a section.
+     *
+     * @param questionId the ID of the question
+     * @param section if null, will retrieve all comments for the question
+     * @return a list of feedback response comments
+     */
+    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentForQuestionInSection(
+            String questionId, @Nullable String section) {
+        if (section == null) {
+            return frcDb.getFeedbackResponseCommentsForQuestion(questionId);
+        }
+        return frcDb.getFeedbackResponseCommentsForQuestionInSection(questionId, section);
     }
 
     /*

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -86,8 +88,16 @@ public final class FeedbackResponsesLogic {
         return frDb.getFeedbackResponsesForSession(feedbackSessionName, courseId);
     }
 
+    /**
+     * Gets all responses given to/from a section in a feedback session in a course.
+     *
+     * @param feedbackSessionName the name if the session
+     * @param courseId the course ID of the session
+     * @param section if null, will retrieve all responses in the session
+     * @return a list of responses
+     */
     public List<FeedbackResponseAttributes> getFeedbackResponsesForSessionInSection(
-            String feedbackSessionName, String courseId, String section) {
+            String feedbackSessionName, String courseId, @Nullable String section) {
         if (section == null) {
             return getFeedbackResponsesForSession(feedbackSessionName, courseId);
         }
@@ -166,8 +176,15 @@ public final class FeedbackResponsesLogic {
         return frDb.areThereResponsesForQuestion(feedbackQuestionId);
     }
 
+    /**
+     * Gets all responses given to/from a section for a question.
+     *
+     * @param feedbackQuestionId the ID of the question
+     * @param section if null, will retrieve all responses for the question
+     * @return a list of responses
+     */
     public List<FeedbackResponseAttributes> getFeedbackResponsesForQuestionInSection(
-            String feedbackQuestionId, String section, SectionDetail sectionDetail) {
+            String feedbackQuestionId, @Nullable String section, @Deprecated SectionDetail sectionDetail) {
         if (section == null) {
             return getFeedbackResponsesForQuestion(feedbackQuestionId);
         }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -3,6 +3,7 @@ package teammates.logic.core;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -12,6 +13,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -20,6 +23,7 @@ import teammates.common.datatransfer.FeedbackSessionQuestionsBundle;
 import teammates.common.datatransfer.FeedbackSessionResponseStatus;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.SectionDetail;
+import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.UserRole;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -1484,6 +1488,141 @@ public final class FeedbackSessionsLogic {
         return details;
     }
 
+    /**
+     * Gets the session result for a feedback session.
+     *
+     * @param feedbackSessionName the feedback session name
+     * @param courseId the ID of the course
+     * @param userEmail the user viewing the feedback session
+     * @param role the role of the use
+     * @param questionId if not null, will only return partial bundle for the question
+     * @param section if not null, will only return partial bundle for the section
+     * @return the session result bundle
+     */
+    public SessionResultsBundle getSessionResultsForUser(
+            String feedbackSessionName, String courseId, String userEmail, UserRole role,
+            @Nullable String questionId, @Nullable String section) {
+        CourseRoster roster = new CourseRoster(
+                studentsLogic.getStudentsForCourse(courseId),
+                instructorsLogic.getInstructorsForCourse(courseId));
+
+        FeedbackSessionAttributes session = fsDb.getFeedbackSession(courseId, feedbackSessionName);
+
+        // load question(s)
+        List<FeedbackQuestionAttributes> allQuestions;
+        Map<String, FeedbackQuestionAttributes> allQuestionsMap = new HashMap<>();
+        if (questionId == null) {
+            allQuestions = fqLogic.getFeedbackQuestionsForSession(feedbackSessionName, courseId);
+        } else {
+            allQuestions = Collections.singletonList(fqLogic.getFeedbackQuestion(questionId));
+        }
+        for (FeedbackQuestionAttributes qn : allQuestions) {
+            allQuestionsMap.put(qn.getId(), qn);
+        }
+
+        // load response(s)
+        List<FeedbackResponseAttributes> allResponses;
+        if (questionId == null) {
+            allResponses = frLogic.getFeedbackResponsesForSessionInSection(feedbackSessionName, courseId, section);
+        } else {
+            allResponses = frLogic.getFeedbackResponsesForQuestionInSection(questionId, section, SectionDetail.EITHER);
+        }
+
+        // load comment(s)
+        List<FeedbackResponseCommentAttributes> allComments;
+        if (questionId == null) {
+            allComments = frcLogic.getFeedbackResponseCommentForSessionInSection(courseId, feedbackSessionName, section);
+        } else {
+            allComments = frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, section);
+        }
+
+        // related questions, responses, and comment
+        Map<String, FeedbackQuestionAttributes> relatedQuestionsMap = new HashMap<>();
+        Map<String, FeedbackResponseAttributes> relatedResponsesMap = new HashMap<>();
+        Map<String, List<FeedbackResponseCommentAttributes>> relatedCommentsMap = new HashMap<>();
+        // student will have no related question at the beginning
+        if (isInstructor(role)) {
+            // all questions are related questions for instructor
+            for (FeedbackQuestionAttributes qn : allQuestions) {
+                relatedQuestionsMap.put(qn.getId(), qn);
+            }
+        }
+
+        // consider the current viewing user
+        StudentAttributes student = getStudent(courseId, userEmail, role);
+        Set<String> studentsEmailInTeam = getTeammateEmails(student, roster);
+        InstructorAttributes instructor = getInstructor(courseId, userEmail, role);
+
+        // visibility table for each response and comment
+        Map<String, boolean[]> responseVisibilityTable = new HashMap<>();
+        Map<Long, boolean[]> commentVisibilityTable = new HashMap<>();
+
+        // build response
+        for (FeedbackResponseAttributes response : allResponses) {
+            FeedbackQuestionAttributes correspondingQuestion = allQuestionsMap.get(response.feedbackQuestionId);
+            if (correspondingQuestion == null) {
+                // orphan response without corresponding question, ignore it
+                continue;
+            }
+            // check visibility of response
+            boolean isVisibleResponse = isResponseVisibleForUser(
+                    userEmail, role, student, studentsEmailInTeam, response, correspondingQuestion, instructor);
+            if (!isVisibleResponse) {
+                continue;
+            }
+
+            // only if there are viewable responses, the corresponding question becomes related.
+            // this operation is redundant for instructor but necessary for student
+            relatedQuestionsMap.put(response.getFeedbackQuestionId(), correspondingQuestion);
+            relatedResponsesMap.put(response.getId(), response);
+            // generate giver/recipient name visibility table
+            addResponseVisibilityToTable(responseVisibilityTable, correspondingQuestion, response, userEmail, role, roster);
+        }
+
+        // build comment
+        for (FeedbackResponseCommentAttributes frc : allComments) {
+            FeedbackResponseAttributes relatedResponse = relatedResponsesMap.get(frc.feedbackResponseId);
+            FeedbackQuestionAttributes relatedQuestion = relatedQuestionsMap.get(frc.feedbackQuestionId);
+            // the comment needs to be relevant to the question and response
+            if (relatedQuestion == null || relatedResponse == null) {
+                continue;
+            }
+            // check visibility of comment
+            boolean isVisibleResponseComment = frcLogic.isResponseCommentVisibleForUser(
+                    userEmail, role, student, studentsEmailInTeam, relatedResponse, relatedQuestion, frc);
+            if (!isVisibleResponseComment) {
+                continue;
+            }
+
+            relatedCommentsMap.computeIfAbsent(relatedResponse.getId(), key -> new ArrayList<>()).add(frc);
+            // generate comment giver name visibility table
+            addCommentVisibilityToTable(commentVisibilityTable, frc, relatedResponse, userEmail, roster);
+        }
+
+        return new SessionResultsBundle(session, relatedQuestionsMap, new ArrayList<>(relatedResponsesMap.values()),
+                responseVisibilityTable, relatedCommentsMap, commentVisibilityTable, roster);
+    }
+
+    private void addResponseVisibilityToTable(
+            Map<String, boolean[]> responseVisibilityTable, FeedbackQuestionAttributes question,
+            FeedbackResponseAttributes response, String userEmail,
+            UserRole role, CourseRoster roster) {
+        boolean[] responseVisibility = new boolean[2];
+        responseVisibility[Const.VISIBILITY_TABLE_GIVER] = frLogic.isNameVisibleToUser(
+                question, response, userEmail, role, true, roster);
+        responseVisibility[Const.VISIBILITY_TABLE_RECIPIENT] = frLogic.isNameVisibleToUser(
+                question, response, userEmail, role, false, roster);
+        responseVisibilityTable.put(response.getId(), responseVisibility);
+    }
+
+    private void addCommentVisibilityToTable(
+            Map<Long, boolean[]> commentVisibilityTable, FeedbackResponseCommentAttributes frc,
+            FeedbackResponseAttributes response, String userEmail, CourseRoster roster) {
+        boolean[] commentVisibility = new boolean[1];
+        commentVisibility[Const.VISIBILITY_TABLE_GIVER] = frcLogic.isNameVisibleToUser(frc, response, userEmail, roster);
+        commentVisibilityTable.put(frc.getId(), commentVisibility);
+    }
+
     /* Get the feedback results for user in a section iterated by questions */
     private FeedbackSessionResultsBundle getFeedbackSessionResultsForUserInSectionByQuestions(
             String feedbackSessionName, String courseId, String userEmail,
@@ -1774,6 +1913,22 @@ public final class FeedbackSessionsLogic {
             for (StudentAttributes teammates : studentsInTeam) {
                 studentsEmailInTeam.add(teammates.email);
             }
+        }
+        return studentsEmailInTeam;
+    }
+
+    /*
+     * Gets emails of student's teammates if student is not null, else returns an empty set.
+     */
+    private Set<String> getTeammateEmails(StudentAttributes student, CourseRoster roster) {
+        if (student == null) {
+            return Collections.emptySet();
+        }
+        Set<String> studentsEmailInTeam = new HashSet<>();
+        List<StudentAttributes> studentsInTeam =
+                roster.getTeamToMembersTable().getOrDefault(student.getTeam(), Collections.emptyList());
+        for (StudentAttributes teammates : studentsInTeam) {
+            studentsEmailInTeam.add(teammates.getEmail());
         }
         return studentsEmailInTeam;
     }

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -147,6 +147,15 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
     }
 
     /**
+     * Gets all comments of a feedback question of a course.
+     */
+    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentsForQuestion(String questionId) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, questionId);
+
+        return makeAttributes(getFeedbackResponseCommentEntitiesForQuestion(questionId));
+    }
+
+    /**
      * Gets all comments which have its corresponding response given to/from a section of a feedback session of a course.
      */
     public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentsForSessionInSection(
@@ -156,6 +165,17 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, section);
 
         return makeAttributes(getFeedbackResponseCommentEntitiesForSessionInSection(courseId, feedbackSessionName, section));
+    }
+
+    /**
+     * Gets all comments which have its corresponding response given to/from a section of a feedback question of a course.
+     */
+    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentsForQuestionInSection(
+            String questionId, String section) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, questionId);
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, section);
+
+        return makeAttributes(getFeedbackResponseCommentEntitiesForQuestionInSection(questionId, section));
     }
 
     /**
@@ -393,6 +413,38 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
                 .filter("courseId =", courseId)
                 .filter("feedbackSessionName =", feedbackSessionName)
                 .list();
+    }
+
+    private Collection<FeedbackResponseComment> getFeedbackResponseCommentEntitiesForQuestion(String questionId) {
+        return load()
+                .filter("feedbackQuestionId =", questionId)
+                .list();
+    }
+
+    private Collection<FeedbackResponseComment> getFeedbackResponseCommentEntitiesForQuestionInSection(
+            String questionId, String section) {
+        // creating map to remove duplicates
+        Map<Long, FeedbackResponseComment> comments = new HashMap<>();
+
+        List<FeedbackResponseComment> responseCommentsFromSection = load()
+                .filter("feedbackQuestionId =", questionId)
+                .filter("giverSection =", section)
+                .list();
+
+        for (FeedbackResponseComment comment : responseCommentsFromSection) {
+            comments.put(comment.getFeedbackResponseCommentId(), comment);
+        }
+
+        List<FeedbackResponseComment> responseCommentsToSection = load()
+                .filter("feedbackQuestionId =", questionId)
+                .filter("receiverSection =", section)
+                .list();
+
+        for (FeedbackResponseComment comment : responseCommentsToSection) {
+            comments.put(comment.getFeedbackResponseCommentId(), comment);
+        }
+
+        return comments.values();
     }
 
     private Collection<FeedbackResponseComment> getFeedbackResponseCommentEntitiesForSessionInSection(

--- a/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
@@ -1,7 +1,7 @@
 package teammates.ui.webapi.action;
 
-import teammates.common.datatransfer.FeedbackSessionResultsBundle;
-import teammates.common.datatransfer.SectionDetail;
+import teammates.common.datatransfer.SessionResultsBundle;
+import teammates.common.datatransfer.UserRole;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -78,56 +78,24 @@ public class GetSessionResultsAction extends Action {
         String questionId = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
         String selectedSection = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESULTS_GROUPBYSECTION);
 
-        FeedbackSessionResultsBundle bundle;
+        SessionResultsBundle bundle;
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         switch (intent) {
         case INSTRUCTOR_RESULT:
             InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
 
-            try {
-                // TODO optimize the logic layer to get rid of functions that are no longer necessary
-                if (questionId == null) {
-                    if (selectedSection == null) {
-                        bundle = logic.getFeedbackSessionResultsForInstructorWithinRangeFromView(
-                                feedbackSessionName, courseId, instructor.email,
-                                1, Const.FeedbackSessionResults.QUESTION_SORT_TYPE);
-                    } else {
-                        bundle = logic.getFeedbackSessionResultsForInstructorInSection(
-                                feedbackSessionName, courseId, instructor.email, selectedSection,
-                                SectionDetail.EITHER);
-                    }
-                } else {
-                    if (selectedSection == null) {
-                        bundle = logic.getFeedbackSessionResultsForInstructorFromQuestion(feedbackSessionName, courseId,
-                                instructor.email, questionId);
-                    } else {
-                        bundle = logic.getFeedbackSessionResultsForInstructorFromQuestionInSection(
-                                feedbackSessionName, courseId,
-                                instructor.email, questionId, selectedSection, SectionDetail.EITHER);
-                    }
-                }
-            } catch (EntityDoesNotExistException e) {
-                throw new EntityNotFoundException(e);
-            }
+            bundle = logic.getSessionResultsForUser(feedbackSessionName, courseId, instructor.getEmail(),
+                    UserRole.INSTRUCTOR, questionId, selectedSection);
 
-            return new JsonResult(new SessionResultsData(bundle));
+            return new JsonResult(SessionResultsData.initForInstructor(bundle));
         case STUDENT_RESULT:
             // Question number and section name filters are not applied here
             StudentAttributes student = getStudent(courseId);
 
-            try {
-                bundle = logic.getFeedbackSessionResultsForStudent(feedbackSessionName, courseId, student.email);
-            } catch (EntityDoesNotExistException e) {
-                throw new EntityNotFoundException(e);
-            }
+            bundle = logic.getSessionResultsForUser(feedbackSessionName, courseId, student.getEmail(),
+                    UserRole.STUDENT, null, null);
 
-            if (bundle.isStudentHasSomethingNewToSee(student)) {
-                // TODO do something
-            } else {
-                // TODO do something else
-            }
-
-            return new JsonResult(new SessionResultsData(bundle, student));
+            return new JsonResult(SessionResultsData.initForStudent(bundle, student));
         case INSTRUCTOR_SUBMISSION:
         case STUDENT_SUBMISSION:
             throw new InvalidHttpParameterException("Invalid intent for this action");

--- a/src/test/java/teammates/test/cases/datatransfer/SessionResultsBundleTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/SessionResultsBundleTest.java
@@ -1,0 +1,113 @@
+package teammates.test.cases.datatransfer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.CourseRoster;
+import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.SessionResultsBundle;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.util.Const;
+import teammates.test.cases.BaseTestCase;
+
+/**
+ * SUT: {@link SessionResultsBundle}.
+ */
+public class SessionResultsBundleTest extends BaseTestCase {
+
+    @Test
+    public void testGetResponseCommentsMap() {
+        DataBundle responseBundle = loadDataBundle("/FeedbackSessionResultsBundleTest.json");
+
+        FeedbackSessionAttributes session = responseBundle.feedbackSessions.get("session1InCourse1");
+
+        List<String> allExpectedResponses = new ArrayList<>();
+        allExpectedResponses.add(responseBundle.feedbackResponses.get("response1ForQ1S1C1").toString());
+        allExpectedResponses.add(responseBundle.feedbackResponses.get("response2ForQ1S1C1").toString());
+
+        SessionResultsBundle bundle =
+                new SessionResultsBundle(session,
+                        responseBundle.feedbackQuestions, new ArrayList<>(responseBundle.feedbackResponses.values()),
+                        new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                        new CourseRoster(new ArrayList<>(responseBundle.students.values()),
+                                new ArrayList<>(responseBundle.instructors.values())));
+
+        ______TS("Test question having responses");
+        FeedbackQuestionAttributes fqa = responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        List<FeedbackResponseAttributes> allResponses = bundle.getQuestionResponseMap().get(fqa.getId());
+        assertEquals(2, allResponses.size());
+        List<String> allResponsesString = new ArrayList<>();
+        allResponsesString.add(allResponses.get(0).toString());
+        allResponsesString.add(allResponses.get(1).toString());
+        assertEquals(allExpectedResponses, allResponsesString);
+
+        ______TS("Test question having no responses");
+        fqa = responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
+        allResponses = bundle.getQuestionResponseMap().get(fqa.getId());
+        assertEquals(0, allResponses.size());
+    }
+
+    @Test
+    public void testIsResponseGiverRecipientVisible_typicalCase_shouldReturnCorrectValues() {
+
+        DataBundle responseBundle = loadDataBundle("/FeedbackSessionResultsBundleTest.json");
+
+        FeedbackSessionAttributes session = responseBundle.feedbackSessions.get("session1InCourse1");
+
+        Map<String, boolean[]> responseVisibilityTable = new HashMap<>();
+        responseVisibilityTable.put("response1ForQ1S1C1", new boolean[] {true, false});
+        responseVisibilityTable.put("response2ForQ1S1C1", new boolean[] {false, true});
+        responseVisibilityTable.put("response1ForQ2S1C1", new boolean[] {true, true});
+        responseVisibilityTable.put("response2ForQ2S1C1", new boolean[] {false, false});
+
+        SessionResultsBundle bundle =
+                new SessionResultsBundle(session,
+                        responseBundle.feedbackQuestions, new ArrayList<>(responseBundle.feedbackResponses.values()),
+                        responseVisibilityTable, new HashMap<>(), new HashMap<>(),
+                        new CourseRoster(new ArrayList<>(responseBundle.students.values()),
+                                new ArrayList<>(responseBundle.instructors.values())));
+
+        for (Map.Entry<String, boolean[]> visibilityEntry : responseVisibilityTable.entrySet()) {
+            assertEquals(visibilityEntry.getValue()[Const.VISIBILITY_TABLE_GIVER],
+                    bundle.isResponseGiverVisible(responseBundle.feedbackResponses.get(visibilityEntry.getKey())));
+        }
+    }
+
+    @Test
+    public void testIsCommentGiverVisible_typicalCase_shouldReturnCorrectValues() {
+
+        DataBundle responseBundle = loadDataBundle("/FeedbackSessionResultsBundleTest.json");
+
+        FeedbackSessionAttributes session = responseBundle.feedbackSessions.get("session1InCourse1");
+
+        Map<Long, boolean[]> commentVisibilityTable = new HashMap<>();
+        commentVisibilityTable.put(1L, new boolean[] {true});
+        commentVisibilityTable.put(2L, new boolean[] {false});
+
+        SessionResultsBundle bundle =
+                new SessionResultsBundle(session,
+                        responseBundle.feedbackQuestions, new ArrayList<>(responseBundle.feedbackResponses.values()),
+                        new HashMap<>(), new HashMap<>(), commentVisibilityTable,
+                        new CourseRoster(new ArrayList<>(responseBundle.students.values()),
+                                new ArrayList<>(responseBundle.instructors.values())));
+
+        assertTrue(bundle.isCommentGiverVisible(responseBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1")));
+        assertFalse(bundle.isCommentGiverVisible(responseBundle.feedbackResponseComments.get("comment2FromT1C1ToR1Q1S1C1")));
+    }
+
+    @Test
+    public void testGetAnonName_typicalCase_shouldGenerateCorrectly() {
+        String anonName = SessionResultsBundle.getAnonName(FeedbackParticipantType.STUDENTS, "");
+        assertTrue(anonName.startsWith(Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT));
+
+        anonName = SessionResultsBundle.getAnonName(FeedbackParticipantType.STUDENTS, "test@gmail.com");
+        assertTrue(anonName.startsWith(Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT));
+    }
+}

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -287,6 +287,67 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         assertEquals(0, frcList.size());
     }
 
+    @Test
+    public void testGetFeedbackResponseCommentForSessionInSection_noSectionName_shouldReturnCommentsInSession() {
+        List<FeedbackResponseCommentAttributes> comments =
+                frcLogic.getFeedbackResponseCommentForSessionInSection(
+                        "idOfTypicalCourse1", "First feedback session", null);
+        assertEquals(3, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForSessionInSection(
+                        "not_exist", "First feedback session", null);
+        assertEquals(0, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForSessionInSection(
+                "idOfTypicalCourse1", "not_exist", null);
+        assertEquals(0, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForSessionInSection(
+                "not_exist", "not_exist", null);
+        assertEquals(0, comments.size());
+    }
+
+    @Test
+    public void testGetFeedbackResponseCommentForSessionInSection_withSectionName_shouldReturnCommentsInSection() {
+        List<FeedbackResponseCommentAttributes> comments =
+                frcLogic.getFeedbackResponseCommentForSessionInSection(
+                        "idOfTypicalCourse1", "First feedback session", "Section 1");
+        assertEquals(2, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForSessionInSection(
+                "idOfTypicalCourse1", "First feedback session", "Section 2");
+        assertEquals(1, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForSessionInSection(
+                "idOfTypicalCourse1", "First feedback session", "not_exist");
+        assertEquals(0, comments.size());
+    }
+
+    @Test
+    public void testGetFeedbackResponseCommentsForQuestionInSection_noSectionName_shouldReturnCommentsForQuestion() {
+        String questionId = getQuestionIdInDataBundle("qn1InSession1InCourse1");
+        List<FeedbackResponseCommentAttributes> comments =
+                frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, null);
+        assertEquals(1, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForQuestionInSection("not_exist", null);
+        assertEquals(0, comments.size());
+    }
+
+    @Test
+    public void testGetFeedbackResponseCommentsForQuestionInSection_withSectionName_shouldReturnCommentsForQuestion() {
+        String questionId = getQuestionIdInDataBundle("qn2InSession1InCourse1");
+        List<FeedbackResponseCommentAttributes> comments =
+                frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, "Section 1");
+        assertEquals(1, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, "Section 2");
+        assertEquals(1, comments.size());
+
+        comments = frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, "not_exist");
+        assertEquals(0, comments.size());
+    }
+
     private void verifyNullFromGetFrCommentForSession(FeedbackResponseCommentAttributes frComment) {
         List<FeedbackResponseCommentAttributes> frCommentsGot =
                 frcLogic.getFeedbackResponseCommentForSession(frComment.courseId, frComment.feedbackSessionName);

--- a/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
@@ -73,11 +73,12 @@ public class FeedbackResponseCommentSearchTest extends BaseSearchTest {
         ______TS("success: search for comments in instructor's course; query string matches some comments");
 
         bundle = commentsDb.search("\"self feedback\"", instructors);
-        verifySearchResults(bundle, frc1I1Q1S1C1, frc1I1Q2S1C1, frc1I1Q3S1C1);
+        verifySearchResults(bundle, frc1I1Q1S1C1, frc1I1Q3S1C1);
 
         ______TS("success: search for comments in instructor's course; confirms query string is case insensitive");
 
-        bundle = commentsDb.search("\"Instructor 1 COMMENT to student 2 self feedback Question 2\"", instructors);
+        bundle = commentsDb.search("\"Instructor 1 comment to response from "
+                + "student 2 to student 5 in feedback Question 2\"", instructors);
         verifySearchResults(bundle, frc1I1Q2S1C1);
 
         ______TS("success: search for comments using feedbackSessionName");

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -49,6 +50,12 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         frcasData.add(frcaData);
         frcasData.add(anotherFrcaData);
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception {
+        frcDb.deleteFeedbackResponseComment(frcaData.getId());
+        frcDb.deleteFeedbackResponseComment(anotherFrcaData.getId());
     }
 
     @Test
@@ -603,21 +610,37 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
     private void verifyListsContainSameResponseCommentAttributes(
             List<FeedbackResponseCommentAttributes> expectedFrcas,
             List<FeedbackResponseCommentAttributes> actualFrcas) {
-
-        for (FeedbackResponseCommentAttributes frca : expectedFrcas) {
-            frca.feedbackQuestionId = "";
-            frca.feedbackResponseId = "";
-            frca.setId(0L);
-        }
-
-        for (FeedbackResponseCommentAttributes frca : actualFrcas) {
-            frca.feedbackQuestionId = "";
-            frca.feedbackResponseId = "";
-            frca.setId(0L);
-        }
-
         AssertHelper.assertSameContentIgnoreOrder(expectedFrcas, actualFrcas);
+    }
 
+    @Test
+    public void testGetFeedbackResponseCommentsForQuestion_typicalCase_shouldQueryCorrectly() {
+        FeedbackResponseCommentAttributes frc = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");
+        frc = frcDb.getFeedbackResponseComment(frc.getCourseId(), frc.getCreatedAt(), frc.getCommentGiver());
+        List<FeedbackResponseCommentAttributes> comments =
+                frcDb.getFeedbackResponseCommentsForQuestion(frc.getFeedbackQuestionId());
+        assertEquals(1, comments.size());
+
+        comments = frcDb.getFeedbackResponseCommentsForQuestion("not_exist");
+        assertEquals(0, comments.size());
+    }
+
+    @Test
+    public void testGetFeedbackResponseCommentsForQuestionInSection_typicalCase_shouldQueryCorrectly() {
+        FeedbackResponseCommentAttributes frc = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");
+        frc = frcDb.getFeedbackResponseComment(frc.getCourseId(), frc.getCreatedAt(), frc.getCommentGiver());
+        List<FeedbackResponseCommentAttributes> comments =
+                frcDb.getFeedbackResponseCommentsForQuestionInSection(frc.getFeedbackQuestionId(), "Section 1");
+        assertEquals(1, comments.size());
+
+        comments = frcDb.getFeedbackResponseCommentsForQuestionInSection(frc.getFeedbackQuestionId(), "not_exist");
+        assertEquals(0, comments.size());
+
+        comments = frcDb.getFeedbackResponseCommentsForQuestionInSection("not_exist", "Section 1");
+        assertEquals(0, comments.size());
+
+        comments = frcDb.getFeedbackResponseCommentsForQuestionInSection("not_exist", "not_exist");
+        assertEquals(0, comments.size());
     }
 
 }

--- a/src/test/resources/csv/feedbackSessionResultsC1S1NewLastName_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1NewLastName_actionTest.csv
@@ -12,7 +12,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 Question 2,"Rate 1 other student's product"
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to student 2 self feedback Question 2"
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Both_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Both_actionTest.csv
@@ -6,8 +6,8 @@ Section View Detail,"Show response only if both are in the selected section"
 
 Question 1,"What is the best selling point of your product?"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback.",Instructor1 Course1,"Instructor 1 comment to student 1 self feedback"
 "Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","I'm cool'"
 
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Either_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Either_actionTest.csv
@@ -6,15 +6,15 @@ Section View Detail,"Show response if either the giver or evaluee is in the sele
 
 Question 1,"What is the best selling point of your product?"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback.",Instructor1 Course1,"Instructor 1 comment to student 1 self feedback"
 "Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","I'm cool'"
 
 
 Question 2,"Rate 1 other student's product"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Giver_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Giver_actionTest.csv
@@ -6,15 +6,15 @@ Section View Detail,"Show response if the giver is in the selected section"
 
 Question 1,"What is the best selling point of your product?"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback.",Instructor1 Course1,"Instructor 1 comment to student 1 self feedback"
 "Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","I'm cool'"
 
 
 Question 2,"Rate 1 other student's product"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Q2Either_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Q2Either_actionTest.csv
@@ -6,8 +6,8 @@ Section View Detail,"Show response if either the giver or evaluee is in the sele
 
 Question 2,"Rate 1 other student's product"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Q2Giver_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Q2Giver_actionTest.csv
@@ -6,8 +6,8 @@ Section View Detail,"Show response if the giver is in the selected section"
 
 Question 2,"Rate 1 other student's product"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1S1Recipient_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1S1Recipient_actionTest.csv
@@ -6,8 +6,8 @@ Section View Detail,"Show response if the evaluee is in the selected section"
 
 Question 1,"What is the best selling point of your product?"
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback."
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+"Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Team 1.1</td></div>'""","student1 In Course1</td></div>'""","Course1</td></div>'""","student1InCourse1@gmail.tmt","Student 1 self feedback.",Instructor1 Course1,"Instructor 1 comment to student 1 self feedback"
 "Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","I'm cool'"
 
 

--- a/src/test/resources/csv/feedbackSessionResultsC1S1_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsC1S1_actionTest.csv
@@ -12,7 +12,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 Question 2,"Rate 1 other student's product"
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to student 2 self feedback Question 2"
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/csv/feedbackSessionResultsMissingResponsesHidden_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsMissingResponsesHidden_actionTest.csv
@@ -12,7 +12,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 Question 2,"Rate 1 other student's product"
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to student 2 self feedback Question 2"
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/csv/feedbackSessionResultsMissingResponsesShown_actionTest.csv
+++ b/src/test/resources/csv/feedbackSessionResultsMissingResponsesShown_actionTest.csv
@@ -15,7 +15,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 Question 2,"Rate 1 other student's product"
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
-"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to student 2 self feedback Question 2"
+"Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Response from student 2 to student 5.",Instructor1 Course1,"Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
 "Team 1.1</td></div>'""","student3 In Course1","Course1","student3InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 3 ""to"" student 2. Multiline test."
 "Team 1.2","student5 In Course1","Course1","student5InCourse1@gmail.tmt","Team 1.1</td></div>'""","student2 In Course1","Course1","student2InCourse1@gmail.tmt","Response from student 5 to student 2."
 

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -187,7 +187,7 @@
       "recipient": "student2InCourse1@gmail.tmt",
       "giverSection": "Section 1",
       "recipientSection": "Section 1",
-      "feedbackResponseId": "response1ForQ1S1C1",
+      "feedbackResponseId": "response2ForQ1S1C1",
       "responseDetails": {
         "questionType": "TEXT",
         "answer": "I'm cool'"
@@ -238,6 +238,7 @@
   },
   "feedbackResponseComments": {
     "comment1FromT1C1ToR1Q1S1C1": {
+      "feedbackResponseCommentId": 1,
       "courseId": "idOfTypicalCourse1",
       "feedbackSessionName": "First feedback session",
       "feedbackQuestionId": "1",
@@ -256,6 +257,7 @@
       "commentText": "Instructor 1 comment to student 1 self feedback"
     },
     "comment2FromT1C1ToR1Q1S1C1": {
+      "feedbackResponseCommentId": 2,
       "courseId": "idOfTypicalCourse1",
       "feedbackSessionName": "First feedback session",
       "feedbackQuestionId": "1",

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -1593,8 +1593,8 @@
       "feedbackSessionName": "First feedback session",
       "feedbackQuestionId": "1",
       "commentGiver": "instructor1@course1.tmt",
-      "giverSection": "None",
-      "receiverSection": "None",
+      "giverSection": "Section 1",
+      "receiverSection": "Section 1",
       "feedbackResponseId": "1%student1InCourse1@gmail.tmt%student1InCourse1@gmail.tmt",
       "showCommentTo": [],
       "showGiverNameTo": [],
@@ -1611,8 +1611,8 @@
       "feedbackSessionName": "First feedback session",
       "feedbackQuestionId": "2",
       "commentGiver": "instructor1@course1.tmt",
-      "giverSection": "None",
-      "receiverSection": "None",
+      "giverSection": "Section 1",
+      "receiverSection": "Section 2",
       "commentGiverType": "INSTRUCTORS",
       "feedbackResponseId": "2%student2InCourse1@gmail.tmt%student5InCourse1@gmail.tmt",
       "showCommentTo": [],
@@ -1620,7 +1620,7 @@
       "isVisibilityFollowingFeedbackQuestion": false,
       "isCommentFromFeedbackParticipant": false,
       "createdAt": "2026-02-01T23:59:00Z",
-      "commentText": "Instructor 1 comment to student 2 self feedback Question 2"
+      "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2"
     },
     "comment1FromT1C1ToR1Q3S1C1": {
       "courseId": "idOfTypicalCourse1",

--- a/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
+++ b/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
@@ -3,7 +3,7 @@ import {
   FeedbackParticipantType,
   FeedbackQuestionDetails,
   FeedbackQuestionType,
-  FeedbackResponseDetails,
+  ResponseOutput,
 } from '../../../../types/api-output';
 
 /**
@@ -16,7 +16,7 @@ import {
 })
 export class SingleStatisticsComponent implements OnInit, OnChanges {
 
-  @Input() responses: FeedbackResponseDetails[] = [];
+  @Input() responses: ResponseOutput[] = [];
   @Input() question: FeedbackQuestionDetails = {
     questionType: FeedbackQuestionType.TEXT,
     questionText: '',

--- a/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.ts
@@ -48,7 +48,7 @@ export class ConstsumRecipientsQuestionStatisticsComponent
         || this.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF;
 
     for (const response of this.responses) {
-      const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail;
+      const identifier: string = isRecipientTeam ? response.recipient : (response.recipientEmail || response.recipient);
 
       this.pointsPerOption[identifier] = this.pointsPerOption[identifier] || [];
       this.pointsPerOption[identifier].push(response.responseDetails.answers[0]);

--- a/src/web/app/components/question-types/question-statistics/contribution-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/contribution-question-statistics.component.ts
@@ -65,6 +65,11 @@ export class ContributionQuestionStatisticsComponent
         }
       } else {
         for (const response of this.responses) {
+          // the recipient email will always exist for contribution question when viewing by instructors
+          if (!response.recipientEmail) {
+            continue;
+          }
+
           if (!this.emailToTeamName[response.recipientEmail]) {
             this.emailToTeamName[response.recipientEmail] = response.recipientTeam;
           }

--- a/src/web/app/components/question-types/question-statistics/question-statistics.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics.ts
@@ -18,7 +18,7 @@ interface Response<R extends FeedbackResponseDetails> {
   giverTeam: string;
   giverSection: string;
   recipient: string;
-  recipientEmail: string;
+  recipientEmail?: string;
   recipientTeam: string;
   recipientSection: string;
   responseDetails: R;

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
@@ -52,7 +52,7 @@ export class RankRecipientsQuestionStatisticsComponent
         || this.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF;
 
     for (const response of this.responses) {
-      const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail;
+      const identifier: string = isRecipientTeam ? response.recipient : (response.recipientEmail || response.recipient);
 
       this.ranksReceivedPerOption[identifier] = this.ranksReceivedPerOption[identifier] || [];
       this.ranksReceivedPerOption[identifier].push(response.responseDetails.answer);

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -301,6 +301,9 @@ export class InstructorSessionResultPageComponent implements OnInit {
       this.sectionsModel[sectionName].questions = resp.questions;
       this.sectionsModel[sectionName].hasPopulated = true;
 
+      // sort questions by question number
+      resp.questions.sort((a: QuestionOutput, b: QuestionOutput) =>
+          a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
       resp.questions.forEach((question: QuestionOutput) => {
         this.preprocessComments(question.allResponses);
       });


### PR DESCRIPTION
Part of #10146 

**Outline of Solution**

First commit:
- Correct one type definition in the frontend. Basically, `recipientEmail` can be null for anonymous case.

Second commit:
- Fix data inconsistency in the `typicalDataBundle`. The `giverSection` and `recipientSection` should follow those of its corresponding response.

Third commit:
- I purely add a common method for both student and instructor to get feedback session result. I also create a new bundle called `SessionResultsBundle` (The old `FeedbackSessionResultsBundle` is too complicated to change)
    - All responses and comments are fetched first and them checked one by one (so it is a compute-intensive operation). The old method fetches viewable responses by issuing multiple queries (communication-intensive operation)
    - Remove all complicated and unnecessary maps in the bundle and purely use `CourseRoster` to get name, teamName and sectionName.
    - Move the giver/recipient name hiding logic to `SessionResultData`. Similarly, data transformation will all be made there. The hiding logic will also not modify fields in `*Attributes`.
    - I have gone through the code base and look for session result related tests. The tests are migrated to test the new method as much as possible.
    - Rewrite the building process of `SessionResultData`. Also applied builder pattern to make the constructor more readable.

We decide to move irrelevant code in a separate PR as it related to the functionality of the CSV generation.

<strike>First commit:
- I purely add a common method for both student and instructor to get feedback session result. I also create a new bundle called `SessionResultsBundle` (The old `FeedbackSessionResultsBundle` is too complicated to change)
    - All responses and comments are fetched first and them checked one by one (so it is a compute-intensive operation). The old method fetches viewable responses by issuing multiple queries (communication-intensive operation)
    - Remove all complicated and unnecessary maps in the bundle and purely use `CourseRoster` to get name, teamName and sectionName.
    - Move the giver/recipient name hiding logic to `SessionResultData`. Similarly, data transformation will all be made there. The hiding logic will also not modify fields in `*Attributes`.
    - I have gone through the code base and look for session result related tests. The tests are migrated to test the new method as much as possible.

Second commit:
- Remove all unused methods related to session result.
- **Remove** get CSV functionality. I believe we can generate the CSV in the frontend by using the RESTFul data returned. Anyway, I need to remove them or the dependencies can be de-coupled.

Third commit:
- Just move a method to the correct place.</strike>

