### PR TITLE
[#10219] Add instructor/participant comment in CSV

### DIFF
--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -275,12 +275,12 @@ It's good,2,66.67
 It's perfect,1,33.33
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,It's good,It's perfect
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,,It's good,It's perfect
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,,It's good,
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,It's good,It's perfect,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,,It's good,It's perfect,
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,,It's good,,
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,,
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response,
+Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response,
 
 
 Question 2,What do you like best about the class' product?
@@ -291,10 +291,10 @@ It's good,1,33.33
 It's perfect,2,66.67
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,It's good,It's perfect
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,,It's good,It's perfect
-Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,,,It's perfect
-Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,It's good,It's perfect,Giver's Comments
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,,It's good,It's perfect,
+Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,,,It's perfect,
+Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,,
 
 
 Question 3,Choose all the food you like
@@ -313,12 +313,12 @@ Team,Recipient Name,Pizza [1],Pasta [2],Chicken rice [0],Other [3],Total,Average
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,0,0,0,1,3,3
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Pizza,Pasta,Chicken rice
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,,Pizza,Pasta,Chicken rice
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,,,Pasta,
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,,,,
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Pizza,Pasta,Chicken rice,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,,Pizza,Pasta,Chicken rice,
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,,,Pasta,,
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,,,,,
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response,
+Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response,
 
 "
 `;

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -7,23 +7,23 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",new name new last name,new last name,student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",new name new last name,new last name,student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",new name new last name,new last name,student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",new name new last name,new last name,student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -200,12 +200,12 @@ It's good,1,33.33
 It's perfect,2,66.67
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,It's good
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,It's perfect
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,It's perfect
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,It's good,
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,It's perfect,Student 2 comment,Instructor1 Course1,Instructor 1 comment to student 2
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,It's perfect,Student 3 comment
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response,
+Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response,
 
 
 Question 2,What do you like best about the class' product?
@@ -216,10 +216,10 @@ It's good,1,50
 It's perfect,1,50
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,It's good
-Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,It's perfect
-Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,It's good,
+Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,Instructors,Instructor2 Course1,Course1,instructor2@course1.tmt,It's perfect,
+Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,Instructors,Instructor3 Course1,Course1,instructor3@course1.tmt,No Response,
 
 
 Question 3,What can be improved for this class?
@@ -231,12 +231,12 @@ Other,1,100
 Teaching style,0,0
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Lecture notes
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Lecture notes,
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response,
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response,
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response,
+Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response,
 
 
 Question 4,What do you like best about our product?
@@ -252,12 +252,12 @@ Team,Recipient Name,It's good [1.25],It's perfect [1.7],Other [3],Total,Average
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",1,0,0,1.25,1.25
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,It's good
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,It's good,
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response,
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response,
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response,
+Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,No Response,
 
 "
 `;
@@ -520,8 +520,8 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 "
@@ -534,7 +534,7 @@ Session Name,First feedback session
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -542,7 +542,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -568,8 +568,8 @@ Section View Detail,Show response if either the giver or evaluee is in the selec
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
@@ -600,8 +600,8 @@ Section View Detail,Show response if the giver is in the selected section
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 
 "
@@ -630,23 +630,23 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -668,8 +668,8 @@ Session Name,Session with MCQ
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Quality
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Quality,
 
 "
 `;
@@ -683,8 +683,8 @@ Section View Detail,Show response only if both are in the selected section
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
@@ -720,15 +720,15 @@ Section View Detail,Show response if the giver is in the selected section
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 
 
@@ -758,8 +758,8 @@ Section View Detail,Show response if the evaluee is in the selected section
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
@@ -794,8 +794,8 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -804,7 +804,7 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,studen
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -812,7 +812,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -829,8 +829,8 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -858,8 +858,8 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -868,7 +868,7 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,studen
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -876,7 +876,7 @@ Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipien
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,No Response
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,Course1,student4InCourse1@gmail.tmt,No Response
@@ -893,8 +893,8 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -922,23 +922,23 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -960,23 +960,23 @@ Session Name,First feedback session
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
 
 Question 3,My comments on the class
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\"
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,-,-,,,\\"Good work, keep it up!\\",Instructor1 Course1,Instructor 1 comment to instructor 1 self feedback Question 3
 
 
 Question 4,Instructor comments on the class
@@ -1000,15 +1000,15 @@ Section View Detail,Show response if either the giver or evaluee is in the selec
 
 Question 1,What is the best selling point of your product?
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Student 1 self feedback.,Instructor1 Course1,Instructor 1 comment to student 1 self feedback
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,I'm cool'
 
 
 Question 2,Rate 1 other student's product
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Comment From,Comment
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Response from student 2 to student 5.,Instructor1 Course1,Instructor 1 comment to response from student 2 to student 5 in feedback Question 2
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,Course1,student3InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,\\"Response from student 3 \\"\\"to\\"\\" student 2. Multiline test.\\"
 Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,Course1,student2InCourse1@gmail.tmt,Response from student 5 to student 2.
 
@@ -1043,8 +1043,8 @@ Price,0,0
 Quality,1,100
 
 
-Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Quality
+Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Giver's Comments
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",\\"Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,Quality,
 
 "
 `;

--- a/src/web/types/question-details-impl/abstract-feedback-question-details.ts
+++ b/src/web/types/question-details-impl/abstract-feedback-question-details.ts
@@ -29,6 +29,16 @@ export abstract class AbstractFeedbackQuestionDetails {
   }
 
   /**
+   * Check if a feedback participant can comment on responses to the question
+   */
+  abstract isParticipantCommentsOnResponsesAllowed(): boolean;
+
+  /**
+   * Checks if an instructor can comment on responses to the question
+   */
+  abstract isInstructorCommentsOnResponsesAllowed(): boolean;
+
+  /**
    * Gets question stats in CSV.
    */
   abstract getQuestionCsvStats(question: QuestionOutput): string[][];

--- a/src/web/types/question-details-impl/feedback-constsum-options-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-constsum-options-question-details.impl.ts
@@ -65,4 +65,11 @@ export class FeedbackConstantSumOptionsQuestionDetailsImpl extends AbstractFeedb
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
@@ -61,4 +61,11 @@ export class FeedbackConstantSumRecipientsQuestionDetailsImpl extends AbstractFe
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
@@ -111,4 +111,11 @@ export class FeedbackContributionQuestionDetailsImpl extends AbstractFeedbackQue
     return String(point);
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-mcq-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-mcq-question-details.impl.ts
@@ -51,4 +51,11 @@ export class FeedbackMcqQuestionDetailsImpl extends AbstractFeedbackMcqMsqQuesti
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
@@ -57,4 +57,11 @@ export class FeedbackMsqQuestionDetailsImpl extends AbstractFeedbackMcqMsqQuesti
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
@@ -58,7 +58,7 @@ export class FeedbackMsqQuestionDetailsImpl extends AbstractFeedbackMcqMsqQuesti
   }
 
   isParticipantCommentsOnResponsesAllowed(): boolean {
-    return false;
+    return true;
   }
 
   isInstructorCommentsOnResponsesAllowed(): boolean {

--- a/src/web/types/question-details-impl/feedback-num-scale-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-num-scale-question-details.impl.ts
@@ -83,4 +83,11 @@ export class FeedbackNumericalScaleQuestionDetailsImpl extends AbstractFeedbackQ
 
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-rank-options-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rank-options-question-details.impl.ts
@@ -59,4 +59,11 @@ export class FeedbackRankOptionsQuestionDetailsImpl extends AbstractFeedbackQues
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
@@ -63,4 +63,11 @@ export class FeedbackRankRecipientsQuestionDetailsImpl extends AbstractFeedbackQ
     return statsRows;
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -115,4 +115,12 @@ ${ statsCalculation.hasWeights ? `[${ statsCalculation.weights[questionIndex][ch
 
     return statsRows;
   }
+
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }

--- a/src/web/types/question-details-impl/feedback-text-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-text-question-details.impl.ts
@@ -25,4 +25,11 @@ export class FeedbackTextQuestionDetailsImpl extends AbstractFeedbackQuestionDet
     return [];
   }
 
+  isParticipantCommentsOnResponsesAllowed(): boolean {
+    return false;
+  }
+
+  isInstructorCommentsOnResponsesAllowed(): boolean {
+    return true;
+  }
 }


### PR DESCRIPTION
Fixes #10219 

**Outline of Solution**
- Added abstract method to check if instructor/participant can comment on the response
- Add the headers and actual comment to `csvRows`
- Manually verified all snapshot tests matches up with the CSV files generated in V6 for comments

**Concerns**
- For `should show responses along with stats for feedbackSessionResultC1S1` (The second test), the CSV file mentioned in the comment seems incorrect?
- There were some test data where there seems to be more data in the json in V7 compared to V6 so there wasn't a one to one match so I checked against the json for these tests for comments.