### PR TITLE
[#10176] Update submission of MSQ to follow V6's format

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
@@ -71,14 +71,29 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
             errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION);
         }
 
+        // if other is not chosen while other field is not empty trigger this error
+        if (isOtherEnabled && !isOther && !getOtherFieldContent().isEmpty()) {
+            errors.add(Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION);
+        }
+
+        List<String> validChoices = new ArrayList<>(msqChoices);
+        if (isOtherEnabled && isOther) {
+            // other field content becomes a valid choice if other is enabled
+            validChoices.add(getOtherFieldContent());
+        }
         // if selected answers are not a part of the Msq option list trigger this error
-        boolean isAnswersPartOfChoices = msqChoices.containsAll(answers);
+        boolean isAnswersPartOfChoices = validChoices.containsAll(answers);
         if (!isAnswersPartOfChoices && !isNoneOfTheAboveOptionEnabled) {
             errors.add(getAnswerString() + " " + Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION);
         }
 
         // if other option is selected but no text is provided trigger this error
         if (isOther && getOtherFieldContent().trim().equals("")) {
+            errors.add(Const.FeedbackQuestion.MSQ_ERROR_OTHER_CONTENT_NOT_PROVIDED);
+        }
+
+        // if other option is selected but not in the answer list trigger this error
+        if (isOther && !answers.contains(otherFieldContent)) {
             errors.add(Const.FeedbackQuestion.MSQ_ERROR_OTHER_CONTENT_NOT_PROVIDED);
         }
 
@@ -117,4 +132,15 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
         return otherFieldContent;
     }
 
