### PR TITLE
[#10176] Fix most issues in instructor results page from UAT

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetFeedbackSessionAction.java
@@ -59,10 +59,10 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         case STUDENT_SUBMISSION:
         case INSTRUCTOR_SUBMISSION:
         case STUDENT_RESULT:
-        case INSTRUCTOR_RESULT:
             // hide some attributes for submission
             response.hideInformationForStudent();
             break;
+        case INSTRUCTOR_RESULT:
         case FULL_DETAIL:
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/webapi/output/FeedbackSessionData.java
@@ -18,6 +18,8 @@ public class FeedbackSessionData extends ApiOutput {
 
     private final Long submissionStartTimestamp;
     private final Long submissionEndTimestamp;
+    @Nullable
+    private Long resultVisibleFromTimestamp;
     private Long gracePeriod;
 
     private SessionVisibleSetting sessionVisibleSetting;
@@ -45,6 +47,7 @@ public class FeedbackSessionData extends ApiOutput {
         this.instructions = feedbackSessionAttributes.getInstructions();
         this.submissionStartTimestamp = feedbackSessionAttributes.getStartTime().toEpochMilli();
         this.submissionEndTimestamp = feedbackSessionAttributes.getEndTime().toEpochMilli();
+        this.resultVisibleFromTimestamp = feedbackSessionAttributes.getResultsVisibleFromTime().toEpochMilli();
         this.gracePeriod = feedbackSessionAttributes.getGracePeriodMinutes();
 
         Instant sessionVisibleTime = feedbackSessionAttributes.getSessionVisibleFromTime();
@@ -122,6 +125,10 @@ public class FeedbackSessionData extends ApiOutput {
         return submissionEndTimestamp;
     }
 
+    public Long getResultVisibleFromTimestamp() {
+        return resultVisibleFromTimestamp;
+    }
+
     public Long getGracePeriod() {
         return gracePeriod;
     }
@@ -156,6 +163,10 @@ public class FeedbackSessionData extends ApiOutput {
 
     public Boolean getIsPublishedEmailEnabled() {
         return isPublishedEmailEnabled;
+    }
+
+    public void setResultVisibleFromTimestamp(Long resultVisibleFromTimestamp) {
+        this.resultVisibleFromTimestamp = resultVisibleFromTimestamp;
     }
 
     public void setGracePeriod(Long gracePeriod) {
@@ -202,6 +213,7 @@ public class FeedbackSessionData extends ApiOutput {
      * Hides some attributes to student.
      */
     public void hideInformationForStudent() {
+        setResultVisibleFromTimestamp(null);
         setGracePeriod(null);
         setSessionVisibleSetting(null);
         setCustomSessionVisibleTimestamp(null);

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.html
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.html
@@ -1,5 +1,5 @@
-<div class="card">
-  <div class="card-header comment-table-header" *ngIf="!model.isReadOnly && !model.isAddingNewComment">
+<div class="card" [class.no-border]="!displayAddCommentButton && !model.isAddingNewComment && !model.commentRows.length">
+  <div class="card-header comment-table-header" *ngIf="!model.isReadOnly && !model.isAddingNewComment && displayAddCommentButton">
     <button (click)="handleAddingNewCommentEvent()" type="button" class="btn btn-secondary btn-sm float-right">
       <i class="fas fa-comment"></i>&nbsp;<i class="fas fa-plus"></i>
     </button>

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.scss
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.scss
@@ -1,3 +1,7 @@
 .comment-table-header {
   background-color: transparent;
 }
+
+.no-border {
+  border-width: 0;
+}

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.ts
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.ts
@@ -35,6 +35,9 @@ export class CommentTableComponent implements OnInit {
   questionShowResponsesTo: FeedbackVisibilityType[] = [];
 
   @Input()
+  displayAddCommentButton: boolean = false;
+
+  @Input()
   model: CommentTableModel = {
     commentRows: [],
     newCommentRow: {

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -10,30 +10,32 @@
       </div>
       <div [ngbCollapse]="!teamExpanded[teamInfo.key]">
         <div class="card-body">
-          <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
-          <hr>
-          <div class="card top-padded" *ngFor="let question of teamsToQuestions[teamInfo.key]">
-            <div class="card-header bg-info text-white">
-              <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber"
-                                          [questionDetails]="question.feedbackQuestion.questionDetails"
-                                          (click)="$event.stopPropagation()"></tm-question-text-with-info>
+          <div *ngIf="teamsToQuestions[teamInfo.key] && teamsToQuestions[teamInfo.key].length">
+            <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
+            <hr>
+            <div class="card top-padded" *ngFor="let question of teamsToQuestions[teamInfo.key]">
+              <div class="card-header bg-info text-white">
+                <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber"
+                                            [questionDetails]="question.feedbackQuestion.questionDetails"
+                                            (click)="$event.stopPropagation()"></tm-question-text-with-info>
+              </div>
+              <div class="card-body">
+                <tm-single-statistics [responses]="question.allResponses"
+                                      [question]="question.feedbackQuestion.questionDetails"
+                                      [statistics]="question.questionStatistics"
+                                      [recipientType]="question.feedbackQuestion.recipientType"
+                                      [displayContributionStats]="false"
+                ></tm-single-statistics>
+              </div>
             </div>
-            <div class="card-body">
-              <tm-single-statistics [responses]="question.allResponses"
-                                    [question]="question.feedbackQuestion.questionDetails"
-                                    [statistics]="question.questionStatistics"
-                                    [recipientType]="question.feedbackQuestion.recipientType"
-                                    [displayContributionStats]="false"
-              ></tm-single-statistics>
+            <h3>{{ teamInfo.key }} Detailed Responses</h3>
+            <hr>
+            <div *ngFor="let userInfo of teamInfo.value">
+              <ng-container
+                  [ngTemplateOutlet]="userTab"
+                  [ngTemplateOutletContext]="{userInfo:userInfo}">
+              </ng-container>
             </div>
-          </div>
-          <h3>{{ teamInfo.key }} Detailed Responses</h3>
-          <hr>
-          <div *ngFor="let userInfo of teamInfo.value">
-            <ng-container
-                [ngTemplateOutlet]="userTab"
-                [ngTemplateOutletContext]="{userInfo:userInfo}">
-            </ng-container>
           </div>
         </div>
       </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { FeedbackResponsesService } from '../../../../services/feedback-responses.service';
 import {
-  FeedbackParticipantType,
+  FeedbackParticipantType, FeedbackQuestionType,
   FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
   QuestionOutput, ResponseOutput,
   ResponseVisibleSetting,
@@ -182,6 +182,11 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
 
     for (const team of Object.keys(this.teamExpanded)) {
       for (const question of this.responses) {
+        if (question.feedbackQuestion.questionType === FeedbackQuestionType.CONTRIB
+            || question.feedbackQuestion.questionType === FeedbackQuestionType.TEXT) {
+          // Should not display anything for contribution and text questions
+          continue;
+        }
         const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
         questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (response.isMissingResponse) {

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -30,10 +30,16 @@
           <tm-question-text-with-info [questionNumber]="response.feedbackQuestion.questionNumber" [questionDetails]="response.feedbackQuestion.questionDetails"></tm-question-text-with-info>
         </div>
         <div class="card-body">
-          <tm-single-response
-              [class.color-neutral]="response.allResponses[0].isMissingResponse"
-              [responseDetails]="response.allResponses[0].responseDetails"
-              [questionDetails]="response.feedbackQuestion.questionDetails"></tm-single-response>
+          <div class="row" style="margin: 0;">
+            <tm-single-response
+                    [class.color-neutral]="response.allResponses[0].isMissingResponse"
+                    [responseDetails]="response.allResponses[0].responseDetails"
+                    [questionDetails]="response.feedbackQuestion.questionDetails"></tm-single-response>
+            <button (click)="toggleAddComment(response.allResponses[0].responseId)"
+                    ngbTooltip="Add comment" type="button" class="btn btn-secondary btn-sm" style="margin-left: auto;">
+              <i class="fas fa-comment"></i>
+            </button>
+          </div>
           <tm-comment-row *ngIf="response.allResponses[0].participantComment"
                           [model]="response.allResponses[0].participantComment | commentToCommentRowModel: session.timeZone"
                           [questionShowResponsesTo]="response.feedbackQuestion.showResponsesTo"

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -36,6 +36,7 @@
                     [responseDetails]="response.allResponses[0].responseDetails"
                     [questionDetails]="response.feedbackQuestion.questionDetails"></tm-single-response>
             <button (click)="toggleAddComment(response.allResponses[0].responseId)"
+                    *ngIf="response.feedbackQuestion.questionType !== 'CONTRIB'"
                     ngbTooltip="Add comment" type="button" class="btn btn-secondary btn-sm" style="margin-left: auto;">
               <i class="fas fa-comment"></i>
             </button>
@@ -50,7 +51,7 @@
                           [shouldHideEditButton]="true"
           ></tm-comment-row>
           <br/>
-          <tm-comment-table *ngIf="!response.allResponses[0].isMissingResponse"
+          <tm-comment-table *ngIf="!response.allResponses[0].isMissingResponse && response.feedbackQuestion.questionType !== 'CONTRIB'"
                             [model]="instructorCommentTableModel[response.allResponses[0].responseId]"
                             [questionShowResponsesTo]="response.feedbackQuestion.showResponsesTo"
                             [response]="response.allResponses[0]"

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -6,6 +6,7 @@ import {
   SessionVisibleSetting,
 } from '../../../../types/api-output';
 import { CommentRowMode } from '../../comment-box/comment-row/comment-row.component';
+import { CommentTableModel } from '../../comment-box/comment-table/comment-table.component';
 import { InstructorResponsesViewBase } from '../instructor-responses-view-base';
 
 /**
@@ -60,4 +61,11 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
     team.giver = `(${this.responses[0].allResponses[0].giverTeam})`;
     return team;
   }
+
+  toggleAddComment(responseId: string): void {
+    const commentTable: CommentTableModel = this.instructorCommentTableModel[responseId];
+    commentTable.isAddingNewComment = !commentTable.isAddingNewComment;
+    this.triggerModelChangeForSingleResponse(responseId, commentTable);
+  }
+
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.module.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
 import { CommentBoxModule } from '../../comment-box/comment-box.module';
@@ -22,6 +23,7 @@ import { GroupedResponsesComponent } from './grouped-responses.component';
     ResponseModerationButtonModule,
     CommentBoxModule,
     TeammatesCommonModule,
+    NgbTooltipModule,
   ],
 })
 export class GroupedResponsesModule { }

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -57,7 +57,7 @@
           <tm-response-moderation-button *ngIf="response.relatedGiverEmail" [session]="session" [relatedGiverEmail]="response.relatedGiverEmail"
                                          [moderatedQuestionId]="question.feedbackQuestionId" [isGiverInstructor]="question.giverType === 'INSTRUCTORS'"></tm-response-moderation-button>
           <button class="btn btn-light btn-sm" style="margin-left:5px; margin-top:5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
-                  *ngIf="!response.isMissingResponse"
+                  *ngIf="!response.isMissingResponse && question.questionType !== 'CONTRIB'"
                   (click)="showCommentTableModel(response, commentTableModal)">Add Comment <span class="badge badge-secondary">
             {{this.instructorCommentTableModel[response.responseId].commentRows.length}}</span>
           </button>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -94,6 +94,7 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
         responsesToShow.some((response: ResponseOutput) => !response.isMissingResponse);
     if (hasRealResponse) {
       this.responsesToShow = responsesToShow;
+      this.sortResponses(this.sortBy);
     } else {
       // If there is no real response, it is not necessary to show any of the missing responses
       this.responsesToShow = [];
@@ -101,7 +102,7 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
   }
 
   sortResponses(by: SortBy): void {
-    if (this.sortBy === by) {
+    if (by !== SortBy.NONE && this.sortBy === by) {
       this.sortOrder = this.sortOrder === SortOrder.ASC ? SortOrder.DESC : SortOrder.ASC;
     } else {
       this.sortBy = by;
@@ -112,6 +113,15 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
 
   sortResponsesBy(by: SortBy, order: SortOrder):
     ((a: ResponseOutput, b: ResponseOutput) => number) {
+    if (by === SortBy.NONE) {
+      // Default order: giver team > giver name > recipient team > recipient name
+      return ((a: ResponseOutput, b: ResponseOutput): number => {
+        return this.tableComparatorService.compare(SortBy.GIVER_TEAM, order, a.giverTeam, b.giverTeam)
+            || this.tableComparatorService.compare(SortBy.GIVER_NAME, order, a.giver, b.giver)
+            || this.tableComparatorService.compare(SortBy.RECIPIENT_TEAM, order, a.recipientTeam, b.recipientTeam)
+            || this.tableComparatorService.compare(SortBy.RECIPIENT_NAME, order, a.recipient, b.recipient);
+      });
+    }
     return ((a: ResponseOutput, b: ResponseOutput): number => {
       let strA: string;
       let strB: string;

--- a/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.html
@@ -11,14 +11,15 @@
           </span>
         </div>
         <div class="col-sm-2">
-          <strong>of me:</strong> <tm-contribution [value]="questionStatisticsForStudent.claimed"></tm-contribution>
+          <strong>of me:</strong>&nbsp;<tm-contribution [value]="questionStatisticsForStudent.claimed"></tm-contribution>
         </div>
         <div class="col-sm-8">
-          <strong>of others:</strong>
+          <strong>of others:</strong>&nbsp;
           <span *ngFor="let other of questionStatisticsForStudent.claimedOthers; let i = index;">
-            <span *ngIf="i !== 0">,</span>
+            <span *ngIf="i !== 0">,&nbsp;</span>
             <tm-contribution [value]="other"></tm-contribution>
           </span>
+          &nbsp;<a (click)="openModal(contribInfoModal)" [routerLink]="" queryParamsHandling="preserve"><i class="fas fa-info-circle"></i></a>
         </div>
       </div>
       <div class="row">
@@ -27,14 +28,14 @@
         </div>
         <div class="col-sm-2">
           <span ngbTooltip="The average contribution the other members of your team attributed to you">
-            <strong>of me:</strong>
+            <strong>of me:&nbsp;</strong>
           </span>
           <tm-contribution [value]="questionStatisticsForStudent.perceived"></tm-contribution>
         </div>
         <div class="col-sm-8">
-          <strong>of others:</strong>
+          <strong>of others:</strong>&nbsp;
           <span *ngFor="let other of questionStatisticsForStudent.perceivedOthers; let i = index;">
-            <span *ngIf="i !== 0">,</span>
+            <span *ngIf="i !== 0">,&nbsp;</span>
             <tm-contribution [value]="other"></tm-contribution>
           </span>
         </div>
@@ -49,6 +50,9 @@
         Response Summary
       </strong>
     </div>
+    <div class="col-sm-8" style="text-align: right;">
+      [<a href="/web/instructor/help#team-contribution-questions" rel="noopener noreferrer" target="_blank">How do I interpret/use these values?</a>]
+    </div>
   </div>
   <div class="row">
     <div class="col-sm-12 table-responsive">
@@ -56,3 +60,57 @@
     </div>
   </div>
 </div>
+
+<ng-template #contribInfoModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">More info about contribution questions</h4>
+  </div>
+  <div class="modal-body">
+    <h4>How do I interpret these results?</h4>
+    <ul>
+      <li>
+        Compare the values given in 'My view' with those under 'Team's view'.
+        This tells you whether your perception matches what the team thinks, particularly regarding your own contribution.
+        You may ignore minor differences.
+      </li>
+      <li>
+        From the estimates you submit, we try to deduce the answer to this question:
+        In your opinion, if your teammates are doing the project by themselves without you,
+        how do they compare against each other in terms of contribution?
+        We want to deduce your unbiased opinion about your team members' contributions.
+      </li>
+    </ul>
+    <h4>How are contribution question results used in grading?</h4>
+    <ul>
+      <li>
+        TEAMMATES does not calculate grades. Instructors are free to choose how they use contribution question results.
+      </li>
+      <li>
+        TEAMMATES recommends that contribution question results be used only as flags to identify teams with contribution imbalances.
+        Once identified, the instructor is recommended to investigate further before taking action.
+      </li>
+    </ul>
+    <h4>How are the scores for contribution questions calculated?</h4>
+    <p>
+      Here are the important things to note about
+      <a href="/web/front/help/instructor#team-contribution-questions" rel="noopener noreferrer" target="_blank">how contribution scores are calculated</a>:
+    </p>
+    <ul>
+      <li>
+        The contribution value you attribute to yourself is not used to calculate the team's view of your contribution.
+        That means you cannot boost your perceived contribution by claiming a high contribution for yourself
+        or attributing a low contribution to team members.
+      </li>
+      <li>
+        We adjust the estimates you submitted to remove artificial inflation/deflation.
+        For example, giving everyone <code>[Equal share + 20%]</code> is as same as giving everyone
+        <code>[Equal share]</code> because in both cases all members have done a similar share of work.
+      </li>
+      <li>
+        The sum of values in the team's view has been scaled to equal the sum of values in your view.
+        That way, you can make a direct comparison between your view and the team's view.
+        As this scaling is specific to you, the values you see in team's view may not match the values your team members see in their results.
+      </li>
+    </ul>
+  </div>
+</ng-template>

--- a/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.spec.ts
+++ b/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { DynamicModule } from 'ng-dynamic-component';
@@ -12,7 +13,7 @@ describe('ContributionQuestionStatisticsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [NgbTooltipModule, DynamicModule],
+      imports: [NgbTooltipModule, DynamicModule, RouterTestingModule],
       declarations: [
         ContributionQuestionStatisticsComponent,
         ContributionComponent,

--- a/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-ratings-list.component.html
+++ b/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-ratings-list.component.html
@@ -1,4 +1,4 @@
 <span *ngFor="let rating of ratingsList; let i = index;">
-  <span *ngIf="i !== 0">,</span>
+  <span *ngIf="i !== 0">,&nbsp;</span>
   <tm-contribution [value]="rating"></tm-contribution>
 </span>

--- a/src/web/app/components/question-types/question-statistics/question-statistics.module.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { SortableTableModule } from '../../sortable-table/sortable-table.module';
 import { ConstsumOptionsQuestionStatisticsComponent } from './constsum-options-question-statistics.component';
@@ -50,6 +51,7 @@ import { TextQuestionStatisticsComponent } from './text-question-statistics.comp
     FormsModule,
     NgbModule,
     SortableTableModule,
+    RouterModule,
     ContributionQuestionStatisticsModule,
   ],
 })

--- a/src/web/app/components/teammates-common/view-photo-popover/view-photo-popover.component.html
+++ b/src/web/app/components/teammates-common/view-photo-popover/view-photo-popover.component.html
@@ -2,7 +2,7 @@
   <img *ngIf="isPhotoShown; else viewPhotoBtn" class="profile-pic" src="{{photoUrl}}" (error)="missingPhotoEventHandler()">
 </ng-template>
 
-<span *ngIf="isViewPhotoLinkInPopover; else viewPhotoBtn" [ngbPopover]="popContent" triggers="mouseenter:mouseleave" closeDelay="500">
+<span *ngIf="isViewPhotoLinkInPopover; else viewPhotoBtn" [ngbPopover]="popContent" triggers="mouseenter" closeDelay="0" [autoClose]="'outside'">
   <ng-content></ng-content>
 </span>
 
@@ -12,5 +12,5 @@
     View Photo
   </a>
   <img *ngIf="!isViewPhotoLinkInPopover && isPhotoShown" class="profile-pic-icon" src="{{photoUrl}}" (error)="missingPhotoEventHandler()"
-       [ngbPopover]="popContent" triggers="mouseenter:mouseleave" closeDelay="500"/>
+       [ngbPopover]="popContent" [autoClose]="'outside'" triggers="mouseenter" closeDelay="0"/>
 </ng-template>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
@@ -315,7 +315,7 @@
         <div class="card-body">
           <p>
             The most likely reason for this is that the student has changed the primary email address associated with his/her Google ID. Please ask the student to email
-            <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a> so that we help to rectify the problem.
+            <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a> so that we help to rectify the problem.
           </p>
         </div>
       </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -292,7 +292,7 @@
     </div>
   </div>
   <!--Question-->
-  <div *ngIf="showQuestion.length === 0 || showQuestion[6]" #question>
+  <div *ngIf="showQuestion.length === 0 || showQuestion[6]" #question id="team-contribution-questions">
     <p>
       <button type="button" class="btn btn-outline-primary" (click)="isContributionQsCollapsed = !isContributionQsCollapsed" [attr.aria-expanded]="!isContributionQsCollapsed">
         Team Contribution Questions

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -12,6 +12,7 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -88,6 +89,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -253,6 +255,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -830,6 +833,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -1554,6 +1558,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -1881,6 +1886,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}
@@ -2208,6 +2214,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
   hasCoursesLoaded="false"
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
+  isNewUser="false"
   loadingBarService={[Function LoadingBarService]}
   modalService={[Function NgbModal]}
   navigationService={[Function NavigationService]}

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -13,12 +13,12 @@
   </div>
 </div>
 
-<ng-template #noCourseMessage class="bg-light-blue">
-  <ng-container *ngIf="hasCoursesLoaded">
-    New to TEAMMATES? You may wish to have a look at our <a routerLink="/web/front/help/instructor">Getting Started Guide</a>.
-    A video tour is also available in our <a routerLink="/web">home page</a>.
-  </ng-container>
-</ng-template>
+<div class="card bg-light" style="margin-bottom: 20px;" *ngIf="isNewUser">
+  <div class="card-body">
+    New to TEAMMATES? You may wish to have a look at our <a href="/web/instructor/getting-started" target="_blank" rel="noopener noreferrer">Getting Started Guide</a>.
+    A video tour is also available in our <a href="/web" target="_blank" rel="noopener noreferrer">home page</a>.
+  </div>
+</div>
 
 <div class="row">
   <div class="col-4">
@@ -37,7 +37,7 @@
 </div>
 <br/>
 
-<div *ngIf="courseTabModels.length > 0; else noCourseMessage">
+<div *ngIf="courseTabModels.length > 0">
   <div class="card margin-bottom-15px" *ngFor="let courseTabModel of courseTabModels; let idx = index">
     <div class="card-header bg-primary text-white course-tab-header" (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(courseTabModel);">
       <div class="row">

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -66,6 +66,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
   courseTabModels: CourseTabModel[] = [];
 
   hasCoursesLoaded: boolean = false;
+  isNewUser: boolean = false;
 
   constructor(router: Router,
               statusMessageService: StatusMessageService,
@@ -181,6 +182,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
           this.courseTabModels.push(model);
           this.updateCourseInstructorPrivilege(model);
         });
+        this.isNewUser = !courses.courses.some((course: Course) => !/-demo\d*$/.test(course.courseId));
         this.sortCoursesBy(this.instructorCoursesSortBy);
       }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
   }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -15,7 +15,7 @@
         <label class="col-lg-4 control-label"><b>Session:</b></label>
         <div class="col-lg-8">
           <p class="form-control-static">{{ session.feedbackSessionName }}</p>
-          <!-- TODO session edit link -->
+          <a routerLink="/web/instructor/sessions/edit" [queryParams]="{ courseid: session.courseId, fsname: session.feedbackSessionName }"><i class="fas fa-edit"></i></a>
         </div>
       </div>
     </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -21,19 +21,17 @@
     </div>
     <div class="col-sm-12 col-md-12 col-lg-5">
       <div class="form-group row">
-      <label class="col-lg-4 control-label"><b>Session duration:</b></label>
+        <label class="col-lg-4 control-label"><b>Session duration:</b></label>
         <div class="col-lg-8">
           <p class="form-control-static">{{ formattedSessionOpeningTime }}&nbsp;&nbsp;&nbsp;<b>to</b>&nbsp;&nbsp;&nbsp;{{ formattedSessionClosingTime }}</p>
         </div>
       </div>
-      <!-- <div class="form-group">
-        <label class="col-lg-4 control-label">Results visible from:</label>
+      <div class="form-group row">
+        <label class="col-lg-4 control-label"><b>Results visible from:</b></label>
         <div class="col-lg-8">
-          <p class="form-control-static">
-            {{ formattedResultVisibleFromTime }}
-          </p>
+          <p class="form-control-static">{{ formattedResultVisibleFromTime }}</p>
         </div>
-      </div> -->
+      </div>
     </div>
     <div class="action-btn-group col-sm-12 col-md-12 col-lg-3">
       <button class="btn btn-primary action-btn" ngbTooltip="{{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED? 'Make responses no longer visible': 'Make session responses available for viewing' }}"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -82,6 +82,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
 
   formattedSessionOpeningTime: string = '';
   formattedSessionClosingTime: string = '';
+  formattedResultVisibleFromTime: string = '';
 
   viewType: string = InstructorSessionResultViewType.QUESTION;
   section: string = '';
@@ -139,6 +140,10 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
             moment(this.session.submissionStartTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
         this.formattedSessionClosingTime =
             moment(this.session.submissionEndTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
+        if (this.session.resultVisibleFromTimestamp) {
+          this.formattedResultVisibleFromTime =
+              moment(this.session.resultVisibleFromTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
+        }
 
         // load section tabs
         this.courseService.getCourseSectionNames(queryParams.courseid)


### PR DESCRIPTION
Part of #10176 

This fixes the following issues:
- Instructor help page: Managing courses > What should I do if a student says his/her courses have disappeared from the system > The email address is hard-coded to `teammates@comp.nus.edu.sg` while it should be read from `environment.supportEmail`.
- Instructor results page: Edit feedback session detail button beside "Session:"
- V6 has a Results visible from info in the top info box but not in V7
- Responses should be ordered by giver team > giver name > recipient team > recipient name
- GRQ/RGQ view: Adding response comment interface is different
- Contribution question: should not be able to add response comment
- In V6, Team contribution question statistics table has a link to the help page on interpreting the E-20% E+20% etc... values at the top of the table. V7 does not
- Instructor home page: Missing “New to TEAMMATES” welcome tab
