### PR TITLE
[#10176] Avoid expensive missing responses generation when recipient type is all students

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -161,6 +161,14 @@ public abstract class FeedbackQuestionDetails {
             && question.recipientType != FeedbackParticipantType.TEAMS;
     }
 
+    /**
+     * Checks whether missing responses should be generated.
+     */
+    public boolean shouldGenerateMissingResponses(FeedbackQuestionAttributes question) {
+        // generate combinations against all students are meaningless
+        return question.getRecipientType() != FeedbackParticipantType.STUDENTS;
+    }
+
     public String getNoResponseTextInCsv(String giverEmail, String recipientEmail,
                                          FeedbackSessionResultsBundle bundle,
                                          FeedbackQuestionAttributes question) {

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -1,7 +1,6 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -507,52 +506,47 @@ public final class FeedbackQuestionsLogic {
     }
 
     /**
-     * Builds a complete giver to recipient map for all {@code relatedQuestions}.
+     * Builds a complete giver to recipient map for a {@code relatedQuestion}.
      *
-     * @param feedbackSession The feedback session that contains the questions
-     * @param relatedQuestions The questions to be considered
+     * @param feedbackSession The feedback session that contains the question
+     * @param relatedQuestion The question to be considered
      * @param courseRoster the roster in the course
-     * @return a map from the question ID to the giver to recipient map for the question.
+     * @return a map from giver to recipient for the question.
      */
-    public Map<String, Map<String, Set<String>>> buildCompleteGiverRecipientMap(
-            FeedbackSessionAttributes feedbackSession,
-            Collection<FeedbackQuestionAttributes> relatedQuestions, CourseRoster courseRoster) {
-        Map<String, Map<String, Set<String>>> completeGiverRecipientMap = new HashMap<>();
+    public Map<String, Set<String>> buildCompleteGiverRecipientMap(
+            FeedbackSessionAttributes feedbackSession, FeedbackQuestionAttributes relatedQuestion,
+            CourseRoster courseRoster) {
+        Map<String, Set<String>> completeGiverRecipientMap = new HashMap<>();
 
-        for (FeedbackQuestionAttributes feedbackQuestion : relatedQuestions) {
-            Map<String, Set<String>> questionGiverRecipientMap = new HashMap<>();
-            completeGiverRecipientMap.put(feedbackQuestion.getId(), questionGiverRecipientMap);
-
-            List<String> possibleGivers = getPossibleGivers(feedbackSession, feedbackQuestion, courseRoster);
-            for (String possibleGiver : possibleGivers) {
-                switch (feedbackQuestion.getGiverType()) {
-                case STUDENTS:
-                    StudentAttributes studentGiver = courseRoster.getStudentForEmail(possibleGiver);
-                    questionGiverRecipientMap
-                            .computeIfAbsent(possibleGiver, key -> new HashSet<>())
-                            .addAll(getRecipientsOfQuestion(
-                                    feedbackQuestion, null, studentGiver, courseRoster).keySet());
-                    break;
-                case TEAMS:
-                    StudentAttributes oneTeamMember =
-                            courseRoster.getTeamToMembersTable().get(possibleGiver).iterator().next();
-                    questionGiverRecipientMap
-                            .computeIfAbsent(possibleGiver, key -> new HashSet<>())
-                            .addAll(getRecipientsOfQuestion(
-                                    feedbackQuestion, null, oneTeamMember, courseRoster).keySet());
-                    break;
-                case INSTRUCTORS:
-                case SELF:
-                    InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
-                    questionGiverRecipientMap
-                            .computeIfAbsent(possibleGiver, key -> new HashSet<>())
-                            .addAll(getRecipientsOfQuestion(
-                                    feedbackQuestion, instructorGiver, null, courseRoster).keySet());
-                    break;
-                default:
-                    log.severe("Invalid giver type specified");
-                    break;
-                }
+        List<String> possibleGivers = getPossibleGivers(feedbackSession, relatedQuestion, courseRoster);
+        for (String possibleGiver : possibleGivers) {
+            switch (relatedQuestion.getGiverType()) {
+            case STUDENTS:
+                StudentAttributes studentGiver = courseRoster.getStudentForEmail(possibleGiver);
+                completeGiverRecipientMap
+                        .computeIfAbsent(possibleGiver, key -> new HashSet<>())
+                        .addAll(getRecipientsOfQuestion(
+                                relatedQuestion, null, studentGiver, courseRoster).keySet());
+                break;
+            case TEAMS:
+                StudentAttributes oneTeamMember =
+                        courseRoster.getTeamToMembersTable().get(possibleGiver).iterator().next();
+                completeGiverRecipientMap
+                        .computeIfAbsent(possibleGiver, key -> new HashSet<>())
+                        .addAll(getRecipientsOfQuestion(
+                                relatedQuestion, null, oneTeamMember, courseRoster).keySet());
+                break;
+            case INSTRUCTORS:
+            case SELF:
+                InstructorAttributes instructorGiver = courseRoster.getInstructorForEmail(possibleGiver);
+                completeGiverRecipientMap
+                        .computeIfAbsent(possibleGiver, key -> new HashSet<>())
+                        .addAll(getRecipientsOfQuestion(
+                                relatedQuestion, instructorGiver, null, courseRoster).keySet());
+                break;
+            default:
+                log.severe("Invalid giver type specified");
+                break;
             }
         }
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
@@ -2,7 +2,6 @@ package teammates.test.cases.logic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -839,25 +838,20 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackSessionAttributes session1 = fsLogic.getFeedbackSession(
                 qn1InSession1InCourse1.getFeedbackSessionName(), qn1InSession1InCourse1.getCourseId());
 
-        Map<String, Map<String, Set<String>>> completeGiverRecipientMap =
-                fqLogic.buildCompleteGiverRecipientMap(
-                        session1, Collections.singletonList(qn1InSession1InCourse1), courseRoster);
+        Map<String, Set<String>> completeGiverRecipientMap =
+                fqLogic.buildCompleteGiverRecipientMap(session1, qn1InSession1InCourse1, courseRoster);
 
-        assertEquals(1, completeGiverRecipientMap.size());
-        assertTrue(completeGiverRecipientMap.containsKey(qn1InSession1InCourse1.getId()));
-        Map<String, Set<String>> questionGiverRecipientMap =
-                completeGiverRecipientMap.get(qn1InSession1InCourse1.getId());
-        assertEquals(5, questionGiverRecipientMap.size());
-        assertEquals(1, questionGiverRecipientMap.get("student1InCourse1@gmail.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("student1InCourse1@gmail.tmt").contains("student1InCourse1@gmail.tmt"));
-        assertEquals(1, questionGiverRecipientMap.get("student2InCourse1@gmail.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("student2InCourse1@gmail.tmt").contains("student2InCourse1@gmail.tmt"));
-        assertEquals(1, questionGiverRecipientMap.get("student3InCourse1@gmail.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("student3InCourse1@gmail.tmt").contains("student3InCourse1@gmail.tmt"));
-        assertEquals(1, questionGiverRecipientMap.get("student4InCourse1@gmail.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("student4InCourse1@gmail.tmt").contains("student4InCourse1@gmail.tmt"));
-        assertEquals(1, questionGiverRecipientMap.get("student5InCourse1@gmail.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("student5InCourse1@gmail.tmt").contains("student5InCourse1@gmail.tmt"));
+        assertEquals(5, completeGiverRecipientMap.size());
+        assertEquals(1, completeGiverRecipientMap.get("student1InCourse1@gmail.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("student1InCourse1@gmail.tmt").contains("student1InCourse1@gmail.tmt"));
+        assertEquals(1, completeGiverRecipientMap.get("student2InCourse1@gmail.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("student2InCourse1@gmail.tmt").contains("student2InCourse1@gmail.tmt"));
+        assertEquals(1, completeGiverRecipientMap.get("student3InCourse1@gmail.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("student3InCourse1@gmail.tmt").contains("student3InCourse1@gmail.tmt"));
+        assertEquals(1, completeGiverRecipientMap.get("student4InCourse1@gmail.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("student4InCourse1@gmail.tmt").contains("student4InCourse1@gmail.tmt"));
+        assertEquals(1, completeGiverRecipientMap.get("student5InCourse1@gmail.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("student5InCourse1@gmail.tmt").contains("student5InCourse1@gmail.tmt"));
     }
 
     @Test
@@ -869,25 +863,20 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackSessionAttributes session1 = fsLogic.getFeedbackSession(
                 qn4InSession1InCourse1.getFeedbackSessionName(), qn4InSession1InCourse1.getCourseId());
 
-        Map<String, Map<String, Set<String>>> completeGiverRecipientMap =
-                fqLogic.buildCompleteGiverRecipientMap(
-                        session1, Collections.singletonList(qn4InSession1InCourse1), courseRoster);
+        Map<String, Set<String>> completeGiverRecipientMap =
+                fqLogic.buildCompleteGiverRecipientMap(session1, qn4InSession1InCourse1, courseRoster);
 
-        assertEquals(1, completeGiverRecipientMap.size());
-        assertTrue(completeGiverRecipientMap.containsKey(qn4InSession1InCourse1.getId()));
-        Map<String, Set<String>> questionGiverRecipientMap =
-                completeGiverRecipientMap.get(qn4InSession1InCourse1.getId());
-        assertEquals(5, questionGiverRecipientMap.size());
-        assertEquals(1, questionGiverRecipientMap.get("instructor1@course1.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("instructor1@course1.tmt").contains(Const.GENERAL_QUESTION));
-        assertEquals(1, questionGiverRecipientMap.get("instructor2@course1.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("instructor2@course1.tmt").contains(Const.GENERAL_QUESTION));
-        assertEquals(1, questionGiverRecipientMap.get("instructor3@course1.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("instructor3@course1.tmt").contains(Const.GENERAL_QUESTION));
-        assertEquals(1, questionGiverRecipientMap.get("helper@course1.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("helper@course1.tmt").contains(Const.GENERAL_QUESTION));
-        assertEquals(1, questionGiverRecipientMap.get("instructorNotYetJoinedCourse1@email.tmt").size());
-        assertTrue(questionGiverRecipientMap.get("instructorNotYetJoinedCourse1@email.tmt")
+        assertEquals(5, completeGiverRecipientMap.size());
+        assertEquals(1, completeGiverRecipientMap.get("instructor1@course1.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("instructor1@course1.tmt").contains(Const.GENERAL_QUESTION));
+        assertEquals(1, completeGiverRecipientMap.get("instructor2@course1.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("instructor2@course1.tmt").contains(Const.GENERAL_QUESTION));
+        assertEquals(1, completeGiverRecipientMap.get("instructor3@course1.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("instructor3@course1.tmt").contains(Const.GENERAL_QUESTION));
+        assertEquals(1, completeGiverRecipientMap.get("helper@course1.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("helper@course1.tmt").contains(Const.GENERAL_QUESTION));
+        assertEquals(1, completeGiverRecipientMap.get("instructorNotYetJoinedCourse1@email.tmt").size());
+        assertTrue(completeGiverRecipientMap.get("instructorNotYetJoinedCourse1@email.tmt")
                 .contains(Const.GENERAL_QUESTION));
     }
 
@@ -900,17 +889,12 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackSessionAttributes session1 = fsLogic.getFeedbackSession(
                 qn3InSession1InCourse1.getFeedbackSessionName(), qn3InSession1InCourse1.getCourseId());
 
-        Map<String, Map<String, Set<String>>> completeGiverRecipientMap =
-                fqLogic.buildCompleteGiverRecipientMap(
-                        session1, Collections.singletonList(qn3InSession1InCourse1), courseRoster);
+        Map<String, Set<String>> completeGiverRecipientMap =
+                fqLogic.buildCompleteGiverRecipientMap(session1, qn3InSession1InCourse1, courseRoster);
 
         assertEquals(1, completeGiverRecipientMap.size());
-        assertTrue(completeGiverRecipientMap.containsKey(qn3InSession1InCourse1.getId()));
-        Map<String, Set<String>> questionGiverRecipientMap =
-                completeGiverRecipientMap.get(qn3InSession1InCourse1.getId());
-        assertEquals(1, questionGiverRecipientMap.size());
-        assertEquals(1, questionGiverRecipientMap.get(session1.getCreatorEmail()).size());
-        assertTrue(questionGiverRecipientMap.get(session1.getCreatorEmail()).contains(Const.GENERAL_QUESTION));
+        assertEquals(1, completeGiverRecipientMap.get(session1.getCreatorEmail()).size());
+        assertTrue(completeGiverRecipientMap.get(session1.getCreatorEmail()).contains(Const.GENERAL_QUESTION));
     }
 
     @Test
@@ -922,19 +906,14 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackSessionAttributes session2 = fsLogic.getFeedbackSession(
                 teamFeedbackQuestion.getFeedbackSessionName(), teamFeedbackQuestion.getCourseId());
 
-        Map<String, Map<String, Set<String>>> completeGiverRecipientMap =
-                fqLogic.buildCompleteGiverRecipientMap(
-                        session2, Collections.singletonList(teamFeedbackQuestion), courseRoster);
+        Map<String, Set<String>> completeGiverRecipientMap =
+                fqLogic.buildCompleteGiverRecipientMap(session2, teamFeedbackQuestion, courseRoster);
 
-        assertEquals(1, completeGiverRecipientMap.size());
-        assertTrue(completeGiverRecipientMap.containsKey(teamFeedbackQuestion.getId()));
-        Map<String, Set<String>> questionGiverRecipientMap =
-                completeGiverRecipientMap.get(teamFeedbackQuestion.getId());
-        assertEquals(2, questionGiverRecipientMap.size());
-        assertEquals(1, questionGiverRecipientMap.get("Team 1.1</td></div>'\"").size());
-        assertTrue(questionGiverRecipientMap.get("Team 1.1</td></div>'\"").contains("Team 1.2"));
-        assertEquals(1, questionGiverRecipientMap.get("Team 1.2").size());
-        assertTrue(questionGiverRecipientMap.get("Team 1.2").contains("Team 1.1</td></div>'\""));
+        assertEquals(2, completeGiverRecipientMap.size());
+        assertEquals(1, completeGiverRecipientMap.get("Team 1.1</td></div>'\"").size());
+        assertTrue(completeGiverRecipientMap.get("Team 1.1</td></div>'\"").contains("Team 1.2"));
+        assertEquals(1, completeGiverRecipientMap.get("Team 1.2").size());
+        assertTrue(completeGiverRecipientMap.get("Team 1.2").contains("Team 1.1</td></div>'\""));
     }
 
     private void testGetFeedbackQuestionsForInstructor() throws Exception {

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -2016,7 +2016,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             totalMissingResponse += entry.getValue().size();
         }
         assertEquals(10, totalResponse);
-        assertEquals(48, totalMissingResponse);
+        assertEquals(19, totalMissingResponse);
         // Instructor should still see all questions
         assertEquals(8, bundle.getQuestionsMap().size());
         assertEquals(8, bundle.getQuestionResponseMap().size());
@@ -2071,7 +2071,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             totalMissingResponse += entry.getValue().size();
         }
         assertEquals(7, totalResponse);
-        assertEquals(36, totalMissingResponse);
+        assertEquals(13, totalMissingResponse);
         // Instructor should still see all questions
         assertEquals(8, bundle.getQuestionsMap().size());
         assertEquals(8, bundle.getQuestionResponseMap().size());


### PR DESCRIPTION
Part of #10176

**Outline of Solution**

- Missing responses are not generated when the recipient type is "STUDENTS" (V6 enforces a more strict check where the generation is skipped when recipient is "TEAM". However, we assume the number of team will not grow that large). 
