### PR TITLE
[#10176] Fix section-related problems in session results page

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
@@ -152,10 +152,24 @@ public abstract class BasicFeedbackSubmissionAction extends Action {
      * Gets the section of a recipient.
      */
     protected String getRecipientSection(
-            String courseId, FeedbackParticipantType recipientType, String recipientIdentifier) {
+            String courseId, FeedbackParticipantType giverType, FeedbackParticipantType recipientType,
+            String recipientIdentifier) {
         switch (recipientType) {
-        case INSTRUCTORS:
         case SELF:
+            switch (giverType) {
+            case INSTRUCTORS:
+            case SELF:
+                return Const.DEFAULT_SECTION;
+            case TEAMS:
+                return logic.getSectionForTeam(courseId, recipientIdentifier);
+            case STUDENTS:
+                StudentAttributes student = logic.getStudentForEmail(courseId, recipientIdentifier);
+                return student == null ? Const.DEFAULT_SECTION : student.section;
+            default:
+                Assumption.fail("Invalid giver type " + giverType + " for recipient type " + recipientType);
+                return null;
+            }
+        case INSTRUCTORS:
         case NONE:
             return Const.DEFAULT_SECTION;
         case TEAMS:

--- a/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseAction.java
@@ -100,7 +100,7 @@ public class CreateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
                 FeedbackResponseAttributes
                         .builder(feedbackQuestion.getId(), giverIdentifier, createRequest.getRecipientIdentifier())
                 .withGiverSection(giverSection)
-                .withRecipientSection(getRecipientSection(feedbackQuestion.getCourseId(),
+                .withRecipientSection(getRecipientSection(feedbackQuestion.getCourseId(), feedbackQuestion.getGiverType(),
                         feedbackQuestion.getRecipientType(), createRequest.getRecipientIdentifier()))
                 .withCourseId(feedbackQuestion.getCourseId())
                 .withFeedbackSessionName(feedbackQuestion.getFeedbackSessionName())

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
@@ -108,7 +108,7 @@ public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
         feedbackResponse.giverSection = giverSection;
         feedbackResponse.recipient = updateRequest.getRecipientIdentifier();
         feedbackResponse.recipientSection =
-                getRecipientSection(feedbackQuestion.getCourseId(),
+                getRecipientSection(feedbackQuestion.getCourseId(), feedbackQuestion.getGiverType(),
                         feedbackQuestion.getRecipientType(), updateRequest.getRecipientIdentifier());
         feedbackResponse.responseDetails = updateRequest.getResponseDetails();
 

--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -191,12 +191,23 @@ public class SessionResultsData extends ApiOutput {
         }
         String giverName = getGiverNameOfResponse(response, bundle);
         String giverTeam = bundle.getRoster().getInfoForIdentifier(response.getGiver()).getTeamName();
+        String giverSection = response.getGiverSection();
+        FeedbackQuestionAttributes question = bundle.getQuestionsMap().get(response.getFeedbackQuestionId());
+        if (question.giverType == FeedbackParticipantType.INSTRUCTORS) {
+            giverTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
+            giverSection = Const.DEFAULT_SECTION;
+        }
 
         // process recipient
         String recipientEmail = null;
         String recipientName = getRecipientNameOfResponse(response, bundle);
         String recipientTeam =
                 bundle.getRoster().getInfoForIdentifier(response.getRecipient()).getTeamName();
+        String recipientSection = response.getRecipientSection();
+        if (question.recipientType == FeedbackParticipantType.INSTRUCTORS) {
+            recipientTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
+            recipientSection = Const.DEFAULT_SECTION;
+        }
         if (bundle.isResponseRecipientVisible(response)) {
             recipientEmail = response.getRecipient();
 
@@ -221,11 +232,11 @@ public class SessionResultsData extends ApiOutput {
                 .withGiverTeam(giverTeam)
                 .withGiverEmail(giverEmail)
                 .withRelatedGiverEmail(relatedGiverEmail)
-                .withGiverSection(response.getGiverSection())
+                .withGiverSection(giverSection)
                 .withRecipient(recipientName)
                 .withRecipientTeam(recipientTeam)
                 .withRecipientEmail(recipientEmail)
-                .withRecipientSection(response.getRecipientSection())
+                .withRecipientSection(recipientSection)
                 .withResponseDetails(response.getResponseDetails())
                 .withParticipantComment(comments.poll())
                 .withInstructorComments(new ArrayList<>(comments))

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -885,7 +885,7 @@
       "giver": "alice.b.tmms@gmail.tmt",
       "recipient": "teammates.demo.instructor@demo.course",
       "giverSection": "Tutorial Group 1",
-      "recipientSection": "Tutorial Group 2",
+      "recipientSection": "No specific section",
       "responseDetails": {
         "answer": 4,
         "questionType": "NUMSCALE"
@@ -1224,7 +1224,7 @@
       "giver": "charlie.d.tmms@gmail.tmt",
       "recipient": "teammates.demo.instructor@demo.course",
       "giverSection": "Tutorial Group 2",
-      "recipientSection": "Tutorial Group 2",
+      "recipientSection": "No specific section",
       "responseDetails": {
         "answer": 5,
         "questionType": "NUMSCALE"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
     <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
-      {{ sectionInfo.key }}
+      {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
     <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
-      {{ sectionInfo.key }}
+      {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -75,7 +75,7 @@
           <select class="form-control" [(ngModel)]="section">
             <option value="">All</option>
             <option *ngFor="let section of sectionsModel | keyvalue" [value]="section.key">{{ section.key }}</option>
-            <!-- <option value="None">No specific section</option> -->
+            <option value="None">No specific section</option>
           </select>
         </div>
       </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -144,6 +144,11 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         this.courseService.getCourseSectionNames(queryParams.courseid)
             .subscribe((courseSectionNames: CourseSectionNames) => {
               for (const sectionName of courseSectionNames.sectionNames) {
+                this.sectionsModel.None = {
+                  questions: [],
+                  hasPopulated: false,
+                  isTabExpanded: false,
+                };
                 this.sectionsModel[sectionName] = {
                   questions: [],
                   hasPopulated: false,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
     <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
-      {{ sectionInfo.key }}
+      {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -1,7 +1,7 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
     <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
-      {{ sectionInfo.key }}
+      {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>


### PR DESCRIPTION
Part of #10176 

This fixes the following tickets:
- Missing "No specific section"
- Missing response to/from instructors

However, this PR also appears to solve an age-old problem in TEAMMATES where an entity who is a both a student and an instructor will have some mixed up logic in V6.