### PR TITLE
[#10213] Fix misaligned label and add collapsable archive table

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
@@ -58,6 +58,9 @@ public class InstructorCoursesPage extends AppPage {
     @FindBy(id = "deleted-table-heading")
     private WebElement deleteTableHeading;
 
+    @FindBy(id = "archived-table-heading")
+    private WebElement archiveTableHeading;
+
     public InstructorCoursesPage(Browser browser) {
         super(browser);
     }
@@ -82,6 +85,7 @@ public class InstructorCoursesPage extends AppPage {
     }
 
     public void verifyArchivedCoursesDetails(CourseAttributes[] courses) {
+        showArchiveTable();
         String[][] courseDetails = getCourseDetails(courses);
         for (int i = 0; i < courses.length; i++) {
             // use verifyTableRowValues as archive courses are not sorted
@@ -187,6 +191,12 @@ public class InstructorCoursesPage extends AppPage {
     public void showDeleteTable() {
         if (!isElementVisible(By.id("deleted-course-id-0"))) {
             click(deleteTableHeading);
+        }
+    }
+
+    public void showArchiveTable() {
+        if (!isElementVisible(By.id("archived-course-id-0"))) {
+            click(archiveTableHeading);
         }
     }
 

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -59,7 +59,7 @@
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
         <div class="row text-center">
-          <div class="col-md-2 text-md-right font-bold" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''">
+          <div class="col-md-2 text-md-right font-bold" [ngClass]="{'col-form-label': formMode === SessionEditFormMode.ADD}">
             Course ID
           </div>
           <div class="col-md-4 text-md-left">
@@ -73,10 +73,10 @@
             </div>
             <div *ngIf="formMode === SessionEditFormMode.EDIT"> {{ model.courseId }} </div>
           </div>
-          <div class="col-md-2 text-md-right font-bold mt-3 mt-md-0" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''">
+          <div class="col-md-2 text-md-right font-bold mt-3 mt-md-0" [ngClass]="{'col-form-label': formMode === SessionEditFormMode.ADD}">
             Time Zone
           </div>
-          <div class="col-md-4 text-md-left" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
+          <div class="col-md-4 text-md-left" [ngClass]="{'col-form-label': formMode === SessionEditFormMode.ADD}" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
             {{ model.timeZone }}
           </div>
         </div>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class="row" *ngIf="formMode === SessionEditFormMode.EDIT">
-      <div class="col-12 text-right session-form-buttons">
+      <div class="col-12 text-center text-md-right session-form-buttons">
         <button type="button" class="btn btn-primary" (click)="triggerModelChange('isEditable', true)" *ngIf="formMode == SessionEditFormMode.EDIT && !model.isEditable"><i class="fas fa-pencil-alt"></i> Edit</button>
         <button type="button" class="btn btn-primary" (click)="submitFormHandler()" [disabled]="model.isSaving" *ngIf="model.isEditable"><i class="fas fa-check"></i> Save <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading></button>
         <button type="button" class="btn btn-primary" ngbTooltip="Delete the feedback session" (click)="deleteHandler(sessionDeleteModal)"><i class="fas fa-trash"></i> Delete</button>
@@ -59,10 +59,10 @@
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
         <div class="row text-center">
-          <div class="col-md-2 text-md-right font-bold mt-md-2">
+          <div class="col-md-2 text-md-right font-bold" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''">
             Course ID
           </div>
-          <div class="col-md-3 text-md-left">
+          <div class="col-md-4 text-md-left">
             <div *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
               <select class="form-control" [ngClass]="{'is-invalid': courseCandidates.length === 0}" [ngModel]="model.courseId" (ngModelChange)="courseIdChangeHandler($event)" [disabled]="courseCandidates.length === 0">
                 <option *ngFor="let course of courseCandidates" [ngValue]="course.courseId">{{ course.courseId }}</option>
@@ -73,13 +73,11 @@
             </div>
             <div *ngIf="formMode === SessionEditFormMode.EDIT"> {{ model.courseId }} </div>
           </div>
-          <div class="row col-md-6 mt-md-1 ml-1">
-            <div class="col-md-8 text-md-right font-bold">
-              Time Zone
-            </div>
-            <div class="col-md-4 text-md-left" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
-              {{ model.timeZone }}
-            </div>
+          <div class="col-md-2 text-md-right font-bold mt-3 mt-md-0" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''">
+            Time Zone
+          </div>
+          <div class="col-md-4 text-md-left" [ngClass]="formMode === SessionEditFormMode.ADD ? 'col-form-label': ''" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
+            {{ model.timeZone }}
           </div>
         </div>
         <br/>
@@ -123,10 +121,10 @@
           <div class="col-md-4 text-md-left">
             {{ model.submissionStatus | submissionStatusName }}
           </div>
-          <div class="col-md-2 text-md-left font-bold">
+          <div class="col-md-2 text-md-right font-bold mt-3 mt-md-0">
             Published Status
           </div>
-          <div class="col-md-3 text-md-left">
+          <div class="col-md-4 text-md-left">
             {{ model.publishStatus | publishStatusName }}
           </div>
         </div>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -114,17 +114,17 @@
 <div>
   <footer>
     <div class="container footer">
-      <div class="row">
-        <div class="col-sm-4 col-md-4 text-left">
+      <div class="row text-center">
+        <div class="col-sm-4 text-md-left">
           <i class="fas fa-bolt"></i><a routerLink="/web/front/home"> TEAMMATES</a> V{{ version }}
         </div>
-        <div class="col-sm-4 col-md-4 text-center">
+        <div class="col-sm-4 text-md-center">
           <span *ngIf="institute"><i class="fas fa-university"></i> for {{ institute }}</span>
         </div>
-        <div class="col-sm-4 col-md-4 text-right">
+        <div class="col-sm-4 text-md-right">
           <i class="far fa-comments"></i> Send <a routerLink="/web/front/contact" target="_blank">Feedback</a>
         </div>
-        <div class="col-sm-12 text-center">
+        <div class="col-sm-12">
           Sponsored by School of Computing, National University of Singapore. (<a routerLink="/web/front/contact">Become a sponsor</a>)
         </div>
       </div>

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -379,6 +379,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
     >
       <div
         class="card-header archive-course-header bg-info"
+        id="archived-table-heading"
       >
         <div
           class="row text-white align-items-center"
@@ -421,7 +422,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
         class="card bg-light top-padded"
       >
         <div
-          class="card-header bg-secondary recycle-bin-header"
+          class="card-header recycle-bin-header"
           id="deleted-table-heading"
         >
           <div
@@ -851,6 +852,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
     >
       <div
         class="card-header archive-course-header bg-info"
+        id="archived-table-heading"
       >
         <div
           class="row text-white align-items-center"
@@ -893,7 +895,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
         class="card bg-light top-padded"
       >
         <div
-          class="card-header bg-secondary recycle-bin-header"
+          class="card-header recycle-bin-header"
           id="deleted-table-heading"
         >
           <div

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -12,6 +12,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
   courseStats={[Function Object]}
   instructorService={[Function InstructorService]}
   isAddNewCourseFormExpanded="false"
+  isArchivedCourseExpanded="false"
   isRecycleBinExpanded="false"
   modalService={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -374,108 +375,33 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
        Archived Courses 
     </h2>
     <div
-      class="table-responsive"
+      class="card top-padded"
     >
-      <table
-        class="table table-striped table-bordered margin-0"
-        id="archived-courses-table"
+      <div
+        class="card-header archive-course-header bg-info"
       >
-        <thead>
-          <tr
-            class="bg-info text-white"
+        <div
+          class="row text-white align-items-center"
+        >
+          <div
+            class="col-6"
           >
-            <th>
-              Course ID
-            </th>
-            <th>
-              Course Name
-            </th>
-            <th>
-              Creation Date
-            </th>
-            <th
-              class="text-center"
-            >
-              Action(s)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          
-          <tr>
-            <td
-              id="archived-course-id-0"
-            >
-              CS2104
-            </td>
-            <td>
-              Can modify archived
-            </td>
-            <td
-              container="body"
-              ng-reflect-container="body"
-              ng-reflect-ngb-tooltip="Tue, 05 Nov 2002, 8:15AM"
-            >
-               5 Nov 2002 
-            </td>
-            <td
-              class="text-center"
-            >
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-unarchive-0"
-              >
-                 Unarchive 
-              </button>
-              
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-soft-delete-archived-0"
-                ng-reflect-ngb-tooltip="Delete the course and its corr"
-                ngbtooltip="Delete the course and its corresponding students and sessions"
-              >
-                 Delete 
-              </button>
-              
-              
-            </td>
-          </tr>
-          <tr>
-            <td
-              id="archived-course-id-1"
-            >
-              CS2106
-            </td>
-            <td>
-              Cannot modify archived
-            </td>
-            <td
-              container="body"
-              ng-reflect-container="body"
-              ng-reflect-ngb-tooltip="Tue, 05 Nov 2002, 8:15AM"
-            >
-               5 Nov 2002 
-            </td>
-            <td
-              class="text-center"
-            >
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-unarchive-1"
-              >
-                 Unarchive 
-              </button>
-              
-              
-              <button
-                class="btn btn-light btn-sm disabled"
-              >
-                 Delete 
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            <b>
+              Archive
+            </b>
+          </div>
+          <div
+            class="col-6 text-right"
+          >
+            
+            <i
+              class="fas fa-chevron-down"
+            />
+            
+          </div>
+        </div>
+      </div>
+      
     </div>
   </div><div
     class="row course-section margin-top-30px"
@@ -558,6 +484,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
   courseStats={[Function Object]}
   instructorService={[Function InstructorService]}
   isAddNewCourseFormExpanded="false"
+  isArchivedCourseExpanded="false"
   isRecycleBinExpanded="false"
   modalService={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -920,108 +847,33 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
        Archived Courses 
     </h2>
     <div
-      class="table-responsive"
+      class="card top-padded"
     >
-      <table
-        class="table table-striped table-bordered margin-0"
-        id="archived-courses-table"
+      <div
+        class="card-header archive-course-header bg-info"
       >
-        <thead>
-          <tr
-            class="bg-info text-white"
+        <div
+          class="row text-white align-items-center"
+        >
+          <div
+            class="col-6"
           >
-            <th>
-              Course ID
-            </th>
-            <th>
-              Course Name
-            </th>
-            <th>
-              Creation Date
-            </th>
-            <th
-              class="text-center"
-            >
-              Action(s)
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          
-          <tr>
-            <td
-              id="archived-course-id-0"
-            >
-              CS2104
-            </td>
-            <td>
-              Can modify archived
-            </td>
-            <td
-              container="body"
-              ng-reflect-container="body"
-              ng-reflect-ngb-tooltip="Tue, 05 Nov 2002, 8:15AM"
-            >
-               5 Nov 2002 
-            </td>
-            <td
-              class="text-center"
-            >
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-unarchive-0"
-              >
-                 Unarchive 
-              </button>
-              
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-soft-delete-archived-0"
-                ng-reflect-ngb-tooltip="Delete the course and its corr"
-                ngbtooltip="Delete the course and its corresponding students and sessions"
-              >
-                 Delete 
-              </button>
-              
-              
-            </td>
-          </tr>
-          <tr>
-            <td
-              id="archived-course-id-1"
-            >
-              CS2106
-            </td>
-            <td>
-              Cannot modify archived
-            </td>
-            <td
-              container="body"
-              ng-reflect-container="body"
-              ng-reflect-ngb-tooltip="Tue, 05 Nov 2002, 8:15AM"
-            >
-               5 Nov 2002 
-            </td>
-            <td
-              class="text-center"
-            >
-              <button
-                class="btn btn-light btn-sm"
-                id="btn-unarchive-1"
-              >
-                 Unarchive 
-              </button>
-              
-              
-              <button
-                class="btn btn-light btn-sm disabled"
-              >
-                 Delete 
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            <b>
+              Archive
+            </b>
+          </div>
+          <div
+            class="col-6 text-right"
+          >
+            
+            <i
+              class="fas fa-chevron-down"
+            />
+            
+          </div>
+        </div>
+      </div>
+      
     </div>
   </div><div
     class="row course-section margin-top-30px"
@@ -1112,6 +964,7 @@ exports[`InstructorCoursesPageComponent should snap with default fields 1`] = `
   courseStats={[Function Object]}
   instructorService={[Function InstructorService]}
   isAddNewCourseFormExpanded="false"
+  isArchivedCourseExpanded="false"
   isRecycleBinExpanded="false"
   modalService={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -1158,6 +1011,7 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
   courseStats={[Function Object]}
   instructorService={[Function InstructorService]}
   isAddNewCourseFormExpanded="false"
+  isArchivedCourseExpanded="false"
   isRecycleBinExpanded="false"
   modalService={[Function NgbModal]}
   route={[Function ActivatedRoute]}

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/__snapshots__/add-course-form.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/__snapshots__/add-course-form.component.spec.ts.snap
@@ -33,18 +33,18 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
       </button>
     </div>
     <div
-      class="card-body"
+      class="card-body text-center"
     >
       <div
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Course ID:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -63,12 +63,12 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Course Name:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -87,12 +87,12 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Time Zone:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <div
             class="input-group"
@@ -131,7 +131,7 @@ exports[`AddCourseFormComponent should snap when not enabled 1`] = `
         class="form-group row"
       >
         <div
-          class="offset-sm-3 col-sm-9"
+          class="col-md-12"
         >
           <button
             class="btn btn-primary"
@@ -179,18 +179,18 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
       </button>
     </div>
     <div
-      class="card-body"
+      class="card-body text-center"
     >
       <div
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Course ID:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -209,12 +209,12 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Course Name:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <input
             class="form-control ng-untouched ng-pristine ng-valid"
@@ -233,12 +233,12 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
         class="form-group row"
       >
         <label
-          class="col-sm-3 control-label bold-label text-right"
+          class="col-md-3 text-md-right col-form-label"
         >
           Time Zone:
         </label>
         <div
-          class="col-sm-6"
+          class="col-md-6 text-md-left"
         >
           <div
             class="input-group"
@@ -277,7 +277,7 @@ exports[`AddCourseFormComponent should snap with default fields 1`] = `
         class="form-group row"
       >
         <div
-          class="offset-sm-3 col-sm-9"
+          class="col-md-12"
         >
           <button
             class="btn btn-primary"

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
@@ -4,26 +4,26 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="card-body">
+  <div class="card-body text-center">
     <div class="form-group row">
-      <label class="col-sm-3 control-label bold-label text-right">Course ID:</label>
-      <div class="col-sm-6">
+      <label class="col-md-3 text-md-right col-form-label">Course ID:</label>
+      <div class="col-md-6 text-md-left">
         <input id="new-course-id" class="form-control" type="text" [(ngModel)]="newCourseId"
             ngbTooltip="Enter the identifier of the course, e.g.CS3215-2013Semester1."
             [maxlength]="40" placeholder="e.g. CS3215-2013Semester1"/>
       </div>
     </div>
     <div class="form-group row">
-      <label class="col-sm-3 control-label bold-label text-right">Course Name:</label>
-      <div class="col-sm-6">
+      <label class="col-md-3 text-md-right col-form-label">Course Name:</label>
+      <div class="col-md-6 text-md-left">
         <input id="new-course-name" class="form-control" type="text" [(ngModel)]="newCourseName"
             ngbTooltip="Enter the name of the course, e.g. Software Engineering."
             [maxlength]="64" placeholder="e.g. Software Engineering"/>
       </div>
     </div>
     <div class="form-group row">
-      <label class="col-sm-3 control-label bold-label text-right">Time Zone:</label>
-      <div class="col-sm-6">
+      <label class="col-md-3 text-md-right col-form-label">Time Zone:</label>
+      <div class="col-md-6 text-md-left">
         <div class="input-group">
           <select id="new-time-zone" class="form-control" [(ngModel)]="timezone" ngbTooltip="The time zone for the course. You should not
                 need to change this as it is auto-detected based on your device settings. TEAMMATES automatically adjusts
@@ -37,7 +37,7 @@
       </div>
     </div>
     <div class="form-group row">
-      <div class="offset-sm-3 col-sm-9">
+      <div class="col-md-12">
         <button id="btn-save-course" class="btn btn-primary" (click)="onSubmit()">Add Course</button>
       </div>
     </div>

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.scss
@@ -1,7 +1,3 @@
-.bold-label {
-  font-weight: 700 !important;
-}
-
 .fill-plain {
   background-color: #EAEFF5;
 }
@@ -12,6 +8,6 @@
   margin-bottom: 0;
 }
 
-.form-group {
-  min-width: 700px;
+.col-form-label {
+  font-weight: bold;
 }

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
@@ -7,7 +7,7 @@ import { Course } from '../../../../types/api-output';
 import { ErrorMessageOutput } from '../../../error-message-output';
 
 /**
- * The actual component
+ * Instructor add new course form
  */
 @Component({
   selector: 'tm-add-course-form',

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -155,7 +155,7 @@
     <span class="fa fa-file-archive"></span> Archived Courses
   </h2>
   <div class="card top-padded">
-    <div class="card-header archive-course-header bg-info" (click)="isArchivedCourseExpanded = !isArchivedCourseExpanded">
+    <div id="archived-table-heading" class="card-header archive-course-header bg-info" (click)="isArchivedCourseExpanded = !isArchivedCourseExpanded">
       <div class="row text-white align-items-center">
         <div class="col-6">
           <b>Archive</b>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -208,7 +208,7 @@
       <span class="fa fa-trash-alt"></span> Deleted Courses
     </h2>
     <div class="card bg-light top-padded">
-      <div id="deleted-table-heading" class="card-header bg-secondary recycle-bin-header" (click)="isRecycleBinExpanded = !isRecycleBinExpanded">
+      <div id="deleted-table-heading" class="card-header recycle-bin-header" (click)="isRecycleBinExpanded = !isRecycleBinExpanded">
         <div class="row align-items-center">
           <div class="col-6 text-white">
             <b>Recycle Bin</b>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -154,17 +154,29 @@
   <h2 class="text-muted">
     <span class="fa fa-file-archive"></span> Archived Courses
   </h2>
-  <div class="table-responsive">
-    <table id="archived-courses-table" class="table table-striped table-bordered margin-0">
-      <thead>
-        <tr class="bg-info text-white">
-          <th>Course ID</th>
-          <th>Course Name</th>
-          <th>Creation Date</th>
-          <th class="text-center">Action(s)</th>
-        </tr>
-      </thead>
-      <tbody>
+  <div class="card top-padded">
+    <div class="card-header archive-course-header bg-info" (click)="isArchivedCourseExpanded = !isArchivedCourseExpanded">
+      <div class="row text-white align-items-center">
+        <div class="col-6">
+          <b>Archive</b>
+        </div>
+        <div class="col-6 text-right">
+          <i class="fas fa-chevron-down" *ngIf="!isArchivedCourseExpanded"></i>
+          <i class="fas fa-chevron-up" *ngIf="isArchivedCourseExpanded"></i>
+        </div>
+      </div>
+    </div>
+    <div class="card-body archive-body table-responsive" *ngIf="isArchivedCourseExpanded">
+      <table id="archived-courses-table" class="table table-striped table-bordered archive-table">
+        <thead>
+          <tr class="background-color-medium-gray text-color-gray">
+            <th>Course ID</th>
+            <th>Course Name</th>
+            <th>Creation Date</th>
+            <th class="text-center">Action(s)</th>
+          </tr>
+        </thead>
+        <tbody>
         <tr *ngFor="let course of archivedCourses; let i = index">
           <td id="archived-course-id-{{ i }}">{{course.course.courseId}}</td>
           <td>{{course.course.courseName}}</td>
@@ -184,8 +196,9 @@
             </button>
           </td>
         </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
@@ -14,6 +14,11 @@
   padding: 0;
 }
 
+.recycle-bin-header {
+  background-color: var(--secondary);
+  cursor: pointer;
+}
+
 .margin-left-10px {
   margin-left: 10px;
 }

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
@@ -22,6 +22,12 @@
   background-color: #E5E5E6;
 }
 
+.archive-course-header {
+  cursor: pointer;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
 .text-color-black {
   color: #000;
 }
@@ -41,6 +47,14 @@
 }
 
 .recycle-bin-table {
+  margin-bottom: 0;
+}
+
+.archive-body {
+  padding: 0;
+}
+
+.archive-table {
   margin-bottom: 0;
 }
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -58,6 +58,7 @@ export class InstructorCoursesPageComponent implements OnInit {
   canDeleteAll: boolean = true;
   canRestoreAll: boolean = true;
   isAddNewCourseFormExpanded: boolean = false;
+  isArchivedCourseExpanded: boolean = false;
 
   constructor(private route: ActivatedRoute,
               private statusMessageService: StatusMessageService,


### PR DESCRIPTION
Part of #10213 

**Resolves**:
- Archived course table in the Courses tab is not collapsible but the Recycle Bin table is collapsible.
![g](https://user-images.githubusercontent.com/28994607/85360262-3683bf80-b54b-11ea-8b80-c40c66693f7e.gif)

- Misaligned labels in Adding new course on instructor page
![cc](https://user-images.githubusercontent.com/28994607/85360292-4bf8e980-b54b-11ea-8ede-e0a81b3dfcab.PNG)

- Misaligned labels in Edit feedback session Course ID label and data in the top box
![fs](https://user-images.githubusercontent.com/28994607/85360296-4dc2ad00-b54b-11ea-87b0-579f6c5b8a49.PNG)

- Bottom banner not centralised in mobile view
![central](https://user-images.githubusercontent.com/28994607/85360316-66cb5e00-b54b-11ea-843e-6487b79d7912.PNG)

**Outline of Solution**
- Add necessary css classes to views 
- Add new variable to control toggling of the archive table tab
- ~Fixing E2E tests for now~ Fixed
