### PR TITLE
[#10213] Remove Angular Material

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1004,14 +1004,6 @@
       "integrity": "sha512-7EhN9JJbAJcH2xCa+rIOmekjiEuB0qwPdHuD5qn/wwMfRzMZo+Db4hHbR9KHrLH6H82PTwYKye/LLpDaZqoHOA==",
       "dev": true
     },
-    "@angular/material": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-8.2.3.tgz",
-      "integrity": "sha512-SOczkIaqes+r+9XF/UUiokidfFKBpHkOPIaFK857sFD0FBNPvPEpOr5oHKCG3feERRwAFqHS7Wo2ohVEWypb5A==",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
-    },
     "@angular/platform-browser": {
       "version": "8.2.14",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.14.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@angular/compiler": "~8.2.14",
     "@angular/core": "~8.2.14",
     "@angular/forms": "~8.2.14",
-    "@angular/material": "^8.2.3",
     "@angular/platform-browser": "~8.2.14",
     "@angular/platform-browser-dynamic": "~8.2.14",
     "@angular/pwa": "~0.803.22",

--- a/src/e2e/java/teammates/e2e/cases/e2e/AdminSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/AdminSearchPageE2ETest.java
@@ -35,7 +35,7 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
         loginAdminToPage(url, AdminHomePage.class);
         searchPage = AppPage.getNewPageInstance(browser, url, AdminSearchPage.class);
 
-        browser.waitForPageLoad();
+        searchPage.waitForPageToLoad();
         StudentAttributes student = testData.students.get("student1InCourse1");
         AccountAttributes studentAccount = testData.accounts.get("student1InCourse1");
         InstructorAttributes instructor = testData.instructors.get("instructor1OfCourse1");
@@ -60,6 +60,7 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
 
         searchPage.regenerateLinksForStudent(student);
         verifyRegenerateStudentCourseLinks(studentRow, originalJoinLink);
+        searchPage.waitForPageToLoad();
 
         ______TS("Typical case: Search for instructor email");
         searchPage.clearSearchBox();

--- a/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEditPageE2ETest.java
@@ -93,6 +93,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS, true);
 
         editPage.editInstructor(1, instructors[0]);
