### PR TITLE
[#9382] Add redirect from old pages to new one

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -683,6 +683,8 @@ public final class Const {
         public static final String INSTRUCTOR_COURSE_JOIN = "/page/instructorCourseJoin";
         public static final String STUDENT_COURSE_JOIN = "/page/studentCourseJoin";
         public static final String STUDENT_COURSE_JOIN_NEW = "/page/studentCourseJoinAuthentication";
+        public static final String INSTRUCTOR_HOME_PAGE = "/page/instructorHomePage";
+        public static final String STUDENT_HOME_PAGE = "/page/studentHomePage";
         public static final String STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE = "/page/studentFeedbackSubmissionEditPage";
         public static final String STUDENT_FEEDBACK_RESULTS_PAGE = "/page/studentFeedbackResultsPage";
         public static final String INSTRUCTOR_FEEDBACK_SUBMISSION_EDIT_PAGE = "/page/instructorFeedbackSubmissionEditPage";

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -711,6 +711,7 @@ public final class Const {
         public static final String INSTRUCTOR_SESSIONS_PAGE = INSTRUCTOR_PAGE + "/sessions";
         public static final String INSTRUCTOR_SESSION_SUBMISSION_PAGE = INSTRUCTOR_PAGE + "/sessions/submission";
         public static final String INSTRUCTOR_SESSION_EDIT_PAGE = INSTRUCTOR_PAGE + "/sessions/edit";
+        public static final String INSTRUCTOR_SESSION_RESULTS_PAGE = INSTRUCTOR_PAGE + "/sessions/result";
         public static final String INSTRUCTOR_COURSES_PAGE = INSTRUCTOR_PAGE + "/courses";
         public static final String INSTRUCTOR_COURSE_DETAILS_PAGE = INSTRUCTOR_PAGE + "/courses/details";
         public static final String INSTRUCTOR_COURSE_EDIT_PAGE = INSTRUCTOR_PAGE + "/courses/edit";

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -405,7 +405,7 @@ public class EmailGenerator {
                 .withSessionName(session.getFeedbackSessionName())
                 .toAbsoluteString();
 
-        String reportUrl = Config.getFrontEndAppUrl(Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESULTS_PAGE)
+        String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(session.getFeedbackSessionName())
                 .toAbsoluteString();

--- a/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
+++ b/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
@@ -44,6 +44,14 @@ public class LegacyUrlMapper extends HttpServlet {
                     .withParam(Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT)
                     .toString();
             break;
+        case Const.LegacyURIs.STUDENT_HOME_PAGE:
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.STUDENT_HOME_PAGE)
+                    .toString();
+            break;
+        case Const.LegacyURIs.INSTRUCTOR_HOME_PAGE:
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
+                    .toString();
+            break;
         case Const.LegacyURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE:
             key = req.getParameter(Const.ParamsNames.REGKEY);
             courseId = req.getParameter(Const.ParamsNames.COURSE_ID);

--- a/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
+++ b/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
@@ -25,6 +25,8 @@ public class LegacyUrlMapper extends HttpServlet {
         }
         String redirectUrl;
         String key;
+        String courseId;
+        String fsName;
 
         switch (uri) {
         case Const.LegacyURIs.INSTRUCTOR_COURSE_JOIN:
@@ -43,11 +45,40 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         case Const.LegacyURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE:
+            key = req.getParameter(Const.ParamsNames.REGKEY);
+            courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
+            fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
+                    .withRegistrationKey(key)
+                    .withCourseId(courseId)
+                    .withSessionName(fsName)
+                    .toString();
+            break;
         case Const.LegacyURIs.INSTRUCTOR_FEEDBACK_SUBMISSION_EDIT_PAGE:
+            courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
+            fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
+                    .withCourseId(courseId)
+                    .withSessionName(fsName)
+                    .toString();
+            break;
         case Const.LegacyURIs.STUDENT_FEEDBACK_RESULTS_PAGE:
+            key = req.getParameter(Const.ParamsNames.REGKEY);
+            courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
+            fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
+                    .withRegistrationKey(key)
+                    .withCourseId(courseId)
+                    .withSessionName(fsName)
+                    .toString();
+            break;
         case Const.LegacyURIs.INSTRUCTOR_FEEDBACK_RESULTS_PAGE:
-            // TODO
-            redirectUrl = "/";
+            courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
+            fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
+                    .withCourseId(courseId)
+                    .withSessionName(fsName)
+                    .toString();
             break;
         default:
             redirectUrl = "/";


### PR DESCRIPTION
Part of #9382

During the first few weeks (maybe even months) of V7, we will still have users accessing links from meant for V6, e.g. links sent via email. We cannot simply reject those links; they must be properly redirected to the V7 counterpart.
