### PR TITLE
[#10213] Add animations for all collapsable tabs

### DIFF
--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -8,31 +8,33 @@
           <i class="fas fa-chevron-up" *ngIf="teamExpanded[teamInfo.key]"></i>
         </div>
       </div>
-      <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
-        <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
-        <hr>
-        <div class="card top-padded" *ngFor="let question of teamsToQuestions[teamInfo.key]">
-          <div class="card-header bg-info text-white">
-            <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber"
-                                        [questionDetails]="question.feedbackQuestion.questionDetails"
-                                        (click)="$event.stopPropagation()"></tm-question-text-with-info>
+      <div [ngbCollapse]="!teamExpanded[teamInfo.key]">
+        <div class="card-body">
+          <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
+          <hr>
+          <div class="card top-padded" *ngFor="let question of teamsToQuestions[teamInfo.key]">
+            <div class="card-header bg-info text-white">
+              <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber"
+                                          [questionDetails]="question.feedbackQuestion.questionDetails"
+                                          (click)="$event.stopPropagation()"></tm-question-text-with-info>
+            </div>
+            <div class="card-body">
+              <tm-single-statistics [responses]="question.allResponses"
+                                    [question]="question.feedbackQuestion.questionDetails"
+                                    [statistics]="question.questionStatistics"
+                                    [recipientType]="question.feedbackQuestion.recipientType"
+                                    [displayContributionStats]="false"
+              ></tm-single-statistics>
+            </div>
           </div>
-          <div class="card-body">
-            <tm-single-statistics [responses]="question.allResponses"
-                                  [question]="question.feedbackQuestion.questionDetails"
-                                  [statistics]="question.questionStatistics"
-                                  [recipientType]="question.feedbackQuestion.recipientType"
-                                  [displayContributionStats]="false"
-            ></tm-single-statistics>
+          <h3>{{ teamInfo.key }} Detailed Responses</h3>
+          <hr>
+          <div *ngFor="let userInfo of teamInfo.value">
+            <ng-container
+                [ngTemplateOutlet]="userTab"
+                [ngTemplateOutletContext]="{userInfo:userInfo}">
+            </ng-container>
           </div>
-        </div>
-        <h3>{{ teamInfo.key }} Detailed Responses</h3>
-        <hr>
-        <div *ngFor="let userInfo of teamInfo.value">
-          <ng-container
-              [ngTemplateOutlet]="userTab"
-              [ngTemplateOutletContext]="{userInfo:userInfo}">
-          </ng-container>
         </div>
       </div>
     </div>
@@ -66,32 +68,36 @@
         <i class="fas fa-chevron-up" *ngIf="userExpanded[userInfo]"></i>
       </div>
     </div>
-    <div class="card-body" *ngIf="userExpanded[userInfo]">
-      <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo]">
-        <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
-          <tm-question-text-with-info [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
-                                      [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
-                                      (click)="$event.stopPropagation()"></tm-question-text-with-info>
-          <div class="float-right">
-            <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
-            <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
+    <div [ngbCollapse]="!userExpanded[userInfo]">
+      <div class="card-body">
+        <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo]">
+          <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
+            <tm-question-text-with-info [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
+                                        [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
+                                        (click)="$event.stopPropagation()"></tm-question-text-with-info>
+            <div class="float-right">
+              <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
+              <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
+            </div>
           </div>
-        </div>
-        <div class="card-body" *ngIf="question.isTabExpanded">
-          <tm-single-statistics [responses]="question.questionOutput.allResponses"
-                                [question]="question.questionOutput.feedbackQuestion.questionDetails"
-                                [statistics]="question.questionOutput.questionStatistics"
-                                [recipientType]="question.questionOutput.feedbackQuestion.recipientType"
-                                [displayContributionStats]="false"
-          ></tm-single-statistics>
-          <tm-per-question-view-responses [responses]="question.questionOutput.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                                          [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [question]="question.questionOutput.feedbackQuestion"
-                                          [instructorCommentTableModel]="instructorCommentTableModel"
-                                          (instructorCommentTableModelChange)="triggerModelChange($event)"
-                                          (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                          (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
-                                          (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
-          ></tm-per-question-view-responses>
+          <div [ngbCollapse]="!question.isTabExpanded">
+            <div class="card-body">
+              <tm-single-statistics [responses]="question.questionOutput.allResponses"
+                                    [question]="question.questionOutput.feedbackQuestion.questionDetails"
+                                    [statistics]="question.questionOutput.questionStatistics"
+                                    [recipientType]="question.questionOutput.feedbackQuestion.recipientType"
+                                    [displayContributionStats]="false"
+              ></tm-single-statistics>
+              <tm-per-question-view-responses [responses]="question.questionOutput.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
+                                              [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [question]="question.questionOutput.feedbackQuestion"
+                                              [instructorCommentTableModel]="instructorCommentTableModel"
+                                              (instructorCommentTableModelChange)="triggerModelChange($event)"
+                                              (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                              (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
+                                              (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
+              ></tm-per-question-view-responses>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
 import { QuestionTextWithInfoModule } from '../../question-text-with-info/question-text-with-info.module';
@@ -23,6 +24,7 @@ describe('GqrRqgViewResponsesComponent', () => {
         SingleStatisticsModule,
         TeammatesCommonModule,
         HttpClientTestingModule,
+        NgbModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.module.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { QuestionTextWithInfoModule } from '../../question-text-with-info/question-text-with-info.module';
 import { TeammatesCommonModule } from '../../teammates-common/teammates-common.module';
 import { PerQuestionViewResponsesModule } from '../per-question-view-responses/per-question-view-responses.module';
@@ -23,6 +24,7 @@ import { GqrRqgViewResponsesComponent } from './gqr-rqg-view-responses.component
     ResponseModerationButtonModule,
     SingleStatisticsModule,
     TeammatesCommonModule,
+    NgbModule,
   ],
 })
 export class GqrRqgViewResponsesModule { }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -8,15 +8,15 @@
           <i class="fas fa-chevron-up" *ngIf="teamExpanded[teamInfo.key]"></i>
         </div>
       </div>
-      <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
-
-        <div *ngFor="let userInfo of teamInfo.value">
-          <ng-container
-              [ngTemplateOutlet]="userTab"
-              [ngTemplateOutletContext]="{userInfo:userInfo}">
-          </ng-container>
+      <div [ngbCollapse]="!teamExpanded[teamInfo.key]">
+        <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
+          <div *ngFor="let userInfo of teamInfo.value">
+            <ng-container
+                [ngTemplateOutlet]="userTab"
+                [ngTemplateOutletContext]="{userInfo:userInfo}">
+            </ng-container>
+          </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -49,23 +49,25 @@
       <i class="fas fa-chevron-up" *ngIf="userExpanded[userInfo]"></i>
     </div>
   </div>
-    <div class="card-body" *ngIf="userExpanded[userInfo]">
-      <ng-container *ngIf="userHasRealResponses[userInfo]">
-        <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
-          <tm-grouped-responses [responses]="other.value"
-                                [isGrq]="isGrq" [session]="session"
-                                [instructorCommentTableModel]="instructorCommentTableModel"
-                                [userToEmail]="userToEmail"
-                                (instructorCommentTableModelChange)="triggerModelChange($event)"
-                                (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
-                                (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
-                                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"></tm-grouped-responses>
+    <div [ngbCollapse]="!userExpanded[userInfo]">
+      <div class="card-body">
+        <ng-container *ngIf="userHasRealResponses[userInfo]">
+          <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
+            <tm-grouped-responses [responses]="other.value"
+                                  [isGrq]="isGrq" [session]="session"
+                                  [instructorCommentTableModel]="instructorCommentTableModel"
+                                  [userToEmail]="userToEmail"
+                                  (instructorCommentTableModelChange)="triggerModelChange($event)"
+                                  (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
+                                  (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
+                                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"></tm-grouped-responses>
+          </div>
+        </ng-container>
+        <div *ngIf="!userHasRealResponses[userInfo]">
+          <i>
+            There are no responses {{ isGrq ? 'given' : 'received' }} by this user or you may not have the permission to see the responses.
+          </i>
         </div>
-      </ng-container>
-      <div *ngIf="!userHasRealResponses[userInfo]">
-        <i>
-          There are no responses {{ isGrq ? 'given' : 'received' }} by this user or you may not have the permission to see the responses.
-        </i>
       </div>
     </div>
   </div>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -9,7 +9,7 @@
         </div>
       </div>
       <div [ngbCollapse]="!teamExpanded[teamInfo.key]">
-        <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
+        <div class="card-body">
           <div *ngFor="let userInfo of teamInfo.value">
             <ng-container
                 [ngTemplateOutlet]="userTab"

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
 import { TeammatesCommonModule } from '../../teammates-common/teammates-common.module';
@@ -19,6 +20,7 @@ describe('GrqRgqViewResponsesComponent', () => {
         ResponseModerationButtonModule,
         TeammatesCommonModule,
         HttpClientTestingModule,
+        NgbModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
 import { TeammatesCommonModule } from '../../teammates-common/teammates-common.module';
@@ -18,6 +19,7 @@ import { GrqRgqViewResponsesComponent } from './grq-rgq-view-responses.component
     GroupedResponsesModule,
     ResponseModerationButtonModule,
     TeammatesCommonModule,
+    NgbModule,
   ],
 })
 export class GrqRgqViewResponsesModule { }

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -5,7 +5,7 @@
   <button class="navbar-toggler d-lg-none" type="button" (click)="toggleCollapse()" [attr.aria-expanded]="!isCollapsed" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <div class="collapse navbar-collapse" [ngbCollapse]="isCollapsed">
+  <div class="navbar-collapse" [ngStyle]="{display: isCollapsed ? 'none' : 'block'}">
     <ul class="nav navbar-nav mr-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -60,7 +60,7 @@
     <p><button type="button" class="btn btn-outline-primary" (click)="isEditDetailsCollapsed = !isEditDetailsCollapsed" [attr.aria-expanded]="!isEditDetailsCollapsed">
       How do I edit a student's details after enrolling the student?
     </button></p>
-    <div [ngbCollapse]="!isEditDetailsCollapsed" class="collapse">
+    <div [ngbCollapse]="!isEditDetailsCollapsed">
       <div class="card">
         <div class="card-body">
           <p>

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -216,8 +216,8 @@ exports[`InstructorHomePageComponent should snap with one course with error load
       
       
       <div
-        class="card-body padding-0 collapse"
-        ng-reflect-collapsed="true"
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -543,8 +543,8 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
       
       
       <div
-        class="card-body padding-0 collapse"
-        ng-reflect-collapsed="true"
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -1098,8 +1098,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
       
       
       <div
-        class="card-body padding-0 collapse"
-        ng-reflect-collapsed="true"
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -1844,8 +1844,8 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
       
       
       <div
-        class="card-body padding-0 collapse show"
-        ng-reflect-collapsed="false"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -2171,8 +2171,8 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
       
       
       <div
-        class="card-body padding-0 collapse"
-        ng-reflect-collapsed="true"
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -2498,8 +2498,8 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
       
       
       <div
-        class="card-body padding-0 collapse"
-        ng-reflect-collapsed="true"
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -215,9 +215,9 @@ exports[`InstructorHomePageComponent should snap with one course with error load
       
       
       
-      
       <div
-        class="card-body padding-0"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -542,9 +542,9 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
       
       
       
-      
       <div
-        class="card-body padding-0"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -1097,9 +1097,9 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
       
       
       
-      
       <div
-        class="card-body padding-0"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -1843,7 +1843,27 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
       
       
       
-      
+      <div
+        class="card-body padding-0 collapse show"
+        ng-reflect-collapsed="false"
+      >
+        <tm-sessions-table
+          ng-reflect-columns-to-show="1,2"
+          ng-reflect-course-candidates="[object Object]"
+          ng-reflect-header-color-scheme="1"
+          ng-reflect-sessions-table-row-models=""
+          ng-reflect-sessions-table-row-models-sort-by="0"
+          ng-reflect-sessions-table-row-models-sort-order="1"
+        >
+          
+          <div
+            class="no-session-message"
+          >
+             There are no feedback sessions in this course. 
+          </div>
+          
+        </tm-sessions-table>
+      </div>
     </div>
   </div>
 </tm-instructor-home-page>
@@ -2150,9 +2170,9 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
       
       
       
-      
       <div
-        class="card-body padding-0"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"
@@ -2477,9 +2497,9 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
       
       
       
-      
       <div
-        class="card-body padding-0"
+        class="card-body padding-0 collapse"
+        ng-reflect-collapsed="true"
       >
         <tm-sessions-table
           ng-reflect-columns-to-show="1,2"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -143,7 +143,7 @@
       </div>
     </ng-template>
 
-    <div class="card-body padding-0" *ngIf="courseTabModel.isTabExpanded">
+    <div class="card-body padding-0" [ngbCollapse]="courseTabModel.isTabExpanded">
       <tm-sessions-table
           [sessionsTableRowModels]="courseTabModel.sessionsTableRowModels" [sessionsTableRowModelsSortBy]="courseTabModel.sessionsTableRowModelsSortBy"
           [sessionsTableRowModelsSortOrder]="courseTabModel.sessionsTableRowModelsSortOrder" [courseCandidates]="courseCandidates"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -143,7 +143,7 @@
       </div>
     </ng-template>
 
-    <div class="card-body padding-0" [ngbCollapse]="courseTabModel.isTabExpanded">
+    <div class="card-body padding-0" [ngbCollapse]="!courseTabModel.isTabExpanded">
       <tm-sessions-table
           [sessionsTableRowModels]="courseTabModel.sessionsTableRowModels" [sessionsTableRowModelsSortBy]="courseTabModel.sessionsTableRowModelsSortBy"
           [sessionsTableRowModelsSortOrder]="courseTabModel.sessionsTableRowModelsSortOrder" [courseCandidates]="courseCandidates"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.html
@@ -13,8 +13,10 @@
       <span [innerHTML]="templateQuestionModel.description" class="template-description"
             (click)="templateQuestionModel.isShowDetails = !templateQuestionModel.isShowDetails"></span>
     </div>
-    <div class="card-body" *ngIf="templateQuestionModel.isShowDetails">
-      <tm-question-edit-form [formModel]="templateQuestionModel.model" isDisplayOnly="true"></tm-question-edit-form>
+    <div [ngbCollapse]="!templateQuestionModel.isShowDetails">
+      <div class="card-body">
+        <tm-question-edit-form [formModel]="templateQuestionModel.model" isDisplayOnly="true"></tm-question-edit-form>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormsModule } from '@angular/forms';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { QuestionEditFormModule } from '../../../components/question-edit-form/question-edit-form.module';
 import { TeammatesCommonModule } from '../../../components/teammates-common/teammates-common.module';
 import { TemplateQuestionModalComponent } from './template-question-modal.component';
@@ -20,6 +20,7 @@ describe('TemplateQuestionModalComponent', () => {
         QuestionEditFormModule,
         TeammatesCommonModule,
         HttpClientTestingModule,
+        NgbModule,
       ],
       declarations: [
         TemplateQuestionModalComponent,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -10,33 +10,35 @@
       </button>
   </div>
 </div>
-<div class="card-body" *ngIf="isTabExpanded">
-  <div *ngIf="noResponseStudentsInSection.length">
-    <table class="table">
-      <thead>
-      <tr>
-        <th>Team</th>
-        <th>Name</th>
-        <th>Actions</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr *ngFor="let noResponseStudent of noResponseStudentsInSection">
-        <td>{{ noResponseStudent.teamName }}</td>
-        <td>{{ noResponseStudent.name }}</td>
-        <td>
-          <a *ngIf="!isDisplayOnly; else displayOnlySubmitResponseButton" routerLink="/web/student/sessions/submission"
-             [queryParams]="{courseid: session.courseId, fsname: session.feedbackSessionName, moderatedperson: noResponseStudent.email}"
-             class="btn btn-light btn-sm button">
-            Submit response
-          </a>
-          <ng-template #displayOnlySubmitResponseButton><a class="btn btn-light btn-sm button">Submit response</a></ng-template>
-        </td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-  <div *ngIf="!noResponseStudentsInSection.length">
-    <i>All students have responded to some questions in this session.</i>
+<div [ngbCollapse]="!isTabExpanded">
+  <div class="card-body">
+    <div *ngIf="noResponseStudentsInSection.length">
+      <table class="table">
+        <thead>
+        <tr>
+          <th>Team</th>
+          <th>Name</th>
+          <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let noResponseStudent of noResponseStudentsInSection">
+          <td>{{ noResponseStudent.teamName }}</td>
+          <td>{{ noResponseStudent.name }}</td>
+          <td>
+            <a *ngIf="!isDisplayOnly; else displayOnlySubmitResponseButton" routerLink="/web/student/sessions/submission"
+               [queryParams]="{courseid: session.courseId, fsname: session.feedbackSessionName, moderatedperson: noResponseStudent.email}"
+               class="btn btn-light btn-sm button">
+              Submit response
+            </a>
+            <ng-template #displayOnlySubmitResponseButton><a class="btn btn-light btn-sm button">Submit response</a></ng-template>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+    <div *ngIf="!noResponseStudentsInSection.length">
+      <i>All students have responded to some questions in this session.</i>
+    </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -7,16 +7,18 @@
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>
       </div>
     </div>
-    <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
-      <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
-                                 [indicateMissingResponses]="indicateMissingResponses"
-                                 [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="true" [session]="session"
-                                 [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
-                                 (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                 (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                 (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                 (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                 style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
+    <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+      <div class="card-body">
+        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+                                   [indicateMissingResponses]="indicateMissingResponses"
+                                   [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="true" [session]="session"
+                                   [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
+                                   (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                   (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                   (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                   style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   GqrRqgViewResponsesModule,
 } from '../../components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.module';
@@ -12,7 +13,7 @@ describe('InstructorSessionResultGqrViewComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorSessionResultGqrViewComponent],
-      imports: [GqrRqgViewResponsesModule],
+      imports: [GqrRqgViewResponsesModule, NgbModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -7,16 +7,18 @@
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>
       </div>
     </div>
-    <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
-      <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
-                                 [indicateMissingResponses]="indicateMissingResponses"
-                                 [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="true" [session]="session"
-                                 [isExpandAll]="isExpandAll" [instructorCommentTableModel]="instructorCommentTableModel"
-                                 (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                 (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                 (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                 (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                 style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
+    <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+      <div class="card-body">
+        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+                                   [indicateMissingResponses]="indicateMissingResponses"
+                                   [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="true" [session]="session"
+                                   [isExpandAll]="isExpandAll" [instructorCommentTableModel]="instructorCommentTableModel"
+                                   (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                   (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                   (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                   style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   GrqRgqViewResponsesModule,
 } from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module';
@@ -12,7 +13,7 @@ describe('InstructorSessionResultGrqViewComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorSessionResultGrqViewComponent],
-      imports: [GrqRgqViewResponsesModule],
+      imports: [GrqRgqViewResponsesModule, NgbModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -6,26 +6,28 @@
       <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
     </div>
   </div>
-  <div class="card-body" *ngIf="question.isTabExpanded">
-    <div class="stats-table">
-      <tm-single-statistics *ngIf="showStatistics"
-                            [question]="question.question.questionDetails"
-                            [statistics]="question.statistics"
-                            [responses]="question.responses"
-                            [recipientType]="question.question.recipientType"
-                            [section]="section" [sectionType]="sectionType"
-      ></tm-single-statistics>
-    </div>
-    <div class="stats-table">
-      <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
-                                      [indicateMissingResponses]="indicateMissingResponses" [question]="question.question"
-                                      [isDisplayOnly]="isDisplayOnly"
-                                      [instructorCommentTableModel]="instructorCommentTableModel"
-                                      (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                      (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                      (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                      (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-      ></tm-per-question-view-responses>
+  <div [ngbCollapse]="!question.isTabExpanded">
+    <div class="card-body">
+      <div class="stats-table">
+        <tm-single-statistics *ngIf="showStatistics"
+                              [question]="question.question.questionDetails"
+                              [statistics]="question.statistics"
+                              [responses]="question.responses"
+                              [recipientType]="question.question.recipientType"
+                              [section]="section" [sectionType]="sectionType"
+        ></tm-single-statistics>
+      </div>
+      <div class="stats-table">
+        <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
+                                        [indicateMissingResponses]="indicateMissingResponses" [question]="question.question"
+                                        [isDisplayOnly]="isDisplayOnly"
+                                        [instructorCommentTableModel]="instructorCommentTableModel"
+                                        (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                        (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                        (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                        (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+        ></tm-per-question-view-responses>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.scss
@@ -10,7 +10,7 @@
 
 .card-body {
   width: inherit;
-  display: inline-block;
+  display: block;
   overflow-x: auto;
 }
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   PerQuestionViewResponsesModule,
 } from '../../components/question-responses/per-question-view-responses/per-question-view-responses.module';
@@ -20,6 +21,7 @@ describe('InstructorSessionResultQuestionViewComponent', () => {
         PerQuestionViewResponsesModule,
         QuestionTextWithInfoModule,
         SingleStatisticsModule,
+        NgbModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -7,16 +7,18 @@
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>
       </div>
     </div>
-    <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
-      <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
-                                 [indicateMissingResponses]="indicateMissingResponses"
-                                 [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="false" [session]="session"
-                                 [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
-                                 (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                 (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                 (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                 (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                 style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
+    <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+      <div class="card-body">
+        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+                                   [indicateMissingResponses]="indicateMissingResponses"
+                                   [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="false" [session]="session"
+                                   [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
+                                   (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                   (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                   (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                   style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   GrqRgqViewResponsesModule,
 } from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module';
@@ -12,7 +13,7 @@ describe('InstructorSessionResultRgqViewComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorSessionResultRgqViewComponent],
-      imports: [GrqRgqViewResponsesModule],
+      imports: [GrqRgqViewResponsesModule, NgbModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -7,16 +7,18 @@
         <i class="fas fa-chevron-up" *ngIf="sectionInfo.value.isTabExpanded"></i>
       </div>
     </div>
-    <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
-      <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
-                                 [indicateMissingResponses]="indicateMissingResponses"
-                                 [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="false" [session]="session"
-                                 [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
-                                 (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                                 (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                                 (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                                 (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                 style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
+    <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+      <div class="card-body">
+        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+                                   [indicateMissingResponses]="indicateMissingResponses"
+                                   [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="false" [session]="session"
+                                   [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"
+                                   (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                                   (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                                   (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                   style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   GqrRqgViewResponsesModule,
 } from '../../components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.module';
@@ -12,7 +13,7 @@ describe('InstructorSessionResultRqgViewComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorSessionResultRqgViewComponent],
-      imports: [GqrRqgViewResponsesModule],
+      imports: [GqrRqgViewResponsesModule, NgbModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -28,44 +28,46 @@
         </div>
       </div>
 
-      <div class="card-body" *ngIf="courseTab.hasTabExpanded">
-        <ng-container *ngIf="courseTab.stats.numOfStudents > 0, else noStudentsTemplate">
-          <div class="card-deck" *ngIf="courseTab.stats">
-            <div class="card">
-              <div class="card-body">
-                <h2 class="card-title">{{courseTab.stats.numOfStudents}}</h2>
-                <h4 class="card-text">Students</h4>
+      <div [ngbCollapse]="!courseTab.hasTabExpanded">
+        <div class="card-body">
+          <ng-container *ngIf="courseTab.stats.numOfStudents > 0, else noStudentsTemplate">
+            <div class="card-deck" *ngIf="courseTab.stats">
+              <div class="card">
+                <div class="card-body">
+                  <h2 class="card-title">{{courseTab.stats.numOfStudents}}</h2>
+                  <h4 class="card-text">Students</h4>
+                </div>
+              </div>
+              <div class="card">
+                <div class="card-body">
+                  <h2 class="card-title">{{courseTab.stats.numOfSections}}</h2>
+                  <h4 class="card-text">Sections</h4>
+                </div>
+              </div>
+              <div class="card">
+                <div class="card-body">
+                  <h2 class="card-title">{{courseTab.stats.numOfTeams}}</h2>
+                  <h4 class="card-text">Teams</h4>
+                </div>
               </div>
             </div>
-            <div class="card">
-              <div class="card-body">
-                <h2 class="card-title">{{courseTab.stats.numOfSections}}</h2>
-                <h4 class="card-text">Sections</h4>
-              </div>
-            </div>
-            <div class="card">
-              <div class="card-body">
-                <h2 class="card-title">{{courseTab.stats.numOfTeams}}</h2>
-                <h4 class="card-text">Teams</h4>
-              </div>
-            </div>
-          </div>
 
-          <hr/>
+            <hr/>
 
-          <button class="btn btn-success"
-            routerLink="/web/instructor/courses/enroll"
-            [queryParams]="{courseid: courseTab.course.courseId}">
-          Enroll Students
-          </button>
-          <br/><br/>
-          <tm-student-list
-              [courseId]="courseTab.course.courseId"
-              [students]="courseTab.studentList" [useGrayHeading]="false"
-              [enableRemindButton]="true"
-              (removeStudentFromCourseEvent)="removeStudentFromCourse(courseTab, $event)">
-          </tm-student-list>
-        </ng-container>
+            <button class="btn btn-success"
+              routerLink="/web/instructor/courses/enroll"
+              [queryParams]="{courseid: courseTab.course.courseId}">
+            Enroll Students
+            </button>
+            <br/><br/>
+            <tm-student-list
+                [courseId]="courseTab.course.courseId"
+                [students]="courseTab.studentList" [useGrayHeading]="false"
+                [enableRemindButton]="true"
+                (removeStudentFromCourseEvent)="removeStudentFromCourse(courseTab, $event)">
+            </tm-student-list>
+          </ng-container>
+        </div>
       </div>
 
       <ng-template #noStudentsTemplate>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { StudentListModule } from '../../components/student-list/student-list.module';
 import { InstructorStudentListPageComponent } from './instructor-student-list-page.component';
 
@@ -20,6 +21,7 @@ import { InstructorStudentListPageComponent } from './instructor-student-list-pa
     FormsModule,
     RouterModule,
     StudentListModule,
+    NgbModule,
   ],
 })
 export class InstructorStudentListPageModule { }

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -149,13 +149,29 @@ body {
   }
 }
 
+@keyframes collapseTab {
+  from {
+    opacity: 1;
+    max-height: 800px;
+    overflow: visible;
+    visibility: visible;
+  }
+
+  to {
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+    visibility: collapse;
+  }
+}
+
 .collapse {
-  transition: .35s ease-in-out;
-  opacity: 0;
-  visibility: collapse;
-  max-height: 0;
   display: block !important;
+  opacity: 0;
+  max-height: 0;
+  visibility: collapse;
   overflow: hidden;
+  animation: collapseTab .35s ease-in-out;
 
   &.show {
     opacity: 1;

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -137,7 +137,7 @@ body {
   cursor: not-allowed;
 }
 
-@keyframes myExpand {
+@keyframes expandTab {
   from {
     opacity: 0;
     max-height: 0;
@@ -162,6 +162,6 @@ body {
     max-height: 99999999px;
     overflow: visible;
     visibility: visible;
-    animation: myExpand .35s ease-in-out;
+    animation: expandTab .35s ease-in-out;
   }
 }

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -136,3 +136,32 @@ body {
 .editor.editor-disabled {
   cursor: not-allowed;
 }
+
+@keyframes myExpand {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+
+  to {
+    opacity: 1;
+    max-height: 800px;
+  }
+}
+
+.collapse {
+  transition: .35s ease-in-out;
+  opacity: 0;
+  visibility: collapse;
+  max-height: 0;
+  display: block !important;
+  overflow: hidden;
+
+  &.show {
+    opacity: 1;
+    max-height: 99999999px;
+    overflow: visible;
+    visibility: visible;
+    animation: myExpand .35s ease-in-out;
+  }
+}


### PR DESCRIPTION
Part of #10213 

Most changes in this PR are mainly wrapping elements with `[ngbCollapse]`.

Note that this PR is mainly a workaround as the lack of animation for `[ngbCollapse]` is currently being worked on by [ng-bootstrap](https://github.com/ng-bootstrap/ng-bootstrap). Follow the progression at [this thread](https://github.com/ng-bootstrap/ng-bootstrap/issues/295). 

We should revert parts of this PR when they do a release for proper animations for collapsing.

Added animations for:
- Result page question collapsing
- Instructor help section
- Template question modal expanding
- Student list page

Some samples:
![resultsopt](https://user-images.githubusercontent.com/32454748/85506816-ad8c8700-b623-11ea-9c36-42494868ae86.gif)
![template_qnopt](https://user-images.githubusercontent.com/32454748/85506847-bc733980-b623-11ea-9526-3bba3438585d.gif)


