### PR TITLE
[#10197] Fix Instructor Help page text to text align left

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.scss
@@ -5,3 +5,8 @@
 .instr-help-qn-last {
   padding-bottom: 5px;
 }
+@media (max-width:700px){
+  button{
+    text-align:left;
+  }
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
@@ -34,3 +34,9 @@
 .instr-help-qn-last {
   padding-bottom: 5px;
 }
+
+@media (max-width:700px){
+  button{
+    text-align:left;
+  }
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.scss
@@ -5,3 +5,8 @@
 .instr-help-qn-last {
   padding-bottom: 5px;
 }
+@media (max-width:700px){
+  button{
+    text-align:left;
+  }
+}


### PR DESCRIPTION
Part of #10197 

Changing conditions of text-align after a fastbreak to put the text at the left instead of align it at center.

Before:

<img width="367" alt="before" src="https://user-images.githubusercontent.com/50500740/85082192-7571e800-b1ce-11ea-8e32-1216065ce662.png">

After:

![After](https://user-images.githubusercontent.com/50500740/85082206-81f64080-b1ce-11ea-9613-2b3ac9c31d26.png)



