### PR TITLE
[#10155] Add sortable statistic table for MSQ, plus finishing up

### DIFF
--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.html
@@ -8,36 +8,13 @@
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
-      <tm-sortable-table [columns]="columnsData"
-                         [rows]="rowsData"
-      ></tm-sortable-table>
+      <tm-sortable-table [columns]="summaryColumnsData" [rows]="summaryRowsData"></tm-sortable-table>
     </div>
     <div class="col-sm-12 table-responsive" *ngIf="question.hasAssignedWeights" style="margin-top: 20px;">
       <strong class="text-color-gray">
         Per Recipient Statistics
       </strong>
-      <table class="table table-striped table-bordered margin-0">
-        <thead>
-          <tr>
-            <th>Team</th>
-            <th>Recipient Name</th>
-            <th *ngFor="let answer of weightPerOption | keyvalue">{{ answer.key }} [{{ answer.value }}]</th>
-            <th>Total</th>
-            <th>Average</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let recipientResponse of perRecipientResponses | keyvalue">
-            <td>{{ recipientResponse.value.recipientTeam }}</td>
-            <td>{{ recipientResponse.value.recipient }}</td>
-            <td *ngFor="let answer of weightPerOption | keyvalue">
-              {{ recipientResponse.value.responses[answer.key] }}
-            </td>
-            <td>{{ recipientResponse.value.total }}</td>
-            <td>{{ recipientResponse.value.average }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [columns]="perRecipientColumnsData" [rows]="perRecipientRowsData"></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -23,8 +23,10 @@ export class McqQuestionStatisticsComponent
   weightedPercentagePerOption: Record<string, number> = {};
   perRecipientResponses: Record<string, any> = {};
 
-  columnsData: ColumnData[] = [];
-  rowsData: SortableTableCellData[][] = [];
+  summaryColumnsData: ColumnData[] = [];
+  summaryRowsData: SortableTableCellData[][] = [];
+  perRecipientColumnsData: ColumnData[] = [];
+  perRecipientRowsData: SortableTableCellData[][] = [];
 
   constructor() {
     super(DEFAULT_MCQ_QUESTION_DETAILS());
@@ -132,7 +134,7 @@ export class McqQuestionStatisticsComponent
   }
 
   private getTableData(): void {
-    this.columnsData = [
+    this.summaryColumnsData = [
       { header: 'Choice', sortBy: SortBy.MCQ_CHOICE },
       { header: 'Weight', sortBy: SortBy.MCQ_WEIGHT },
       { header: 'Response Count', sortBy: SortBy.MCQ_RESPONSE_COUNT },
@@ -140,13 +142,40 @@ export class McqQuestionStatisticsComponent
       { header: 'Weighted Percentage (%)', sortBy: SortBy.MCQ_WEIGHTED_PERCENTAGE },
     ];
 
-    this.rowsData = Object.keys(this.answerFrequency).map((key: string) => {
+    this.summaryRowsData = Object.keys(this.answerFrequency).map((key: string) => {
       return [
         { value: key },
         { value: this.weightPerOption[key] || '-' },
         { value: this.answerFrequency[key] },
         { value: this.percentagePerOption[key] },
         { value: this.weightedPercentagePerOption[key] || '-' },
+      ];
+    });
+
+    this.perRecipientColumnsData = [
+      { header: 'Team', sortBy: SortBy.MCQ_TEAM },
+      { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
+      ...Object.keys(this.weightPerOption).map((key: string) => {
+        return {
+          header: `${key} [${this.weightPerOption[key]}]`,
+          sortBy: SortBy.MCQ_NUMBER_SELECTED,
+        };
+      }),
+      { header: 'Total', sortBy: SortBy.MCQ_TOTAL },
+      { header: 'Average', sortBy: SortBy.MCQ_AVERAGE },
+    ];
+
+    this.perRecipientRowsData = Object.keys(this.perRecipientResponses).map((key: string) => {
+      return [
+        { value: this.perRecipientResponses[key].recipientTeam },
+        { value: this.perRecipientResponses[key].recipient },
+        ...Object.keys(this.weightPerOption).map((option: string) => {
+          return {
+            value: this.perRecipientResponses[key].responses[option],
+          };
+        }),
+        { value: this.perRecipientResponses[key].total },
+        { value: this.perRecipientResponses[key].average },
       ];
     });
   }

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -158,11 +158,11 @@ export class McqQuestionStatisticsComponent
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
           header: `${key} [${this.weightPerOption[key]}]`,
-          sortBy: SortBy.MCQ_NUMBER_SELECTED,
+          sortBy: SortBy.MCQ_OPTION_SELECTED_TIMES,
         };
       }),
-      { header: 'Total', sortBy: SortBy.MCQ_TOTAL },
-      { header: 'Average', sortBy: SortBy.MCQ_AVERAGE },
+      { header: 'Total', sortBy: SortBy.MCQ_WEIGHT_TOTAL },
+      { header: 'Average', sortBy: SortBy.MCQ_WEIGHT_AVERAGE },
     ];
 
     this.perRecipientRowsData = Object.keys(this.perRecipientResponses).map((key: string) => {

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.html
@@ -8,53 +8,13 @@
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
-      <table class="table table-bordered table-striped margin-0">
-        <thead>
-          <tr>
-            <td>Choice</td>
-            <td>Weight</td>
-            <td>Response Count</td>
-            <td>Percentage (%)</td>
-            <td>Weighted Percentage (%)</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let answer of answerFrequency | keyvalue">
-            <td>{{ answer.key }}</td>
-            <td>{{ weightPerOption[answer.key] || '-' }}</td>
-            <td>{{ answer.value }}</td>
-            <td>{{ percentagePerOption[answer.key] }}</td>
-            <td>{{ weightedPercentagePerOption[answer.key] || '-' }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="summaryRowsData" [columns]="summaryColumnsData"></tm-sortable-table>
     </div>
     <div class="col-sm-12 table-responsive" *ngIf="question.hasAssignedWeights" style="margin-top: 20px;">
       <strong class="text-color-gray">
         Per Recipient Statistics
       </strong>
-      <table class="table table-striped table-bordered margin-0">
-        <thead>
-          <tr>
-            <th>Team</th>
-            <th>Recipient Name</th>
-            <th *ngFor="let answer of weightPerOption | keyvalue">{{ answer.key }} [{{ answer.value }}]</th>
-            <th>Total</th>
-            <th>Average</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let recipientResponse of perRecipientResponses | keyvalue">
-            <td>{{ recipientResponse.value.recipientTeam }}</td>
-            <td>{{ recipientResponse.value.recipient }}</td>
-            <td *ngFor="let answer of weightPerOption | keyvalue">
-              {{ recipientResponse.value.responses[answer.key] }}
-            </td>
-            <td>{{ recipientResponse.value.total }}</td>
-            <td>{{ recipientResponse.value.average }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="perRecipientRowsData" [columns]="perRecipientColumnsData"></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { MsqQuestionStatisticsComponent } from './msq-question-statistics.component';
 
 describe('MsqQuestionStatisticsComponent', () => {
@@ -9,6 +10,7 @@ describe('MsqQuestionStatisticsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [MsqQuestionStatisticsComponent],
+      imports: [SortableTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnChanges, OnInit } from '@angular/core';
 import { FeedbackMsqQuestionDetails, FeedbackMsqResponseDetails } from '../../../../types/api-output';
 import { DEFAULT_MSQ_QUESTION_DETAILS } from '../../../../types/default-question-structs';
+import { SortBy } from '../../../../types/sort-properties';
+import { ColumnData, SortableTableCellData } from '../../sortable-table/sortable-table.component';
 import { QuestionStatistics } from './question-statistics';
 
 /**
@@ -22,16 +24,23 @@ export class MsqQuestionStatisticsComponent
   perRecipientResponses: Record<string, any> = {};
   hasAnswers: boolean = false;
 
+  summaryColumnsData: ColumnData[] = [];
+  summaryRowsData: SortableTableCellData[][] = [];
+  perRecipientColumnsData: ColumnData[] = [];
+  perRecipientRowsData: SortableTableCellData[][] = [];
+
   constructor() {
     super(DEFAULT_MSQ_QUESTION_DETAILS());
   }
 
   ngOnInit(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   ngOnChanges(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   private calculateStatistics(): void {
@@ -142,6 +151,53 @@ export class MsqQuestionStatisticsComponent
         };
       }
     }
+  }
+
+  private getTableData(): void {
+    this.summaryColumnsData = [
+      { header: 'Choice', sortBy: SortBy.MSQ_CHOICE },
+      { header: 'Weight', sortBy: SortBy.MSQ_WEIGHT },
+      { header: 'Response Count', sortBy: SortBy.MSQ_RESPONSE_COUNT },
+      { header: 'Percentage (%)', sortBy: SortBy.MSQ_PERCENTAGE },
+      { header: 'Weighted Percentage (%)', sortBy: SortBy.MSQ_WEIGHTED_PERCENTAGE },
+    ];
+
+    this.summaryRowsData = Object.keys(this.answerFrequency).map((key: string) => {
+      return [
+        { value: key },
+        { value: this.weightPerOption[key] || '-' },
+        { value: this.answerFrequency[key] },
+        { value: this.percentagePerOption[key] },
+        { value: this.weightedPercentagePerOption[key] || '-' },
+      ];
+    });
+
+    this.perRecipientColumnsData = [
+      { header: 'Team', sortBy: SortBy.MSQ_TEAM },
+      { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
+      ...Object.keys(this.weightPerOption).map((key: string) => {
+        return {
+          header: `${key} [${this.weightPerOption[key]}]`,
+          sortBy: SortBy.MSQ_NUMBER_SELECTED,
+        };
+      }),
+      { header: 'Total', sortBy: SortBy.MSQ_TOTAL },
+      { header: 'Average', sortBy: SortBy.MSQ_AVERAGE },
+    ];
+
+    this.perRecipientRowsData = Object.keys(this.perRecipientResponses).map((key: string) => {
+      return [
+        { value: this.perRecipientResponses[key].recipientTeam },
+        { value: this.perRecipientResponses[key].recipient },
+        ...Object.keys(this.weightPerOption).map((option: string) => {
+          return {
+            value: this.perRecipientResponses[key].responses[option],
+          };
+        }),
+        { value: this.perRecipientResponses[key].total },
+        { value: this.perRecipientResponses[key].average },
+      ];
+    });
   }
 
 }

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -178,11 +178,11 @@ export class MsqQuestionStatisticsComponent
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
           header: `${key} [${this.weightPerOption[key]}]`,
-          sortBy: SortBy.MSQ_NUMBER_SELECTED,
+          sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),
-      { header: 'Total', sortBy: SortBy.MSQ_TOTAL },
-      { header: 'Average', sortBy: SortBy.MSQ_AVERAGE },
+      { header: 'Total', sortBy: SortBy.MSQ_WEIGHT_TOTAL },
+      { header: 'Average', sortBy: SortBy.MSQ_WEIGHT_AVERAGE },
     ];
 
     this.perRecipientRowsData = Object.keys(this.perRecipientResponses).map((key: string) => {

--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
@@ -8,60 +8,7 @@
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <table class="table table-bordered striped margin-0">
-        <thead>
-        <tr>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.TEAM_NAME)">
-              Team
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.TEAM_NAME"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.TEAM_NAME && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.TEAM_NAME && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.RECIPIENT_NAME)">
-              Recipient
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.RECIPIENT_NAME"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.RECIPIENT_NAME && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.RECIPIENT_NAME && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.NUMERICAL_SCALE_AVERAGE)">
-              <span ngbTooltip="Average of the visible responses">Average </span>
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.NUMERICAL_SCALE_AVERAGE"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_AVERAGE && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_AVERAGE && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.NUMERICAL_SCALE_MAX)">
-              <span ngbTooltip="Maximum of the visible responses">Max </span>
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.NUMERICAL_SCALE_MAX"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_MAX && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_MAX && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.NUMERICAL_SCALE_MIN)">
-              <span ngbTooltip="Minimum of the visible responses">Min </span>
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.NUMERICAL_SCALE_MIN"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_MIN && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_MIN && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-          <th class="sortable-header" (click)="sortNumericalScaleStatsRowModel(SortBy.NUMERICAL_SCALE_AVERAGE_EXCLUDE_SELF)">
-              <span ngbTooltip="Average of the visible responses excluding recipient's own response to himself/herself">Average excluding self response </span>
-              <span *ngIf="teamToRecipientToScoresSortBy !== SortBy.NUMERICAL_SCALE_AVERAGE_EXCLUDE_SELF"><i class="fas fa-sort"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_AVERAGE_EXCLUDE_SELF && teamToRecipientToScoresSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-              <span *ngIf="teamToRecipientToScoresSortBy === SortBy.NUMERICAL_SCALE_AVERAGE_EXCLUDE_SELF && teamToRecipientToScoresSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-          </th>
-        </tr>
-        </thead>
-        <tbody>
-        <ng-container>
-          <tr *ngFor="let statsRow of numericalScaleStatsRowModel">
-            <td>{{ statsRow.teamName }}</td>
-            <td>{{ statsRow.recipientName }}</td>
-            <td>{{ statsRow.average }}</td>
-            <td>{{ statsRow.max }}</td>
-            <td>{{ statsRow.min }}</td>
-            <td>{{ statsRow.averageExceptSelf }}</td>
-          </tr>
-        </ng-container>
-        </tbody>
-      </table>
+      <tm-sortable-table [rows]="rowsData" [columns]="columnsData"></tm-sortable-table>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { NumScaleQuestionStatisticsComponent } from './num-scale-question-statistics.component';
 
 describe('NumScaleQuestionStatisticsComponent', () => {
@@ -9,6 +10,7 @@ describe('NumScaleQuestionStatisticsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [NumScaleQuestionStatisticsComponent],
+      imports: [SortableTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnChanges, OnInit } from '@angular/core';
-import { TableComparatorService } from '../../../../services/table-comparator.service';
 import {
   FeedbackNumericalScaleQuestionDetails,
   FeedbackNumericalScaleResponseDetails,
 } from '../../../../types/api-output';
 import { DEFAULT_NUMSCALE_QUESTION_DETAILS } from '../../../../types/default-question-structs';
 import { SortBy, SortOrder } from '../../../../types/sort-properties';
+import { ColumnData, SortableTableCellData } from '../../sortable-table/sortable-table.component';
 import { QuestionStatistics } from './question-statistics';
 
 interface NumericalScaleStatsRowModel {
@@ -41,65 +41,21 @@ export class NumScaleQuestionStatisticsComponent
 
   numericalScaleStatsRowModel: NumericalScaleStatsRowModel[] = [];
 
-  constructor(private tableComparatorService: TableComparatorService) {
+  columnsData: ColumnData[] = [];
+  rowsData: SortableTableCellData[][] = [];
+
+  constructor() {
     super(DEFAULT_NUMSCALE_QUESTION_DETAILS());
   }
 
   ngOnInit(): void {
     this.calculateStatistics();
+    this.getTableData();
   }
 
   ngOnChanges(): void {
     this.calculateStatistics();
-  }
-
-  sortNumericalScaleStatsRowModel(by: SortBy): void {
-    this.teamToRecipientToScoresSortBy = by;
-    this.teamToRecipientToScoresSortOrder =
-      (this.teamToRecipientToScoresSortOrder === SortOrder.DESC) ? SortOrder.ASC : SortOrder.DESC;
-
-    this.numericalScaleStatsRowModel.sort(this.sortStatsRowBy(by, this.teamToRecipientToScoresSortOrder));
-  }
-
-  sortStatsRowBy(by: SortBy, order: SortOrder):
-      ((a: NumericalScaleStatsRowModel, b: NumericalScaleStatsRowModel) => number) {
-
-    return ((a: NumericalScaleStatsRowModel, b: NumericalScaleStatsRowModel): number => {
-      let strA: string;
-      let strB: string;
-
-      switch (by) {
-        case SortBy.TEAM_NAME:
-          strA = a.teamName;
-          strB = b.teamName;
-          break;
-        case SortBy.RECIPIENT_NAME:
-          strA = a.recipientName;
-          strB = b.recipientName;
-          break;
-        case SortBy.NUMERICAL_SCALE_AVERAGE:
-          strA = String(a.average);
-          strB = String(b.average);
-          break;
-        case SortBy.NUMERICAL_SCALE_MAX:
-          strA = String(a.max);
-          strB = String(b.max);
-          break;
-        case SortBy.NUMERICAL_SCALE_MIN:
-          strA = String(a.min);
-          strB = String(b.min);
-          break;
-        case SortBy.NUMERICAL_SCALE_AVERAGE_EXCLUDE_SELF:
-          strA = String(a.averageExceptSelf);
-          strB = String(b.averageExceptSelf);
-          break;
-        default:
-          strA = '';
-          strB = '';
-      }
-
-      return this.tableComparatorService.compare(by, order, strA, strB);
-    });
+    this.getTableData();
   }
 
   private calculateStatistics(): void {
@@ -144,6 +100,29 @@ export class NumScaleQuestionStatisticsComponent
         });
       }
     }
+  }
+
+  private getTableData(): void {
+    this.columnsData = [
+      { header: 'Team', sortBy: SortBy.MCQ_CHOICE },
+      { header: 'Recipient', sortBy: SortBy.MCQ_WEIGHT },
+      { header: 'Average', sortBy: SortBy.MCQ_RESPONSE_COUNT, headerToolTip: 'Average of the visible responses' },
+      { header: 'Max', sortBy: SortBy.MCQ_PERCENTAGE, headerToolTip: 'Maximum of the visible responses' },
+      { header: 'Min', sortBy: SortBy.MCQ_WEIGHTED_PERCENTAGE, headerToolTip: 'Minimum of the visible responses' },
+      { header: 'Average excluding self response', sortBy: SortBy.MCQ_WEIGHTED_PERCENTAGE,
+        headerToolTip: 'Average of the visible responses excluding recipient\'s own response to himself/herself'},
+    ];
+
+    this.rowsData = Object.values(this.numericalScaleStatsRowModel).map((statsRow: NumericalScaleStatsRowModel) => {
+      return [
+        { value: statsRow.teamName },
+        { value: statsRow.recipientName },
+        { value: statsRow.average },
+        { value: statsRow.max },
+        { value: statsRow.min },
+        { value: statsRow.averageExceptSelf },
+      ];
+    });
   }
 
 }

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)">
-        <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
+        <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }} </span>
         <span *ngIf="column.sortBy && columnToSortBy !== column.header"><i class="fas fa-sort"></i></span>
         <span *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
         <span *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)">
-        <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }} </span>
+        <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
         <span *ngIf="column.sortBy && columnToSortBy !== column.header"><i class="fas fa-sort"></i></span>
         <span *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
         <span *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -2,6 +2,6 @@
   cursor: pointer;
 
   i {
-    margin-left: 0.3em;
+    margin-left: .3em;
   }
 }

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -1,3 +1,7 @@
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: 0.3em;
+  }
 }

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -57,16 +57,16 @@ export class TableComparatorService {
       case SortBy.MCQ_RESPONSE_COUNT:
       case SortBy.MCQ_PERCENTAGE:
       case SortBy.MCQ_WEIGHTED_PERCENTAGE:
-      case SortBy.MCQ_NUMBER_SELECTED:
-      case SortBy.MCQ_TOTAL:
-      case SortBy.MCQ_AVERAGE:
+      case SortBy.MCQ_OPTION_SELECTED_TIMES:
+      case SortBy.MCQ_WEIGHT_TOTAL:
+      case SortBy.MCQ_WEIGHT_AVERAGE:
       case SortBy.MSQ_WEIGHT:
       case SortBy.MSQ_RESPONSE_COUNT:
       case SortBy.MSQ_PERCENTAGE:
       case SortBy.MSQ_WEIGHTED_PERCENTAGE:
-      case SortBy.MSQ_NUMBER_SELECTED:
-      case SortBy.MSQ_TOTAL:
-      case SortBy.MSQ_AVERAGE:
+      case SortBy.MSQ_OPTION_SELECTED_TIMES:
+      case SortBy.MSQ_WEIGHT_TOTAL:
+      case SortBy.MSQ_WEIGHT_AVERAGE:
       case SortBy.SECTION_NAME:
       case SortBy.TEAM_NAME:
       case SortBy.SESSION_NAME:

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -57,6 +57,9 @@ export class TableComparatorService {
       case SortBy.MCQ_RESPONSE_COUNT:
       case SortBy.MCQ_PERCENTAGE:
       case SortBy.MCQ_WEIGHTED_PERCENTAGE:
+      case SortBy.MCQ_NUMBER_SELECTED:
+      case SortBy.MCQ_TOTAL:
+      case SortBy.MCQ_AVERAGE:
       case SortBy.MSQ_WEIGHT:
       case SortBy.MSQ_RESPONSE_COUNT:
       case SortBy.MSQ_PERCENTAGE:
@@ -76,6 +79,8 @@ export class TableComparatorService {
       case SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF:
       case SortBy.RANK_OPTIONS_OPTION:
       case SortBy.MCQ_CHOICE:
+      case SortBy.MCQ_TEAM:
+      case SortBy.MCQ_RECIPIENT_NAME:
       case SortBy.MSQ_CHOICE:
       case SortBy.MSQ_TEAM:
       case SortBy.MSQ_RECIPIENT_NAME:

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -57,6 +57,13 @@ export class TableComparatorService {
       case SortBy.MCQ_RESPONSE_COUNT:
       case SortBy.MCQ_PERCENTAGE:
       case SortBy.MCQ_WEIGHTED_PERCENTAGE:
+      case SortBy.MSQ_WEIGHT:
+      case SortBy.MSQ_RESPONSE_COUNT:
+      case SortBy.MSQ_PERCENTAGE:
+      case SortBy.MSQ_WEIGHTED_PERCENTAGE:
+      case SortBy.MSQ_NUMBER_SELECTED:
+      case SortBy.MSQ_TOTAL:
+      case SortBy.MSQ_AVERAGE:
       case SortBy.SECTION_NAME:
       case SortBy.TEAM_NAME:
       case SortBy.SESSION_NAME:
@@ -69,6 +76,9 @@ export class TableComparatorService {
       case SortBy.RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF:
       case SortBy.RANK_OPTIONS_OPTION:
       case SortBy.MCQ_CHOICE:
+      case SortBy.MSQ_CHOICE:
+      case SortBy.MSQ_TEAM:
+      case SortBy.MSQ_RECIPIENT_NAME:
       case SortBy.STUDENT_NAME:
       case SortBy.EMAIL:
       case SortBy.STUDENT_GENDER:

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -168,6 +168,31 @@ export enum SortBy {
     MCQ_WEIGHTED_PERCENTAGE,
 
     /**
+     * Recipient's Team
+     */
+    MCQ_TEAM,
+
+    /**
+     * Recipient's Name
+     */
+    MCQ_RECIPIENT_NAME,
+
+    /**
+     * Number of times option chosen
+     */
+    MCQ_NUMBER_SELECTED,
+
+    /**
+     * Sum of weight of options
+     */
+    MCQ_TOTAL,
+
+    /**
+     * Average of weights
+     */
+    MCQ_AVERAGE,
+
+    /**
      * Option text
      */
     MSQ_CHOICE,

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -180,17 +180,17 @@ export enum SortBy {
     /**
      * Number of times option chosen
      */
-    MCQ_NUMBER_SELECTED,
+    MCQ_OPTION_SELECTED_TIMES,
 
     /**
      * Sum of weight of options
      */
-    MCQ_TOTAL,
+    MCQ_WEIGHT_TOTAL,
 
     /**
      * Average of weights
      */
-    MCQ_AVERAGE,
+    MCQ_WEIGHT_AVERAGE,
 
     /**
      * Option text
@@ -230,17 +230,17 @@ export enum SortBy {
     /**
      * Number of times option chosen
      */
-    MSQ_NUMBER_SELECTED,
+    MSQ_OPTION_SELECTED_TIMES,
 
     /**
      * Sum of weight of options
      */
-    MSQ_TOTAL,
+    MSQ_WEIGHT_TOTAL,
 
     /**
      * Average of weights
      */
-    MSQ_AVERAGE,
+    MSQ_WEIGHT_AVERAGE,
 
     /**
      * Option to rank

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -168,6 +168,56 @@ export enum SortBy {
     MCQ_WEIGHTED_PERCENTAGE,
 
     /**
+     * Option text
+     */
+    MSQ_CHOICE,
+
+    /**
+     * Weight assigned to the option
+     */
+    MSQ_WEIGHT,
+
+    /**
+     * Number of selection of that option
+     */
+    MSQ_RESPONSE_COUNT,
+
+    /**
+     * Percentage of selection of that option
+     */
+    MSQ_PERCENTAGE,
+
+    /**
+     * Weighted percentage of selection of that option
+     */
+    MSQ_WEIGHTED_PERCENTAGE,
+
+    /**
+     * Recipient's Team
+     */
+    MSQ_TEAM,
+
+    /**
+     * Recipient's Name
+     */
+    MSQ_RECIPIENT_NAME,
+
+    /**
+     * Number of times option chosen
+     */
+    MSQ_NUMBER_SELECTED,
+
+    /**
+     * Sum of weight of options
+     */
+    MSQ_TOTAL,
+
+    /**
+     * Average of weights
+     */
+    MSQ_AVERAGE,
+
+    /**
      * Option to rank
      */
     RANK_OPTIONS_OPTION,


### PR DESCRIPTION
Fixes #10155 

- Refactor num scale statistics to use sortable table 
- Add sortable statistic table for MSQ

![msq](https://user-images.githubusercontent.com/32454748/84750244-9cbd8f00-afed-11ea-9198-a14d8018460d.gif)

- Add sortable per recipient statistics table for MCQ

![mcq](https://user-images.githubusercontent.com/32454748/84750722-3f760d80-afee-11ea-8143-a59d2d67b70c.gif)
