### PR TITLE
[#10176] Instructor home page UI fixes

### DIFF
--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -40,6 +40,9 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
   </div><div
     class="course-section"
   >
+    <h3>
+      Active courses
+    </h3>
     <div
       class="table-responsive"
     >
@@ -583,6 +586,9 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
   </div><div
     class="course-section"
   >
+    <h3>
+      Active courses
+    </h3>
     <div
       class="table-responsive"
     >
@@ -1134,6 +1140,9 @@ exports[`InstructorCoursesPageComponent should snap with default fields 1`] = `
   </div><div
     class="course-section"
   >
+    <h3>
+      Active courses
+    </h3>
     <div
       class="table-responsive"
     >
@@ -1270,6 +1279,9 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
   </div><div
     class="course-section"
   >
+    <h3>
+      Active courses
+    </h3>
     <div
       class="table-responsive"
     >

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/__snapshots__/add-course-form.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/__snapshots__/add-course-form.component.spec.ts.snap
@@ -44,7 +44,7 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
           Course ID:
         </label>
         <div
-          class="col-sm-3"
+          class="col-sm-6"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -68,7 +68,7 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
           Course Name:
         </label>
         <div
-          class="col-sm-9"
+          class="col-sm-6"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -92,7 +92,7 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
           Time Zone:
         </label>
         <div
-          class="col-sm-9"
+          class="col-sm-6"
         >
           <div
             class="input-group"
@@ -116,6 +116,7 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
             </select>
             <span
               class="input-group-btn"
+              style="margin-left: 5px;"
             >
               <button
                 class="btn btn-primary"
@@ -189,7 +190,7 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
           Course ID:
         </label>
         <div
-          class="col-sm-3"
+          class="col-sm-6"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -213,7 +214,7 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
           Course Name:
         </label>
         <div
-          class="col-sm-9"
+          class="col-sm-6"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -237,7 +238,7 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
           Time Zone:
         </label>
         <div
-          class="col-sm-9"
+          class="col-sm-6"
         >
           <div
             class="input-group"
@@ -261,6 +262,7 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
             </select>
             <span
               class="input-group-btn"
+              style="margin-left: 5px;"
             >
               <button
                 class="btn btn-primary"

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
@@ -7,7 +7,7 @@
   <div class="card-body">
     <div class="form-group row">
       <label class="col-sm-3 control-label bold-label text-right">Course ID:</label>
-      <div class="col-sm-3">
+      <div class="col-sm-6">
         <input id="new-course-id" class="form-control" type="text" [(ngModel)]="newCourseId"
             ngbTooltip="Enter the identifier of the course, e.g.CS3215-2013Semester1."
             [maxlength]="40" placeholder="e.g. CS3215-2013Semester1"/>
@@ -15,7 +15,7 @@
     </div>
     <div class="form-group row">
       <label class="col-sm-3 control-label bold-label text-right">Course Name:</label>
-      <div class="col-sm-9">
+      <div class="col-sm-6">
         <input id="new-course-name" class="form-control" type="text" [(ngModel)]="newCourseName"
             ngbTooltip="Enter the name of the course, e.g. Software Engineering."
             [maxlength]="64" placeholder="e.g. Software Engineering"/>
@@ -23,14 +23,14 @@
     </div>
     <div class="form-group row">
       <label class="col-sm-3 control-label bold-label text-right">Time Zone:</label>
-      <div class="col-sm-9">
+      <div class="col-sm-6">
         <div class="input-group">
           <select id="new-time-zone" class="form-control" [(ngModel)]="timezone" ngbTooltip="The time zone for the course. You should not
                 need to change this as it is auto-detected based on your device settings. TEAMMATES automatically adjusts
                 to match the current time offset in your area, including clock changes due to daylight saving time.">
             <option *ngFor="let timezone of timezones" [value]="timezone">{{ timezone }}</option>
           </select>
-          <span class="input-group-btn">
+          <span class="input-group-btn" style="margin-left: 5px;">
             <button class="btn btn-primary" (click)="onAutoDetectTimezone()">Auto Detect</button>
           </span>
         </div>

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.scss
@@ -11,3 +11,7 @@
   padding-right: 1.25rem;
   margin-bottom: 0;
 }
+
+.form-group {
+  min-width: 700px;
+}

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -11,6 +11,7 @@
 </div>
 
 <div class="course-section">
+  <h3>Active courses</h3>
   <div class="table-responsive">
     <table id="active-courses-table" class="table table-striped table-bordered margin-0">
       <thead>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
@@ -61,5 +61,9 @@
 }
 
 .table-responsive {
-  overflow: visible;
+  overflow: auto;
+}
+
+.d-inline-block {
+  position: inherit;
 }

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -196,15 +196,17 @@ exports[`InstructorHomePageComponent should snap with one course with error load
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3281]: Thematic Systems
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+             Error loading feedback sessions. Click here to retry. 
             
              Error loading feedback sessions. Click here to retry. 
           </div>
@@ -359,15 +361,25 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3281]: Thematic Systems
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+            <div
+              class="float-right"
+            >
+              
+              
+              <i
+                class="fas fa-chevron-up"
+              />
+            </div>
             
             <div
               class="float-right"
@@ -523,11 +535,6 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   
                 </div>
               </span>
