### PR TITLE
[#10155] Add sortable statistics tables for instructor result page

### DIFF
--- a/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.html
@@ -8,22 +8,9 @@
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
-      <table class="table table-bordered table-striped margin-0">
-        <thead>
-        <tr>
-          <td>Option</td>
-          <td>Ranks Received</td>
-          <td>Overall Rank</td>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let option of ranksReceivedPerOption | keyvalue">
-          <td>{{ option.key }}</td>
-          <td>{{ option.value.join(', ') }}</td>
-          <td>{{ rankPerOption[option.key] }}</td>
-        </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="rowsData"
+                         [columns]="columnsData"
+      ></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { RankOptionsQuestionStatisticsComponent } from './rank-options-question-statistics.component';
 
 describe('RankOptionsQuestionStatisticsComponent', () => {
@@ -9,6 +10,7 @@ describe('RankOptionsQuestionStatisticsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RankOptionsQuestionStatisticsComponent],
+      imports: [SortableTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.ts
@@ -4,9 +4,9 @@ import {
   FeedbackRankOptionsResponseDetails,
 } from '../../../../types/api-output';
 import { DEFAULT_RANK_OPTIONS_QUESTION_DETAILS } from '../../../../types/default-question-structs';
+import { SortBy } from '../../../../types/sort-properties';
+import { ColumnData } from '../../sortable-table/sortable-table.component';
 import { QuestionStatistics } from './question-statistics';
-import {ColumnData} from "../../sortable-table/sortable-table.component";
-import {SortBy} from "../../../../types/sort-properties";
 
 /**
  * Statistics for rank options questions.

--- a/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.ts
@@ -5,6 +5,8 @@ import {
 } from '../../../../types/api-output';
 import { DEFAULT_RANK_OPTIONS_QUESTION_DETAILS } from '../../../../types/default-question-structs';
 import { QuestionStatistics } from './question-statistics';
+import {ColumnData} from "../../sortable-table/sortable-table.component";
+import {SortBy} from "../../../../types/sort-properties";
 
 /**
  * Statistics for rank options questions.
@@ -20,6 +22,8 @@ export class RankOptionsQuestionStatisticsComponent
 
   ranksReceivedPerOption: Record<string, number[]> = {};
   rankPerOption: Record<string, number> = {};
+  columnsData: ColumnData[] = [];
+  rowsData: any[][] = [];
 
   constructor() {
     super(DEFAULT_RANK_OPTIONS_QUESTION_DETAILS());
@@ -27,10 +31,12 @@ export class RankOptionsQuestionStatisticsComponent
 
   ngOnInit(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   ngOnChanges(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   private calculateStatistics(): void {
@@ -79,6 +85,22 @@ export class RankOptionsQuestionStatisticsComponent
         this.rankPerOption[option] = i + 1;
       }
     }
+  }
+
+  private getTableData(): void {
+    this.columnsData = [
+      { header: 'Option', sortBy: SortBy.RANK_OPTIONS_OPTION },
+      { header: 'Ranks Received' },
+      { header: 'Overall Rank', sortBy: SortBy.RANK_OPTIONS_OVERALL_RANK },
+    ];
+
+    this.rowsData = Object.keys(this.ranksReceivedPerOption).map((key: string) => {
+      return [
+        key,
+        this.ranksReceivedPerOption[key].join(', '),
+        this.rankPerOption[key],
+      ];
+    });
   }
 
 }

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.html
@@ -8,28 +8,9 @@
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
-      <table class="table table-bordered table-striped margin-0">
-        <thead>
-        <tr>
-          <td>Team</td>
-          <td>Recipient</td>
-          <td>Ranks Received</td>
-          <td>Self Rank</td>
-          <td>Overall Rank</td>
-          <td>Overall Rank Excluding Self</td>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let option of ranksReceivedPerOption | keyvalue">
-          <td>{{ emailToTeamName[option.key] }}</td>
-          <td>{{ emailToName[option.key] }}</td>
-          <td>{{ option.value.join(', ') }}</td>
-          <td>{{ selfRankPerOption[option.key] || '-' }}</td>
-          <td>{{ rankPerOption[option.key] }}</td>
-          <td>{{ rankPerOptionExcludeSelf[option.key] || '-' }}</td>
-        </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="rowsData"
+                         [columns]="columnsData"
+      ></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { RankRecipientsQuestionStatisticsComponent } from './rank-recipients-question-statistics.component';
 
 describe('RankRecipientsQuestionStatisticsComponent', () => {
@@ -9,6 +10,7 @@ describe('RankRecipientsQuestionStatisticsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RankRecipientsQuestionStatisticsComponent],
+      imports: [SortableTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
@@ -6,6 +6,8 @@ import {
 } from '../../../../types/api-output';
 import { DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS } from '../../../../types/default-question-structs';
 import { QuestionStatistics } from './question-statistics';
+import {SortBy} from "../../../../types/sort-properties";
+import {ColumnData} from "../../sortable-table/sortable-table.component";
 
 /**
  * Statistics for rank recipients questions.
@@ -25,6 +27,8 @@ export class RankRecipientsQuestionStatisticsComponent
   selfRankPerOption: Record<string, number> = {};
   rankPerOption: Record<string, number> = {};
   rankPerOptionExcludeSelf: Record<string, number> = {};
+  columnsData: ColumnData[] = [];
+  rowsData: any[][] = [];
 
   constructor() {
     super(DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS());
@@ -32,10 +36,12 @@ export class RankRecipientsQuestionStatisticsComponent
 
   ngOnInit(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   ngOnChanges(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   private calculateStatistics(): void {
@@ -110,6 +116,28 @@ export class RankRecipientsQuestionStatisticsComponent
     }
 
     return rankPerOption;
+  }
+
+  private getTableData(): void {
+    this.columnsData = [
+      { header: 'Team', sortBy: SortBy.RANK_RECIPIENTS_TEAM },
+      { header: 'Recipient', sortBy: SortBy.RANK_RECIPIENTS_RECIPIENT },
+      { header: 'Ranks Received' },
+      { header: 'Self Rank', sortBy: SortBy.RANK_RECIPIENTS_SELF_RANK },
+      { header: 'Overall Rank', sortBy: SortBy.RANK_RECIPIENTS_OVERALL_RANK },
+      { header: 'Overall Rank Excluding Self', sortBy: SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF},
+    ];
+
+    this.rowsData = Object.keys(this.ranksReceivedPerOption).map((key: string) => {
+      return [
+        this.emailToTeamName[key],
+        this.emailToName[key],
+        this.ranksReceivedPerOption[key].join(', '),
+        this.selfRankPerOption[key] || '-',
+        this.rankPerOption[key],
+        this.rankPerOptionExcludeSelf[key] || '-',
+      ];
+    });
   }
 
 }

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.ts
@@ -5,9 +5,9 @@ import {
   FeedbackRankRecipientsResponseDetails,
 } from '../../../../types/api-output';
 import { DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS } from '../../../../types/default-question-structs';
+import { SortBy } from '../../../../types/sort-properties';
+import { ColumnData } from '../../sortable-table/sortable-table.component';
 import { QuestionStatistics } from './question-statistics';
-import {SortBy} from "../../../../types/sort-properties";
-import {ColumnData} from "../../sortable-table/sortable-table.component";
 
 /**
  * Statistics for rank recipients questions.
@@ -125,7 +125,7 @@ export class RankRecipientsQuestionStatisticsComponent
       { header: 'Ranks Received' },
       { header: 'Self Rank', sortBy: SortBy.RANK_RECIPIENTS_SELF_RANK },
       { header: 'Overall Rank', sortBy: SortBy.RANK_RECIPIENTS_OVERALL_RANK },
-      { header: 'Overall Rank Excluding Self', sortBy: SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF},
+      { header: 'Overall Rank Excluding Self', sortBy: SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF },
     ];
 
     this.rowsData = Object.keys(this.ranksReceivedPerOption).map((key: string) => {

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -8,33 +8,15 @@
     </div>
     <div class="col-sm-8" style="text-align: right;">
       <label class="form-check-label">
-        <input type="checkbox" [(ngModel)]="excludeSelf" class="form-check-input"> <span ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+        <input type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
       </label>
     </div>
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
-      <table class="table table-bordered table-striped margin-0">
-        <thead>
-        <tr>
-          <td></td>
-          <td *ngFor="let choice of choices">{{ choice }}</td>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let subQuestion of subQuestions; let i = index;">
-          <td>{{ subQuestion }}</td>
-          <td *ngFor="let _ of choices; let j = index;">
-            <span *ngIf="excludeSelf">
-              {{ percentagesExcludeSelf[i][j] }}% ({{ answersExcludeSelf[i][j] }}) <span *ngIf="hasWeights">[{{ weights[i][j] }}]</span>
-            </span>
-            <span *ngIf="!excludeSelf">
-              {{ percentages[i][j] }}% ({{ answers[i][j] }}) <span *ngIf="hasWeights">[{{ weights[i][j] }}]</span>
-            </span>
-          </td>
-        </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="rowsData"
+                         [columns]="columnsData"
+      ></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
+import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { RubricQuestionStatisticsComponent } from './rubric-question-statistics.component';
 
 describe('RubricQuestionStatisticsComponent', () => {
@@ -10,7 +11,7 @@ describe('RubricQuestionStatisticsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RubricQuestionStatisticsComponent],
-      imports: [FormsModule],
+      imports: [FormsModule, SortableTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -125,16 +125,17 @@ export class RubricQuestionStatisticsComponent
       ...this.choices.map((choice: string) => ({ header: choice, sortBy: SortBy.RUBRIC_CHOICE })),
     ];
 
-    this.rowsData = this.subQuestions.map((subQuestion: string, i: number) => {
+    this.rowsData = this.subQuestions.map((subQuestion: string, questionIndex: number) => {
       return [
         subQuestion,
-        ...this.choices.map((_: string, j: number) => {
+        ...this.choices.map((_: string, choiceIndex: number) => {
           if (this.excludeSelf) {
-            return `${ this.percentagesExcludeSelf[i][j] }% (${ this.answersExcludeSelf[i][j] }) \
-            ${ this.hasWeights ? `[${ this.weights[i][j] }]` : '' }`;
+            return `${ this.percentagesExcludeSelf[questionIndex][choiceIndex] }% \
+            (${ this.answersExcludeSelf[questionIndex][choiceIndex] }) \
+            ${ this.hasWeights ? `[${ this.weights[questionIndex][choiceIndex] }]` : '' }`;
           }
-          return `${ this.percentages[i][j] }% (${ this.answers[i][j] }) \
-          ${ this.hasWeights ? `[${ this.weights[i][j] }]` : '' }`;
+          return `${ this.percentages[questionIndex][choiceIndex] }% (${ this.answers[questionIndex][choiceIndex] }) \
+          ${ this.hasWeights ? `[${ this.weights[questionIndex][choiceIndex] }]` : '' }`;
         }),
       ];
     });

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -5,6 +5,8 @@ import {
   FeedbackRubricResponseDetails,
 } from '../../../../types/api-output';
 import { DEFAULT_RUBRIC_QUESTION_DETAILS } from '../../../../types/default-question-structs';
+import { SortBy } from '../../../../types/sort-properties';
+import { ColumnData } from '../../sortable-table/sortable-table.component';
 import { QuestionStatistics } from './question-statistics';
 
 /**
@@ -30,16 +32,21 @@ export class RubricQuestionStatisticsComponent
   answersExcludeSelf: number[][] = [];
   percentagesExcludeSelf: number[][] = [];
 
+  columnsData: ColumnData[] = [];
+  rowsData: any[][] = [];
+
   constructor() {
     super(DEFAULT_RUBRIC_QUESTION_DETAILS());
   }
 
   ngOnInit(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   ngOnChanges(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   private calculateStatistics(): void {
@@ -110,6 +117,27 @@ export class RubricQuestionStatisticsComponent
     }
 
     return percentages;
+  }
+
+  private getTableData(): void {
+    this.columnsData = [
+        { header: '' },
+      ...this.choices.map((choice: string) => ({ header: choice, sortBy: SortBy.RUBRIC_CHOICE })),
+    ];
+
+    this.rowsData = this.subQuestions.map((subQuestion: string, i: number) => {
+      return [
+        subQuestion,
+        ...this.choices.map((_: string, j: number) => {
+          if (this.excludeSelf) {
+            return `${ this.percentagesExcludeSelf[i][j] }% (${ this.answersExcludeSelf[i][j] }) \
+            ${ this.hasWeights ? `[${ this.weights[i][j] }]` : '' }`;
+          }
+          return `${ this.percentages[i][j] }% (${ this.answers[i][j] }) \
+          ${ this.hasWeights ? `[${ this.weights[i][j] }]` : '' }`;
+        }),
+      ];
+    });
   }
 
 }

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -119,7 +119,7 @@ export class RubricQuestionStatisticsComponent
     return percentages;
   }
 
-  private getTableData(): void {
+  getTableData(): void {
     this.columnsData = [
         { header: '' },
       ...this.choices.map((choice: string) => ({ header: choice, sortBy: SortBy.RUBRIC_CHOICE })),

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -1,5 +1,5 @@
-import {Injectable} from '@angular/core';
-import {SortBy, SortOrder} from '../types/sort-properties';
+import { Injectable } from '@angular/core';
+import { SortBy, SortOrder } from '../types/sort-properties';
 
 /**
  * Handles comparison logic between sortable table elements

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { SortBy, SortOrder } from '../types/sort-properties';
+import {Injectable} from '@angular/core';
+import {SortBy, SortOrder} from '../types/sort-properties';
 
 /**
  * Handles comparison logic between sortable table elements
@@ -42,6 +42,7 @@ export class TableComparatorService {
    */
   compare(sortBy: SortBy, order: SortOrder, strA: string, strB: string): number {
     switch (sortBy) {
+      case SortBy.RUBRIC_CHOICE:
       case SortBy.RANK_RECIPIENTS_TEAM:
       case SortBy.RANK_RECIPIENTS_RECIPIENT:
       case SortBy.RANK_OPTIONS_OVERALL_RANK:

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -42,6 +42,8 @@ export class TableComparatorService {
    */
   compare(sortBy: SortBy, order: SortOrder, strA: string, strB: string): number {
     switch (sortBy) {
+      case SortBy.RANK_RECIPIENTS_TEAM:
+      case SortBy.RANK_RECIPIENTS_RECIPIENT:
       case SortBy.RANK_OPTIONS_OVERALL_RANK:
       case SortBy.NUMERICAL_SCALE_AVERAGE:
       case SortBy.NUMERICAL_SCALE_MAX:
@@ -55,6 +57,9 @@ export class TableComparatorService {
       case SortBy.TEAM_NAME:
       case SortBy.SESSION_NAME:
         return this.compareNaturally(strA, strB, order);
+      case SortBy.RANK_RECIPIENTS_SELF_RANK:
+      case SortBy.RANK_RECIPIENTS_OVERALL_RANK:
+      case SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF:
       case SortBy.RANK_OPTIONS_OPTION:
       case SortBy.MCQ_CHOICE:
       case SortBy.STUDENT_NAME:

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -42,6 +42,7 @@ export class TableComparatorService {
    */
   compare(sortBy: SortBy, order: SortOrder, strA: string, strB: string): number {
     switch (sortBy) {
+      case SortBy.RANK_OPTIONS_OVERALL_RANK:
       case SortBy.NUMERICAL_SCALE_AVERAGE:
       case SortBy.NUMERICAL_SCALE_MAX:
       case SortBy.NUMERICAL_SCALE_MIN:
@@ -54,6 +55,7 @@ export class TableComparatorService {
       case SortBy.TEAM_NAME:
       case SortBy.SESSION_NAME:
         return this.compareNaturally(strA, strB, order);
+      case SortBy.RANK_OPTIONS_OPTION:
       case SortBy.MCQ_CHOICE:
       case SortBy.STUDENT_NAME:
       case SortBy.EMAIL:

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -166,6 +166,16 @@ export enum SortBy {
      * Weighted percentage of selection of that option
      */
     MCQ_WEIGHTED_PERCENTAGE,
+
+    /**
+     * Option to rank
+     */
+    RANK_OPTIONS_OPTION,
+
+    /**
+     * Overall ranking of the option
+     */
+    RANK_OPTIONS_OVERALL_RANK,
 }
 
 /**

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -176,6 +176,31 @@ export enum SortBy {
      * Overall ranking of the option
      */
     RANK_OPTIONS_OVERALL_RANK,
+
+    /**
+     * Giver's / Recipients's team
+     */
+    RANK_RECIPIENTS_TEAM,
+
+    /**
+     * Recipient's name
+     */
+    RANK_RECIPIENTS_RECIPIENT,
+
+    /**
+     * Recipient's self rank
+     */
+    RANK_RECIPIENTS_SELF_RANK,
+
+    /**
+     * Recipient's overall rank
+     */
+    RANK_RECIPIENTS_OVERALL_RANK,
+
+    /**
+     * Recipient's overall rank excluding self
+     */
+    RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF,
 }
 
 /**

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -201,6 +201,11 @@ export enum SortBy {
      * Recipient's overall rank excluding self
      */
     RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF,
+
+    /**
+     * Frequency of choice
+     */
+    RUBRIC_CHOICE,
 }
 
 /**


### PR DESCRIPTION
Part of #10155 

Add sortable statistics table for:

- `tm-rank-options-question-statistics`

![rank_options](https://user-images.githubusercontent.com/32454748/84000724-c5afa580-a997-11ea-906e-44f6607f0345.gif)

- `tm-rank-recipients-question-statistics`

![rank_recipients](https://user-images.githubusercontent.com/32454748/84000713-bf212e00-a997-11ea-8cf3-cacf827fce86.gif)

- `tm-rubric-question-statistics`

![rubric](https://user-images.githubusercontent.com/32454748/84000729-c6e0d280-a997-11ea-8ab5-a5d0528bb6fc.gif)