### PR TITLE
[#10176] UAT Round 1: Fix Instructor Help Examples

### DIFF
--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -109,6 +110,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton={[Function Boolean]}
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -293,15 +295,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             
             
             
-            
             <button
               class="btn btn-light btn-sm mr-2"
+              ng-reflect-klass="btn btn-light btn-sm mr-2"
+              ng-reflect-ng-class="[object Object]"
               ng-reflect-ngb-tooltip="Email an invitation to the stu"
             >
               Send Invite
             </button>
-            
-            
             
             
             
@@ -416,15 +417,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             
             
             
-            
             <button
               class="btn btn-light btn-sm mr-2"
+              ng-reflect-klass="btn btn-light btn-sm mr-2"
+              ng-reflect-ng-class="[object Object]"
               ng-reflect-ngb-tooltip="Email an invitation to the stu"
             >
               Send Invite
             </button>
-            
-            
             
             
             
@@ -693,6 +693,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton={[Function Boolean]}
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -877,16 +878,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             
             
             
-            
-            
             <button
               class="btn btn-light btn-sm mr-2 disabled mouse-hover-only"
-              ng-reflect-ngb-tooltip="'You do not have the permissio"
-              ngbtooltip="'You do not have the permissions to access this feature'"
+              ng-reflect-klass="btn btn-light btn-sm mr-2"
+              ng-reflect-ng-class="[object Object]"
+              ng-reflect-ngb-tooltip="You do not have the permission"
             >
               Send Invite
             </button>
-            
             
             
             
@@ -1267,6 +1266,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -1817,6 +1817,7 @@ exports[`StudentListComponent should snap with some student list data and some s
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -2369,6 +2370,7 @@ exports[`StudentListComponent should snap with some student list data when not a
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -2919,6 +2921,7 @@ exports[`StudentListComponent should snap with some student list data with no se
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead="false"
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}
@@ -3126,6 +3129,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
   courseId=""
   courseService={[Function CourseService]}
   enableRemindButton="false"
+  isActionButtonsEnabled={[Function Boolean]}
   isHideTableHead={[Function Boolean]}
   listOfStudentsToHide={[Function Array]}
   navigationService={[Function NavigationService]}

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -60,14 +60,14 @@
             {{name}}</a>
         </ng-template>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-        isEnabled: studentModel.isAllowedToViewStudentInSection,
+        isEnabled: studentModel.isAllowedToViewStudentInSection && isActionButtonsEnabled,
         tooltip: 'View the details of the student',
         name: 'View',
         routerLink: '/web/instructor/courses/student/details',
         queryParams: {courseid: courseId, studentemail: studentModel.student.email}
       }"></ng-container>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-        isEnabled: studentModel.isAllowedToModifyStudent,
+        isEnabled: studentModel.isAllowedToModifyStudent && isActionButtonsEnabled,
         tooltip: 'Use this to edit the details of this student. To edit multiple students'
           + ' in one go, you can use the enroll page: '
           + 'Simply enroll students using the updated data and existing data will be updated accordingly',
@@ -77,13 +77,15 @@
       }"></ng-container>
       <ng-container *ngIf="enableRemindButton">
         <ng-container *ngIf="studentModel.student.joinState === JoinState.NOT_JOINED">
-          <button class="btn btn-light btn-sm mr-2" *ngIf="studentModel.isAllowedToModifyStudent"
-            [ngbTooltip]="'Email an invitation to the student requesting him/her to join the course using his/her'
+          <button class="btn btn-light btn-sm mr-2"
+            [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
+            [disabled]=!isActionButtonsEnabled
+            [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
+            ? 'Email an invitation to the student requesting him/her to join the course using his/her'
             + ' Google Account. Note: Students can use TEAMMATES without \'joining\','
-            + ' but a joined student can access extra features e.g. set up a user profile'"
-             (click)="openModal(remindModal)">Send Invite</button>
-          <button class="btn btn-light btn-sm mr-2 disabled mouse-hover-only" *ngIf="!studentModel.isAllowedToModifyStudent"
-            ngbTooltip="'You do not have the permissions to access this feature'">Send Invite</button>
+            + ' but a joined student can access extra features e.g. set up a user profile'
+            : 'You do not have the permissions to access this feature'"
+            (click)="openModal(remindModal)">Send Invite</button>
         </ng-container>
       </ng-container>
       <ng-template #remindModal let-modal>
@@ -101,10 +103,11 @@
         </div>
       </ng-template>
       <button class="btn btn-light btn-sm mr-2"
-        [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent}"
-        [ngbTooltip]="studentModel.isAllowedToModifyStudent
+        [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
+        [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
           ? 'Delete the student and the corresponding submissions from the course'
           : 'You do not have the permissions to access this feature'"
+        [disabled]="!isActionButtonsEnabled"
         (click)="openModal(deleteModal)">Delete</button>
       <ng-template #deleteModal let-modal>
         <div class="modal-header text-danger">
@@ -123,7 +126,7 @@
         </div>
       </ng-template>
       <ng-container *ngTemplateOutlet="actionButton; context: {
-        isEnabled: true,
+        isEnabled: isActionButtonsEnabled,
         tooltip: 'View all data about this student',
         name: 'All Records',
         routerLink: '/web/instructor/students/records',

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -40,6 +40,7 @@ export class StudentListComponent implements OnInit {
   @Input() listOfStudentsToHide: string[] = [];
   @Input() isHideTableHead: boolean = false;
   @Input() enableRemindButton: boolean = false;
+  @Input() isActionButtonsEnabled: boolean = true;
   @Input() students: StudentListRowModel[] = [];
 
   @Output() removeStudentFromCourseEvent: EventEmitter<string> = new EventEmitter();

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -162,14 +162,14 @@
             If you search for <code>alice</code>, the search results would show something like this (assuming such a student exists):
           </p>
           <tm-example-box>
-            <tm-student-result-table [studentTables]="exampleSingleStudentResultTables"></tm-student-result-table>
+            <tm-student-result-table [studentTables]="exampleSingleStudentResultTables" [isActionButtonsEnabled]="false"></tm-student-result-table>
           </tm-example-box>
           <p>
             You can search for multiple students based on the attributes mentioned above. To do so, include the terms you wish to search for in the search box separated by spaces.<br>
             For example, if you search for <code>alice Section A Team B jack@email.com</code>, the search would result in something similar to this (assuming the corresponding data exists):
           </p>
           <tm-example-box>
-            <tm-student-result-table [studentTables]="exampleMultipleStudentResultTables"></tm-student-result-table>
+            <tm-student-result-table [studentTables]="exampleMultipleStudentResultTables" [isActionButtonsEnabled]="false"></tm-student-result-table>
           </tm-example-box>
         </div>
       </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.spec.ts
@@ -1,54 +1,10 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { Component, Input } from '@angular/core';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { Gender, JoinState, Student, StudentProfile } from '../../../../types/api-output';
-import {
-  SearchStudentsTable,
-} from '../../../pages-instructor/instructor-search-page/student-result-table/student-result-table.component';
+import { InstructorHelpPageModule } from '../instructor-help-page.module';
 import { InstructorHelpStudentsSectionComponent } from './instructor-help-students-section.component';
-
-@Component({ selector: 'tm-example-box', template: '' })
-class ExampleBoxStubComponent {}
-@Component({ selector: 'tm-instructor-search-bar', template: '' })
-class InstructorSearchBarStubComponent {}
-@Component({ selector: 'tm-instructor-course-student-edit-page', template: '' })
-class InstructorCourseStudentEditPageStubComponent { @Input() isEnabled?: boolean; }
-@Component({ selector: 'tm-student-result-table', template: '' })
-class StudentResultTableStubComponent {
-  @Input() studentTables: SearchStudentsTable[] = [];
-}
-@Component({ selector: 'tm-student-profile', template: '' })
-class StudentProfileStubComponent {
-  @Input() studentProfile: StudentProfile = {
-    name: '',
-    shortName: '',
-    email: '',
-    institute: '',
-    nationality: '',
-    gender: Gender.FEMALE,
-    moreInfo: '',
-  };
-}
-@Component({ selector: 'tm-course-related-info', template: '' })
-class CourseRelatedInfoStubComponent {
-  @Input() student: Student = {
-    email: '',
-    courseId: '',
-    name: '',
-    lastName: '',
-    comments: '',
-    teamName: '',
-    sectionName: '',
-    joinState: JoinState.JOINED,
-  };
-}
-@Component({ selector: 'tm-more-info', template: '' })
-class MoreInfoStubComponent {
-  @Input() studentName: string = '';
-  @Input() moreInfoText: string = '';
-}
 
 describe('InstructorHelpStudentsSectionComponent', () => {
   let component: InstructorHelpStudentsSectionComponent;
@@ -56,19 +12,12 @@ describe('InstructorHelpStudentsSectionComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        InstructorHelpStudentsSectionComponent,
-        ExampleBoxStubComponent,
-        InstructorSearchBarStubComponent,
-        InstructorCourseStudentEditPageStubComponent,
-        StudentResultTableStubComponent,
-        StudentProfileStubComponent,
-        CourseRelatedInfoStubComponent,
-        MoreInfoStubComponent,
-      ],
       imports: [
         NgbModule,
         RouterTestingModule,
+        MatSnackBarModule,
+        HttpClientTestingModule,
+        InstructorHelpPageModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -554,15 +554,14 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     
                     
                     
-                    
                     <button
                       class="btn btn-light btn-sm mr-2"
+                      ng-reflect-klass="btn btn-light btn-sm mr-2"
+                      ng-reflect-ng-class="[object Object]"
                       ng-reflect-ngb-tooltip="Email an invitation to the stu"
                     >
                       Send Invite
                     </button>
-                    
-                    
                     
                     
                     

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -258,6 +258,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
             <tm-student-list
               ng-reflect-course-id="test-exa.demo"
               ng-reflect-enable-remind-button="false"
+              ng-reflect-is-action-buttons-enabled="true"
               ng-reflect-students="[object Object],[object Object"
               ng-reflect-use-gray-heading="true"
             >

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
@@ -4,7 +4,12 @@
     <div *ngFor="let course of studentTables" class="card border border-light-blue mb-3">
       <div class="card-header text-dark-blue bg-light-blue font-weight-bold">[{{course.courseId}}]</div>
       <div class="card-body p-0">
-        <tm-student-list [courseId]="course.courseId" [students]="course.students" [useGrayHeading]="true" [enableRemindButton]="false">
+        <tm-student-list
+          [courseId]="course.courseId"
+          [students]="course.students"
+          [useGrayHeading]="true"
+          [enableRemindButton]="false"
+          [isActionButtonsEnabled]="isActionButtonsEnabled">
         </tm-student-list>
       </div>
     </div>

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
@@ -29,6 +29,7 @@ export interface SearchStudentsListRowTable {
 export class StudentResultTableComponent implements OnInit {
 
   @Input() studentTables: SearchStudentsListRowTable[] = [];
+  @Input() isActionButtonsEnabled: boolean = true;
 
   constructor() { }
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -5,7 +5,7 @@
     <i class="fas fa-chevron-up" *ngIf="isTabExpanded"></i>
   </div>
   <div class="float-right" style='padding-right:15px; margin:-5px;'>
-      <button class="btn btn-light btn-sm button" type="button" (click)="!isDisplayOnly && openSendReminderModal($event)">
+      <button class="btn btn-light btn-sm button" type="button" (click)="!isDisplayOnly && openSendReminderModal($event); $event.stopPropagation();">
           Remind All
       </button>
   </div>


### PR DESCRIPTION
Part of #10176

**Addressed Issues:**
- Managing session responses > How do I view the results of my session > 2nd example box > "Remind all" collapses the modal when clicked. Might be the problem of the actual component also.

![651](https://user-images.githubusercontent.com/28994607/85259738-219c2300-b49c-11ea-87d1-c98060bcda39.gif)

- Finding students > How do I search for students in my course > 2nd and 3rd example boxes > the view/edit/all records buttons are active.

![g](https://user-images.githubusercontent.com/28994607/85259741-22cd5000-b49c-11ea-97e0-718ee2123af2.gif)

**Outline of Solution**
- Added a new `isActionButtonsDisabled` to `student-list` component
- Prevent propagation of click event in remind all button
- Also removed the stubs that were in the help section test files