### PR TITLE
[#10176] UAT Round 1: Fix Instructor Pages UI

### DIFF
--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -7,7 +7,9 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
   questionDetails={[Function Object]}
   questionNumber="0"
 >
-  Question 0: Text question details
+  <b>
+    Question 0:
+  </b> Text question details
   
 </tm-question-text-with-info>
 `;
@@ -19,7 +21,9 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
   questionDetails={[Function Object]}
   questionNumber="0"
 >
-  Question 0: MCQ question details
+  <b>
+    Question 0:
+  </b> MCQ question details
   <a
     href="/"
     ng-reflect-query-params-handling="merge"
@@ -38,7 +42,9 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
   questionDetails={[Function Object]}
   questionNumber="0"
 >
-  Question 0: MCQ question details
+  <b>
+    Question 0:
+  </b> MCQ question details
   <a
     href="/"
     ng-reflect-query-params-handling="merge"

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,4 +1,4 @@
-Question {{ questionNumber }}: {{ questionDetails.questionText }}
+<b>Question {{ questionNumber }}:</b> {{ questionDetails.questionText }}
 <a (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
   [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
 </a>

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.scss
@@ -13,3 +13,7 @@ button {
 label {
   font-weight: bold;
 }
+
+.btn-link:hover {
+  cursor: pointer;
+}

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
@@ -10,56 +10,72 @@
         <div class="col-6">
 
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canModifyCourse"
-                   (ngModelChange)="triggerOverallPermissionChange('canModifyCourse', $event)">
-            Edit/Delete/Restore Course
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canModifyCourse"
+                     (ngModelChange)="triggerOverallPermissionChange('canModifyCourse', $event)">
+              Edit/Delete/Restore Course
+            </label>
           </div>
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canModifyInstructor"
-                   (ngModelChange)="triggerOverallPermissionChange('canModifyInstructor', $event)">
-            Add/Edit/Delete Instructors
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canModifyInstructor"
+                     (ngModelChange)="triggerOverallPermissionChange('canModifyInstructor', $event)">
+              Add/Edit/Delete Instructors
+            </label>
           </div>
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canModifySession"
-                   (ngModelChange)="triggerOverallPermissionChange('canModifySession', $event)">
-            Create/Edit/Delete/Restore Sessions
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canModifySession"
+                     (ngModelChange)="triggerOverallPermissionChange('canModifySession', $event)">
+              Create/Edit/Delete/Restore Sessions
+            </label>
           </div>
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canModifyStudent"
-                   (ngModelChange)="triggerOverallPermissionChange('canModifyStudent', $event)">
-            Enroll/Edit/Delete Students
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canModifyStudent"
+                     (ngModelChange)="triggerOverallPermissionChange('canModifyStudent', $event)">
+              Enroll/Edit/Delete Students
+            </label>
           </div>
           <hr/>
         </div>
         <div class="col-6">
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canViewStudentInSections"
-                   (ngModelChange)="triggerOverallPermissionChange('canViewStudentInSections', $event)">
-            View Students' Details
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canViewStudentInSections"
+                     (ngModelChange)="triggerOverallPermissionChange('canViewStudentInSections', $event)">
+              View Students' Details
+            </label>
           </div>
 
           <hr/>
 
           <div class="col-12">
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canSubmitSessionInSections"
-                   (ngModelChange)="triggerOverallPermissionChange('canSubmitSessionInSections', $event)">
-            Sessions: Submit Responses and Add Comments
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canSubmitSessionInSections"
+                     (ngModelChange)="triggerOverallPermissionChange('canSubmitSessionInSections', $event)">
+              Sessions: Submit Responses and Add Comments
+            </label>
             <br>
-            <input type="checkbox" [disabled]="permission.privilege.canModifySessionCommentsInSections"
-                   [ngModel]="permission.privilege.canViewSessionInSections || permission.privilege.canModifySessionCommentsInSections"
-                   (ngModelChange)="triggerOverallPermissionChange('canViewSessionInSections', $event)">
-            Sessions: View Responses and Comments
+            <label>
+              <input type="checkbox" [disabled]="permission.privilege.canModifySessionCommentsInSections"
+                     [ngModel]="permission.privilege.canViewSessionInSections || permission.privilege.canModifySessionCommentsInSections"
+                     (ngModelChange)="triggerOverallPermissionChange('canViewSessionInSections', $event)">
+              Sessions: View Responses and Comments
+            </label>
             <br>
-            <input type="checkbox"
-                   [ngModel]="permission.privilege.canModifySessionCommentsInSections"
-                   (ngModelChange)="triggerOverallPermissionChange('canModifySessionCommentsInSections', $event)">
-            Sessions: Edit/Delete Responses/Comments by Others
+            <label>
+              <input type="checkbox"
+                     [ngModel]="permission.privilege.canModifySessionCommentsInSections"
+                     (ngModelChange)="triggerOverallPermissionChange('canModifySessionCommentsInSections', $event)">
+              Sessions: Edit/Delete Responses/Comments by Others
+            </label>
             <br>
           </div>
         </div>
@@ -79,10 +95,12 @@
         </div>
         <div id="custom-sections" class="col-sm-9">
           <div *ngFor="let section of this.allSections">
-            <input type="checkbox" [ngModel]="sectionLevel.sectionNames.includes(section)"
-                   (ngModelChange)="editSectionToSectionLevelPermission(i, section, $event)"
-                   [disabled]="!sectionLevel.sectionNames.includes(section) && hasSectionLevelPermission(section)">
-            {{ section }}
+            <label>
+              <input type="checkbox" [ngModel]="sectionLevel.sectionNames.includes(section)"
+                     (ngModelChange)="editSectionToSectionLevelPermission(i, section, $event)"
+                     [disabled]="!sectionLevel.sectionNames.includes(section) && hasSectionLevelPermission(section)">
+              {{ section }}
+            </label>
           </div>
         </div>
         <div class="col-sm-1">
@@ -101,27 +119,35 @@
     <div id="custom-sections-access-levels"  class="card-body">
       <div class="row">
         <div class="col-6">
-          <input type="checkbox"
-                 [ngModel]="sectionLevel.privilege.canViewStudentInSections"
-                 (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canViewStudentInSections', $event)">&nbsp;
-          <span>View Students' Details</span>
+          <label>
+            <input type="checkbox"
+                   [ngModel]="sectionLevel.privilege.canViewStudentInSections"
+                   (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canViewStudentInSections', $event)">&nbsp;
+            View Students' Details
+          </label>
           <hr/>
         </div>
         <div class="col-6">
-          <input type="checkbox"
-                 [ngModel]="sectionLevel.privilege.canSubmitSessionInSections"
-                 (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canSubmitSessionInSections', $event)">&nbsp;
-          <span>Sessions: Submit Responses and Add Comments</span>
+          <label>
+            <input type="checkbox"
+                   [ngModel]="sectionLevel.privilege.canSubmitSessionInSections"
+                   (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canSubmitSessionInSections', $event)">&nbsp;
+            Sessions: Submit Responses and Add Comments
+          </label>
           <br>
-          <input type="checkbox" [disabled]="sectionLevel.privilege.canModifySessionCommentsInSections"
-                 [ngModel]="sectionLevel.privilege.canViewSessionInSections || sectionLevel.privilege.canModifySessionCommentsInSections"
-                 (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canViewSessionInSections', $event)">&nbsp;
-          <span>Sessions: View Responses and Comments</span>
+          <label>
+            <input type="checkbox" [disabled]="sectionLevel.privilege.canModifySessionCommentsInSections"
+                   [ngModel]="sectionLevel.privilege.canViewSessionInSections || sectionLevel.privilege.canModifySessionCommentsInSections"
+                   (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canViewSessionInSections', $event)">&nbsp;
+            Sessions: View Responses and Comments
+          </label>
           <br>
-          <input type="checkbox"
-                 [ngModel]="sectionLevel.privilege.canModifySessionCommentsInSections"
-                 (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canModifySessionCommentsInSections', $event)">&nbsp;
-          <span>Sessions: Edit/Delete Responses/Comments by Others</span>
+          <label>
+            <input type="checkbox"
+                   [ngModel]="sectionLevel.privilege.canModifySessionCommentsInSections"
+                   (ngModelChange)="triggerSectionLevelPermissionChange(i, 'canModifySessionCommentsInSections', $event)">&nbsp;
+            Sessions: Edit/Delete Responses/Comments by Others
+          </label>
           <br>
         </div>
       </div>
@@ -166,6 +192,8 @@
   </div>
 
   <button id="btn-add-section-level" class="btn btn-link" (click)="addSectionLevelPermission()"
-          [disabled]="hasSectionLevelPermissionForAllSections">Give different permissions for a specific section</button>
+          [disabled]="hasSectionLevelPermissionForAllSections">
+    Give different permissions for a specific section
+  </button>
 
 </div>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
@@ -78,9 +78,10 @@ export class CustomPrivilegeSettingPanelComponent implements OnInit {
    * Checks whether there is section level permission for all sections.
    */
   get hasSectionLevelPermissionForAllSections(): boolean {
-    return this.permission.sectionLevel
-        .map((sectionLevel: InstructorSectionLevelPermission) => sectionLevel.sectionNames.length)
-        .reduce((prev: number, curr: number) => prev + curr, 0) === this.allSections.length;
+    return this.permission.sectionLevel.length >= this.allSections.length
+        || this.permission.sectionLevel
+            .map((section: InstructorSectionLevelPermission) => section.sectionNames.length)
+            .reduce((prev: number, curr: number) => prev + curr, 0) >= this.allSections.length;
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
@@ -84,9 +84,11 @@
       </label>
       <div id="access-levels-instructor-{{ instructorIndex + 1 }}" class="col-sm-9">
         <div *ngFor="let role of InstructorPermissionRole | enumToArray">
-          <input type="radio" [checked]="role == instructor.role" (click)="triggerModelChange('role', role)" [disabled]="!instructor.isEditing">
-          {{ role | instructorRoleDescription }}
-          <br/><button *ngIf="role != InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
+          <label>
+            <input id="{{role + instructorIndex + 1}}" type="radio" [checked]="role == instructor.role" (click)="triggerModelChange('role', role)" [disabled]="!instructor.isEditing">
+            {{ role | instructorRoleDescription }}
+          </label>
+          <button *ngIf="role != InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
                   (click)="viewRolePrivilegeModel.emit(role)" type="button" class="btn btn-secondary btn-sm btn-block mb-3">View Details</button>
         </div>
       </div>

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -1138,103 +1138,10 @@ exports[`InstructorCoursesPageComponent should snap with default fields 1`] = `
   >
     <tm-add-course-form />
   </div><div
-    class="course-section"
+    class="alert alert-warning margin-top-30px"
+    role="alert"
   >
-    <h3>
-      Active courses
-    </h3>
-    <div
-      class="table-responsive"
-    >
-      <table
-        class="table table-striped table-bordered margin-0"
-        id="active-courses-table"
-      >
-        <thead>
-          <tr
-            class="bg-primary text-white"
-          >
-            <th
-              class="sortable-header"
-              id="sort-course-id"
-            >
-               Course ID 
-              
-              <span>
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
-              
-              
-            </th>
-            <th
-              class="sortable-header"
-              id="sort-course-name"
-            >
-               Course Name 
-              
-              <span>
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
-              
-              
-            </th>
-            <th
-              class="sortable-header"
-              id="sort-creation-date"
-            >
-               Creation Date 
-              
-              <span>
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
-              
-              
-            </th>
-            <th>
-              Sections
-            </th>
-            <th>
-              Teams
-            </th>
-            <th>
-              Total Students
-            </th>
-            <th>
-              Total Unregistered
-            </th>
-            <th
-              class="text-center"
-            >
-              Action(s)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          
-        </tbody>
-        
-        <tr>
-          <td />
-          <td />
-          <td />
-          <td />
-          <td />
-          <td />
-          <td />
-          <td />
-        </tr>
-      </table>
-      
-      <p>
-        No records found.
-      </p>
-    </div>
+     You do not seem to have any active courses. Use the button above to create a new course. 
   </div>
 </tm-instructor-courses-page>
 `;

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -10,7 +10,13 @@
   ></tm-add-course-form>
 </div>
 
-<div class="course-section">
+<ng-template #addCourseAlert>
+  <div class="alert alert-warning margin-top-30px" role="alert">
+    You do not seem to have any active courses. Use the button above to create a new course.
+  </div>
+</ng-template>
+
+<div class="course-section" *ngIf="activeCourses.length; else addCourseAlert;">
   <div class="table-responsive">
     <table id="active-courses-table" class="table table-striped table-bordered margin-0">
       <thead>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -55,7 +55,7 @@
     <div class="col-md-6">
       <div ngbTooltip="View results in different formats">
         <label class="control-label">
-          View:
+          <b>View:</b>
         </label>
         <div>
           <select class="form-control" [ngModel]="viewType" (ngModelChange)="handleViewTypeChange($event)">
@@ -68,8 +68,8 @@
         </div>
       </div>
       <div ngbTooltip="View results by sections">
-        <label class="control-label">
-          Section:
+        <label class="control-label mt-md-1">
+          <b>Section:</b>
         </label>
         <div>
           <select class="form-control" [(ngModel)]="section">

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
@@ -1,5 +1,5 @@
 <a routerLink="/web/student/sessions/submission"
    [queryParams]="{courseid: session.courseId, fsname: session.feedbackSessionName, moderatedperson: relatedGiverEmail, moderatedquestionId: moderatedQuestionId}"
-   class="btn btn-light btn-sm button">
+   class="btn btn-light btn-sm btn-border">
   Moderate response
 </a>

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.scss
@@ -1,0 +1,3 @@
+.btn-border {
+  border: 1px solid #CCC;
+}


### PR DESCRIPTION
Part of #10176

**Outline of Solution**
- Add bold tags where necessary
- Add label tags for checkboxes/radio buttons
- Add css styling for `Moderate Response` button

**Instructor Course Page Fix**
- Course page table should not show when instructors has no courses available to him. Currently, the headers are shown

![Capture](https://user-images.githubusercontent.com/28994607/85007853-afbb9500-b18e-11ea-90f8-6e3f9cdaee5f.PNG)

**Instructor Edit Course Details Page Fix**
- Edit course details allows users to click on the Give different permissions for a specific section infinitely
- In edit course details page, labels for checkboxes are not clickable, only the checkboxes are clickable

![dfdf](https://user-images.githubusercontent.com/28994607/85007857-b0ecc200-b18e-11ea-99b1-ad930b842cb6.gif)

**Instructor View Course Details Page Fix**
- In view course details page, the non-english characters not displayed properly does not change cursor to pointer when hovering above it

![651](https://user-images.githubusercontent.com/28994607/85007863-b2b68580-b18e-11ea-9b9e-4e2f0ea8503b.gif)

**Instructor View Results Page Fix**
- Second information panel View: and Section: not bold
- Moderate Response button does not stand out as a button. Could do with a border or change of colour 
- Question number and the question word should be bolded in each question tab

![asd](https://user-images.githubusercontent.com/28994607/85007868-b3e7b280-b18e-11ea-9eab-c23a3d0beae8.PNG)
