### PR TITLE
[#10176] Instructor Session Result Page fixes

### DIFF
--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="responsesToShow.length">
   <table class="table">
     <thead>
-      <tr>
+      <tr class="header">
         <th class="sortable-header" (click)="sortResponses(SortBy.GIVER_TEAM)" *ngIf="showGiver">
           Team
           <span *ngIf="sortBy !== SortBy.GIVER_TEAM"><i class="fas fa-sort"></i></span>
@@ -55,7 +55,7 @@
         </td>
         <td>
           <tm-response-moderation-button *ngIf="response.relatedGiverEmail" [session]="session" [relatedGiverEmail]="response.relatedGiverEmail" [moderatedQuestionId]="question.feedbackQuestionId"></tm-response-moderation-button>
-          <button class="btn btn-light btn-sm" style="margin-left:5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
+          <button class="btn btn-light btn-sm" style="margin-left:5px; margin-top:5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
                   *ngIf="!response.isMissingResponse"
                   (click)="showCommentTableModel(response, commentTableModal)">Add Comment <span class="badge badge-secondary">
             {{this.instructorCommentTableModel[response.responseId].commentRows.length}}</span>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
@@ -1,5 +1,6 @@
 .sortable-header {
   cursor: pointer;
+  min-width: 120px;
 }
 
 .color-neutral {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -55,7 +55,7 @@
     <div class="col-md-6">
       <div ngbTooltip="View results in different formats">
         <label class="control-label">
-          View:
+          <b>View:</b>
         </label>
         <div>
           <select class="form-control" [ngModel]="viewType" (ngModelChange)="handleViewTypeChange($event)">
@@ -67,9 +67,9 @@
           </select>
         </div>
       </div>
-      <div ngbTooltip="View results by sections">
+      <div ngbTooltip="View results by sections" style="margin-top: 10px;">
         <label class="control-label">
-          Section:
+          <b>Section:</b>
         </label>
         <div>
           <select class="form-control" [(ngModel)]="section">
@@ -101,9 +101,9 @@
         </div>
       </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" style="margin-top: 10px;">
       <label class="control-label">
-        Additional settings:
+        <b>Additional settings:</b>
       </label>
       <div>
         <label class="form-check-label" ngbTooltip="Group results in the current view by team"><input type="checkbox" [(ngModel)]="groupByTeam" [disabled]="viewType === 'QUESTION'"> Group by Teams</label>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -4,24 +4,24 @@
 
 <div class="card bg-light top-padded" *ngIf="session">
   <div class="card-body row" style="padding: 40px;">
-    <div class="col-sm-4 col-lg-4">
+    <div class="col-sm-12 col-md-12 col-lg-4">
       <div class="form-group row">
-        <label class="col-lg-4 control-label">Course ID:</label>
+        <label class="col-lg-4 control-label"><b>Course ID:</b></label>
         <div class="col-lg-8">
           <p class="form-control-static">{{ session.courseId }}</p>
         </div>
       </div>
       <div class="form-group row">
-        <label class="col-lg-4 control-label">Session:</label>
+        <label class="col-lg-4 control-label"><b>Session:</b></label>
         <div class="col-lg-8">
           <p class="form-control-static">{{ session.feedbackSessionName }}</p>
           <!-- TODO session edit link -->
         </div>
       </div>
     </div>
-    <div class="col-sm-6 col-lg-6">
+    <div class="col-sm-12 col-md-12 col-lg-5">
       <div class="form-group row">
-      <label class="col-lg-4 control-label">Session duration:</label>
+      <label class="col-lg-4 control-label"><b>Session duration:</b></label>
         <div class="col-lg-8">
           <p class="form-control-static">{{ formattedSessionOpeningTime }}&nbsp;&nbsp;&nbsp;<b>to</b>&nbsp;&nbsp;&nbsp;{{ formattedSessionClosingTime }}</p>
         </div>
@@ -35,7 +35,7 @@
         </div>
       </div> -->
     </div>
-    <div class="col-sm-2 col-lg-2">
+    <div class="action-btn-group col-sm-12 col-md-12 col-lg-3">
       <button class="btn btn-primary action-btn" ngbTooltip="{{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED? 'Make responses no longer visible': 'Make session responses available for viewing' }}"
          placement="top" (click)="publishResultHandler()">
         {{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED? "Unpublish": "Publish"}} Results

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
@@ -5,6 +5,7 @@
 .action-btn {
   margin-bottom: 15px;
   width: 100%;
+  white-space: nowrap;
 }
 
 .expand-btn {
@@ -15,4 +16,8 @@
   .action-btn {
     display: none;
   }
+}
+
+.action-btn-group {
+  max-width: 600px;
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -8,22 +8,23 @@
   </div>
   <div class="card-body" *ngIf="question.isTabExpanded">
     <div class="stats-table">
-    <tm-single-statistics *ngIf="showStatistics"
-                          [question]="question.question.questionDetails"
-                          [statistics]="question.statistics"
-                          [responses]="question.responses"
-                          [recipientType]="question.question.recipientType"
-    ></tm-single-statistics>
+      <tm-single-statistics *ngIf="showStatistics"
+                            [question]="question.question.questionDetails"
+                            [statistics]="question.statistics"
+                            [responses]="question.responses"
+                            [recipientType]="question.question.recipientType"
+      ></tm-single-statistics>
     </div>
     <div class="stats-table">
-    <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
-                                    [indicateMissingResponses]="indicateMissingResponses" [question]="question.question"
-                                    [isDisplayOnly]="isDisplayOnly"
-                                    [instructorCommentTableModel]="instructorCommentTableModel"
-                                    (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                    (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                    (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                    (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"></tm-per-question-view-responses>
+      <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
+                                      [indicateMissingResponses]="indicateMissingResponses" [question]="question.question"
+                                      [isDisplayOnly]="isDisplayOnly"
+                                      [instructorCommentTableModel]="instructorCommentTableModel"
+                                      (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                      (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                      (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                      (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+      ></tm-per-question-view-responses>
   </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -7,12 +7,15 @@
     </div>
   </div>
   <div class="card-body" *ngIf="question.isTabExpanded">
+    <div class="stats-table">
     <tm-single-statistics *ngIf="showStatistics"
                           [question]="question.question.questionDetails"
                           [statistics]="question.statistics"
                           [responses]="question.responses"
                           [recipientType]="question.question.recipientType"
     ></tm-single-statistics>
+    </div>
+    <div class="stats-table">
     <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
                                     [indicateMissingResponses]="indicateMissingResponses" [question]="question.question"
                                     [isDisplayOnly]="isDisplayOnly"
@@ -21,5 +24,6 @@
                                     (updateCommentEvent)="triggerUpdateCommentEvent($event)"
                                     (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
                                     (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"></tm-per-question-view-responses>
+  </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.scss
@@ -7,3 +7,13 @@
 .card-header {
   cursor: pointer;
 }
+
+.card-body {
+  width: inherit;
+  display: inline-block;
+  overflow-x: auto;
+}
+
+.stats-table {
+  min-width: 800px;
+}


### PR DESCRIPTION
Part of #10176 

**Previous snapshot** (mobile)

<img width="471" alt="prev-header" src="https://user-images.githubusercontent.com/32880438/85009034-610efa80-b190-11ea-9bbd-39156a1f8ff7.png">

<img width="466" alt="prev-table" src="https://user-images.githubusercontent.com/32880438/85009058-68360880-b190-11ea-93ac-b8c1270cecbc.png">

**Current snapshot** (mobile)

<img width="475" alt="post-header" src="https://user-images.githubusercontent.com/32880438/85009106-7be16f00-b190-11ea-9431-1f8a8611c564.png">

![post-table](https://user-images.githubusercontent.com/32880438/85009132-88fe5e00-b190-11ea-9339-29d6235b51f1.gif)


**Outline of Solution**
- fixed action buttons alignment in all screens
- bold all headers in the page and improve necessary spacing
- fix sortable table header alignment by giving min width and add horizontal scroll for overflow