### PR TITLE
[#10176] UAT fixes

### DIFF
--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -270,13 +270,13 @@
 </div>
 <ng-template #saveModal let-modal>
   <div class="modal-header bg-danger">
-    <h5 class="modal-title text-white"><i class="fas fa-times-circle"></i> Warning: Existing responses will be deleted by your action</h5>
+    <h5 class="modal-title text-white"><i class="fas fa-times-circle"></i> Warning: Existing responses might be deleted by your action</h5>
     <button type="button" class="close" (click)="modal.dismiss()">
       <i class="fas fa-times"></i>
     </button>
   </div>
   <div class="modal-body">
-    <p>Editing some fields will result in <b>all existing responses for this question to be deleted.</b></p>
+    <p>Editing fields affecting responders' answers will result in <b>all existing responses for this question to be deleted.</b></p>
     <p>Are you sure you want to continue?</p>
   </div>
   <div class="modal-footer">

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -143,7 +143,7 @@
                 <button *ngIf="!recipientSubmissionFormModel.commentByGiver" class="btn btn-secondary btn-sm"
                         (click)="addNewParticipantCommentToResponse(i)"
                         [disabled]="isDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
-                  <i class="fas fa-comment"></i> Comment on your response
+                  <i class="fas fa-comment"></i> [Optional] Comment on your response
                 </button>
               </div>
               <div *ngIf="recipientSubmissionFormModel.commentByGiver">

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-4" ngbTooltip="Minimum acceptable response value">
     Minimum value:
-    <input type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" min="0" [step]="1">
+    <input type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1">
   </div>
   <div class="col-sm-4" ngbTooltip="Value to be increased/decreased each step">
     Increment:

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-4" ngbTooltip="Minimum acceptable response value">
     Minimum value:
-    <input type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event)" [disabled]="!isEditable" min="1" [step]="model.step">
+    <input type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" min="0" [step]="1">
   </div>
   <div class="col-sm-4" ngbTooltip="Value to be increased/decreased each step">
     Increment:
@@ -10,7 +10,7 @@
   </div>
   <div class="col-sm-4" ngbTooltip="Maximum acceptable response value">
     Maximum value:
-    <input type="number" class="form-control" [ngModel]="model.maxScale" (ngModelChange)="triggerModelChange('maxScale', $event)" [disabled]="!isEditable" [step]="model.step" min="{{ model.minScale + model.step }}">
+    <input type="number" class="form-control" [ngModel]="model.maxScale" (ngModelChange)="triggerModelChange('maxScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1" min="{{ Math.ceil(model.minScale + model.step) }}">
   </div>
 </div>
 <br>

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.ts
@@ -14,6 +14,9 @@ import { QuestionEditDetailsFormComponent } from './question-edit-details-form.c
 export class NumScaleQuestionEditDetailsFormComponent
     extends QuestionEditDetailsFormComponent<FeedbackNumericalScaleQuestionDetails> {
 
+  // enum
+  Math: typeof Math = Math;
+
   constructor() {
     super(DEFAULT_NUMSCALE_QUESTION_DETAILS());
   }

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.ts
@@ -14,7 +14,6 @@ import { QuestionEditDetailsFormComponent } from './question-edit-details-form.c
 export class NumScaleQuestionEditDetailsFormComponent
     extends QuestionEditDetailsFormComponent<FeedbackNumericalScaleQuestionDetails> {
 
-  // enum
   Math: typeof Math = Math;
 
   constructor() {


### PR DESCRIPTION
Part of #10176 

- Restrict min and max values to integers
  - The backend only accepts integer values, and I don't see any compelling reason to change it
- Make edit question save warning less scary and more accurate
  - Seems like popping out this modal only once is intended, so I did not touch that
<img width="780" alt="image" src="https://user-images.githubusercontent.com/32454748/85402262-f5f96580-b58d-11ea-8ac5-838b30c2b2ca.png">

- Indicate MCQ MSQ answer comments are optional
<img width="361" alt="image" src="https://user-images.githubusercontent.com/32454748/85402186-d104f280-b58d-11ea-9796-0492923c41b6.png">
