### PR TITLE
[#10176] Fix MCQ delete after reorder bug

### DIFF
--- a/src/web/app/components/question-types/question-edit-details-form/option-rich-text-editor/option-rich-text-editor.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/option-rich-text-editor/option-rich-text-editor.component.html
@@ -1,4 +1,4 @@
 <editor class="editor" [ngClass]="{ 'editor-disabled': isDisabled }" [ngStyle]="{ 'min-height.px': minHeightInPx }"
-        [init]="init" [disabled]="isDisabled" [inline]="isInlineMode"
+        [init]="init" [disabled]="isDisabled" [inline]="isInlineMode" [ngModelOptions]="{ updateOn: 'blur' }"
         [ngModel]="richText" (ngModelChange)="richTextChange.emit($event)" [attr.placeholder]="placeholderText">
 </editor>


### PR DESCRIPTION
Part of #10176 

Can't believe this took me a full day to resolve...

**Outline of Solution**

The original bug is caused by the `trackBy: trackMcqOption` option, which is necessary to prevent the input field from rerendering every time the input value changes.

However, when the options gets reordered, this `trackBy` option causes the editor instances to not get reordered, which causes some sort of de-sync which I still do not fully understand. 

Thus, when a reordered option gets deleted, both the `onMcqOptionDeleted` and `onMcqOptionEntered` gets called, whereas only `onMcqOptionDeleted` is supposed to be called. The `onMcqOptionEntered` call would thus overwrite the result of the previous `onMcqOptionDeleted` and cause the model to become invalid (E.g. `numberOfMcqChoices=2` but there are 3 items in the `mcqChoices` array. 

The most consistent way to reproduce the bug is to swap the position of the last 2 options, and then delete the last option.

This PR prevents `onMcqOptionEntered` from being called when an option is deleted. It doesn't fully resolve the root of the bug, but it works well enough. A better way should be to assign a unique ID for each options, and track each options by their ID. Not sure if it works though.