+    public void setAnswers(List<String> answers) {
+        this.answers = answers;
+    }
+
+    public void setOther(boolean other) {
+        isOther = other;
+    }
+
+    public void setOtherFieldContent(String otherFieldContent) {
+        this.otherFieldContent = otherFieldContent;
+    }
 }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -220,7 +220,10 @@ public final class Const {
         public static final String MSQ_ERROR_INVALID_WEIGHT =
                 "The weights for the choices of a " + Const.FeedbackQuestionTypeNames.MSQ
                 + " must be valid numbers with precision up to 2 decimal places.";
-        public static final String MSQ_ANSWER_NONE_OF_THE_ABOVE = "None of the above";
+        /**
+         * Special answer of a MSQ question indicating 'None of the above'.
+         */
+        public static final String MSQ_ANSWER_NONE_OF_THE_ABOVE = "";
         public static final String MSQ_ERROR_DUPLICATE_MSQ_OPTION = "The Msq options cannot be duplicate";
 
         // Numscale

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqResponseDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqResponseDetailsTest.java
@@ -1,0 +1,87 @@
+package teammates.test.cases.datatransfer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.questions.FeedbackMsqQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackMsqResponseDetails;
+import teammates.common.util.Const;
+import teammates.test.cases.BaseTestCase;
+
+/**
+ * SUT: {@link FeedbackMsqResponseDetails}.
+ */
+public class FeedbackMsqResponseDetailsTest extends BaseTestCase {
+
+    @Test
+    public void testValidateResponseDetails_otherAnswerNotChosenButOtherFieldIsNotEmpty_shouldTriggerError() {
+        FeedbackMsqQuestionDetails msqQuestionDetails = new FeedbackMsqQuestionDetails();
+        msqQuestionDetails.setMsqChoices(Arrays.asList("choiceA", "choiceB"));
+        msqQuestionDetails.setOtherEnabled(true);
+        msqQuestionDetails.setHasAssignedWeights(false);
+
+        FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withQuestionDetails(msqQuestionDetails)
+                .build();
+
+        FeedbackMsqResponseDetails feedbackMsqResponseDetails = new FeedbackMsqResponseDetails();
+        feedbackMsqResponseDetails.setOther(false);
+        feedbackMsqResponseDetails.setOtherFieldContent("NonEmpty");
+        feedbackMsqResponseDetails.setAnswers(Arrays.asList("choiceA"));
+
+        List<String> errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(1, errors.size());
+        assertEquals(Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION, errors.get(0));
+
+        // now set other field to empty
+        feedbackMsqResponseDetails.setOtherFieldContent("");
+        errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(0, errors.size());
+    }
+
+    @Test
+    public void testValidateResponseDetails_choiceNotInValidChoices_shouldTriggerError() {
+        FeedbackMsqQuestionDetails msqQuestionDetails = new FeedbackMsqQuestionDetails();
+        msqQuestionDetails.setMsqChoices(Arrays.asList("choiceA", "choiceB"));
+        msqQuestionDetails.setOtherEnabled(true);
+        msqQuestionDetails.setHasAssignedWeights(false);
+        FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withQuestionDetails(msqQuestionDetails)
+                .build();
+
+        // typical case: answers not in valid choices
+        FeedbackMsqResponseDetails feedbackMsqResponseDetails = new FeedbackMsqResponseDetails();
+        feedbackMsqResponseDetails.setOther(false);
+        feedbackMsqResponseDetails.setOtherFieldContent("");
+        feedbackMsqResponseDetails.setAnswers(Arrays.asList("choiceC"));
+        List<String> errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(1, errors.size());
+        assertEquals(feedbackMsqResponseDetails.getAnswerString()
+                + " " + Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION, errors.get(0));
+
+        // now set choice to be within the valid choices
+        feedbackMsqResponseDetails.setAnswers(Arrays.asList("choiceA"));
+        errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(0, errors.size());
+
+        // when other field is enabled, the other field content will become a valid choice
+        feedbackMsqResponseDetails.setOther(true);
+        feedbackMsqResponseDetails.setOtherFieldContent("Other");
+        feedbackMsqResponseDetails.setAnswers(Arrays.asList("Other1"));
+        errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(2, errors.size());
+        assertEquals(feedbackMsqResponseDetails.getAnswerString()
+                + " " + Const.FeedbackQuestion.MSQ_ERROR_INVALID_OPTION, errors.get(0));
+        assertEquals(Const.FeedbackQuestion.MSQ_ERROR_OTHER_CONTENT_NOT_PROVIDED, errors.get(1));
+
+        // make answer list and other field content consistent
+        feedbackMsqResponseDetails.setOther(true);
+        feedbackMsqResponseDetails.setOtherFieldContent("Other");
+        feedbackMsqResponseDetails.setAnswers(Arrays.asList("Other"));
+        errors = feedbackMsqResponseDetails.validateResponseDetails(feedbackQuestionAttributes);
+        assertEquals(0, errors.size());
+    }
+}

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.html
@@ -15,7 +15,7 @@
       </label>
       <input #inputTextBoxOther class="form-control" style="display: inline; width: 60%;" type="text" [disabled]="!responseDetails.isOther || isDisabled"
              [ngModel]="responseDetails.otherFieldContent"
-             (ngModelChange)="triggerResponseDetailsChange('otherFieldContent', $event)">
+             (ngModelChange)="updateOtherAnswerField($event)">
     </div>
     <div class="check-box" *ngIf="questionDetails.minSelectableChoices === NO_VALUE">
       <label class="margin-right-15px">

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -4,10 +4,8 @@ import {
   FeedbackMsqResponseDetails,
 } from '../../../../types/api-output';
 import { DEFAULT_MSQ_QUESTION_DETAILS, DEFAULT_MSQ_RESPONSE_DETAILS } from '../../../../types/default-question-structs';
-import { NO_VALUE } from '../../../../types/feedback-response-details';
+import { MSQ_ANSWER_NONE_OF_THE_ABOVE, NO_VALUE } from '../../../../types/feedback-response-details';
 import { QuestionEditAnswerFormComponent } from './question-edit-answer-form';
-
-const NONE_OF_THE_ABOVE: string = 'None of the above';
 
 /**
  * The Msq question submission form for a recipient.
@@ -59,7 +57,7 @@ export class MsqQuestionEditAnswerFormComponent
     if (indexInResponseArray > -1) {
       newAnswers.splice(indexInResponseArray, 1);
     } else {
-      newAnswers.push(this.questionDetails.msqChoices[index]);
+      newAnswers.unshift(this.questionDetails.msqChoices[index]);
     }
 
     this.triggerResponseDetailsChange('answers', newAnswers);
@@ -71,16 +69,33 @@ export class MsqQuestionEditAnswerFormComponent
   updateIsOtherOption(): void {
     const fieldsToUpdate: any = {};
     fieldsToUpdate.isOther = !this.responseDetails.isOther;
+    fieldsToUpdate.answers = this.responseDetails.answers;
     if (this.isNoneOfTheAboveEnabled) {
       fieldsToUpdate.answers = [];
     }
-    if (!fieldsToUpdate.isOther) {
-      fieldsToUpdate.otherFieldContent = '';
-    } else {
+    if (fieldsToUpdate.isOther) {
+      // create a placeholder for other answer
+      fieldsToUpdate.answers.push('');
       setTimeout(() => { // focus on the text box after the isOther field is updated to enable the text box
         (this.inputTextBoxOther as ElementRef).nativeElement.focus();
       }, 0);
+    } else {
+      // remove other answer (last element) from the answer list
+      fieldsToUpdate.answers.splice(-1, 1);
+      fieldsToUpdate.otherFieldContent = '';
     }
+    this.triggerResponseDetailsChangeBatch(fieldsToUpdate);
+  }
+
+  /**
+   * Updates other answer field.
+   */
+  updateOtherAnswerField($event: string): void {
+    const fieldsToUpdate: any = {};
+    // we shall update both the other field content and the answer list
+    fieldsToUpdate.otherFieldContent = $event;
+    fieldsToUpdate.answers = this.responseDetails.answers.slice();
+    fieldsToUpdate.answers[fieldsToUpdate.answers.length - 1] = $event;
     this.triggerResponseDetailsChangeBatch(fieldsToUpdate);
   }
 
@@ -88,8 +103,8 @@ export class MsqQuestionEditAnswerFormComponent
    * Checks if None of the above checkbox is enabled.
    */
   get isNoneOfTheAboveEnabled(): boolean {
-    return this.responseDetails.answers.length === 1
-        && this.responseDetails.answers[0] === NONE_OF_THE_ABOVE;
+    return !this.responseDetails.isOther && this.responseDetails.answers.length === 1
+        && this.responseDetails.answers[0] === MSQ_ANSWER_NONE_OF_THE_ABOVE;
   }
 
   /**
@@ -97,7 +112,7 @@ export class MsqQuestionEditAnswerFormComponent
    */
   updateNoneOfTheAbove(): void {
     this.triggerResponseDetailsChangeBatch({
-      answers: this.isNoneOfTheAboveEnabled ? [] : [NONE_OF_THE_ABOVE],
+      answers: this.isNoneOfTheAboveEnabled ? [] : [MSQ_ANSWER_NONE_OF_THE_ABOVE],
       isOther: false,
       otherFieldContent: '',
     });

--- a/src/web/app/components/question-types/question-response/msq-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/msq-question-response.component.html
@@ -1,3 +1,3 @@
-<ul>
+<ul *ngIf="!isNoneOfTheAboveAnswer">
   <li *ngFor="let answer of responseDetails.answers">{{ answer }}</li>
 </ul>

--- a/src/web/app/components/question-types/question-response/msq-question-response.component.ts
+++ b/src/web/app/components/question-types/question-response/msq-question-response.component.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_MSQ_QUESTION_DETAILS,
   DEFAULT_MSQ_RESPONSE_DETAILS,
 } from '../../../../types/default-question-structs';
+import { MSQ_ANSWER_NONE_OF_THE_ABOVE } from '../../../../types/feedback-response-details';
 import { QuestionResponse } from './question-response';
 
 /**
@@ -22,6 +23,14 @@ export class MsqQuestionResponseComponent
 
   constructor() {
     super(DEFAULT_MSQ_RESPONSE_DETAILS(), DEFAULT_MSQ_QUESTION_DETAILS());
+  }
+
+  /**
+   * Checks whether the MSQ answer is 'None of the above'.
+   */
+  get isNoneOfTheAboveAnswer(): boolean {
+    return this.responseDetails.answers.length === 1
+        && this.responseDetails.answers[0] === MSQ_ANSWER_NONE_OF_THE_ABOVE;
   }
 
 }

--- a/src/web/types/feedback-response-details.ts
+++ b/src/web/types/feedback-response-details.ts
@@ -9,6 +9,11 @@ export const CONTRIBUTION_POINT_NOT_SUBMITTED: number = -999;
 export const CONTRIBUTION_POINT_NOT_SURE: number = -101;
 
 /**
+ * Special answer of a MSQ question indicating 'None of the above'.
+ */
+export const MSQ_ANSWER_NONE_OF_THE_ABOVE: string = '';
+
+/**
  * Special answer of a contribution question response for 'Equal Share' answer.
  */
 export const CONTRIBUTION_POINT_EQUAL_SHARE: number = 100;


### PR DESCRIPTION
Part of #10176

**V6 Behaviors**

- In V6, we use empty string to indicates `None of the above` answer.
- In V6, the `otherFieldContent` for MSQ is duplicated in the answer list as the last element.

I would the above practices are not ideal but change any of the behavior above would result in data migration.