### PR TITLE
[#10176] UAT Round 1: Fix admin session page issues

### DIFF
--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.html
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.html
@@ -23,14 +23,14 @@
   <div class="card bg-light" *ngIf="showFilter">
     <div class="card-body">
       <div class="row">
-        <div class="col-md-4" data-toggle="tooltip" data-placement="top">
+        <div class="col-xl-4" data-toggle="tooltip" data-placement="top">
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-6">
               <label class="label-control">From</label>
             </div>
           </div>
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-6">
               <form>
                 <div class="form-group">
                   <div class="input-group">
@@ -44,19 +44,19 @@
                 </div>
               </form>
             </div>
-            <div class="col-md-6">
+            <div class="col-6">
               <ngb-timepicker [(ngModel)]="startTime" [spinners]="false"></ngb-timepicker>
             </div>
           </div>
         </div>
-        <div class="col-md-4 border-left-gray" data-toggle="tooltip" data-placement="top">
+        <div class="col-xl-4 border-left-gray" data-toggle="tooltip" data-placement="top">
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-6">
               <label class="label-control">To</label>
             </div>
           </div>
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-6">
               <form>
                 <div class="form-group">
                   <div class="input-group">
@@ -70,24 +70,24 @@
                 </div>
               </form>
             </div>
-            <div class="col-md-6">
+            <div class="col-6">
               <ngb-timepicker [(ngModel)]="endTime" [spinners]="false"></ngb-timepicker>
             </div>
           </div>
         </div>
-        <div class="col-md-4 border-left-gray">
+        <div class="col-xl-4 border-left-gray">
           <div class="row">
-            <div class="col-md-12">
+            <div class="col-12">
               <label class="control-label">Time Zone</label>
             </div>
           </div>
           <div class="row">
-            <div class="col-sm-6">
+            <div class="col-6">
               <select class="form-control" [(ngModel)]="timezone">
                 <option *ngFor="let timezone of timezones" [value]="timezone">{{ timezone }}</option>
               </select>
             </div>
-            <div class="col-sm-6">
+            <div class="col-6">
               <button class="btn btn-primary btn-block" (click)="getFeedbackSessions()">
                 Filter by Range
               </button>
@@ -99,15 +99,27 @@
   </div>
 </div>
 
-<div class="card bg-light" style="margin-top: 20px;" *ngFor="let mapping of sessions | keyvalue">
-  <div class="card-header bg-primary text-white" style="cursor: pointer;" (click)="institutionPanelsStatus[mapping.key] = !institutionPanelsStatus[mapping.key]">
-    <strong>{{ mapping.key }}</strong>
-    <strong class="float-sm-right">{{ mapping.value.length }}</strong>
+<ng-template #noOngoingSessions>
+  <div class="alert alert-warning margin-top-30px" role="alert">
+    Currently No Ongoing Sessions
   </div>
-  <div class="card-body" *ngIf="institutionPanelsStatus[mapping.key]">
-    <div class="table-responsive">
-      <table class="table table-striped data-table">
-        <thead>
+</ng-template>
+
+<div *ngIf="totalOngoingSessions; else noOngoingSessions">
+  <div class="card bg-light margin-top-30px" *ngFor="let mapping of sessions | keyvalue">
+    <div class="row no-gutters text-left text-white card-header bg-primary" style="cursor: pointer;" (click)="institutionPanelsStatus[mapping.key] = !institutionPanelsStatus[mapping.key]">
+      <div class="col-11">
+        <strong>{{ mapping.key }} - Number of sessions: {{ mapping.value.length }}</strong>
+      </div>
+      <div class="col-1 text-right">
+        <i class="fas fa-chevron-down" *ngIf="!institutionPanelsStatus[mapping.key]"></i>
+        <i class="fas fa-chevron-up" *ngIf="institutionPanelsStatus[mapping.key]"></i>
+      </div>
+    </div>
+    <div class="card-body session-table-body" *ngIf="institutionPanelsStatus[mapping.key]">
+      <div class="table-responsive">
+        <table class="table table-striped data-table session-table">
+          <thead>
           <tr>
             <th>Status</th>
             <th>[Course ID] Session Name</th>
@@ -116,9 +128,9 @@
             <th>End Time</th>
             <th>Creator</th>
           </tr>
-        </thead>
+          </thead>
 
-        <tbody>
+          <tbody>
           <tr *ngFor="let session of mapping.value">
             <td>{{ session.ongoingSession.sessionStatus }}</td>
             <td><strong>[{{ session.ongoingSession.courseId }}]</strong> {{ session.ongoingSession.feedbackSessionName }}</td>
@@ -128,10 +140,11 @@
             </td>
             <td>{{ showDateFromMillis(session.ongoingSession.startTime) }}</td>
             <td>{{ showDateFromMillis(session.ongoingSession.endTime) }}</td>
-            <td><a [href]="session.ongoingSession.instructorHomePageLink">{{ session.ongoingSession.creatorEmail }}</a></td>
+            <td><a target="_blank" rel="noopener noreferrer" [href]="session.ongoingSession.instructorHomePageLink">{{ session.ongoingSession.creatorEmail }}</a></td>
           </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.scss
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.scss
@@ -1,3 +1,17 @@
-.border-left-gray {
-  border-left: 1px solid rgba(0, 0, 0, .2);
+@media (min-width: 1200px) {
+  .border-left-gray {
+    border-left: 1px solid rgba(0, 0, 0, .2);
+  }
+}
+
+.margin-top-30px {
+  margin-top: 30px;
+}
+
+.session-table-body {
+  padding: 0;
+}
+
+.session-table {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Part of #10176

**Screenshots**
Fixes
- Missing “Currently no ongoing session” tab from v6, leaving large white space.
- "Filter by Range" button did not provide any feedback when no result is found. (V6 shows “Currently no ongoing session”)
- Filter panel should change to vertical mode starting from larger screen, prevent date and Time Zone input from being hidden by input box.

![no ongg ss](https://user-images.githubusercontent.com/28994607/85652748-23552900-b6de-11ea-8460-3681bbf2ab43.PNG)

- Separators near “To” and “Time Zone” persist in vertical mode.

![mobile filter](https://user-images.githubusercontent.com/28994607/85652752-25b78300-b6de-11ea-98eb-1a7171ea7237.PNG)

- No text explanation for number in result panel header. (which reports number of results found)
- No widget indication that panels are collapsable. (However, onHover is present)
- Click on creator link should open in new tab, since the current result is not cached when going back.

![g](https://user-images.githubusercontent.com/28994607/85652758-28b27380-b6de-11ea-90bc-40f45abb3127.gif)


**Outline of Solution**
- Add appropriate size breakpoints
- Add no ongoing session texts
- Add arrow widget to show state of collapsible table
- Add target to `<a>` to open new tab