### PR TITLE
[#10029] Add "Enroll this student to my course" button in Student-Profile page

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -73,7 +73,8 @@
               [stretchH]="'all'"
               [minSpareRows]="1"
               [contextMenu]="contextMenuOptions"
-              [hidden]="isNewStudentsPanelCollapsed">
+              [hidden]="isNewStudentsPanelCollapsed"
+              [data]="newStudentInfo">
           </hot-table>
         </div>
         <div class="row enroll-students-spreadsheet-buttons" [hidden]="isNewStudentsPanelCollapsed">

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -67,6 +67,9 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   isExistingStudentsPresent: boolean = true;
   loading: boolean = false;
   isAjaxSuccess: boolean = true;
+  newStudentInfo: string[][] = [
+      ['', '', '', '', ''],
+  ];
 
   constructor(private route: ActivatedRoute,
               private statusMessageService: StatusMessageService,
@@ -77,6 +80,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
       this.getCourseEnrollPageData(queryParams.courseid);
+      this.newStudentInfo[0][2] = queryParams.studentname;
+      this.newStudentInfo[0][3] = queryParams.studentemail;
     });
   }
 

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/__snapshots__/instructor-course-student-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/__snapshots__/instructor-course-student-details-page.component.spec.ts.snap
@@ -24,7 +24,16 @@ exports[`InstructorCourseStudentDetailsPageComponent should snap with populated 
 >
   <h1>
     firstName
-  </h1><tm-student-profile
+  </h1><button
+    class="btn btn-primary"
+    ng-reflect-query-params="[object Object]"
+    ng-reflect-router-link="/web/instructor/courses"
+    ngbtooltip="Enroll student into your course"
+    routerlink="/web/instructor/courses"
+    tabindex="0"
+  >
+     Enroll this student to my course 
+  </button><tm-student-profile
     ng-reflect-photo-url="http://localhost:8080/webapi/s"
     ng-reflect-student-profile="[object Object]"
   /><tm-course-related-info

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.html
@@ -1,5 +1,11 @@
 <ng-container *ngIf="student">
   <h1>{{student?.name}}</h1>
+  <button class="btn btn-primary"
+          ngbTooltip="Enroll student into your course"
+          routerLink="/web/instructor/courses"
+          [queryParams]="{studentemail:student?.email, studentname:student?.name}">
+      Enroll this student to my course
+  </button>
   <tm-student-profile [studentProfile]="studentProfile" [photoUrl]="photoUrl"></tm-student-profile>
   <tm-course-related-info [student]="student"></tm-course-related-info>
   <tm-more-info [studentName]="student?.name" [moreInfoText]="studentProfile?.moreInfo"></tm-more-info>

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -171,8 +171,10 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                 id="btn-enroll-0"
                 ng-reflect-ngb-tooltip="Enroll student into the course"
                 ng-reflect-query-params="[object Object]"
+                ng-reflect-query-params-handling="merge"
                 ng-reflect-router-link="/web/instructor/courses/enroll"
                 ngbtooltip="Enroll student into the course"
+                queryparamshandling="merge"
                 routerlink="/web/instructor/courses/enroll"
                 tabindex="0"
               >
@@ -644,8 +646,10 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                 id="btn-enroll-0"
                 ng-reflect-ngb-tooltip="Enroll student into the course"
                 ng-reflect-query-params="[object Object]"
+                ng-reflect-query-params-handling="merge"
                 ng-reflect-router-link="/web/instructor/courses/enroll"
                 ngbtooltip="Enroll student into the course"
+                queryparamshandling="merge"
                 routerlink="/web/instructor/courses/enroll"
                 tabindex="0"
               >

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -1193,8 +1193,10 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                 id="btn-enroll-0"
                 ng-reflect-ngb-tooltip="Enroll student into the course"
                 ng-reflect-query-params="[object Object]"
+                ng-reflect-query-params-handling="merge"
                 ng-reflect-router-link="/web/instructor/courses/enroll"
                 ngbtooltip="Enroll student into the course"
+                queryparamshandling="merge"
                 routerlink="/web/instructor/courses/enroll"
                 tabindex="0"
               >

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -98,7 +98,8 @@
               <button id="btn-enroll-{{ i }}" class="btn btn-light btn-sm" *ngIf="course.canModifyStudent"
                 ngbTooltip="Enroll student into the course"
                 routerLink="/web/instructor/courses/enroll"
-                [queryParams]="{courseid: course.course.courseId}">
+                [queryParams]="{courseid: course.course.courseId}"
+                queryParamsHandling="merge">
                 Enroll
               </button>
               <button id="btn-enroll-disabled-{{ i }}" class="btn btn-light btn-sm disabled" *ngIf="!course.canModifyStudent">


### PR DESCRIPTION
Fixes #10029 

**Screen shots**
Student profile detail page 
<img width="854" alt="Screen Shot 2020-06-21 at 14 16 38 PM" src="https://user-images.githubusercontent.com/32270970/85233256-969f2800-b3ca-11ea-81b9-6a5a1af44707.png">

After clicking the "Enroll this student to my course", 
<img width="855" alt="Screen Shot 2020-06-21 at 14 23 48 PM" src="https://user-images.githubusercontent.com/32270970/85233320-fdbcdc80-b3ca-11ea-89bb-5d49a861d1c4.png">

After clicking the "Enroll" button for a specific course, 
<img width="854" alt="Screen Shot 2020-06-21 at 14 24 47 PM" src="https://user-images.githubusercontent.com/32270970/85233342-0ca38f00-b3cb-11ea-9d8c-e6e1f9a34fff.png">


**Solution**
Created a button on the Student-Profile page which carries the student name and email and route to the instructor-courses-page. When the enroll button on the instructor-courses-page is clicked, the previously carried student name and email and the course-id will be carried as query parameters and route to the instructor-course-enroll-page. When the page is initialized, by using the query parameters, we put the new student's information to the spreadsheet.  

**Concern** 
In instructor-course-enroll-page.component.ts file, we created an array (newStudentInfo) to initialize the new students' hands-on-table data, but since the only cells to be filled for the table are name and email, the indexes of the array are hard-coded. 
