### PR TITLE
[#10176] Fix authentication-related problems from UAT

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -663,6 +663,7 @@ public final class Const {
         public static final String EXCEPTION = "/exception";
         public static final String ERROR_REPORT = "/errorreport";
         public static final String AUTH = "/auth";
+        public static final String AUTH_REGKEY = "/auth/regkey";
         public static final String ACCOUNT = "/account";
         public static final String ACCOUNT_RESET = "/account/reset";
         public static final String ACCOUNT_DOWNGRADE = "/account/downgrade";

--- a/src/main/java/teammates/ui/webapi/action/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/action/ActionFactory.java
@@ -38,6 +38,7 @@ public class ActionFactory {
         map(ResourceURIs.TIMEZONE, GET, GetTimeZonesAction.class);
         map(ResourceURIs.NATIONALITIES, GET, GetNationalitiesAction.class);
         map(ResourceURIs.AUTH, GET, GetAuthInfoAction.class);
+        map(ResourceURIs.AUTH_REGKEY, GET, GetRegkeyValidityAction.class);
         map(ResourceURIs.ACCOUNT, GET, GetAccountAction.class);
         map(ResourceURIs.ACCOUNT, POST, CreateAccountAction.class);
         map(ResourceURIs.ACCOUNT, DELETE, DeleteAccountAction.class);

--- a/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
@@ -82,6 +82,15 @@ public abstract class BasicFeedbackSubmissionAction extends Action {
                     logic.getInstructorForGoogleId(feedbackSession.getCourseId(), userInfo.getId()), feedbackSession,
                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
         } else {
+            if (!StringHelper.isEmpty(student.googleId)) {
+                if (userInfo == null) {
+                    // Student is associated to a google ID; even if registration key is passed, do not allow access
+                    throw new UnauthorizedAccessException("Login is required to access this feedback session");
+                } else if (!userInfo.id.equals(student.googleId)) {
+                    // Logged in student is not the same as the student registered for the given key, do not allow access
+                    throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
+                }
+            }
             gateKeeper.verifyAccessible(student, feedbackSession);
         }
     }

--- a/src/main/java/teammates/ui/webapi/action/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetAuthInfoAction.java
@@ -32,17 +32,26 @@ public class GetAuthInfoAction extends Action {
     @Override
     public ActionResult execute() {
         String frontendUrl = getRequestParamValue("frontendUrl");
+        String nextUrl = getRequestParamValue("nextUrl");
         if (frontendUrl == null) {
             frontendUrl = "";
         }
 
         AuthInfo output;
         if (userInfo == null) {
-            output = new AuthInfo(
-                    gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.STUDENT_HOME_PAGE),
-                    gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.INSTRUCTOR_HOME_PAGE),
-                    gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.ADMIN_HOME_PAGE)
-            );
+            if (nextUrl == null) {
+                output = new AuthInfo(
+                        gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.STUDENT_HOME_PAGE),
+                        gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.INSTRUCTOR_HOME_PAGE),
+                        gateKeeper.getLoginUrl(frontendUrl + Const.WebPageURIs.ADMIN_HOME_PAGE)
+                );
+            } else {
+                output = new AuthInfo(
+                        gateKeeper.getLoginUrl(frontendUrl + nextUrl),
+                        gateKeeper.getLoginUrl(frontendUrl + nextUrl),
+                        gateKeeper.getLoginUrl(frontendUrl + nextUrl)
+                );
+            }
         } else {
             String googleId = userInfo.getId();
             AccountAttributes accountInfo = logic.getAccount(googleId);

--- a/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
@@ -1,0 +1,55 @@
+package teammates.ui.webapi.action;
+
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.ui.webapi.output.RegkeyValidityData;
+import teammates.ui.webapi.request.Intent;
+
+/**
+ * Action: checks whether the provided registration key is valid for the logged in user.
+ *
+ * <p>This does not log in or log out the user.
+ */
+public class GetRegkeyValidityAction extends Action {
+
+    @Override
+    public AuthType getMinAuthLevel() {
+        return AuthType.PUBLIC;
+    }
+
+    @Override
+    public void checkSpecificAccessControl() {
+        // Regkey information is available to everyone
+    }
+
+    @Override
+    public ActionResult execute() {
+        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
+        String regkey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
+
+        if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
+            boolean isValid = false;
+            StudentAttributes student = logic.getStudentForRegistrationKey(regkey);
+
+            if (student != null) {
+                if (StringHelper.isEmpty(student.googleId)) {
+                    // If registration key has not been used, always allow access
+                    isValid = true;
+                } else {
+                    // If the registration key has been used to register, the logged in user needs to match
+                    // Block access to not logged in user and mismatched user
+                    isValid = userInfo != null && student.googleId.equals(userInfo.id);
+                }
+            }
+
+            return new JsonResult(new RegkeyValidityData(isValid));
+        }
+
+        // Other intents are invalid for this purpose.
+        // This includes instructor submission/result intents, because instructors are expected to be registered
+        // in order to use the system.
+        return new JsonResult(new RegkeyValidityData(false));
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
@@ -25,10 +25,6 @@ public class GetSessionResultsAction extends Action {
 
     @Override
     public void checkSpecificAccessControl() {
-        if (userInfo.isAdmin) {
-            return;
-        }
-
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 

--- a/src/main/java/teammates/ui/webapi/endpoints/ResourceEndpoints.java
+++ b/src/main/java/teammates/ui/webapi/endpoints/ResourceEndpoints.java
@@ -15,6 +15,7 @@ public enum ResourceEndpoints {
     EXCEPTION(ResourceURIs.EXCEPTION),
     ERROR_REPORT(ResourceURIs.ERROR_REPORT),
     AUTH(ResourceURIs.AUTH),
+    AUTH_REGKEY(ResourceURIs.AUTH_REGKEY),
     ACCOUNT(ResourceURIs.ACCOUNT),
     ACCOUNT_RESET(ResourceURIs.ACCOUNT_RESET),
     ACCOUNT_DOWNGRADE(ResourceURIs.ACCOUNT_DOWNGRADE),

--- a/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
+++ b/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
@@ -1,0 +1,20 @@
+package teammates.ui.webapi.output;
+
+/**
+ * The API output format to represent if the registration key is valid for the logged in user (or lack thereof).
+ */
+public class RegkeyValidityData extends ApiOutput {
+    private final boolean isValid;
+
+    public RegkeyValidityData(boolean isValid) {
+        this.isValid = isValid;
+    }
+
+    /**
+     * Returns true if the registration key is valid, false otherwise.
+     */
+    public boolean isValid() {
+        return isValid;
+    }
+
+}

--- a/src/test/java/teammates/test/cases/webapi/GetAuthInfoActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetAuthInfoActionTest.java
@@ -55,6 +55,24 @@ public class GetAuthInfoActionTest extends BaseActionTest<GetAuthInfoAction> {
         assertNull(output.getInstitute());
         assertFalse(output.isMasquerade());
 
+        ______TS("Normal case: No logged in user, has nextUrl parameter");
+
+        gaeSimulation.logoutUser();
+        String nextUrl = "/web/join";
+
+        a = getAction(new String[] { "nextUrl", nextUrl });
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (AuthInfo) r.getOutput();
+        assertEquals(gateKeeper.getLoginUrl(nextUrl), output.getStudentLoginUrl());
+        assertEquals(gateKeeper.getLoginUrl(nextUrl), output.getInstructorLoginUrl());
+        assertEquals(gateKeeper.getLoginUrl(nextUrl), output.getAdminLoginUrl());
+        assertNull(output.getUser());
+        assertNull(output.getInstitute());
+        assertFalse(output.isMasquerade());
+
         ______TS("Normal case: With logged in user");
 
         loginAsInstructor("idOfInstructor1OfCourse1");

--- a/src/test/java/teammates/test/cases/webapi/GetFeedbackQuestionRecipientsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetFeedbackQuestionRecipientsActionTest.java
@@ -24,6 +24,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
     private FeedbackSessionAttributes secondSessionInCourse1;
     private FeedbackSessionAttributes firstSessionInCourse2;
     private StudentAttributes student1InCourse1;
+    private StudentAttributes student3InCourse1;
     private InstructorAttributes instructor1OfCourse1;
     private InstructorAttributes instructor1OfCourse2;
 
@@ -35,6 +36,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         secondSessionInCourse1 = testData.feedbackSessions.get("session2InCourse1");
         firstSessionInCourse2 = testData.feedbackSessions.get("session1InCourse2");
         student1InCourse1 = testData.students.get("student1InCourse1");
+        student3InCourse1 = testData.students.get("student3InCourse1");
         instructor1OfCourse1 = testData.instructors.get("instructor1OfCourse1");
         instructor1OfCourse2 = testData.instructors.get("instructor1OfCourse2");
     }
@@ -191,13 +193,25 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
                 generateParameters(firstSessionInCourse1, 2, Intent.STUDENT_SUBMISSION, "", "", "");
         verifyAccessibleForStudentsOfTheSameCourse(studentSubmissionParams);
 
-        ______TS("Unregistered student access with correct regKey, should be accessible");
-        StudentAttributes unloggedStudent =
-                logic.getStudentForGoogleId(student1InCourse1.getCourse(), student1InCourse1.googleId);
+        ______TS("Not logged in user access with correct unused regKey, should be accessible");
+        logic.resetStudentGoogleId(student3InCourse1.email, student3InCourse1.getCourse());
+        StudentAttributes unregisteredStudent =
+                logic.getStudentForEmail(student3InCourse1.getCourse(), student3InCourse1.email);
         String[] unregisteredStudentSubmissionParams =
                 generateParameters(firstSessionInCourse1, 2, Intent.STUDENT_SUBMISSION,
-                        StringHelper.encrypt(unloggedStudent.getKey()), "", "");
+                        StringHelper.encrypt(unregisteredStudent.getKey()), "", "");
         verifyAccessibleWithoutLogin(unregisteredStudentSubmissionParams);
+
+        ______TS("Access with correct but used regKey, should not be accessible by anyone");
+        StudentAttributes registeredStudent =
+                logic.getStudentForEmail(student1InCourse1.getCourse(), student1InCourse1.email);
+        String[] registeredStudentSubmissionParams =
+                generateParameters(firstSessionInCourse1, 2, Intent.STUDENT_SUBMISSION,
+                        StringHelper.encrypt(registeredStudent.getKey()), "", "");
+        verifyCannotAccess(registeredStudentSubmissionParams);
+
+        gaeSimulation.logoutUser();
+        verifyCannotAccess(registeredStudentSubmissionParams);
 
         ______TS("Question not intended shown to instructor, moderated instructor should not be accessible");
         loginAsInstructor(instructor1OfCourse1.googleId);
@@ -243,6 +257,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         secondSessionInCourse1 = typicalBundle.feedbackSessions.get("session2InCourse1");
         firstSessionInCourse2 = typicalBundle.feedbackSessions.get("session1InCourse2");
         student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+        student3InCourse1 = typicalBundle.students.get("student3InCourse1");
         instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         instructor1OfCourse2 = typicalBundle.instructors.get("instructor1OfCourse2");
     }

--- a/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
@@ -1,0 +1,160 @@
+package teammates.test.cases.webapi;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.ui.webapi.action.GetRegkeyValidityAction;
+import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.RegkeyValidityData;
+import teammates.ui.webapi.request.Intent;
+
+/**
+ * SUT: {@link GetRegkeyValidityAction}.
+ */
+public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidityAction> {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.AUTH_REGKEY;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Override
+    @Test
+    protected void testExecute() throws Exception {
+
+        String[] params;
+
+        String student1Key = StringHelper.encrypt(
+                logic.getStudentForEmail("idOfTypicalCourse1", "student1InCourse1@gmail.tmt").key
+        );
+
+        ______TS("Failure Case: No intent parameter");
+
+        params = new String[] {
+                Const.ParamsNames.REGKEY, student1Key,
+        };
+
+        verifyHttpParameterFailure(params);
+
+        ______TS("Failure Case: No regkey parameter");
+
+        params = new String[] {
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
+        };
+
+        verifyHttpParameterFailure(params);
+
+        ______TS("Normal case: No logged in user for a used regkey; should be invalid");
+
+        gaeSimulation.logoutUser();
+
+        params = new String[] {
+                Const.ParamsNames.REGKEY, student1Key,
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
+        };
+
+        GetRegkeyValidityAction a = getAction(params);
+        JsonResult r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        RegkeyValidityData output = (RegkeyValidityData) r.getOutput();
+        assertFalse(output.isValid());
+
+        ______TS("Normal case: Wrong logged in user for a used regkey; should be invalid");
+
+        loginAsStudent("student2InCourse1");
+
+        params = new String[] {
+                Const.ParamsNames.REGKEY, student1Key,
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
+        };
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertFalse(output.isValid());
+
+        ______TS("Normal case: Correct logged in user for a used regkey; should be valid");
+
+        loginAsStudent("student1InCourse1");
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertTrue(output.isValid());
+
+        ______TS("Normal case: No logged in user for an unused regkey; should be valid");
+
+        logic.resetStudentGoogleId("student1InCourse1@gmail.tmt", "idOfTypicalCourse1");
+
+        gaeSimulation.logoutUser();
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertTrue(output.isValid());
+
+        ______TS("Normal case: Any logged in user for an unused regkey; should be valid");
+
+        loginAsStudent("student2InCourse1");
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertTrue(output.isValid());
+
+        loginAsStudent("student3InCourse1");
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertTrue(output.isValid());
+
+        ______TS("Normal case: Invalid intent; should be invalid");
+
+        gaeSimulation.logoutUser();
+
+        params = new String[] {
+                Const.ParamsNames.REGKEY, student1Key,
+                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
+        };
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertFalse(output.isValid());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() {
+        verifyAnyUserCanAccess();
+    }
+
+}

--- a/src/test/java/teammates/test/cases/webapi/GetSessionResultsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetSessionResultsActionTest.java
@@ -95,9 +95,6 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
     protected void testAccessControl() {
         String[] submissionParams;
 
-        ______TS("accessible for admin");
-        verifyAccessibleForAdmin();
-
         ______TS("accessible for authenticated instructor");
         FeedbackSessionAttributes accessibleFeedbackSession = typicalBundle.feedbackSessions.get("session1InCourse1");
         submissionParams = new String[] {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -1,6 +1,14 @@
 <h1>
   Feedback Session Results
 </h1>
+<div class="row" *ngIf="regKey">
+  <div class="col-12">
+    <div class="alert alert-primary" role="alert">
+      You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to
+      <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">login using a Google account</a> (recommended).
+    </div>
+  </div>
+</div>
 <div class="card card-plain">
   <div class="card-body">
     <br/>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -1,15 +1,20 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import moment from 'moment-timezone';
+import { environment } from '../../../environments/environment';
+import { AuthService } from '../../../services/auth.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
+import { NavigationService } from '../../../services/navigation.service';
 import { StatusMessageService } from '../../../services/status-message.service';
+import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
+  AuthInfo,
   FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
-  QuestionOutput,
+  QuestionOutput, RegkeyValidity,
   ResponseVisibleSetting,
   SessionResults,
-  SessionVisibleSetting,
+  SessionVisibleSetting, Student,
 } from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
 import { ErrorMessageOutput } from '../../error-message-output';
@@ -43,41 +48,112 @@ export class SessionResultPageComponent implements OnInit {
   questions: QuestionOutput[] = [];
   formattedSessionOpeningTime: string = '';
   formattedSessionClosingTime: string = '';
+  personName: string = '';
+  courseId: string = '';
+  feedbackSessionName: string = '';
+  regKey: string = '';
 
-  constructor(private feedbackSessionsService: FeedbackSessionsService, private route: ActivatedRoute,
-      private timezoneService: TimezoneService, private statusMessageService: StatusMessageService) {
+  private backendUrl: string = environment.backendUrl;
+
+  constructor(private feedbackSessionsService: FeedbackSessionsService,
+              private route: ActivatedRoute,
+              private router: Router,
+              private timezoneService: TimezoneService,
+              private navigationService: NavigationService,
+              private authService: AuthService,
+              private studentService: StudentService,
+              private statusMessageService: StatusMessageService) {
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
   }
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
-      const { courseid: courseId, fsname: feedbackSessionName }: Record<string, string> = queryParams;
-      this.feedbackSessionsService.getFeedbackSession({
-        courseId,
-        feedbackSessionName,
+      this.courseId = queryParams.courseid;
+      this.feedbackSessionName = queryParams.fsname;
+      this.regKey = queryParams.key || '';
+
+      const nextUrl: string = `${window.location.pathname}${window.location.search}`;
+      this.authService.getAuthUser(undefined, nextUrl).subscribe((auth: AuthInfo) => {
+        if (this.regKey) {
+          const intent: Intent = Intent.STUDENT_RESULT;
+          this.authService.getAuthRegkeyValidity(this.regKey, intent).subscribe((resp: RegkeyValidity) => {
+            if (resp.isValid) {
+              if (auth.user) {
+                // The logged in user matches the registration key; redirect to the logged in URL
+
+                this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/submission',
+                    { courseid: this.courseId, fsname: this.feedbackSessionName });
+              } else {
+                // There is no logged in user for valid, unused registration key; load information based on the key
+                this.loadPersonName();
+                this.loadFeedbackSession();
+              }
+            } else if (!auth.user) {
+              // If there is no logged in user for a valid, used registration key, redirect to login page
+              window.location.href = `${this.backendUrl}${auth.studentLoginUrl}`;
+            } else {
+              this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+                  'You are not authorized to view this page.');
+            }
+          }, () => {
+            this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+                'You are not authorized to view this page.');
+          });
+        } else if (auth.user) {
+          // Load information based on logged in user
+          this.loadFeedbackSession();
+        } else {
+          this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+              'You are not authorized to view this page.');
+        }
+      }, () => {
+        this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+            'You are not authorized to view this page.');
+      });
+    });
+  }
+
+  private loadPersonName(): void {
+    this.studentService.getStudent(this.courseId, '', this.regKey).subscribe((student: Student) => {
+      this.personName = student.name;
+    });
+  }
+
+  private loadFeedbackSession(): void {
+    this.feedbackSessionsService.getFeedbackSession({
+      courseId: this.courseId,
+      feedbackSessionName: this.feedbackSessionName,
+      intent: Intent.STUDENT_RESULT,
+      key: this.regKey,
+    }).subscribe((feedbackSession: FeedbackSession) => {
+      const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
+      this.session = feedbackSession;
+      this.formattedSessionOpeningTime =
+          moment(this.session.submissionStartTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
+      this.formattedSessionClosingTime =
+          moment(this.session.submissionEndTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
+      this.feedbackSessionsService.getFeedbackSessionResults({
+        courseId: this.courseId,
+        feedbackSessionName: this.feedbackSessionName,
         intent: Intent.STUDENT_RESULT,
-      }).subscribe((feedbackSession: FeedbackSession) => {
-        const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
-        this.session = feedbackSession;
-        this.formattedSessionOpeningTime =
-            moment(this.session.submissionStartTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
-        this.formattedSessionClosingTime =
-              moment(this.session.submissionEndTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
-        this.feedbackSessionsService.getFeedbackSessionResults({
-          courseId,
-          feedbackSessionName,
-          intent: Intent.STUDENT_RESULT,
-        }).subscribe((sessionResults: SessionResults) => {
-          this.questions = sessionResults.questions.sort(
-              (a: QuestionOutput, b: QuestionOutput) =>
-                  a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
-        }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
-        });
+        key: this.regKey,
+      }).subscribe((sessionResults: SessionResults) => {
+        this.questions = sessionResults.questions.sort(
+            (a: QuestionOutput, b: QuestionOutput) =>
+                a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);
       }, (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorMessage(resp.error.message);
       });
+    }, (resp: ErrorMessageOutput) => {
+      this.statusMessageService.showErrorMessage(resp.error.message);
     });
+  }
+
+  /**
+   * Redirects to join course link for unregistered student.
+   */
+  joinCourseForUnregisteredStudent(): void {
+    this.router.navigateByUrl(`/web/join?entitytype=student&key=${this.regKey}`);
   }
 
 }

--- a/src/web/services/auth.service.ts
+++ b/src/web/services/auth.service.ts
@@ -20,10 +20,13 @@ export class AuthService {
   /**
    * Gets the user authentication information.
    */
-  getAuthUser(user?: string): Observable<AuthInfo> {
+  getAuthUser(user?: string, nextUrl?: string): Observable<AuthInfo> {
     const params: Record<string, string> = { frontendUrl: this.frontendUrl };
     if (user) {
       params.user = user;
+    }
+    if (nextUrl) {
+      params.nextUrl = nextUrl;
     }
     return this.httpRequestService.get(ResourceEndpoints.AUTH, params);
   }

--- a/src/web/services/auth.service.ts
+++ b/src/web/services/auth.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 import { ResourceEndpoints } from '../types/api-endpoints';
-import { AuthInfo } from '../types/api-output';
+import { AuthInfo, RegkeyValidity } from '../types/api-output';
+import { Intent } from '../types/api-request';
 import { HttpRequestService } from './http-request.service';
 
 /**
@@ -29,6 +30,14 @@ export class AuthService {
       params.nextUrl = nextUrl;
     }
     return this.httpRequestService.get(ResourceEndpoints.AUTH, params);
+  }
+
+  /**
+   * Gets the validity of the given registration key for user.
+   */
+  getAuthRegkeyValidity(key: string, intent: Intent): Observable<RegkeyValidity> {
+    const params: Record<string, string> = { key, intent };
+    return this.httpRequestService.get(ResourceEndpoints.AUTH_REGKEY, params);
   }
 
 }

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -320,6 +320,7 @@ export class FeedbackSessionsService {
     intent: Intent
     questionId?: string,
     groupBySection?: string,
+    key?: string,
   }): Observable<SessionResults> {
     const paramMap: Record<string, string> = {
       courseid: queryParams.courseId,
@@ -333,6 +334,10 @@ export class FeedbackSessionsService {
 
     if (queryParams.groupBySection) {
       paramMap.frgroupbysection = queryParams.groupBySection;
+    }
+
+    if (queryParams.key) {
+      paramMap.key = queryParams.key;
     }
 
     return this.httpRequestService.get(ResourceEndpoints.RESULT, paramMap);

--- a/src/web/services/link.service.spec.ts
+++ b/src/web/services/link.service.spec.ts
@@ -69,14 +69,14 @@ describe('Link Service', () => {
   it('should generate the submit url', () => {
     expect(service.generateSubmitUrl(mockStudent, 'did you ever hear the tragedy of darth plagueis the wise'))
       .toBe('http://localhost:4200/web/sessions/submission?courseid=dog.gma-demo&key=keyheehe'
-            + 'e&studentemail=alice.b.tmms%40gmail.tmt&fsName=did%20you%20'
+            + 'e&studentemail=alice.b.tmms%40gmail.tmt&fsname=did%20you%20'
             + 'ever%20hear%20the%20tragedy%20of%20darth%20plagueis%20the%20wise');
   });
 
   it('should generate the result url', () => {
     expect(service.generateResultUrl(mockStudent, 'another happy landing'))
       .toBe('http://localhost:4200/web/sessions/result?courseid'
-            + '=dog.gma-demo&key=keyheehee&studentemail=alice.b.tmms%40gmail.tmt&fsName=another%20happy%20landing');
+            + '=dog.gma-demo&key=keyheehee&studentemail=alice.b.tmms%40gmail.tmt&fsname=another%20happy%20landing');
   });
 
   it('filterEmptyParams should filter empty params', () => {

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -112,7 +112,7 @@ export class LinkService {
   /**
    * Generates submit url for a feedback session.
    */
-  generateSubmitUrl(student: Student, fsName: string): string {
+  generateSubmitUrl(student: Student, fsname: string): string {
     const { frontendUrl }: { frontendUrl: string } = environment;
     const { courseId: courseid, key = '', email: studentemail }: Student = student;
     const params: {
@@ -121,7 +121,7 @@ export class LinkService {
       courseid,
       key,
       studentemail,
-      fsName,
+      fsname,
     };
 
     this.filterEmptyParams(params);
@@ -132,7 +132,7 @@ export class LinkService {
   /**
    * Generates a result url for a feedback session.
    */
-  generateResultUrl(student: Student, fsName: string): string {
+  generateResultUrl(student: Student, fsname: string): string {
     const { frontendUrl }: { frontendUrl: string } = environment;
     const { courseId: courseid, key = '', email: studentemail }: Student = student;
     const params: {
@@ -141,7 +141,7 @@ export class LinkService {
       courseid,
       key,
       studentemail,
-      fsName,
+      fsname,
     };
 
     this.filterEmptyParams(params);


### PR DESCRIPTION
Part of #10176 

This fixes the following:
- v7 does not prompt user when logged in and accessing a link meant for another user (i.e. A & B both in course, logged in as A, accessing email link meant for B). V6 prompts user to associate session with a google account.
- Using regkey alone in incognito mode allows direct access to feedback submission in v7, but doing the same prompts for login in v6.
- No error handling for non google account logged in student when accessing results from link (server error, no option for resolution) v6 prompts you to login via google
- Accessing link will always show results based on logged in google account regardless of email shown in link -> if I access my link from a friend's laptop or device, I will see his results as if I were accessing his link; v6 prompts user to associate session with a google account
- Join course: Does not work properly when user is not logged in to a google account. Error page shown with no prompt for login available. v6 immediately redirects to login page

The root cause for almost all the problems are the same: a fatally wrong assumption that just because a regkey is given, a link is public. The condition is true only if the regkey has not been claimed by a Google ID.