-              
-              
-              <i
-                class="fas fa-chevron-up"
-              />
             </div>
           </div>
         </div>
@@ -931,15 +938,25 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3281]: Thematic Systems
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+            <div
+              class="float-right"
+            >
+              
+              
+              <i
+                class="fas fa-chevron-up"
+              />
+            </div>
             
             <div
               class="float-right"
@@ -1073,11 +1090,6 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   
                 </div>
               </span>
-              
-              
-              <i
-                class="fas fa-chevron-up"
-              />
             </div>
           </div>
         </div>
@@ -1650,15 +1662,25 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3281]: Thematic Systems
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+            <div
+              class="float-right"
+            >
+              
+              <i
+                class="fas fa-chevron-down"
+              />
+              
+            </div>
             
             <div
               class="float-right"
@@ -1814,11 +1836,6 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   
                 </div>
               </span>
-              
-              <i
-                class="fas fa-chevron-down"
-              />
-              
             </div>
           </div>
         </div>
@@ -1952,15 +1969,25 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3281]: Thematic Systems
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+            <div
+              class="float-right"
+            >
+              
+              
+              <i
+                class="fas fa-chevron-up"
+              />
+            </div>
             
             <div
               class="float-right"
@@ -2116,11 +2143,6 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   
                 </div>
               </span>
-              
-              
-              <i
-                class="fas fa-chevron-up"
-              />
             </div>
           </div>
         </div>
@@ -2274,15 +2296,25 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
           class="row"
         >
           <div
-            class="col-6"
+            class="course-header col-md-6"
           >
             <b>
               [CS3243]: Introduction to AI
             </b>
           </div>
           <div
-            class="col-sm-6"
+            class="btn-toolbar col-md-6"
           >
+            
+            <div
+              class="float-right"
+            >
+              
+              
+              <i
+                class="fas fa-chevron-up"
+              />
+            </div>
             
             <div
               class="float-right"
@@ -2438,11 +2470,6 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   
                 </div>
               </span>
-              
-              
-              <i
-                class="fas fa-chevron-up"
-              />
             </div>
           </div>
         </div>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -41,10 +41,14 @@
   <div class="card margin-bottom-15px" *ngFor="let courseTabModel of courseTabModels; let idx = index">
     <div class="card-header bg-primary text-white course-tab-header" (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(courseTabModel);">
       <div class="row">
-        <div class="col-6">
+        <div class="course-header col-md-6">
           <b>[{{ courseTabModel.course.courseId }}]: {{ courseTabModel.course.courseName }}</b>
         </div>
-        <div class="col-sm-6">
+        <div class="btn-toolbar col-md-6">
+            <div class="float-right" *ngIf="courseTabModel.isAjaxSuccess; else errorLoadingFeedbackSessions">
+                <i class="fas fa-chevron-down" *ngIf="!courseTabModel.isTabExpanded"></i>
+                <i class="fas fa-chevron-up" *ngIf="courseTabModel.isTabExpanded"></i>
+            </div>
           <div class="float-right" *ngIf="courseTabModel.isAjaxSuccess; else errorLoadingFeedbackSessions">
             <span ngbDropdown class="padding-right-10px">
               <button class="btn btn-light btn-sm" ngbDropdownToggle> Students </button>
@@ -98,9 +102,6 @@
                 </ng-container>
               </div>
             </span>
-
-            <i class="fas fa-chevron-down" *ngIf="!courseTabModel.isTabExpanded"></i>
-            <i class="fas fa-chevron-up" *ngIf="courseTabModel.isTabExpanded"></i>
           </div>
         </div>
       </div>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -15,13 +15,13 @@
 }
 
 .btn-toolbar {
-    display: inline;
-    white-space: nowrap;
-    margin-top: 5px;
-    margin-bottom: 2px;
+  display: inline;
+  white-space: nowrap;
+  margin-top: 5px;
+  margin-bottom: 2px;
 }
 
 .course-header {
-    display: inline;
-    white-space: nowrap;
+  display: inline;
+  white-space: nowrap;
 }

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -13,3 +13,15 @@
 .padding-right-10px {
   padding-right: 10px;
 }
+
+.btn-toolbar {
+    display: inline;
+    white-space: nowrap;
+    margin-top: 5px;
+    margin-bottom: 2px;
+}
+
+.course-header {
+    display: inline;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Part of #10176 

**Previous snapshot** (mobile)

<img width="482" alt="Screenshot 2020-06-17 at 14 53 19" src="https://user-images.githubusercontent.com/32880438/84865701-39923200-b0ab-11ea-8bb6-e1f21ef7386b.png">

**Current snapshot** (mobile)

<img width="479" alt="Screenshot 2020-06-17 at 14 51 46" src="https://user-images.githubusercontent.com/32880438/84865721-46168a80-b0ab-11ea-8140-fab66ac8dae0.png">

![ezgif-5-5545f12af9e8](https://user-images.githubusercontent.com/32880438/84865748-4ca50200-b0ab-11ea-8879-cf8b873c08df.gif)

**Outline of Solution**
- set header text & button group to be non-break (home page)
- standardise input fields' length (add course form)
- add missing table name (active course table)
- fix course table overflow on mobile screen (active course table)