+        editPage.waitForPageToLoad();
         editPage.toggleCustomCourseLevelPrivilege(1, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
         editPage.toggleCustomCourseLevelPrivilege(1, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT);
         editPage.toggleCustomSectionLevelPrivilege(1, 1, "Section 2",

--- a/src/e2e/java/teammates/e2e/cases/e2e/StudentProfilePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/StudentProfilePageE2ETest.java
@@ -47,9 +47,9 @@ public class StudentProfilePageE2ETest extends BaseE2ETestCase {
         ______TS("Typical case: edit profile page");
         profilePage.editProfileThroughUi("short.name", "e@email.tmt", "inst", "American",
                 StudentProfileAttributes.Gender.FEMALE, "this is enough!$%&*</>");
+        profilePage.verifyStatusMessage(Const.StatusMessages.STUDENT_PROFILE_EDITED);
 
         profilePage.ensureProfileContains("short.name", "e@email.tmt", "inst", "American",
                 StudentProfileAttributes.Gender.FEMALE, "this is enough!$%&*</>");
-        profilePage.verifyStatusMessage(Const.StatusMessages.STUDENT_PROFILE_EDITED);
     }
 }

--- a/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
@@ -84,7 +84,7 @@ public class AdminSearchPage extends AppPage {
         waitForPageToLoad();
 
         regenerateLinksModal.findElement(By.className("btn-warning")).click();
-        waitForPageToLoad();
+        waitForPageToLoad(true);
     }
 
     public void clickExpandStudentLinks() {

--- a/src/e2e/java/teammates/e2e/pageobjects/Browser.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/Browser.java
@@ -77,9 +77,21 @@ public class Browser {
      * Waits for the page to load. This includes all AJAX requests and Angular animations in the page.
      */
     public void waitForPageLoad() {
+        waitForPageLoad(false);
+    }
+
+    /**
+     * Waits for the page to load. This includes all AJAX requests and Angular animations in the page.
+     *
+     * @param excludeToast Set this to true if toast message's disappearance should not be counted
+     *         as criteria for page load's completion.
+     */
+    public void waitForPageLoad(boolean excludeToast) {
         WebDriverWait wait = new WebDriverWait(driver, TestProperties.TEST_TIMEOUT);
         wait.until(driver -> {
-            return "complete".equals(((JavascriptExecutor) driver).executeAsyncScript(PAGE_LOAD_SCRIPT));
+            return "complete".equals(
+                    ((JavascriptExecutor) driver).executeAsyncScript(PAGE_LOAD_SCRIPT, excludeToast ? 1 : 0)
+            );
         });
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -307,7 +307,7 @@ public class InstructorCourseEditPage extends AppPage {
 
     private void clickSaveInstructorButton(int instrNum) {
         click(getSaveInstructorButton(instrNum));
-        waitForPageToLoad();
+        waitForPageToLoad(true);
     }
 
     private void clickAddSectionPrivilegeLink(int instrNum) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
@@ -7,7 +7,6 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -127,26 +126,14 @@ public class InstructorCoursesPage extends AppPage {
         assertEquals(expectedNum, getDeletedCourseCount());
     }
 
-    public void verifyStatusMessageWithLinks(String expected, String[] expectedLinks) {
-        WebElement statusMessage = browser.driver.findElement(By.className("mat-snack-bar-container"));
-        assertEquals(expected, statusMessage.getText());
-
-        List<WebElement> actualLinks = statusMessage.findElements(By.tagName("a"));
-        for (int i = 0; i < expectedLinks.length; i++) {
-            assertTrue(actualLinks.get(i).getAttribute("href").contains(expectedLinks[i]));
-        }
-    }
-
     public void addCourse(CourseAttributes newCourse) {
         click(addCourseButton);
 
         fillTextBox(courseIdTextBox, newCourse.getId());
         fillTextBox(courseNameTextBox, newCourse.getName());
         selectNewTimeZone(newCourse.getTimeZone().toString());
-        waitForPageToLoad();
 
         click(submitButton);
-        waitForElementPresence(By.className("mat-snack-bar-container"));
     }
 
     public void showStatistics(String courseId) {
@@ -230,17 +217,14 @@ public class InstructorCoursesPage extends AppPage {
 
     public void sortByCourseName() {
         click(sortByCourseNameIcon);
-        waitForPageToLoad();
     }
 
     public void sortByCourseId() {
         click(sortByCourseIdIcon);
-        waitForPageToLoad();
     }
 
     public void sortByCreationDate() {
         click(sortByCreationDateIcon);
-        waitForPageToLoad();
     }
 
     private WebElement getActiveTableRow(String courseId) {

--- a/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
@@ -76,7 +76,7 @@ public class StudentProfilePage extends AppPage {
     private StudentProfilePage submitEditedProfile() {
         click(saveProfileButton);
         waitForConfirmationModalAndClickOk();
-        waitForPageToLoad();
+        waitForPageToLoad(true);
         return changePageType(StudentProfilePage.class);
     }
 
@@ -128,7 +128,7 @@ public class StudentProfilePage extends AppPage {
 
     public void uploadPicture() {
         click(uploadPictureSubmit);
-        waitForPageToLoad();
+        waitForPageToLoad(true);
     }
 
     public void editProfilePhoto() {

--- a/src/e2e/resources/scripts/waitForPageLoad.js
+++ b/src/e2e/resources/scripts/waitForPageLoad.js
@@ -1,3 +1,4 @@
+var numOfTestabilityToRemain = arguments[0];
 var callback = arguments[arguments.length - 1];
 if (document.readyState !== 'complete') {
   callback('document not ready');
@@ -8,12 +9,12 @@ if (document.readyState !== 'complete') {
     }
     var testabilities = window.getAllAngularTestabilities();
     var count = testabilities.length;
-    if (count === 0) {
+    if (count <= numOfTestabilityToRemain) {
       callback('complete');
     }
     var decrement = function () {
       count--;
-      if (count === 0) {
+      if (count <= numOfTestabilityToRemain) {
         callback('complete');
       }
     };

--- a/src/web/app/app.module.ts
+++ b/src/web/app/app.module.ts
@@ -1,6 +1,5 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule, Routes } from '@angular/router';
@@ -32,7 +31,6 @@ const routes: Routes = [
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    MatSnackBarModule,
     HttpClientModule,
     NgbModule,
     RouterModule.forRoot(routes),

--- a/src/web/app/components/loader-bar/loader-bar.component.html
+++ b/src/web/app/components/loader-bar/loader-bar.component.html
@@ -1,3 +1,3 @@
 <div class="loader-bar-visible" *ngIf="isShown">
-  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  <ngb-progressbar type="info" [value]="100" [striped]="true" [animated]="true"></ngb-progressbar>
 </div>

--- a/src/web/app/components/loader-bar/loader-bar.component.scss
+++ b/src/web/app/components/loader-bar/loader-bar.component.scss
@@ -7,11 +7,8 @@
 }
 
 /* stylelint-disable selector-pseudo-element-no-unknown */
-::ng-deep .mat-progress-bar-fill::after {
-  background-color: #007BFF;
-}
-
-::ng-deep .mat-progress-bar-buffer {
-  background: #E4E8EB;
+::ng-deep .progress {
+  border-radius: 0;
+  height: .25rem;
 }
 /* stylelint-enable */

--- a/src/web/app/components/loader-bar/loader-bar.component.spec.ts
+++ b/src/web/app/components/loader-bar/loader-bar.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatProgressBarModule } from '@angular/material';
+import { NgbProgressbarModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { LoaderBarComponent } from './loader-bar.component';
 
@@ -10,7 +10,7 @@ describe('LoaderBarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [LoaderBarComponent],
-      imports: [MatProgressBarModule],
+      imports: [NgbProgressbarModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/loader-bar/loader-bar.module.ts
+++ b/src/web/app/components/loader-bar/loader-bar.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatProgressBarModule } from '@angular/material';
+import { NgbProgressbarModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarComponent } from './loader-bar.component';
 
 /**
@@ -9,7 +9,7 @@ import { LoaderBarComponent } from './loader-bar.component';
 @NgModule({
   declarations: [LoaderBarComponent],
   imports: [
-    MatProgressBarModule,
+    NgbProgressbarModule,
     CommonModule,
   ],
   exports: [

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.spec.ts
@@ -2,7 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { ConstsumOptionsFieldComponent } from './constsum-options-field/constsum-options-field.component';
 import {
   ConstsumOptionsQuestionEditDetailsFormComponent,
@@ -16,7 +15,6 @@ describe('ConstsumOptionsQuestionEditDetailsFormComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
-        MatSnackBarModule,
         DragDropModule,
       ],
       declarations: [

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
@@ -66,7 +66,7 @@ export class ConstsumOptionsQuestionEditDetailsFormComponent
    */
   onConstsumOptionDeleted(event: number): void {
     if (this.model.constSumOptions.length <= 2) {
-      this.statusMessageService.showErrorMessage('There must be at least one option.');
+      this.statusMessageService.showErrorToast('There must be at least one option.');
       return;
     }
 

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { OptionRichTextEditorModule } from '../option-rich-text-editor/option-rich-text-editor.module';
 import { McqFieldComponent } from './mcq-field.component';
 
@@ -14,7 +13,6 @@ describe('McqFieldComponent', () => {
       declarations: [McqFieldComponent],
       imports: [
         FormsModule,
-        MatSnackBarModule,
         OptionRichTextEditorModule,
       ],
     })

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.ts
@@ -38,7 +38,7 @@ export class McqFieldComponent {
     if (this.numberOfMcqChoices > 2) {
       this.elementDeleted.emit(this.index);
     } else {
-      this.statusMessageService.showErrorMessage('There must be at least two Mcq options.');
+      this.statusMessageService.showErrorToast('There must be at least two Mcq options.');
     }
   }
 

--- a/src/web/app/components/question-types/question-edit-details-form/msq-field/msq-field.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-field/msq-field.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { MsqFieldComponent } from './msq-field.component';
 
 describe('MsqFieldComponent', () => {
@@ -13,7 +12,6 @@ describe('MsqFieldComponent', () => {
       declarations: [MsqFieldComponent],
       imports: [
         FormsModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/question-types/question-edit-details-form/msq-field/msq-field.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-field/msq-field.component.ts
@@ -38,7 +38,7 @@ export class MsqFieldComponent {
     if (this.numberOfMsqChoices > 2) {
       this.elementDeleted.emit(this.index);
     } else {
-      this.statusMessageService.showErrorMessage('There must be at least two Msq options.');
+      this.statusMessageService.showErrorToast('There must be at least two Msq options.');
     }
   }
 

--- a/src/web/app/components/question-types/question-edit-details-form/rank-options-field/rank-options-field.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/rank-options-field/rank-options-field.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RankOptionsFieldComponent } from './rank-options-field.component';
 
 describe('RankOptionsFieldComponent', () => {
@@ -13,7 +12,6 @@ describe('RankOptionsFieldComponent', () => {
       declarations: [RankOptionsFieldComponent],
       imports: [
         FormsModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/question-types/question-edit-details-form/rank-options-field/rank-options-field.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/rank-options-field/rank-options-field.component.ts
@@ -45,7 +45,7 @@ export class RankOptionsFieldComponent {
     if (this.numberOfRankChoices > 2) {
       this.elementDeleted.emit(this.index);
     } else {
-      this.statusMessageService.showErrorMessage('There must be at least two Rank options.');
+      this.statusMessageService.showErrorToast('There must be at least two Rank options.');
     }
   }
 

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { SessionEditFormComponent } from './session-edit-form.component';
 import { SessionEditFormModule } from './session-edit-form.module';
 
@@ -14,7 +13,6 @@ describe('SessionEditFormComponent', () => {
       imports: [
         SessionEditFormModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/sessions-table/resend-results-link-to-student-modal/resend-results-link-to-student-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/resend-results-link-to-student-modal/resend-results-link-to-student-modal.component.spec.ts
@@ -3,8 +3,6 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-
-import { MatSnackBarModule } from '@angular/material';
 import { StudentListInfoTableComponent } from '../student-list-info-table/student-list-info-table.component';
 import { ResendResultsLinkToStudentModalComponent } from './resend-results-link-to-student-modal.component';
 
@@ -25,7 +23,6 @@ describe('ResendResultsLinkToStudentModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         FormsModule,
-        MatSnackBarModule,
       ],
       providers: [NgbActiveModal],
     })

--- a/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.spec.ts
@@ -3,7 +3,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { StudentListInfoTableComponent } from '../student-list-info-table/student-list-info-table.component';
 import { SendRemindersToStudentModalComponent } from './send-reminders-to-student-modal.component';
@@ -25,7 +24,6 @@ describe('SendRemindersToStudentModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         FormsModule,
-        MatSnackBarModule,
       ],
       providers: [NgbActiveModal],
     })

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { JoinState } from '../../../types/api-output';
@@ -19,7 +18,6 @@ describe('StudentListComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
-        MatSnackBarModule,
         TeammatesCommonModule,
       ],
     })

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -95,7 +95,7 @@ export class StudentListComponent implements OnInit {
         this.navigationService.navigateWithSuccessMessage(this.router,
             `/web/instructor/courses/details?courseid=${this.courseId}`, resp.message);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 

--- a/src/web/app/components/toast/toast.component.html
+++ b/src/web/app/components/toast/toast.component.html
@@ -1,0 +1,6 @@
+<ngb-toast *ngIf="toast" [delay]="toast.delay || 5000" (hide)="removeToast(toast)" [class]="toast.classes">
+  <ng-template [ngIf]="isTemplate()">
+    <ng-template [ngTemplateOutlet]="toast.message"></ng-template>
+  </ng-template>
+  <div *ngIf="!isTemplate()">{{ toast.message }}</div>
+</ngb-toast>

--- a/src/web/app/components/toast/toast.component.scss
+++ b/src/web/app/components/toast/toast.component.scss
@@ -1,0 +1,13 @@
+:host {
+  left: 50%;
+  margin: .5em;
+  position: fixed;
+  top: 55px;
+  transform: translateX(-50%);
+  // make toast over the modal
+  z-index: 1100;
+
+  .toast {
+    max-width: 100%;
+  }
+}

--- a/src/web/app/components/toast/toast.component.spec.ts
+++ b/src/web/app/components/toast/toast.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NgbToastModule } from '@ng-bootstrap/ng-bootstrap';
+import { ToastComponent } from './toast.component';
+
+describe('ToastComponent', () => {
+  let component: ToastComponent;
+  let fixture: ComponentFixture<ToastComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ToastComponent],
+      imports: [NgbToastModule],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ToastComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/toast/toast.component.ts
+++ b/src/web/app/components/toast/toast.component.ts
@@ -1,0 +1,40 @@
+import { Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
+import { Toast } from './toast';
+
+/**
+ * Displays status messages as toasts.
+ */
+@Component({
+  selector: 'tm-toast',
+  templateUrl: './toast.component.html',
+  styleUrls: ['./toast.component.scss'],
+})
+export class ToastComponent implements OnInit {
+
+  @Input() toast: Toast | null = null;
+  @Output() toastChange: EventEmitter<Toast | null> = new EventEmitter<Toast | null>();
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  /**
+   * Removes the toast from view.
+   */
+  removeToast(): void {
+    this.toast = null;
+    this.toastChange.emit(null);
+  }
+
+  /**
+   * Returns true if the argument passed is a TemplateRef.
+   */
+  isTemplate(): boolean {
+    if (!this.toast) {
+      return false;
+    }
+    return this.toast.message instanceof TemplateRef;
+  }
+
+}

--- a/src/web/app/components/toast/toast.module.ts
+++ b/src/web/app/components/toast/toast.module.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { NgbToastModule } from '@ng-bootstrap/ng-bootstrap';
+import { ToastComponent } from './toast.component';
+
+/**
+ * Module for toasts.
+ */
+@NgModule({
+  declarations: [ToastComponent],
+  exports: [
+    ToastComponent,
+  ],
+  imports: [
+    CommonModule,
+    NgbToastModule,
+  ],
+})
+export class ToastModule { }

--- a/src/web/app/components/toast/toast.ts
+++ b/src/web/app/components/toast/toast.ts
@@ -1,0 +1,10 @@
+import { TemplateRef } from '@angular/core';
+
+/**
+ * Represents a status message toast.
+ */
+export interface Toast {
+  message: string | TemplateRef<any>;
+  delay?: number;
+  classes: string;
+}

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -43,6 +43,7 @@
 </nav>
 <tm-loader-bar></tm-loader-bar>
 <tm-loading-spinner *ngIf="isFetchingAuthDetails"></tm-loading-spinner>
+<tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
 <div *ngIf="!isFetchingAuthDetails" id="main-content" class="container main-content">
   <div *ngIf="isUnsupportedBrowser">
     <div class="alert alert-danger" role="alert">

--- a/src/web/app/page.component.spec.ts
+++ b/src/web/app/page.component.spec.ts
@@ -4,6 +4,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from './components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
+import { ToastModule } from './components/toast/toast.module';
 import { PageComponent } from './page.component';
 
 describe('PageComponent', () => {
@@ -21,6 +22,7 @@ describe('PageComponent', () => {
         LoaderBarModule,
         RouterTestingModule,
         StatusMessageModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -11,11 +11,12 @@ import {
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import uaParser from 'ua-parser-js';
-import { environment } from '../environments/environment';
-
 import { fromEvent, merge, Observable, of } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
+import uaParser from 'ua-parser-js';
+import { environment } from '../environments/environment';
+import { StatusMessageService } from '../services/status-message.service';
+import { Toast } from './components/toast/toast';
 
 const DEFAULT_TITLE: string = 'TEAMMATES - Online Peer Feedback/Evaluation System for Student Team Projects';
 
@@ -49,6 +50,7 @@ export class PageComponent {
   isNetworkOnline$: Observable<boolean>;
   version: string = environment.version;
   logoutUrl: string = `${environment.backendUrl}/logout`;
+  toast: Toast | null = null;
 
   /**
    * Minimum versions of browsers supported.
@@ -66,11 +68,13 @@ export class PageComponent {
   };
 
   constructor(private router: Router, private route: ActivatedRoute, private title: Title,
-              private modalService: NgbModal, location: Location) {
+              private modalService: NgbModal, location: Location,
+              private statusMessageService: StatusMessageService) {
     this.checkBrowserVersion();
     this.router.events.subscribe((val: any) => {
       if (val instanceof NavigationEnd) {
         window.scrollTo(0, 0); // reset viewport
+        this.toast = null; // reset toast
         let r: ActivatedRoute = this.route;
         while (r.firstChild) {
           r = r.firstChild;
@@ -96,6 +100,10 @@ export class PageComponent {
       if (this.modalService.hasOpenModals()) {
         this.modalService.dismissAll();
       }
+    });
+
+    this.statusMessageService.getToastEvent().subscribe((toast: Toast) => {
+      this.toast = toast;
     });
   }
 

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AdminAccountsPageComponent } from './admin-accounts-page.component';
 
@@ -14,7 +13,6 @@ describe('AdminAccountsPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
@@ -52,14 +52,14 @@ export class AdminAccountsPageComponent implements OnInit {
     this.accountService.getAccount(instructorid).subscribe((resp: Account) => {
       this.accountInfo = resp;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
 
     this.courseService.getStudentCoursesInMasqueradeMode(instructorid).subscribe((resp: Courses) => {
       this.studentCourses = resp.courses;
     }, (resp: ErrorMessageOutput) => {
       if (resp.status !== 403) {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       }
     });
 
@@ -67,7 +67,7 @@ export class AdminAccountsPageComponent implements OnInit {
       this.instructorCourses = resp.courses;
     }, (resp: ErrorMessageOutput) => {
       if (resp.status !== 403) {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       }
     });
   }
@@ -79,9 +79,9 @@ export class AdminAccountsPageComponent implements OnInit {
     const id: string = this.accountInfo.googleId;
     this.accountService.downgradeAccount(id).subscribe(() => {
       this.loadAccountInfo(id);
-      this.statusMessageService.showSuccessMessage('Instructor account is successfully downgraded to student.');
+      this.statusMessageService.showSuccessToast('Instructor account is successfully downgraded to student.');
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -94,7 +94,7 @@ export class AdminAccountsPageComponent implements OnInit {
       this.navigationService.navigateWithSuccessMessage(this.router, '/web/admin/search',
           `Instructor account "${id}" is successfully deleted.`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -107,9 +107,9 @@ export class AdminAccountsPageComponent implements OnInit {
       googleId: this.accountInfo.googleId,
     }).subscribe(() => {
       this.studentCourses = this.studentCourses.filter((course: Course) => course.courseId !== courseId);
-      this.statusMessageService.showSuccessMessage(`Student is successfully deleted from course "${courseId}"`);
+      this.statusMessageService.showSuccessToast(`Student is successfully deleted from course "${courseId}"`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -122,9 +122,9 @@ export class AdminAccountsPageComponent implements OnInit {
       instructorId: this.accountInfo.googleId,
     }).subscribe(() => {
       this.instructorCourses = this.instructorCourses.filter((course: Course) => course.courseId !== courseId);
-      this.statusMessageService.showSuccessMessage(`Instructor is successfully deleted from course "${courseId}"`);
+      this.statusMessageService.showSuccessToast(`Instructor is successfully deleted from course "${courseId}"`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 

--- a/src/web/app/pages-admin/admin-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-page.component.spec.ts
@@ -1,11 +1,11 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from '../components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
+import { ToastModule } from '../components/toast/toast.module';
 import { PageComponent } from '../page.component';
 import { AdminPageComponent } from './admin-page.component';
 
@@ -26,7 +26,7 @@ describe('AdminPageComponent', () => {
         LoaderBarModule,
         RouterTestingModule,
         StatusMessageModule,
-        MatSnackBarModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { of, throwError } from 'rxjs';
 import { AccountService } from '../../../services/account.service';
@@ -26,7 +25,6 @@ describe('AdminSearchPageComponent', () => {
       imports: [
         FormsModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
         NgbTooltipModule,
       ],
       providers: [AccountService, SearchService, StatusMessageService, NgbModal],
@@ -56,7 +54,7 @@ describe('AdminSearchPageComponent', () => {
       },
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('This is the error message');
       });
@@ -73,7 +71,7 @@ describe('AdminSearchPageComponent', () => {
       instructors: [],
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showWarningMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showWarningToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('No results found.');
       });
@@ -258,7 +256,7 @@ describe('AdminSearchPageComponent', () => {
     });
 
     spyOn(accountService, 'resetInstructorAccount').and.returnValue(of('Success'));
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('The instructor\'s Google ID has been reset.');
       });
@@ -300,7 +298,7 @@ describe('AdminSearchPageComponent', () => {
       },
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('This is the error message');
       });
@@ -346,7 +344,7 @@ describe('AdminSearchPageComponent', () => {
 
     spyOn(accountService, 'resetStudentAccount').and.returnValue(of('success'));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('The student\'s Google ID has been reset.');
       });
@@ -396,7 +394,7 @@ describe('AdminSearchPageComponent', () => {
       },
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorToast').and.callFake(
       (args: string): void => {
         expect(args).toEqual('This is the error message.');
       });
@@ -445,7 +443,7 @@ describe('AdminSearchPageComponent', () => {
       newRegistrationKey: 'newKey',
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showSuccessToast').and.callFake(
         (args: string): void => {
           expect(args).toEqual('success');
         });
@@ -500,7 +498,7 @@ describe('AdminSearchPageComponent', () => {
       },
     }));
 
-    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorMessage').and.callFake(
+    const spyStatusMessageService: any = spyOn(statusMessageService, 'showErrorToast').and.callFake(
         (args: string): void => {
           expect(args).toEqual('This is the error message.');
         });

--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.ts
@@ -49,7 +49,7 @@ export class AdminSearchPageComponent {
       const hasInstructors: boolean = !!(resp.instructors && resp.instructors.length);
 
       if (!hasStudents && !hasInstructors) {
-        this.statusMessageService.showWarningMessage('No results found.');
+        this.statusMessageService.showWarningToast('No results found.');
         this.instructors = [];
         this.students = [];
       } else {
@@ -59,7 +59,7 @@ export class AdminSearchPageComponent {
         this.hideAllStudentsLinks();
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -114,9 +114,9 @@ export class AdminSearchPageComponent {
     modalRef.result.then(() => {
       this.accountService.resetInstructorAccount(instructor.courseId, instructor.email).subscribe(() => {
         this.search();
-        this.statusMessageService.showSuccessMessage('The instructor\'s Google ID has been reset.');
+        this.statusMessageService.showSuccessToast('The instructor\'s Google ID has been reset.');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -136,9 +136,9 @@ export class AdminSearchPageComponent {
     modalRef.result.then(() => {
       this.accountService.resetStudentAccount(student.courseId, student.email).subscribe(() => {
         student.googleId = '';
-        this.statusMessageService.showSuccessMessage('The student\'s Google ID has been reset.');
+        this.statusMessageService.showSuccessToast('The student\'s Google ID has been reset.');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -154,10 +154,10 @@ export class AdminSearchPageComponent {
     modalRef.result.then(() => {
       this.studentService.regenerateStudentCourseLinks(student.courseId, student.email)
         .subscribe((resp: RegenerateStudentCourseLinks) => {
-          this.statusMessageService.showSuccessMessage(resp.message);
+          this.statusMessageService.showSuccessToast(resp.message);
           this.updateDisplayedStudentCourseLinks(student, resp.newRegistrationKey);
         }, (response: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(response.error.message);
+          this.statusMessageService.showErrorToast(response.error.message);
         });
     }, () => {});
   }

--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AdminSessionsPageComponent } from './admin-sessions-page.component';
 
@@ -15,7 +14,6 @@ describe('AdminSessionsPageComponent', () => {
         NgbModule,
         FormsModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
       ],
       declarations: [AdminSessionsPageComponent],
     })

--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.ts
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.ts
@@ -144,7 +144,7 @@ export class AdminSessionsPageComponent implements OnInit {
             this.institutionPanelsStatus[institution] = true;
           }
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -166,7 +166,7 @@ export class AdminSessionsPageComponent implements OnInit {
             sessions[0].responseRate = `${resp.submittedTotal} / ${resp.expectedTotal}`;
           }
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPageScrollCoreModule } from 'ngx-page-scroll-core';
@@ -32,7 +31,7 @@ describe('InstructorHelpQuestionsSectionComponent', () => {
       declarations: [InstructorHelpQuestionsSectionComponent, ExampleBoxComponent],
       imports: [
         InstructorSessionResultPageModule, NgbModule, RouterTestingModule, NgxPageScrollCoreModule,
-        QuestionEditFormModule, QuestionStatisticsModule, MatSnackBarModule, QuestionSubmissionFormModule,
+        QuestionEditFormModule, QuestionStatisticsModule, QuestionSubmissionFormModule,
       ],
       providers: [
         { provide: HttpRequestService, useValue: spyHttpRequestService },

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -1,9 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPageScrollCoreModule } from 'ngx-page-scroll-core';
 
@@ -37,7 +35,7 @@ describe('InstructorHelpSessionsSectionComponent', () => {
       imports: [
         CommentBoxModule, FormsModule, HttpClientTestingModule, NgbModule,
         RouterTestingModule, NgxPageScrollCoreModule,
-        SessionEditFormModule, MatSnackBarModule, SessionsRecycleBinTableModule,
+        SessionEditFormModule, SessionsRecycleBinTableModule,
         InstructorSearchPageModule, InstructorSessionResultPageModule, QuestionTextWithInfoModule,
         SingleStatisticsModule, StudentViewResponsesModule],
     })

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InstructorHelpPageModule } from '../instructor-help-page.module';
@@ -15,7 +14,6 @@ describe('InstructorHelpStudentsSectionComponent', () => {
       imports: [
         NgbModule,
         RouterTestingModule,
-        MatSnackBarModule,
         HttpClientTestingModule,
         InstructorHelpPageModule,
       ],

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { NgxCaptchaModule } from 'ngx-captcha';
 import { SessionLinksRecoveryPageComponent } from './session-links-recovery-page.component';
 
@@ -16,7 +15,6 @@ describe('SessionLinksRecoveryPageComponent', () => {
         ReactiveFormsModule,
         HttpClientTestingModule,
         NgxCaptchaModule,
-        MatSnackBarModule,
       ],
     })
         .compileComponents();

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
@@ -48,7 +48,7 @@ export class SessionLinksRecoveryPageComponent implements OnInit {
     }
 
     if (!this.formSessionLinksRecovery.valid || this.captchaResponse === undefined) {
-      this.statusMessageService.showErrorMessage(
+      this.statusMessageService.showErrorToast(
           'Please enter a valid email address and click the reCAPTCHA before submitting.');
       return;
     }
@@ -58,10 +58,10 @@ export class SessionLinksRecoveryPageComponent implements OnInit {
       captchaResponse: this.captchaResponse,
     }).subscribe((resp: SessionLinksRecoveryResponse) => {
       resp.isEmailSent
-            ? this.statusMessageService.showSuccessMessage(resp.message)
-            : this.statusMessageService.showErrorMessage(resp.message);
+            ? this.statusMessageService.showSuccessToast(resp.message)
+            : this.statusMessageService.showErrorToast(resp.message);
     }, (response: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(response.error.message);
+      this.statusMessageService.showErrorToast(response.error.message);
     });
     this.resetFormGroups();
   }

--- a/src/web/app/pages-instructor/instructor-comments.component.ts
+++ b/src/web/app/pages-instructor/instructor-comments.component.ts
@@ -60,7 +60,7 @@ export abstract class InstructorCommentsComponent {
             ...commentTableModel,
           };
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -89,7 +89,7 @@ export abstract class InstructorCommentsComponent {
             ...commentTableModel,
           };
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -126,7 +126,7 @@ export abstract class InstructorCommentsComponent {
             isAddingNewComment: false,
           };
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ClipboardModule } from 'ngx-clipboard';
 import { Course, Instructor, InstructorPermissionRole, JoinState, Student } from '../../../types/api-output';
@@ -37,7 +36,6 @@ describe('InstructorCourseDetailsPageComponent', () => {
         TeammatesCommonModule,
         RouterTestingModule,
         ClipboardModule,
-        MatSnackBarModule,
         InstructorCourseDetailsPageModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -91,7 +91,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
     this.courseService.getCourseAsInstructor(courseid).subscribe((course: Course) => {
       this.courseDetails.course = course;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -103,7 +103,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
     .subscribe((instructors: Instructors) => {
       this.instructors = instructors.instructors;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -133,7 +133,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
       });
       this.courseDetails.stats = this.courseService.calculateCourseStatistics(students.students);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -154,7 +154,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
 
       this.students.push(...students);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -185,9 +185,9 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
           numOfSections: 0,
           numOfTeams: 0,
         };
-        this.statusMessageService.showSuccessMessage(resp.message);
+        this.statusMessageService.showSuccessToast(resp.message);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 
@@ -210,7 +210,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
           this.courseStudentListAsCsv = resp;
           this.loading = false;
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
     }
   }
@@ -231,7 +231,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
       .subscribe((resp: string) => {
         this.courseStudentListAsCsv = resp;
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
         this.isAjaxSuccess = false;
       });
     this.loading = false;
@@ -245,7 +245,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
       this.navigationService.navigateWithSuccessMessagePreservingParams(this.router,
         '/web/instructor/courses/details', resp.message);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -321,9 +321,9 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
       this.courseDetails.stats = this.courseService.calculateCourseStatistics(students);
 
       this.statusMessageService
-          .showSuccessMessage(`Student is successfully deleted from course "${this.courseDetails.course.courseId}"`);
+          .showSuccessToast(`Student is successfully deleted from course "${this.courseDetails.course.courseId}"`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
@@ -42,7 +41,6 @@ describe('InstructorCourseEditPageComponent', () => {
         TeammatesCommonModule,
         RouterTestingModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -185,7 +185,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
       this.course = resp;
       this.originalCourse = Object.assign({}, resp);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -199,14 +199,14 @@ export class InstructorCourseEditPageComponent implements OnInit {
     }).subscribe((resp: InstructorPrivilege) => {
       this.currInstructorCoursePrivilege = resp;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
 
     // login credential
     this.authService.getAuthUser().subscribe((res: AuthInfo) => {
       this.currInstructorGoogleId = res.user === undefined ? '' : res.user.id;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -218,7 +218,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
       this.navigationService.navigateWithSuccessMessage(this.router, '/web/instructor/courses',
           `The course ${course.courseId} has been deleted. You can restore it from the Recycle Bin manually.`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -234,12 +234,12 @@ export class InstructorCourseEditPageComponent implements OnInit {
       courseName: this.course.courseName,
       timeZone: this.course.timeZone,
     }).subscribe((resp: Course) => {
-      this.statusMessageService.showSuccessMessage('The course has been edited.');
+      this.statusMessageService.showSuccessToast('The course has been edited.');
       this.isEditingCourse = false;
       this.course = resp;
       this.originalCourse = Object.assign({}, resp);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
     Object.values(this.form.controls).forEach((control: any) => control.markAsUntouched());
     Object.values(this.form.controls).forEach((control: any) => control.markAsPristine());
@@ -273,7 +273,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
             this.loadPermissionForInstructor(panel);
           });
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -329,7 +329,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
     }).subscribe((resp: InstructorPrivilege) => {
       modalRef.componentInstance.instructorPrivilege = resp;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -369,10 +369,10 @@ export class InstructorCourseEditPageComponent implements OnInit {
 
       this.updatePrivilegeForInstructor(panelDetail.originalInstructor, panelDetail.editPanel.permission);
 
-      this.statusMessageService.showSuccessMessage(`The instructor ${resp.name} has been updated.`);
+      this.statusMessageService.showSuccessToast(`The instructor ${resp.name} has been updated.`);
 
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
 
     panelDetail.editPanel.isEditing = false;
@@ -398,10 +398,10 @@ export class InstructorCourseEditPageComponent implements OnInit {
                   this.router, '/web/instructor/courses', 'Instructor is successfully deleted.');
         } else {
           this.instructorDetailPanels.splice(index, 1);
-          this.statusMessageService.showSuccessMessage('Instructor is successfully deleted.');
+          this.statusMessageService.showSuccessToast('Instructor is successfully deleted.');
         }
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -418,9 +418,9 @@ export class InstructorCourseEditPageComponent implements OnInit {
       this.courseService
           .remindInstructorForJoin(panelDetail.originalInstructor.courseId, panelDetail.originalInstructor.email)
           .subscribe((resp: MessageOutput) => {
-            this.statusMessageService.showSuccessMessage(resp.message);
+            this.statusMessageService.showSuccessToast(resp.message);
           }, (resp: ErrorMessageOutput) => {
-            this.statusMessageService.showErrorMessage(resp.error.message);
+            this.statusMessageService.showErrorToast(resp.error.message);
           });
     }, () => {});
   }
@@ -448,7 +448,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
           newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
 
           this.instructorDetailPanels.push(newDetailPanels);
-          this.statusMessageService.showSuccessMessage(`"The instructor ${resp.name} has been added successfully.
+          this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully.
           An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
 
           this.updatePrivilegeForInstructor(newDetailPanels.originalInstructor, newDetailPanels.editPanel.permission);
@@ -481,7 +481,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
             isEditing: true,
           };
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -613,7 +613,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
       });
       panel.originalPanel = JSON.parse(JSON.stringify(panel.editPanel));
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -700,7 +700,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
       permission.sectionLevel = permission.sectionLevel.filter(
           (sectionLevel: InstructorSectionLevelPermission) => sectionLevel.sectionNames.length !== 0);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HotTableModule } from '@handsontable/angular';
 import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
@@ -19,7 +18,6 @@ describe('InstructorCourseEnrollPageComponent', () => {
         HotTableModule,
         RouterTestingModule,
         AjaxPreloadModule,
-        MatSnackBarModule,
         StatusMessageModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -115,13 +115,13 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       const enrolledStudents: Student[] = resp.students;
       this.showEnrollResults = true;
       this.statusMessage.pop(); // removes any existing error status message
-      this.statusMessageService.showSuccessMessage('Enrollment successful. Summary given below.');
+      this.statusMessageService.showSuccessToast('Enrollment successful. Summary given below.');
       this.enrollResultPanelList =
           this.populateEnrollResultPanelList(this.existingStudents, enrolledStudents,
               studentsEnrollRequest.studentEnrollRequests);
     }, (resp: ErrorMessageOutput) => {
       this.statusMessage.pop(); // removes any existing error status message
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     }, () => {
       this.studentService.getStudentsFromCourse({ courseId: this.courseid }).subscribe((resp: Students) => {
         this.existingStudents = resp.students;
@@ -214,7 +214,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
           'unless wrapped by curly brackets "{}", and should not contain vertical bar "|" and percentage sign"%". ' +
           '"Email" should contain some text followed by one \'@\' sign followed by some more text. ' +
           '"Team" should not have same format of email to avoid mis-interpretation. ';
-      this.statusMessageService.showErrorMessage(`Some students failed to be enrolled, see the summary below.
+      this.statusMessageService.showErrorToast(`Some students failed to be enrolled, see the summary below.
        ${generalEnrollErrorMessage}`);
     }
     return panels;
@@ -313,7 +313,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
             this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed; // Collapse the panel again
           }
         }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
       this.isAjaxSuccess = false;
       this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed; // Collapse the panel again
     });
@@ -354,7 +354,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       this.coursePresent = true;
       this.courseid = courseid;
       if (resp.hasResponses) {
-        this.statusMessageService.showWarningMessageModal('Existing feedback responses',
+        this.statusMessageService.showWarningModal('Existing feedback responses',
         'There are existing feedback responses for this course.',
         'Modifying records of enrolled students will result in some existing responses '
             + 'from those modified students to be deleted. You may wish to download the data '
@@ -362,7 +362,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       }
     }, (resp: ErrorMessageOutput) => {
       this.coursePresent = false;
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
     this.studentService.getStudentsFromCourse({ courseId: courseid }).subscribe((resp: Students) => {
       this.existingStudents = resp.students;

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Gender, JoinState, Student, StudentProfile } from '../../../types/api-output';
 import {
@@ -49,7 +48,6 @@ describe('InstructorCourseStudentDetailsPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.ts
@@ -44,12 +44,12 @@ export class InstructorCourseStudentDetailsPageComponent implements OnInit {
     this.studentProfileService.getStudentProfile(studentEmail, courseId).subscribe((studentProfile: StudentProfile) => {
       this.studentProfile = studentProfile;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
     this.studentService.getStudent(courseId, studentEmail).subscribe((student: Student) => {
       this.student = student;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { JoinState } from '../../../types/api-output';
 import { InstructorCourseStudentEditPageComponent } from './instructor-course-student-edit-page.component';
@@ -17,7 +16,6 @@ describe('InstructorCourseStudentEditPageComponent', () => {
         RouterTestingModule,
         ReactiveFormsModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.ts
@@ -79,7 +79,7 @@ export class InstructorCourseStudentEditPageComponent implements OnInit, OnDestr
       this.student = student;
       this.initEditForm();
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -176,10 +176,10 @@ export class InstructorCourseStudentEditPageComponent implements OnInit, OnDestr
         this.router.navigate(['/web/instructor/courses/details'], {
           queryParams: { courseid: this.courseId },
         }).then(() => {
-          this.statusMessageService.showSuccessMessage(resp.message);
+          this.statusMessageService.showSuccessToast(resp.message);
         });
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 }

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
@@ -45,8 +45,8 @@
 </div>
 
 <ng-template #newCourseMessageTemplate>
-  The course has been added. Click <a href="/web/instructor/courses/enroll?courseid={{course.courseId}}">here</a>
-  to add students to the course or click <a href="/web/instructor/courses/edit?courseid={{course.courseId}}">here</a>
+  The course has been added. Click <a routerLink="/web/instructor/courses/enroll" [queryParams]="{ courseid: course.courseId }">here</a>
+  to add students to the course or click <a routerLink="/web/instructor/courses/edit" [queryParams]="{ courseid: course.courseId }">here</a>
   to add other instructors.<br>If you don't see the course in the list below,
   please refresh the page after a few moments.
 </ng-template>

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
@@ -7,7 +7,6 @@ import { Course } from '../../../../types/api-output';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -32,8 +31,8 @@ describe('AddCourseFormComponent', () => {
   const timeZoneOffsets1: Record<string, number> = { GMT: 0 };
 
   const spyStatusMessageService: any = {
-    showErrorMessage: jest.fn(),
-    showSuccessMessageTemplate: jest.fn(),
+    showErrorToast: jest.fn(),
+    showSuccessToastTemplate: jest.fn(),
   };
   const timezoneServiceStub: any = {
     getTzOffsets: jest.fn(() => timeZoneOffsets1),
@@ -51,7 +50,6 @@ describe('AddCourseFormComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         NgbModule,
-        MatSnackBarModule,
       ],
       providers: [
         { provide: StatusMessageService, useValue: spyStatusMessageService },
@@ -88,11 +86,11 @@ describe('AddCourseFormComponent', () => {
     expect(fixture).toMatchSnapshot();
   });
 
-  it('should call showErrorMessage when courseId is blank', () => {
+  it('should call showErrorToast when courseId is blank', () => {
     component.newCourseId = '';
     component.onSubmit();
     fixture.detectChanges();
-    expect(spyStatusMessageService.showErrorMessage).toHaveBeenCalled();
+    expect(spyStatusMessageService.showErrorToast).toHaveBeenCalled();
   });
 
   it('should hold added course with valid details', () => {
@@ -100,7 +98,7 @@ describe('AddCourseFormComponent', () => {
     component.newCourseName = testCourseName;
     component.onSubmit();
     fixture.detectChanges();
-    expect(spyStatusMessageService.showSuccessMessageTemplate).toHaveBeenCalled();
+    expect(spyStatusMessageService.showSuccessToastTemplate).toHaveBeenCalled();
     expect(component.course).toEqual(testCourse);
   });
 });

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
@@ -59,7 +59,7 @@ export class AddCourseFormComponent implements OnInit {
       return;
     }
     if (!this.newCourseId || !this.newCourseName) {
-      this.statusMessageService.showErrorMessage(
+      this.statusMessageService.showErrorToast(
           'Please make sure you have filled in both Course ID and Name before adding the course!');
       return;
     }
@@ -70,9 +70,9 @@ export class AddCourseFormComponent implements OnInit {
     }).subscribe((course: Course) => {
       this.courseAdded.emit();
       this.course = course;
-      this.statusMessageService.showSuccessMessageTemplate(this.newCourseMessageTemplate);
+      this.statusMessageService.showSuccessToastTemplate(this.newCourseMessageTemplate);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
     this.newCourseId = '';
     this.newCourseName = '';

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InstructorCoursesPageComponent } from './instructor-courses-page.component';
@@ -113,7 +112,6 @@ describe('InstructorCoursesPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -93,11 +93,11 @@ export class InstructorCoursesPageComponent implements OnInit {
           const activeCourse: CourseModel = Object.assign({}, { course, canModifyCourse, canModifyStudent });
           this.activeCourses.push(activeCourse);
         }, (error: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(error.error.message);
+          this.statusMessageService.showErrorToast(error.error.message);
         });
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
 
     this.courseService.getAllCoursesAsInstructor('archived').subscribe((resp: Courses) => {
@@ -110,11 +110,11 @@ export class InstructorCoursesPageComponent implements OnInit {
           const archivedCourse: CourseModel = Object.assign({}, { course, canModifyCourse, canModifyStudent });
           this.archivedCourses.push(archivedCourse);
         }, (error: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(error.error.message);
+          this.statusMessageService.showErrorToast(error.error.message);
         });
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
 
     this.courseService.getAllCoursesAsInstructor('softDeleted').subscribe((resp: Courses) => {
@@ -130,11 +130,11 @@ export class InstructorCoursesPageComponent implements OnInit {
                 this.canRestoreAll = false;
               }
             }, (error: ErrorMessageOutput) => {
-              this.statusMessageService.showErrorMessage(error.error.message);
+              this.statusMessageService.showErrorToast(error.error.message);
             });
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -143,7 +143,7 @@ export class InstructorCoursesPageComponent implements OnInit {
    */
   getCourseStats(courseId: string): void {
     if (!courseId) {
-      this.statusMessageService.showErrorMessage(`Course ${courseId} is not found!`);
+      this.statusMessageService.showErrorToast(`Course ${courseId} is not found!`);
       return;
     }
     this.studentService.getStudentsFromCourse({ courseId }).subscribe((students: Students) => {
@@ -155,7 +155,7 @@ export class InstructorCoursesPageComponent implements OnInit {
           .length,
       };
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -164,7 +164,7 @@ export class InstructorCoursesPageComponent implements OnInit {
    */
   changeArchiveStatus(courseId: string, toArchive: boolean): void {
     if (!courseId) {
-      this.statusMessageService.showErrorMessage(`Course ${courseId} is not found!`);
+      this.statusMessageService.showErrorToast(`Course ${courseId} is not found!`);
       return;
     }
     this.courseService.changeArchiveStatus(courseId, {
@@ -172,14 +172,14 @@ export class InstructorCoursesPageComponent implements OnInit {
     }).subscribe((courseArchive: CourseArchive) => {
       if (courseArchive.isArchived) {
         this.changeModelFromActiveToArchived(courseId);
-        this.statusMessageService.showSuccessMessage(`The course ${courseId} has been archived.
+        this.statusMessageService.showSuccessToast(`The course ${courseId} has been archived.
           It will not appear on the home page anymore.`);
       } else {
         this.changeModelFromArchivedToActive(courseId);
-        this.statusMessageService.showSuccessMessage('The course has been unarchived.');
+        this.statusMessageService.showSuccessToast('The course has been unarchived.');
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -231,17 +231,17 @@ export class InstructorCoursesPageComponent implements OnInit {
    */
   onDelete(courseId: string): void {
     if (!courseId) {
-      this.statusMessageService.showErrorMessage(`Course ${courseId} is not found!`);
+      this.statusMessageService.showErrorToast(`Course ${courseId} is not found!`);
       return;
     }
     const modalRef: NgbModalRef = this.modalService.open(CourseSoftDeletionConfirmModalComponent);
     modalRef.result.then(() => {
       this.courseService.binCourse(courseId).subscribe((course: Course) => {
         this.moveCourseToRecycleBin(courseId, course.deletionTimestamp);
-        this.statusMessageService.showSuccessMessage(
+        this.statusMessageService.showSuccessToast(
           `The course ${course.courseId} has been deleted. You can restore it from the Recycle Bin manually.`);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -271,7 +271,7 @@ export class InstructorCoursesPageComponent implements OnInit {
    */
   onDeletePermanently(courseId: string): void {
     if (!courseId) {
-      this.statusMessageService.showErrorMessage(`Course ${courseId} is not found!`);
+      this.statusMessageService.showErrorToast(`Course ${courseId} is not found!`);
       return;
     }
     const modalRef: NgbModalRef = this.modalService.open(CoursePermanentDeletionConfirmModalComponent);
@@ -279,9 +279,9 @@ export class InstructorCoursesPageComponent implements OnInit {
     modalRef.result.then(() => {
       this.courseService.deleteCourse(courseId).subscribe(() => {
         this.softDeletedCourses = this.removeCourse(this.softDeletedCourses, courseId);
-        this.statusMessageService.showSuccessMessage(`The course ${courseId} has been permanently deleted.`);
+        this.statusMessageService.showSuccessToast(`The course ${courseId} has been permanently deleted.`);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -291,15 +291,15 @@ export class InstructorCoursesPageComponent implements OnInit {
    */
   onRestore(courseId: string): void {
     if (!courseId) {
-      this.statusMessageService.showErrorMessage(`Course ${courseId} is not found!`);
+      this.statusMessageService.showErrorToast(`Course ${courseId} is not found!`);
       return;
     }
 
     this.courseService.restoreCourse(courseId).subscribe((resp: MessageOutput) => {
       this.loadInstructorCourses();
-      this.statusMessageService.showSuccessMessage(resp.message);
+      this.statusMessageService.showSuccessToast(resp.message);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -317,9 +317,9 @@ export class InstructorCoursesPageComponent implements OnInit {
 
       forkJoin(deleteRequests).subscribe(() => {
         this.softDeletedCourses = [];
-        this.statusMessageService.showSuccessMessage('All courses have been permanently deleted.');
+        this.statusMessageService.showSuccessToast('All courses have been permanently deleted.');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
 
     }, () => {});
@@ -336,9 +336,9 @@ export class InstructorCoursesPageComponent implements OnInit {
 
     forkJoin(restoreRequests).subscribe(() => {
       this.loadInstructorCourses();
-      this.statusMessageService.showSuccessMessage('All courses have been restored.');
+      this.statusMessageService.showSuccessToast('All courses have been restored.');
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   Course, FeedbackSession, FeedbackSessionPublishStatus,
@@ -61,7 +60,6 @@ describe('InstructorHomePageComponent', () => {
         InstructorHomePageModule,
         HttpClientTestingModule,
         RouterTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -135,10 +135,10 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
       this.courseTabModels = this.courseTabModels.filter((model: CourseTabModel) => {
         return model.course.courseId !== courseId;
       });
-      this.statusMessageService.showSuccessMessage(`The course ${courseArchive.courseId} has been archived.
+      this.statusMessageService.showSuccessToast(`The course ${courseArchive.courseId} has been archived.
           You can retrieve it from the Courses page.`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -150,10 +150,10 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
       this.courseTabModels = this.courseTabModels.filter((model: CourseTabModel) => {
         return model.course.courseId !== courseId;
       });
-      this.statusMessageService.showSuccessMessage(
+      this.statusMessageService.showSuccessToast(
           `The course ${course.courseId} has been deleted. You can restore it from the Recycle Bin manually.`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
   /**
@@ -184,7 +184,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
         });
         this.isNewUser = !courses.courses.some((course: Course) => !/-demo\d*$/.test(course.courseId));
         this.sortCoursesBy(this.instructorCoursesSortBy);
-      }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+      }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -195,7 +195,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
       .subscribe((instructorPrivilege: InstructorPrivilege) => {
         model.instructorPrivilege = instructorPrivilege;
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 
@@ -222,7 +222,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
             }
           }, (resp: ErrorMessageOutput) => {
             model.isAjaxSuccess = false;
-            this.statusMessageService.showErrorMessage(resp.error.message);
+            this.statusMessageService.showErrorToast(resp.error.message);
           });
     }
   }
@@ -328,9 +328,9 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
         .subscribe(() => {
           this.courseTabModels[tabIndex].sessionsTableRowModels.splice(
               this.courseTabModels[tabIndex].sessionsTableRowModels.indexOf(model), 1);
-          this.statusMessageService.showSuccessMessage(
+          this.statusMessageService.showSuccessToast(
               "The feedback session has been deleted. You can restore it from the 'Sessions' tab.");
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.spec.ts
@@ -5,6 +5,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from '../components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
+import { ToastModule } from '../components/toast/toast.module';
 import { PageComponent } from '../page.component';
 import { InstructorPageComponent } from './instructor-page.component';
 
@@ -25,6 +26,7 @@ describe('InstructorPageComponent', () => {
         LoaderBarModule,
         RouterTestingModule,
         StatusMessageModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { JoinState } from '../../../types/api-output';
 import { InstructorSearchPageComponent } from './instructor-search-page.component';
@@ -16,7 +15,6 @@ describe('InstructorSearchPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
-        MatSnackBarModule,
         InstructorSearchPageModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -83,10 +83,10 @@ export class InstructorSearchPageComponent implements OnInit {
             this.studentsListRowTables = this.flattenStudentTable(searchStudentsTable);
           }
           if (!hasStudents && !hasComments) {
-            this.statusMessageService.showWarningMessage('No results found.');
+            this.statusMessageService.showWarningToast('No results found.');
           }
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -156,7 +156,7 @@ export abstract class InstructorSessionBasePageComponent {
     ).subscribe((instructorPrivilege: InstructorPrivilege) => {
       model.instructorPrivilege = instructorPrivilege;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -172,7 +172,7 @@ export abstract class InstructorSessionBasePageComponent {
         .subscribe((resp: FeedbackSessionStats) => {
           model.isLoadingResponseRate = false;
           model.responseRate = `${resp.submittedTotal} / ${resp.expectedTotal}`;
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -196,7 +196,7 @@ export abstract class InstructorSessionBasePageComponent {
               '/web/instructor/sessions/edit',
               'The feedback session has been copied. Please modify settings/questions as necessary.',
               { courseid: createdSession.courseId, fsname: createdSession.feedbackSessionName });
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -236,7 +236,7 @@ export abstract class InstructorSessionBasePageComponent {
       blob = new Blob([resp], { type: 'text/csv' });
       saveAs(blob, filename);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -253,9 +253,9 @@ export abstract class InstructorSessionBasePageComponent {
           model.feedbackSession = feedbackSession;
           model.responseRate = '';
 
-          this.statusMessageService.showSuccessMessage('The feedback session has been published. '
+          this.statusMessageService.showSuccessToast('The feedback session has been published. '
               + 'Please allow up to 1 hour for all the notification emails to be sent out.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -270,7 +270,7 @@ export abstract class InstructorSessionBasePageComponent {
           model.feedbackSession = feedbackSession;
           model.responseRate = '';
 
-          this.statusMessageService.showSuccessMessage('The feedback session has been unpublished.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The feedback session has been unpublished.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 }

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorSessionEditPageComponent } from './instructor-session-edit-page.component';
 import { InstructorSessionEditPageModule } from './instructor-session-edit-page.module';
@@ -15,7 +14,6 @@ describe('InstructorSessionEditPageComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         InstructorSessionEditPageModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -202,7 +202,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       .subscribe((feedbackSession: FeedbackSession) => {
         this.sessionEditFormModel = this.getSessionEditFormModel(feedbackSession);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     });
   }
@@ -232,9 +232,9 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
               '/web/instructor/sessions/edit',
               'The feedback session has been copied. Please modify settings/questions as necessary.',
               { courseid: createdSession.courseId, fsname: createdSession.feedbackSessionName });
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
       }, () => {});
-    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -368,9 +368,9 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     ).subscribe((feedbackSession: FeedbackSession) => {
       this.sessionEditFormModel = this.getSessionEditFormModel(feedbackSession);
 
-      this.statusMessageService.showSuccessMessage('The feedback session has been updated.');
+      this.statusMessageService.showSuccessToast('The feedback session has been updated.');
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -390,7 +390,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     return this.timezoneService.getResolvedTimestamp(localDateTime, timeZone, fieldName).pipe(
         tap((result: TimeResolvingResult) => {
           if (result.message.length !== 0) {
-            this.statusMessageService.showWarningMessage(result.message);
+            this.statusMessageService.showWarningToast(result.message);
           }
         }),
         map((result: TimeResolvingResult) => result.timestamp));
@@ -404,7 +404,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       this.navigationService.navigateWithSuccessMessage(this.router, '/web/instructor/sessions',
           'The feedback session has been deleted. You can restore it from the deleted sessions table below.');
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -424,7 +424,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             this.loadResponseStatusForQuestion(addedQuestionEditFormModel);
             this.feedbackQuestionModels.set(feedbackQuestion.feedbackQuestionId, feedbackQuestion);
           });
-        }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorMessage(resp.error.message));
+        }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorToast(resp.error.message));
   }
 
   /**
@@ -475,7 +475,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     this.feedbackSessionsService.hasResponsesForQuestion(model.feedbackQuestionId)
         .subscribe((resp: HasResponses) => {
           model.isQuestionHasResponses = resp.hasResponses;
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -523,8 +523,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             this.normalizeQuestionNumberInQuestionForms();
           }
 
-          this.statusMessageService.showSuccessMessage('The changes to the question have been updated.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The changes to the question have been updated.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -591,8 +591,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         .subscribe((newQuestion: FeedbackQuestion) => {
           this.questionEditFormModels.push(this.getQuestionEditFormModel(newQuestion));
           this.feedbackQuestionModels.set(newQuestion.feedbackQuestionId, newQuestion);
-          this.statusMessageService.showSuccessMessage('The question has been duplicated below.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The question has been duplicated below.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -607,8 +607,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           this.questionEditFormModels.splice(index, 1);
           this.normalizeQuestionNumberInQuestionForms();
 
-          this.statusMessageService.showSuccessMessage('The question has been deleted.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The question has been deleted.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -642,11 +642,11 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       ).subscribe((newQuestion: FeedbackQuestion) => {
         this.questionEditFormModels.push(this.getQuestionEditFormModel(newQuestion));
         this.feedbackQuestionModels.set(newQuestion.feedbackQuestionId, newQuestion);
-      }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); }, () => {
+      }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); }, () => {
         if (questions.length === 1) {
-          this.statusMessageService.showSuccessMessage('The question has been added to this feedback session.');
+          this.statusMessageService.showSuccessToast('The question has been added to this feedback session.');
         } else {
-          this.statusMessageService.showSuccessMessage('The questions have been added to this feedback session.');
+          this.statusMessageService.showSuccessToast('The questions have been added to this feedback session.');
         }
       });
     });
@@ -727,8 +727,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           this.normalizeQuestionNumberInQuestionForms();
           this.isAddingQuestionPanelExpanded = false;
 
-          this.statusMessageService.showSuccessMessage('The question has been added to this feedback session.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The question has been added to this feedback session.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -760,7 +760,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         }),
     ).subscribe((questionToCopyCandidate: QuestionToCopyCandidate[]) => {
       questionToCopyCandidates.push(...questionToCopyCandidate);
-    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); }, () => {
+    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); }, () => {
       const ref: NgbModalRef = this.modalService.open(CopyQuestionsFromOtherSessionsModalComponent);
       ref.componentInstance.questionToCopyCandidates = questionToCopyCandidates;
 
@@ -789,8 +789,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         ).subscribe((newQuestion: FeedbackQuestion) => {
           this.questionEditFormModels.push(this.getQuestionEditFormModel(newQuestion));
           this.feedbackQuestionModels.set(newQuestion.feedbackQuestionId, newQuestion);
-          this.statusMessageService.showSuccessMessage('The question has been added to this feedback session.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The question has been added to this feedback session.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
       }, () => {});
     });
   }
@@ -838,7 +838,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           if (this.studentsOfCourse.length >= 1) {
             this.emailOfStudentToPreview = this.studentsOfCourse[0].email;
           }
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -864,7 +864,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           if (this.instructorsCanBePreviewedAs.length >= 1) {
             this.emailOfInstructorToPreview = this.instructorsCanBePreviewedAs[0].email;
           }
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
@@ -74,12 +74,12 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
         this.feedbackSessionsService.remindResultsLinkToStudents(courseId, feedbackSessionName, {
           usersToRemind: studentsToRemind.map((m: StudentListInfoTableRowModel) => m.email),
         }).subscribe(() => {
-          this.statusMessageService.showSuccessMessage(
+          this.statusMessageService.showSuccessToast(
               'Session published notification emails have been resent to those students and instructors. '
               + 'Please allow up to 1 hour for all the notification emails to be sent out.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
       }, () => {});
-    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+    }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -116,12 +116,12 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
                 this.feedbackSessionsService.remindFeedbackSessionSubmissionForStudent(courseId, feedbackSessionName, {
                   usersToRemind: studentsToRemind.map((m: StudentListInfoTableRowModel) => m.email),
                 }).subscribe(() => {
-                  this.statusMessageService.showSuccessMessage(
+                  this.statusMessageService.showSuccessToast(
                       'Reminder e-mails have been sent out to those students and instructors. '
                       + 'Please allow up to 1 hour for all the notification emails to be sent out.');
-                }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+                }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
               }, () => {});
 
-            }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+            }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -16,7 +15,6 @@ describe('InstructorSessionNoResponsePanelComponent', () => {
       imports: [
         RouterModule,
         HttpClientTestingModule,
-        MatSnackBarModule,
         NgbModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { CommentToCommentRowModelPipe } from '../../components/comment-box/comment-to-comment-row-model.pipe';
@@ -51,7 +50,6 @@ describe('InstructorSessionResultPageComponent', () => {
         GqrRqgViewResponsesModule,
         GrqRgqViewResponsesModule,
         PerQuestionViewResponsesModule,
-        MatSnackBarModule,
         SingleStatisticsModule,
       ],
       providers: [

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -162,7 +162,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
               }
               this.isSectionsLoaded = true;
             }, (resp: ErrorMessageOutput) => {
-              this.statusMessageService.showErrorMessage(resp.error.message);
+              this.statusMessageService.showErrorToast(resp.error.message);
             });
 
         // load question tabs
@@ -182,7 +182,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
           }
           this.isQuestionsLoaded = true;
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
 
         // load all students in course
@@ -200,13 +200,13 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
             this.noResponseStudents = this.allStudentsInCourse.filter((student: Student) =>
                                         !feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(student.email));
           }, (resp: ErrorMessageOutput) => {
-            this.statusMessageService.showErrorMessage(resp.error.message);
+            this.statusMessageService.showErrorToast(resp.error.message);
           });
 
           this.isNoResponsePanelLoaded = true;
 
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
 
         // load current instructor name
@@ -217,7 +217,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
           this.currInstructorName = instructor.name;
         });
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     });
   }
@@ -256,7 +256,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         this.preprocessComments(responses.allResponses);
       }
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -295,7 +295,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         this.preprocessComments(question.allResponses);
       });
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -337,7 +337,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       response.subscribe(() => {
         this.router.navigateByUrl('/web/instructor/sessions');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -370,7 +370,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       blob = new Blob([resp], { type: 'text/csv' });
       saveAs(blob, filename);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -439,12 +439,12 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       .remindFeedbackSessionSubmissionForStudent(this.session.courseId, this.session.feedbackSessionName, {
         usersToRemind: studentsToRemindData.map((m: StudentListInfoTableRowModel) => m.email),
       }).subscribe(() => {
-        this.statusMessageService.showSuccessMessage(
+        this.statusMessageService.showSuccessToast(
           'Reminder e-mails have been sent out to those students and instructors. '
           + 'Please allow up to 1 hour for all the notification emails to be sent out.');
 
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorSessionsPageComponent } from './instructor-sessions-page.component';
 import { InstructorSessionsPageModule } from './instructor-sessions-page.module';
@@ -15,7 +14,6 @@ describe('InstructorSessionsPageComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         InstructorSessionsPageModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -176,7 +176,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             this.navigationService.navigateWithSuccessMessage(this.router, '/web/instructor/sessions/edit'
                 + `?courseid=${createdFeedbackSession.courseId}&fsname=${createdFeedbackSession.feedbackSessionName}`,
                 'The feedback session has been copied. Please modify settings/questions as necessary.');
-          }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
     }, () => {});
   }
 
@@ -189,7 +189,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
           this.courseCandidates = courses.courses;
 
           this.initDefaultValuesForSessionEditForm();
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -322,7 +322,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
           }),
       ).subscribe(() => {}, (resp: ErrorMessageOutput) => {
         this.sessionEditFormModel.isSaving = false;
-        this.statusMessageService.showErrorMessage(
+        this.statusMessageService.showErrorToast(
             `The session is created but the template questions cannot be created: ${resp.error.message}`);
       }, () => {
         this.navigationService.navigateByURLWithParamEncoding(
@@ -331,15 +331,15 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             { courseid: feedbackSession.courseId, fsname: feedbackSession.feedbackSessionName })
             .then(() => {
               resolvingResultMessages.forEach((msg: string) => {
-                this.statusMessageService.showWarningMessage(msg);
+                this.statusMessageService.showWarningToast(msg);
               });
-              this.statusMessageService.showSuccessMessage('The feedback session has been added.'
+              this.statusMessageService.showSuccessToast('The feedback session has been added.'
                   + 'Click the "Add New Question" button below to begin adding questions for the feedback session.');
             });
       });
     }, (resp: ErrorMessageOutput) => {
       this.sessionEditFormModel.isSaving = false;
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -383,7 +383,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             this.updateInstructorPrivilege(model);
           });
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -442,8 +442,8 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
           };
           this.sessionsTableRowModels.push(m);
           this.updateInstructorPrivilege(m);
-          this.statusMessageService.showSuccessMessage('The feedback session has been restored.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+          this.statusMessageService.showSuccessToast('The feedback session has been restored.');
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -461,9 +461,9 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
           this.recycleBinFeedbackSessionRowModels.push({
             feedbackSession,
           });
-          this.statusMessageService.showSuccessMessage('The feedback session has been deleted. '
+          this.statusMessageService.showSuccessToast('The feedback session has been deleted. '
               + 'You can restore it from the deleted sessions table below.');
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -520,7 +520,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             });
           });
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -549,9 +549,9 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
         this.sessionsTableRowModels.push(m);
         this.updateInstructorPrivilege(m);
       });
-      this.statusMessageService.showSuccessMessage('All sessions have been restored.');
+      this.statusMessageService.showSuccessToast('All sessions have been restored.');
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -570,9 +570,9 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
       ).subscribe(() => {
         this.recycleBinFeedbackSessionRowModels.splice(
             this.recycleBinFeedbackSessionRowModels.indexOf(model), 1);
-        this.statusMessageService.showSuccessMessage('The feedback session has been permanently deleted.');
+        this.statusMessageService.showSuccessToast('The feedback session has been permanently deleted.');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }
@@ -598,9 +598,9 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
 
       forkJoin(deleteRequests).subscribe(() => {
         this.recycleBinFeedbackSessionRowModels = [];
-        this.statusMessageService.showSuccessMessage('All sessions have been permanently deleted.');
+        this.statusMessageService.showSuccessToast('All sessions have been permanently deleted.');
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, () => {});
   }

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorStudentListPageComponent } from './instructor-student-list-page.component';
 import { InstructorStudentListPageModule } from './instructor-student-list-page.module';
@@ -16,7 +15,6 @@ describe('InstructorStudentListPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         FormsModule,
-        MatSnackBarModule,
         InstructorStudentListPageModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -68,7 +68,7 @@ export class InstructorStudentListPageComponent implements OnInit {
             this.courseTabList.push(courseTab);
           });
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -110,7 +110,7 @@ export class InstructorStudentListPageComponent implements OnInit {
           });
 
           courseTab.stats = this.courseService.calculateCourseStatistics(students.students);
-        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
   }
 
   /**
@@ -128,7 +128,7 @@ export class InstructorStudentListPageComponent implements OnInit {
 
           courseTab.studentList.push(...students);
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -146,9 +146,9 @@ export class InstructorStudentListPageComponent implements OnInit {
       courseTab.stats = this.courseService.calculateCourseStatistics(students);
 
       this.statusMessageService
-          .showSuccessMessage(`Student is successfully deleted from course "${courseTab.course.courseId}"`);
+          .showSuccessToast(`Student is successfully deleted from course "${courseTab.course.courseId}"`);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 }

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -41,7 +40,6 @@ describe('InstructorStudentRecordsPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
-        MatSnackBarModule,
         GrqRgqViewResponsesModule,
       ],
       providers: [

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -86,7 +86,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
         this.currInstructorName = instructor.name;
       });
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -100,7 +100,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
     this.studentProfileService.getStudentProfile(this.studentEmail, this.courseId).subscribe((resp: StudentProfile) => {
       this.studentProfile = resp;
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -144,7 +144,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
           });
           results.questions.forEach((questions: QuestionOutput) => this.preprocessComments(questions.allResponses));
         }, (errorMessageOutput: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(errorMessageOutput.error.message);
+          this.statusMessageService.showErrorToast(errorMessageOutput.error.message);
         });
   }
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SingleStatisticsModule } from '../../components/question-responses/single-statistics/single-statistics.module';
 import {
@@ -20,7 +19,6 @@ describe('SessionResultPageComponent', () => {
         RouterTestingModule,
         StudentViewResponsesModule,
         QuestionTextWithInfoModule,
-        MatSnackBarModule,
         SingleStatisticsModule,
       ],
       declarations: [SessionResultPageComponent],

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -142,10 +142,10 @@ export class SessionResultPageComponent implements OnInit {
             (a: QuestionOutput, b: QuestionOutput) =>
                 a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SessionSubmissionPageComponent } from './session-submission-page.component';
 import { SessionSubmissionPageModule } from './session-submission-page.module';
@@ -15,7 +14,6 @@ describe('SessionSubmissionPageComponent', () => {
         SessionSubmissionPageModule,
         HttpClientTestingModule,
         RouterTestingModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -296,7 +296,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       if (resp.status === 404) {
         this.modalService.open(FeedbackSessionDeletedModalComponent);
       }
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -339,7 +339,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         this.questionSubmissionForms.push(model);
         this.loadFeedbackQuestionRecipientsForQuestion(model);
       });
-    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorMessage(resp.error.message));
+    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorToast(resp.error.message));
   }
 
   /**
@@ -384,7 +384,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       } else {
         this.loadFeedbackResponses(model);
       }
-    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorMessage(resp.error.message));
+    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorToast(resp.error.message));
   }
 
   /**
@@ -457,7 +457,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
       // load comments
       this.loadParticipantComment(model);
-    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorMessage(resp.error.message));
+    }, (resp: ErrorMessageOutput) => this.statusMessageService.showErrorToast(resp.error.message));
   }
 
   /**
@@ -486,7 +486,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     forkJoin(loadCommentRequests).subscribe(() => {
       // comment loading success
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -550,7 +550,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                     recipientSubmissionFormModel.commentByGiver = undefined;
                   }),
                   catchError((error: any) => {
-                    this.statusMessageService.showErrorMessage((error as ErrorMessageOutput).error.message);
+                    this.statusMessageService.showErrorToast((error as ErrorMessageOutput).error.message);
                     failToSaveQuestions.add(questionSubmissionFormModel.questionNumber);
                     return of(error);
                   }),
@@ -576,7 +576,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                       }),
                       switchMap(() => this.createCommentRequest(recipientSubmissionFormModel)),
                       catchError((error: any) => {
-                        this.statusMessageService.showErrorMessage((error as ErrorMessageOutput).error.message);
+                        this.statusMessageService.showErrorToast((error as ErrorMessageOutput).error.message);
                         failToSaveQuestions.add(questionSubmissionFormModel.questionNumber);
                         return of(error);
                       }),
@@ -602,7 +602,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                       }),
                       switchMap(() => this.createCommentRequest(recipientSubmissionFormModel)),
                       catchError((error: any) => {
-                        this.statusMessageService.showErrorMessage((error as ErrorMessageOutput).error.message);
+                        this.statusMessageService.showErrorToast((error as ErrorMessageOutput).error.message);
                         failToSaveQuestions.add(questionSubmissionFormModel.questionNumber);
                         return of(error);
                       }),
@@ -620,14 +620,14 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     forkJoin(savingRequests).pipe(
         switchMap(() => {
           if (failToSaveQuestions.size === 0) {
-            this.statusMessageService.showSuccessMessage('All responses submitted successfully!');
+            this.statusMessageService.showSuccessToast('All responses submitted successfully!');
           } else {
-            this.statusMessageService.showErrorMessage('Some responses are not saved successfully');
+            this.statusMessageService.showErrorToast('Some responses are not saved successfully');
           }
 
           if (notYetAnsweredQuestions.size !== 0) {
             // TODO use showInfoMessage
-            this.statusMessageService.showSuccessMessage(
+            this.statusMessageService.showSuccessToast(
                 `Note that some questions are yet to be answered. They are:
                 ${ Array.from(notYetAnsweredQuestions.values()) }.`);
           }
@@ -655,17 +655,17 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         case ConfirmationResult.SUCCESS:
           break;
         case ConfirmationResult.SUCCESS_BUT_EMAIL_FAIL_TO_SEND:
-          this.statusMessageService.showErrorMessage(
+          this.statusMessageService.showErrorToast(
               `Submission confirmation email failed to send: ${response.message}`);
           break;
         default:
-          this.statusMessageService.showErrorMessage(`Unknown result ${response.result}`);
+          this.statusMessageService.showErrorToast(`Unknown result ${response.result}`);
       }
       hasSubmissionConfirmationError = false;
       this.shouldSendConfirmationEmail = false;
     }, (resp: ErrorMessageOutput) => {
       hasSubmissionConfirmationError = true;
-      this.statusMessageService.showErrorMessage(resp.error.message);
+      this.statusMessageService.showErrorToast(resp.error.message);
     });
   }
 
@@ -757,9 +757,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           moderatedperson: this.moderatedPerson,
         }).subscribe(() => {
           recipientSubmissionFormModel.commentByGiver = undefined;
-          this.statusMessageService.showSuccessMessage('Your comment has been deleted!');
+          this.statusMessageService.showSuccessToast('Your comment has been deleted!');
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -786,9 +786,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     }).subscribe(
         (comment: FeedbackResponseComment) => {
           recipientSubmissionFormModel.commentByGiver = this.getCommentModel(comment);
-          this.statusMessageService.showSuccessMessage('Your comment has been saved!');
+          this.statusMessageService.showSuccessToast('Your comment has been saved!');
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 }

--- a/src/web/app/pages-static/static-page.component.spec.ts
+++ b/src/web/app/pages-static/static-page.component.spec.ts
@@ -5,6 +5,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from '../components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
+import { ToastModule } from '../components/toast/toast.module';
 import { PageComponent } from '../page.component';
 import { StaticPageComponent } from './static-page.component';
 
@@ -25,6 +26,7 @@ describe('StaticPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         StatusMessageModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.spec.ts
+++ b/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Course, Gender, Instructor, InstructorPermissionRole, JoinState, Student } from '../../../types/api-output';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
@@ -17,7 +16,6 @@ describe('StudentCourseDetailsPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         TeammatesCommonModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.ts
+++ b/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.ts
@@ -96,7 +96,7 @@ export class StudentCourseDetailsPageComponent implements OnInit {
           this.student = student;
           this.loadTeammates(courseId, student.teamName);
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 
@@ -133,7 +133,7 @@ export class StudentCourseDetailsPageComponent implements OnInit {
                 });
         });
       }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
+        this.statusMessageService.showErrorToast(resp.error.message);
       });
   }
 
@@ -146,7 +146,7 @@ export class StudentCourseDetailsPageComponent implements OnInit {
         .subscribe((instructors: Instructors) => {
           this.instructorDetails = instructors.instructors;
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessageService.showErrorToast(resp.error.message);
         });
   }
 

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -10,7 +10,6 @@ import {
 } from '../../../types/api-output';
 import { StudentHomePageComponent } from './student-home-page.component';
 
-import { MatSnackBarModule } from '@angular/material';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
 import { ResponseStatusPipe } from '../../pipes/session-response-status.pipe';
 import { SubmissionStatusPipe } from '../../pipes/session-submission-status.pipe';
@@ -30,7 +29,6 @@ describe('StudentHomePageComponent', () => {
         HttpClientTestingModule,
         NgbModule,
         RouterTestingModule,
-        MatSnackBarModule,
         TeammatesCommonModule,
       ],
     })

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -105,7 +105,7 @@ export class StudentHomePageComponent implements OnInit {
           });
       }
     }, (e: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(e.error.message);
+      this.statusMessageService.showErrorToast(e.error.message);
     });
   }
 

--- a/src/web/app/pages-student/student-page.component.spec.ts
+++ b/src/web/app/pages-student/student-page.component.spec.ts
@@ -5,6 +5,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from '../components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
+import { ToastModule } from '../components/toast/toast.module';
 import { PageComponent } from '../page.component';
 import { StudentPageComponent } from './student-page.component';
 
@@ -25,6 +26,7 @@ describe('StudentPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         StatusMessageModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.spec.ts
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.spec.ts
@@ -4,7 +4,6 @@ import { GenderFormatPipe } from './student-profile-gender.pipe';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../../../environments/environment.prod';
 import { Gender } from '../../../types/api-output';
@@ -26,7 +25,6 @@ describe('StudentProfilePageComponent', () => {
         ReactiveFormsModule,
         HttpClientTestingModule,
         TeammatesCommonModule,
-        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
@@ -80,10 +80,10 @@ export class StudentProfilePageComponent implements OnInit {
             this.name = response.name;
             this.initStudentProfileForm(this.student);
           } else {
-            this.statusMessageService.showErrorMessage('Error retrieving student profile');
+            this.statusMessageService.showErrorToast('Error retrieving student profile');
           }
         }, (response: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(response.error.message);
+          this.statusMessageService.showErrorToast(response.error.message);
         });
       }
     });
@@ -148,7 +148,7 @@ export class StudentProfilePageComponent implements OnInit {
         )
         // Display message status
         .subscribe(() => {
-          this.statusMessageService.showSuccessMessage('Your profile picture has been saved successfully');
+          this.statusMessageService.showSuccessToast('Your profile picture has been saved successfully');
 
           // Force reload
           const timestamp: number = (new Date()).getTime();
@@ -159,7 +159,7 @@ export class StudentProfilePageComponent implements OnInit {
             return;
           }
 
-          this.statusMessageService.showErrorMessage(response.error.message);
+          this.statusMessageService.showErrorToast(response.error.message);
         });
   }
 
@@ -177,10 +177,10 @@ export class StudentProfilePageComponent implements OnInit {
       existingNationality: this.editForm.controls.existingNationality.value,
     }).subscribe((response: MessageOutput) => {
       if (response) {
-        this.statusMessageService.showSuccessMessage(response.message);
+        this.statusMessageService.showSuccessToast(response.message);
       }
     }, (response: ErrorMessageOutput) => {
-      this.statusMessageService.showErrorMessage(`Could not save your profile! ${response.error.message}`);
+      this.statusMessageService.showErrorToast(`Could not save your profile! ${response.error.message}`);
     });
   }
 
@@ -201,12 +201,12 @@ export class StudentProfilePageComponent implements OnInit {
     this.studentProfileService.deleteProfilePicture(paramMap)
         .subscribe((response: MessageOutput) => {
           if (response) {
-            this.statusMessageService.showSuccessMessage(response.message);
+            this.statusMessageService.showSuccessToast(response.message);
             this.profilePicLink = '/assets/images/profile_picture_default.png';
           }
         }, (response: ErrorMessageOutput) => {
           this.statusMessageService.
-            showErrorMessage(`Could not delete your profile picture! ${response.error.message}`);
+            showErrorToast(`Could not delete your profile picture! ${response.error.message}`);
         });
   }
 

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.spec.ts
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.spec.ts
@@ -1,6 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 import { NgbActiveModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { UploadEditProfilePictureModalComponent } from './upload-edit-profile-picture-modal.component';
@@ -18,7 +17,6 @@ describe('UploadEditProfilePictureModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         ImageCropperModule,
-        MatSnackBarModule,
         NgbTooltipModule,
       ],
       providers: [

--- a/src/web/app/pages.module.ts
+++ b/src/web/app/pages.module.ts
@@ -7,6 +7,7 @@ import { ErrorReportModule } from './components/error-report/error-report.module
 import { LoaderBarModule } from './components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
+import { ToastsModule } from './components/toasts/toasts.module';
 import { PageNotFoundModule } from './page-not-found/page-not-found.module';
 import { ClickOutsideDirective, PageComponent } from './page.component';
 import { AdminPageComponent } from './pages-admin/admin-page.component';
@@ -92,6 +93,7 @@ const routes: Routes = [
     SessionResultPageModule,
     SessionSubmissionPageModule,
     RouterModule.forChild(routes),
+    ToastsModule,
   ],
   declarations: [
     PageComponent,

--- a/src/web/app/pages.module.ts
+++ b/src/web/app/pages.module.ts
@@ -7,7 +7,7 @@ import { ErrorReportModule } from './components/error-report/error-report.module
 import { LoaderBarModule } from './components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
-import { ToastsModule } from './components/toasts/toasts.module';
+import { ToastModule } from './components/toast/toast.module';
 import { PageNotFoundModule } from './page-not-found/page-not-found.module';
 import { ClickOutsideDirective, PageComponent } from './page.component';
 import { AdminPageComponent } from './pages-admin/admin-page.component';
@@ -93,7 +93,7 @@ const routes: Routes = [
     SessionResultPageModule,
     SessionSubmissionPageModule,
     RouterModule.forChild(routes),
-    ToastsModule,
+    ToastModule,
   ],
   declarations: [
     PageComponent,

--- a/src/web/app/public-page.component.spec.ts
+++ b/src/web/app/public-page.component.spec.ts
@@ -4,6 +4,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoaderBarModule } from './components/loader-bar/loader-bar.module';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
+import { ToastModule } from './components/toast/toast.module';
 import { PageComponent } from './page.component';
 import { PublicPageComponent } from './public-page.component';
 
@@ -23,6 +24,7 @@ describe('PublicPageComponent', () => {
         NgbModule,
         RouterTestingModule,
         StatusMessageModule,
+        ToastModule,
       ],
     })
     .compileComponents();

--- a/src/web/services/link.service.spec.ts
+++ b/src/web/services/link.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 
 import { Instructor, InstructorPermissionRole, JoinState, Student } from '../types/api-output';
 import { LinkService } from './link.service';
@@ -8,9 +7,6 @@ describe('Link Service', () => {
   let service: LinkService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSnackBarModule],
-    });
     service = TestBed.get(LinkService);
   });
 

--- a/src/web/services/navigation.service.spec.ts
+++ b/src/web/services/navigation.service.spec.ts
@@ -1,15 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
-import { MatSnackBarModule } from '@angular/material';
 import { NavigationService } from './navigation.service';
 
 describe('NavigationService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [
-      MatSnackBarModule,
-    ],
-  }));
-
   it('should be created', () => {
     const service: NavigationService = TestBed.get(NavigationService);
     expect(service).toBeTruthy();

--- a/src/web/services/navigation.service.ts
+++ b/src/web/services/navigation.service.ts
@@ -37,7 +37,7 @@ export class NavigationService {
    */
   navigateWithErrorMessage(router: Router, url: string, message: string): void {
     router.navigateByUrl(url).then(() => {
-      this.statusMessageService.showErrorMessage(message);
+      this.statusMessageService.showErrorToast(message);
     });
   }
 
@@ -46,7 +46,7 @@ export class NavigationService {
    */
   navigateWithSuccessMessage(router: Router, url: string, message: string, params: Record<string, string> = {}): void {
     this.navigateByURLWithParamEncoding(router, url, params).then(() => {
-      this.statusMessageService.showSuccessMessage(message);
+      this.statusMessageService.showSuccessToast(message);
     });
   }
 
@@ -55,7 +55,7 @@ export class NavigationService {
    */
   navigateWithSuccessMessagePreservingParams(router: Router, url: string, message: string): void {
     router.navigate([url], { queryParamsHandling: 'preserve' }).then(() => {
-      this.statusMessageService.showSuccessMessage(message);
+      this.statusMessageService.showSuccessToast(message);
     });
   }
 

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
@@ -155,7 +154,7 @@ describe('SearchService', () => {
       delete: jest.fn(),
     };
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatSnackBarModule],
+      imports: [HttpClientTestingModule],
       providers: [
         { provide: HttpRequestService, useValue: spyHttpRequestService },
       ],

--- a/src/web/services/status-message.service.spec.ts
+++ b/src/web/services/status-message.service.spec.ts
@@ -1,15 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
-import { MatSnackBarModule } from '@angular/material';
 import { StatusMessageService } from './status-message.service';
 
 describe('StatusMessageService', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [
-      MatSnackBarModule,
-    ],
-  }));
-
   it('should be created', () => {
     const service: StatusMessageService = TestBed.get(StatusMessageService);
     expect(service).toBeTruthy();

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, TemplateRef } from '@angular/core';
-import { MatSnackBar } from '@angular/material';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { Observable, Subject } from 'rxjs';
 import { StatusMessage } from '../app/components/status-message/status-message';
 import {
   StatusMessageModalComponent,
 } from '../app/components/status-message/status-messsage-modal/status-message-modal.component';
+import { Toast } from '../app/components/toast/toast';
 
 /**
  * Handles operations related to status message provision.
@@ -14,73 +15,63 @@ import {
 })
 export class StatusMessageService {
 
-  constructor(private snackBar: MatSnackBar, private modalService: NgbModal) {}
+  private toast: Subject<Toast> = new Subject();
+
+  constructor(private modalService: NgbModal) {}
+
+  getToastEvent(): Observable<any> {
+    return this.toast.asObservable();
+  }
 
   /**
-   * Shows a success message on the page.
+   * Shows a success toast on the page.
    */
-  showSuccessMessage(message: string): void {
-    this.showMessage({
+  showSuccessToast(message: string, delay: number = 5000): void {
+    this.showToast(message, 'bg-success text-light', delay);
+  }
+
+  /**
+   * Shows a warning toast on the page.
+   */
+  showWarningToast(message: string, delay: number = 5000): void {
+    this.showToast(message, 'bg-warning', delay);
+  }
+
+  /**
+   * Shows an error toast on the page.
+   */
+  showErrorToast(message: string, delay: number = 10000): void {
+    this.showToast(message, 'bg-danger text-light', delay);
+  }
+
+  private showToast(message: string, classes: string, delay: number): void {
+    this.toast.next({
       message,
-      color: 'snackbar-success',
+      classes,
+      delay,
     });
   }
 
   /**
-   * Shows a warning message on the page.
+   * Shows a success toast containing HTML on the page
    */
-  showWarningMessage(message: string): void {
-    this.showMessage({
-      message,
-      color: 'snackbar-warning',
-    });
+  showSuccessToastTemplate(template: TemplateRef<any>, delay: number = 5000): void {
+    this.showToastTemplate(template, 'bg-success text-light', delay);
   }
 
-  /**
-   * Shows an error message on the page.
-   */
-  showErrorMessage(message: string): void {
-    this.showMessage({
-      message,
-      color: 'snackbar-danger',
-    });
-  }
-
-  private showMessage(message: StatusMessage): void {
-    this.snackBar.open(message.message, '', {
-      duration: 10000,
-      verticalPosition: 'top',
-      panelClass: ['snackbar', message.color],
-    });
-  }
-
-  /**
-   * Shows a success message containing HTML on the page
-   */
-  showSuccessMessageTemplate(template: TemplateRef<any>): void {
-    this.showTemplate(template, 'snackbar-success');
-  }
-
-  private showTemplate(template: TemplateRef<any>, color: string): void {
-    this.snackBar.openFromTemplate(template, {
-      duration: 10000,
-      verticalPosition: 'top',
-      panelClass: ['snackbar', color],
+  private showToastTemplate(template: TemplateRef<any>, classes: string, delay: number): void {
+    this.toast.next({
+      classes,
+      delay,
+      message: template,
     });
   }
 
   /**
    * Shows a warning message modal on the page that must be acknowledged.
    */
-  showWarningMessageModal(title: string, subtitle: string, message: string): NgbModalRef {
+  showWarningModal(title: string, subtitle: string, message: string): NgbModalRef {
     return this.showMessageModal(title, subtitle, { message, color: 'warning' });
-  }
-
-  /**
-   * Shows an error message modal on the page that must be acknowledged.
-   */
-  showErrorMessageModal(title: string, subtitle: string, message: string): NgbModalRef {
-    return this.showMessageModal(title, subtitle, { message, color: 'danger' });
   }
 
   private showMessageModal(title: string, subtitle: string, message: StatusMessage): NgbModalRef {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -3,44 +3,10 @@
 @import '~bootstrap/dist/css/bootstrap.css';
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~handsontable/dist/handsontable.full.css';
-@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
-}
-
-// make snackbar over the modal
-.cdk-overlay-container {
-  z-index: 1100;
-}
-
-.snackbar {
-  max-width: 100% !important;
-  margin-top: 60px !important;
-}
-
-.snackbar-danger {
-  background-color: var(--danger);
-  color: var(--light);
-
-  a {
-    color: #000;
-  }
-}
-
-.snackbar-success {
-  background-color: var(--success);
-  color: var(--light);
-
-  a {
-    color: #000;
-  }
-}
-
-.snackbar-warning {
-  background-color: var(--warning);
-  color: var(--dark);
 }
 
 .btn {


### PR DESCRIPTION
Part of #10213 

Angular material is only utilized for two components, both of which have replacements in Bootstrap. Thus there is little reason to use two UI libraries now; it was previously necessary because the toast module in `ng-bootstrap` was only introduced during its Angular 8 support.

Progress bar:
<img width="1440" alt="Screen Shot 2020-06-18 at 10 09 46 PM" src="https://user-images.githubusercontent.com/7261051/85032171-169e7580-b1b2-11ea-93ce-0774f57f6a75.png">

Toasts (previously called snackbars):
<img width="1433" alt="Screen Shot 2020-06-18 at 10 19 09 PM" src="https://user-images.githubusercontent.com/7261051/85032180-1900cf80-b1b2-11ea-9a04-9d78ff2f2a96.png">

Toast with HTML code:
<img width="1427" alt="Screen Shot 2020-06-18 at 10 19 27 PM" src="https://user-images.githubusercontent.com/7261051/85032185-1aca9300-b1b2-11ea-8eec-ded38f447fb9.png">

Interesting to note that the toasts look almost (if not fully) identical compared to the Material counterpart.

~E2E tests are failing; it seems the toast module disrupts the way the page loading logic works in E2E tests. Will be looking into it.~ Fixed.