### PR TITLE
[#10168] Fix checkbox ui at Instructor Session Result Page

### DIFF
--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -7,7 +7,9 @@
       <span ngbTooltip="Format: Response percentage (Response count) [Weight of option], e.g. 50% (2) [1.0]" class="fa fa-info-circle"></span>
     </div>
     <div class="col-sm-8" style="text-align: right;">
-      <input type="checkbox" [(ngModel)]="excludeSelf"> <span ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+      <label class="form-check-label">
+        <input type="checkbox" [(ngModel)]="excludeSelf" class="form-check-input"> <span ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+      </label>
     </div>
   </div>
   <div class="row">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -105,14 +105,14 @@
       <label class="control-label">
         Additional settings:
       </label>
-      <div ngbTooltip="Group results in the current view by team">
-        <input type="checkbox" [(ngModel)]="groupByTeam" [disabled]="viewType === 'QUESTION'"> Group by Teams
+      <div>
+        <label class="form-check-label" ngbTooltip="Group results in the current view by team"><input type="checkbox" class="form-check-input" [(ngModel)]="groupByTeam" [disabled]="viewType === 'QUESTION'"> Group by Teams</label>
       </div>
-      <div ngbTooltip="Show statistics">
-        <input type="checkbox" [(ngModel)]="showStatistics"> Show Statistics
+      <div>
+        <label class="form-check-label"  ngbTooltip="Show statistics"><input type="checkbox" class="form-check-input" [(ngModel)]="showStatistics"> Show Statistics</label>
       </div>
-      <div ngbTooltip="Indicate missing responses">
-        <input type="checkbox" [(ngModel)]="indicateMissingResponses"> Indicate Missing Responses
+      <div>
+        <label class="form-check-label" ngbTooltip="Indicate missing responses"><input type="checkbox" class="form-check-input" [(ngModel)]="indicateMissingResponses"> Indicate Missing Responses</label>
       </div>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -106,13 +106,13 @@
         Additional settings:
       </label>
       <div>
-        <label class="form-check-label" ngbTooltip="Group results in the current view by team"><input type="checkbox" class="form-check-input" [(ngModel)]="groupByTeam" [disabled]="viewType === 'QUESTION'"> Group by Teams</label>
+        <label class="form-check-label" ngbTooltip="Group results in the current view by team"><input type="checkbox" [(ngModel)]="groupByTeam" [disabled]="viewType === 'QUESTION'"> Group by Teams</label>
       </div>
       <div>
-        <label class="form-check-label"  ngbTooltip="Show statistics"><input type="checkbox" class="form-check-input" [(ngModel)]="showStatistics"> Show Statistics</label>
+        <label class="form-check-label"  ngbTooltip="Show statistics"><input type="checkbox" [(ngModel)]="showStatistics"> Show Statistics</label>
       </div>
       <div>
-        <label class="form-check-label" ngbTooltip="Indicate missing responses"><input type="checkbox" class="form-check-input" [(ngModel)]="indicateMissingResponses"> Indicate Missing Responses</label>
+        <label class="form-check-label" ngbTooltip="Indicate missing responses"><input type="checkbox" [(ngModel)]="indicateMissingResponses"> Indicate Missing Responses</label>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #10168 

Clicking on label now checks the checkbox

![good_label](https://user-images.githubusercontent.com/32454748/83858397-ffda3680-a74e-11ea-9e7a-e0abc94b4c2c.gif)

Tooltip now shows above the label properly

<img width="208" alt="good_tooltip" src="https://user-images.githubusercontent.com/32454748/83858325-e76a1c00-a74e-11ea-9dc4-992c7b1c309e.png">

