### PR TITLE
[#10144] Add "numerical question statistics" example box

### DIFF
--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -53,7 +53,7 @@
         </td>
         <td>
           <tm-response-moderation-button *ngIf="response.relatedGiverEmail" [session]="session" [relatedGiverEmail]="response.relatedGiverEmail" [moderatedQuestionId]="question.feedbackQuestionId"></tm-response-moderation-button>
-          <button class="btn btn-light btn-sm" style="margin-left:5px; border: 1px solid #CCC;"
+          <button class="btn btn-light btn-sm" style="margin-left:5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
                   (click)="showCommentTableModel(response, commentTableModal)">Add Comment <span class="badge badge-secondary">
             {{this.instructorCommentTableModel[response.responseId].commentRows.length}}</span>
           </button>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -49,6 +49,7 @@ export class PerQuestionViewResponsesComponent extends ResponsesInstructorCommen
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
   };
+  @Input() isDisplayOnly: boolean = false;
 
   userToEmail: Record<string, string> = {};
 

--- a/src/web/app/components/question-types/question-statistics/question-statistics.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics.ts
@@ -12,7 +12,7 @@ import {
  * is required as the said API output format does not support precise typing
  * for the subclass of FeedbackResponseDetails.
  */
-interface Response<R extends FeedbackResponseDetails> {
+export interface Response<R extends FeedbackResponseDetails> {
   giver: string;
   giverEmail?: string;
   giverTeam: string;

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -15,6 +15,9 @@ import {
     QuestionSubmissionFormModule,
 } from '../../components/question-submission-form/question-submission-form.module';
 import {
+    QuestionStatisticsModule,
+} from '../../components/question-types/question-statistics/question-statistics.module';
+import {
   SessionEditFormModule,
 } from '../../components/session-edit-form/session-edit-form.module';
 import {
@@ -61,6 +64,7 @@ import {
     RouterModule,
     StudentProfileModule,
     QuestionEditFormModule,
+    QuestionStatisticsModule,
     ReactiveFormsModule,
     InstructorSearchPageModule,
     InstructorCourseStudentEditPageModule,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -15,9 +15,6 @@ import {
     QuestionSubmissionFormModule,
 } from '../../components/question-submission-form/question-submission-form.module';
 import {
-    QuestionStatisticsModule,
-} from '../../components/question-types/question-statistics/question-statistics.module';
-import {
   SessionEditFormModule,
 } from '../../components/session-edit-form/session-edit-form.module';
 import {
@@ -35,6 +32,9 @@ import {
 import {
   InstructorSessionEditPageModule,
 } from '../../pages-instructor/instructor-session-edit-page/instructor-session-edit-page.module';
+import {
+    InstructorSessionResultPageModule,
+} from '../../pages-instructor/instructor-session-result-page/instructor-session-result-page.module';
 import { ExampleBoxComponent } from './example-box/example-box.component';
 import {
   InstructorHelpCoursesSectionComponent,
@@ -64,12 +64,12 @@ import {
     RouterModule,
     StudentProfileModule,
     QuestionEditFormModule,
-    QuestionStatisticsModule,
     ReactiveFormsModule,
     InstructorSearchPageModule,
     InstructorCourseStudentEditPageModule,
     InstructorCoursesPageModule,
     InstructorSessionEditPageModule,
+    InstructorSessionResultPageModule,
     SessionEditFormModule,
     QuestionEditFormModule,
     QuestionSubmissionFormModule,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -175,8 +175,8 @@
           </p>
           <tm-example-box>
               <tm-num-scale-question-statistics
-                [responses]="numericalScaleResponses"
-                [question]="numericalScaleResponses.responseDetails"
+                [responses]="exampleNumericalScaleResponses"
+                [question]="exampleNumericalScaleReponseDetail"
                 [recipientType]="exampleNumericalScaleQuestionModel.recipientType"
                 [isStudent]="false">
               </tm-num-scale-question-statistics>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -176,7 +176,7 @@
           <tm-example-box>
               <tm-num-scale-question-statistics
                 [responses]="exampleNumericalScaleResponses"
-                [question]="exampleNumericalScaleReponseDetail"
+                [question]="exampleNumericalScaleQuestionDetails"
                 [recipientType]="exampleNumericalScaleQuestionModel.recipientType"
                 [isStudent]="false">
               </tm-num-scale-question-statistics>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -177,6 +177,7 @@
               <tm-instructor-session-result-question-view
                   [questions]="exampleNumericalScaleQuestions"
                   [section]="" [sectionType]="InstructorSessionResultSectionType.EITHER"
+                  [session]="exampleFeedbackSession"
                   [showStatistics]="true" [indicateMissingResponses]="true"
                   [(instructorCommentTableModel)]="exampleInstructorCommentTableModel">
               </tm-instructor-session-result-question-view>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -174,12 +174,12 @@
             TEAMMATES calculates the mean, minimum and maximum values based on all responses given.
           </p>
           <tm-example-box>
-              <tm-num-scale-question-statistics
-                [responses]="exampleNumericalScaleResponses"
-                [question]="exampleNumericalScaleQuestionDetails"
-                [recipientType]="exampleNumericalScaleQuestionModel.recipientType"
-                [isStudent]="false">
-              </tm-num-scale-question-statistics>
+              <tm-instructor-session-result-question-view
+                  [questions]="exampleNuericalScaleQuestions"
+                  [section]="" [sectionType]="InstructorSessionResultSectionType.EITHER"
+                  [showStatistics]="true" [indicateMissingResponses]="true"
+                  [(instructorCommentTableModel)]="exampleInstructorCommentTableModel">
+              </tm-instructor-session-result-question-view>
           </tm-example-box>
         </div>
       </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -175,7 +175,7 @@
           </p>
           <tm-example-box>
               <tm-instructor-session-result-question-view
-                  [questions]="exampleNuericalScaleQuestions"
+                  [questions]="exampleNumericalScaleQuestions"
                   [section]="" [sectionType]="InstructorSessionResultSectionType.EITHER"
                   [showStatistics]="true" [indicateMissingResponses]="true"
                   [(instructorCommentTableModel)]="exampleInstructorCommentTableModel">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -179,6 +179,7 @@
                   [section]="" [sectionType]="InstructorSessionResultSectionType.EITHER"
                   [session]="exampleFeedbackSession"
                   [showStatistics]="true" [indicateMissingResponses]="true"
+                  [isDisplayOnly]="true"
                   [(instructorCommentTableModel)]="exampleInstructorCommentTableModel">
               </tm-instructor-session-result-question-view>
           </tm-example-box>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -173,7 +173,14 @@
             Statistics for numerical scale questions are also provided for instructors.<br>
             TEAMMATES calculates the mean, minimum and maximum values based on all responses given.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+              <tm-num-scale-question-statistics
+                [responses]="numericalScaleResponses"
+                [question]="numericalScaleResponses.responseDetails"
+                [recipientType]="exampleNumericalScaleQuestionModel.recipientType"
+                [isStudent]="false">
+              </tm-num-scale-question-statistics>
+          </tm-example-box>
         </div>
       </div>
       <br/>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
@@ -7,6 +7,9 @@ import { HttpRequestService } from '../../../../services/http-request.service';
 import { QuestionEditFormModule } from '../../../components/question-edit-form/question-edit-form.module';
 import { QuestionSubmissionFormModule,
 } from '../../../components/question-submission-form/question-submission-form.module';
+import {
+    QuestionStatisticsModule,
+} from '../../../components/question-types/question-statistics/question-statistics.module';
 import { ExampleBoxComponent } from '../example-box/example-box.component';
 import { InstructorHelpQuestionsSectionComponent } from './instructor-help-questions-section.component';
 
@@ -24,8 +27,10 @@ describe('InstructorHelpQuestionsSectionComponent', () => {
     };
     TestBed.configureTestingModule({
       declarations: [InstructorHelpQuestionsSectionComponent, ExampleBoxComponent],
-      imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule, QuestionEditFormModule, MatSnackBarModule,
-        QuestionSubmissionFormModule],
+      imports: [
+        NgbModule, RouterTestingModule, NgxPageScrollCoreModule, QuestionEditFormModule,
+        QuestionStatisticsModule, MatSnackBarModule, QuestionSubmissionFormModule,
+      ],
       providers: [
         { provide: HttpRequestService, useValue: spyHttpRequestService },
       ],

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
@@ -10,6 +10,9 @@ import { QuestionSubmissionFormModule,
 import {
     QuestionStatisticsModule,
 } from '../../../components/question-types/question-statistics/question-statistics.module';
+import {
+    InstructorSessionResultPageModule,
+} from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-page.module';
 import { ExampleBoxComponent } from '../example-box/example-box.component';
 import { InstructorHelpQuestionsSectionComponent } from './instructor-help-questions-section.component';
 
@@ -28,8 +31,8 @@ describe('InstructorHelpQuestionsSectionComponent', () => {
     TestBed.configureTestingModule({
       declarations: [InstructorHelpQuestionsSectionComponent, ExampleBoxComponent],
       imports: [
-        NgbModule, RouterTestingModule, NgxPageScrollCoreModule, QuestionEditFormModule,
-        QuestionStatisticsModule, MatSnackBarModule, QuestionSubmissionFormModule,
+        InstructorSessionResultPageModule, NgbModule, RouterTestingModule, NgxPageScrollCoreModule,
+        QuestionEditFormModule, QuestionStatisticsModule, MatSnackBarModule, QuestionSubmissionFormModule,
       ],
       providers: [
         { provide: HttpRequestService, useValue: spyHttpRequestService },

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -4,7 +4,6 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PageScrollService } from 'ngx-page-scroll-core';
 import {
   FeedbackMcqQuestionDetails,
-  FeedbackNumericalScaleQuestionDetails,
   FeedbackNumericalScaleResponseDetails,
   FeedbackParticipantType,
   FeedbackQuestionType,
@@ -218,14 +217,6 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     },
   ];
 
-  readonly exampleNumericalScaleQuestionDetails: FeedbackNumericalScaleQuestionDetails = {
-    minScale: 1,
-    maxScale: 5,
-    step: 0.1,
-    questionType: FeedbackQuestionType.NUMSCALE,
-    questionText: '',
-  };
-
   readonly exampleNumericalScaleResponseOutput: ResponseOutput[] = [
     {
       responseId: '1',
@@ -357,7 +348,7 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     },
   ];
 
-  readonly exampleNuericalScaleQuestionTabModel: QuestionTabModel = {
+  readonly exampleNumericalScaleQuestionTabModel: QuestionTabModel = {
     question: this.exampleNumericalScaleQuestionModel,
     responses: this.exampleNumericalScaleResponseOutput,
     statistics: '',
@@ -365,8 +356,8 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     isTabExpanded: true,
   };
 
-  readonly exampleNuericalScaleQuestions: Record<string, QuestionTabModel> = {
-    question: this.exampleNuericalScaleQuestionTabModel,
+  readonly exampleNumericalScaleQuestions: Record<string, QuestionTabModel> = {
+    question: this.exampleNumericalScaleQuestionTabModel,
   };
 
   readonly exampleInstructorCommentTableModel: Record<string, CommentTableModel> = {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -4,6 +4,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PageScrollService } from 'ngx-page-scroll-core';
 import {
   FeedbackMcqQuestionDetails,
+  FeedbackNumericalScaleQuestionDetails,
   FeedbackNumericalScaleResponseDetails,
   FeedbackParticipantType,
   FeedbackQuestionType,
@@ -92,7 +93,7 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
-  readonly numericalScaleResponses: Response<FeedbackNumericalScaleResponseDetails>[] = [
+  readonly exampleNumericalScaleResponses: Response<FeedbackNumericalScaleResponseDetails>[] = [
     {
       giver: 'Alice',
       giverEmail: 'alice@gmail.com',
@@ -103,11 +104,117 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
       recipientTeam: 'Team 2',
       recipientSection: '',
       responseDetails: {
-        answer: 50,
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'Charles',
+      giverEmail: 'charles@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientEmail: 'bob@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'David',
+      giverEmail: 'david@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientEmail: 'bob@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 2,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'Bob',
+      giverEmail: 'bob@gmail.com',
+      giverTeam: 'Team 2',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientEmail: 'bob@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'Alice',
+      giverEmail: 'alice@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientEmail: 'emma@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 4,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'Charles',
+      giverEmail: 'charles@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientEmail: 'emma@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 3,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'David',
+      giverEmail: 'david@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientEmail: 'emma@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 4,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+    {
+      giver: 'Emma',
+      giverEmail: 'emma@gmail.com',
+      giverTeam: 'Team 2',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientEmail: 'emma@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
         questionType: FeedbackQuestionType.NUMSCALE,
       },
     },
   ];
+
+  readonly exampleNumericalScaleReponseDetail: FeedbackNumericalScaleQuestionDetails = {
+    minScale: 1,
+    maxScale: 5,
+    step: 0.1,
+    questionType: FeedbackQuestionType.NUMSCALE,
+    questionText: '',
+  };
 
   readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -12,6 +12,11 @@ import {
   FeedbackVisibilityType,
   NumberOfEntitiesToGiveFeedbackToSetting,
   ResponseOutput,
+  SessionVisibleSetting,
+  ResponseVisibleSetting,
+  FeedbackSessionSubmissionStatus,
+  FeedbackSessionPublishStatus,
+  FeedbackSession,
 } from '../../../../types/api-output';
 import {
     DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS,
@@ -490,6 +495,23 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
       isReadOnly: true,
     },
   };
+
+  readonly exampleFeedbackSession: FeedbackSession = {
+     courseId: 'CS2103T',
+     timeZone: 'UTC',
+     feedbackSessionName: 'Project Feedback 1',
+     instructions: 'Enter your feedback for projects',
+     submissionStartTimestamp: 0,
+     submissionEndTimestamp: 0,
+     gracePeriod: 0,
+     sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+     responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+     submissionStatus: FeedbackSessionSubmissionStatus.CLOSED,
+     publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+     isClosingEmailEnabled: true,
+     isPublishedEmailEnabled: true,
+     createdAtTimestamp: 0,
+   };
 
   readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -9,14 +9,14 @@ import {
   FeedbackQuestionType,
   FeedbackRubricQuestionDetails,
   FeedbackRubricResponseDetails,
+  FeedbackSession,
+  FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus,
   FeedbackVisibilityType,
   NumberOfEntitiesToGiveFeedbackToSetting,
   ResponseOutput,
-  SessionVisibleSetting,
   ResponseVisibleSetting,
-  FeedbackSessionSubmissionStatus,
-  FeedbackSessionPublishStatus,
-  FeedbackSession,
+  SessionVisibleSetting,
 } from '../../../../types/api-output';
 import {
     DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS,
@@ -497,21 +497,21 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
   };
 
   readonly exampleFeedbackSession: FeedbackSession = {
-     courseId: 'CS2103T',
-     timeZone: 'UTC',
-     feedbackSessionName: 'Project Feedback 1',
-     instructions: 'Enter your feedback for projects',
-     submissionStartTimestamp: 0,
-     submissionEndTimestamp: 0,
-     gracePeriod: 0,
-     sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
-     responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
-     submissionStatus: FeedbackSessionSubmissionStatus.CLOSED,
-     publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
-     isClosingEmailEnabled: true,
-     isPublishedEmailEnabled: true,
-     createdAtTimestamp: 0,
-   };
+    courseId: 'CS2103T',
+    timeZone: 'UTC',
+    feedbackSessionName: 'Project Feedback 1',
+    instructions: 'Enter your feedback for projects',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.CLOSED,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -4,6 +4,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PageScrollService } from 'ngx-page-scroll-core';
 import {
   FeedbackMcqQuestionDetails,
+  FeedbackNumericalScaleResponseDetails,
   FeedbackParticipantType,
   FeedbackQuestionType,
   FeedbackRubricQuestionDetails,
@@ -28,6 +29,7 @@ import {
 } from '../../../components/question-edit-form/question-edit-form-model';
 import { QuestionSubmissionFormModel,
 } from '../../../components/question-submission-form/question-submission-form-model';
+import { Response } from '../../../components/question-types/question-statistics/question-statistics';
 import { InstructorHelpSectionComponent } from '../instructor-help-section.component';
 
 /**
@@ -89,6 +91,23 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
+
+  readonly numericalScaleResponses: Response<FeedbackNumericalScaleResponseDetails>[] = [
+    {
+      giver: 'Alice',
+      giverEmail: 'alice@gmail.com',
+      giverTeam: 'Team 1',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientEmail: 'bob@gmail.com',
+      recipientTeam: 'Team 2',
+      recipientSection: '',
+      responseDetails: {
+        answer: 50,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      },
+    },
+  ];
 
   readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -12,6 +12,7 @@ import {
   FeedbackRubricResponseDetails,
   FeedbackVisibilityType,
   NumberOfEntitiesToGiveFeedbackToSetting,
+  ResponseOutput,
 } from '../../../../types/api-output';
 import {
     DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS,
@@ -24,6 +25,7 @@ import {
     DEFAULT_RUBRIC_QUESTION_DETAILS,
     DEFAULT_TEXT_QUESTION_DETAILS,
 } from '../../../../types/default-question-structs';
+import { CommentTableModel } from '../../../components/comment-box/comment-table/comment-table.component';
 import {
   QuestionEditFormMode,
   QuestionEditFormModel,
@@ -31,6 +33,12 @@ import {
 import { QuestionSubmissionFormModel,
 } from '../../../components/question-submission-form/question-submission-form-model';
 import { Response } from '../../../components/question-types/question-statistics/question-statistics';
+import {
+    QuestionTabModel,
+} from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-page.component';
+import {
+    InstructorSessionResultSectionType,
+} from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 import { InstructorHelpSectionComponent } from '../instructor-help-section.component';
 
 /**
@@ -43,6 +51,8 @@ import { InstructorHelpSectionComponent } from '../instructor-help-section.compo
 })
 export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSectionComponent implements OnInit {
 
+  // enum
+  InstructorSessionResultSectionType: typeof InstructorSessionResultSectionType = InstructorSessionResultSectionType;
   QuestionEditFormMode: typeof QuestionEditFormMode = QuestionEditFormMode;
 
   readonly exampleEssayQuestionModel: QuestionEditFormModel = {
@@ -214,6 +224,280 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     step: 0.1,
     questionType: FeedbackQuestionType.NUMSCALE,
     questionText: '',
+  };
+
+  readonly exampleNumericalScaleResponseOutput: ResponseOutput[] = [
+    {
+      responseId: '1',
+      giver: 'Alice',
+      giverTeam: 'Team 1',
+      giverEmail: 'alice@gmail.com',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'bob@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '2',
+      giver: 'Charles',
+      giverTeam: 'Team 1',
+      giverEmail: 'charles@gmail.com',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'bob@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '3',
+      giver: 'David',
+      giverTeam: 'Team 1',
+      giverEmail: 'david@gmail.com',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'bob@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 2,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '4',
+      giver: 'Bob',
+      giverTeam: 'Team 2',
+      giverEmail: 'bob@gmail.com',
+      giverSection: '',
+      recipient: 'Bob',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'bob@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '5',
+      giver: 'Alice',
+      giverTeam: 'Team 1',
+      giverEmail: 'alice@gmail.com',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'emma@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 4,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '6',
+      giver: 'Charles',
+      giverTeam: 'Team 1',
+      giverEmail: 'charles@gmail.com',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'emma@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 3,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '7',
+      giver: 'David',
+      giverTeam: 'Team 1',
+      giverEmail: 'david@gmail.com',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'emma@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 4,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+    {
+      responseId: '8',
+      giver: 'Emma',
+      giverTeam: 'Team 2',
+      giverEmail: 'emma@gmail.com',
+      giverSection: '',
+      recipient: 'Emma',
+      recipientTeam: 'Team 2',
+      recipientEmail: 'emma@gmail.com',
+      recipientSection: '',
+      responseDetails: {
+        answer: 5,
+        questionType: FeedbackQuestionType.NUMSCALE,
+      } as FeedbackNumericalScaleResponseDetails,
+      instructorComments: [],
+    },
+  ];
+
+  readonly exampleNuericalScaleQuestionTabModel: QuestionTabModel = {
+    question: this.exampleNumericalScaleQuestionModel,
+    responses: this.exampleNumericalScaleResponseOutput,
+    statistics: '',
+    hasPopulated: true,
+    isTabExpanded: true,
+  };
+
+  readonly exampleNuericalScaleQuestions: Record<string, QuestionTabModel> = {
+    question: this.exampleNuericalScaleQuestionTabModel,
+  };
+
+  readonly exampleInstructorCommentTableModel: Record<string, CommentTableModel> = {
+    1: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    2: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    3: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    4: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    5: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    6: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    7: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
+    8: {
+      commentRows: [],
+      newCommentRow: {
+        commentEditFormModel: {
+          commentText: '',
+
+          isUsingCustomVisibilities: false,
+          showCommentTo: [],
+          showGiverNameTo: [],
+        },
+        isEditing: false,
+      },
+
+      isAddingNewComment: false,
+      isReadOnly: true,
+    },
   };
 
   readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -208,7 +208,7 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     },
   ];
 
-  readonly exampleNumericalScaleReponseDetail: FeedbackNumericalScaleQuestionDetails = {
+  readonly exampleNumericalScaleQuestionDetails: FeedbackNumericalScaleQuestionDetails = {
     minScale: 1,
     maxScale: 5,
     step: 0.1,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.module.ts
@@ -39,6 +39,7 @@ import { InstructorSessionResultRqgViewComponent } from './instructor-session-re
   ],
   exports: [
     InstructorSessionResultPageComponent,
+    InstructorSessionResultQuestionViewComponent,
   ],
   imports: [
     CommonModule,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -15,6 +15,7 @@
     ></tm-single-statistics>
     <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
                                     [indicateMissingResponses]="true" [question]="question.question"
+                                    [isDisplayOnly]="isDisplayOnly"
                                     [instructorCommentTableModel]="instructorCommentTableModel"
                                     (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
                                     (updateCommentEvent)="triggerUpdateCommentEvent($event)"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
@@ -19,6 +19,7 @@ export class InstructorSessionResultQuestionViewComponent
   loadQuestion: EventEmitter<string> = new EventEmitter();
 
   @Input() questions: Record<string, QuestionTabModel> = {};
+  @Input() isDisplayOnly: boolean = false;
 
   questionsOrder: QuestionTabModel[] = [];
 


### PR DESCRIPTION
Part of #10144

**Snapshot**:

<img width="860" alt="Screenshot 2020-06-04 at 13 00 59" src="https://user-images.githubusercontent.com/32880438/83716844-a34e1d00-a663-11ea-97ca-1bf41f5448e7.png">

**Outline of Solution**
- replaced example box with `tm-instructor-session-result-question-view`
- added example data `exampleNumericalScaleQuestions`, `exampleInstructorCommentTableModel`