### PR TITLE
[#10176] Fix some UAT problems in instructor all records page

### DIFF
--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -91,7 +91,7 @@
                                     [displayContributionStats]="false"
               ></tm-single-statistics>
               <tm-per-question-view-responses [responses]="question.questionOutput.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                                              [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [question]="question.questionOutput.feedbackQuestion"
+                                              [indicateMissingResponses]="indicateMissingResponses" [showGiver]="!isGqr" [showRecipient]="isGqr" [question]="question.questionOutput.feedbackQuestion"
                                               [instructorCommentTableModel]="instructorCommentTableModel"
                                               (instructorCommentTableModelChange)="triggerModelChange($event)"
                                               (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"

--- a/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
@@ -20,6 +20,7 @@ exports[`InstructorStudentRecordsPageComponent should snap with default fields 1
   studentProfileService={[Function StudentProfileService]}
   studentSection=""
   studentService={[Function StudentService]}
+  studentTeam=""
 >
   <h1>
     's Records
@@ -60,6 +61,7 @@ exports[`InstructorStudentRecordsPageComponent should snap with populated fields
   studentProfileService={[Function StudentProfileService]}
   studentSection=""
   studentService={[Function StudentService]}
+  studentTeam=""
 >
   <h1>
     Not John Doe's Records

--- a/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`InstructorStudentRecordsPageComponent should snap with default fields 1
   sessionTabs={[Function Array]}
   statusMessageService={[Function StatusMessageService]}
   studentEmail={[Function String]}
+  studentName=""
   studentProfile={[Function Object]}
   studentProfileService={[Function StudentProfileService]}
   studentSection=""
@@ -54,13 +55,14 @@ exports[`InstructorStudentRecordsPageComponent should snap with populated fields
   sessionTabs={[Function Array]}
   statusMessageService={[Function StatusMessageService]}
   studentEmail={[Function String]}
+  studentName={[Function String]}
   studentProfile={[Function Object]}
   studentProfileService={[Function StudentProfileService]}
   studentSection=""
   studentService={[Function StudentService]}
 >
   <h1>
-    John Doe's Records
+    Not John Doe's Records
     <small
       class="text-muted"
     >
@@ -71,7 +73,7 @@ exports[`InstructorStudentRecordsPageComponent should snap with populated fields
     ng-reflect-student-profile="[object Object]"
   /><tm-more-info
     ng-reflect-more-info-text=""
-    ng-reflect-student-name="John Doe"
+    ng-reflect-student-name="Not John Doe"
   /><h2>
     Records in feedback sessions
   </h2>

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
@@ -16,7 +16,7 @@
                                (saveNewCommentEvent)="saveNewComment($event)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event)"
     ></tm-grq-rgq-view-responses>
     <div *ngIf="session.responsesReceivedByStudent.length === 0">
-      No feedback responses for {{studentName}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
+      No feedback responses for {{studentName}} ({{studentTeam}}) found.
     </div>
     <br/>
     <tm-grq-rgq-view-responses *ngIf="session.responsesGivenByStudent.length > 0"
@@ -26,7 +26,7 @@
                                (saveNewCommentEvent)="saveNewComment($event)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event)"
     ></tm-grq-rgq-view-responses>
     <div *ngIf="session.responsesGivenByStudent.length === 0">
-      No feedback responses from {{studentName}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
+      No feedback responses from {{studentName}} ({{studentTeam}}) found.
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
@@ -1,6 +1,6 @@
-<h1>{{studentProfile.name}}'s Records<small class="text-muted"> - {{courseId}}</small></h1>
+<h1>{{studentName}}'s Records<small class="text-muted"> - {{courseId}}</small></h1>
 <tm-student-profile [studentProfile]="studentProfile" [photoUrl]="photoUrl"></tm-student-profile>
-<tm-more-info [studentName]="studentProfile.name" [moreInfoText]="studentProfile.moreInfo"></tm-more-info>
+<tm-more-info [studentName]="studentName" [moreInfoText]="studentProfile.moreInfo"></tm-more-info>
 <h2>Records in feedback sessions</h2>
 <div *ngFor="let session of sessionTabs" class="card card-default mb-4">
   <div class="card-header font-weight-bold cursor-pointer" (click)="session.isCollapsed = !session.isCollapsed">
@@ -16,7 +16,7 @@
                                (saveNewCommentEvent)="saveNewComment($event)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event)"
     ></tm-grq-rgq-view-responses>
     <div *ngIf="session.responsesReceivedByStudent.length === 0">
-      No feedback responses for {{studentProfile.name}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
+      No feedback responses for {{studentName}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
     </div>
     <br/>
     <tm-grq-rgq-view-responses *ngIf="session.responsesGivenByStudent.length > 0"
@@ -26,7 +26,7 @@
                                (saveNewCommentEvent)="saveNewComment($event)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event)"
     ></tm-grq-rgq-view-responses>
     <div *ngIf="session.responsesGivenByStudent.length === 0">
-      No feedback responses from {{studentProfile.name}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
+      No feedback responses from {{studentName}} ({{studentSection}}) in {{session.feedbackSession.feedbackSessionName}} found.
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
@@ -80,6 +80,7 @@ describe('InstructorStudentRecordsPageComponent', () => {
       moreInfo: '',
     };
 
+    component.studentName = 'Not John Doe';
     component.studentProfile = studentProfile;
     component.courseId = 'su1337';
     fixture.detectChanges();

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -41,6 +41,7 @@ interface SessionTab {
 export class InstructorStudentRecordsPageComponent extends InstructorCommentsComponent implements OnInit {
 
   courseId: string = '';
+  studentName: string = '';
   studentEmail: string = '';
   studentSection: string = '';
   instructorCommentTableModel: Record<string, CommentTableModel> = {};
@@ -95,6 +96,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
    */
   loadStudentRecords(): void {
     this.studentService.getStudent(this.courseId, this.studentEmail).subscribe((resp: Student) => {
+      this.studentName = resp.name;
       this.studentSection = resp.sectionName;
     });
     this.studentProfileService.getStudentProfile(this.studentEmail, this.courseId).subscribe((resp: StudentProfile) => {
@@ -123,7 +125,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
           const giverQuestions: QuestionOutput[] = JSON.parse(JSON.stringify(results.questions));
           giverQuestions.forEach((questions: QuestionOutput) => {
             questions.allResponses = questions.allResponses.filter((responses: ResponseOutput) =>
-                responses.giver === this.studentProfile.name && responses.giverEmail === this.studentEmail);
+                responses.giverEmail === this.studentEmail);
           });
           const responsesGivenByStudent: QuestionOutput[] =
               giverQuestions.filter((questions: QuestionOutput) => questions.allResponses.length > 0);
@@ -131,7 +133,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
           const recipientQuestions: QuestionOutput[] = JSON.parse(JSON.stringify(results.questions));
           recipientQuestions.forEach((questions: QuestionOutput) => {
             questions.allResponses = questions.allResponses.filter((responses: ResponseOutput) =>
-                responses.recipient === this.studentProfile.name && responses.recipientEmail === this.studentEmail);
+                responses.recipientEmail === this.studentEmail);
           });
           const responsesReceivedByStudent: QuestionOutput[] =
               recipientQuestions.filter((questions: QuestionOutput) => questions.allResponses.length > 0);

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -43,6 +43,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
   courseId: string = '';
   studentName: string = '';
   studentEmail: string = '';
+  studentTeam: string = '';
   studentSection: string = '';
   instructorCommentTableModel: Record<string, CommentTableModel> = {};
 
@@ -97,6 +98,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
   loadStudentRecords(): void {
     this.studentService.getStudent(this.courseId, this.studentEmail).subscribe((resp: Student) => {
       this.studentName = resp.name;
+      this.studentTeam = resp.teamName;
       this.studentSection = resp.sectionName;
     });
     this.studentProfileService.getStudentProfile(this.studentEmail, this.courseId).subscribe((resp: StudentProfile) => {
@@ -142,7 +144,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
             feedbackSession,
             responsesGivenByStudent,
             responsesReceivedByStudent,
-            isCollapsed: responsesGivenByStudent.length === 0 && responsesReceivedByStudent.length === 0,
+            isCollapsed: false,
           });
           results.questions.forEach((questions: QuestionOutput) => this.preprocessComments(questions.allResponses));
         }, (errorMessageOutput: ErrorMessageOutput) => {

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -124,16 +124,16 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
         ({ results, feedbackSession }: { results: SessionResults, feedbackSession: FeedbackSession }) => {
           const giverQuestions: QuestionOutput[] = JSON.parse(JSON.stringify(results.questions));
           giverQuestions.forEach((questions: QuestionOutput) => {
-            questions.allResponses = questions.allResponses.filter((responses: ResponseOutput) =>
-                responses.giverEmail === this.studentEmail);
+            questions.allResponses = questions.allResponses.filter((response: ResponseOutput) =>
+                !response.isMissingResponse && response.giverEmail === this.studentEmail);
           });
           const responsesGivenByStudent: QuestionOutput[] =
               giverQuestions.filter((questions: QuestionOutput) => questions.allResponses.length > 0);
 
           const recipientQuestions: QuestionOutput[] = JSON.parse(JSON.stringify(results.questions));
           recipientQuestions.forEach((questions: QuestionOutput) => {
-            questions.allResponses = questions.allResponses.filter((responses: ResponseOutput) =>
-                responses.recipientEmail === this.studentEmail);
+            questions.allResponses = questions.allResponses.filter((response: ResponseOutput) =>
+                !response.isMissingResponse && response.recipientEmail === this.studentEmail);
           });
           const responsesReceivedByStudent: QuestionOutput[] =
               recipientQuestions.filter((questions: QuestionOutput) => questions.allResponses.length > 0);


### PR DESCRIPTION
Part of #10176 

This fixes:
- In student all records page, if a student submits an answer, and then deletes it, the a no response tab will show, with the comment button doing nothing.
- In student all records page, if a student has not submitted profile, many parts will be empty.
