### PR TITLE
[#10156] Add image to link for csv comment generation

### DIFF
--- a/src/web/services/session-result-csv.service.ts
+++ b/src/web/services/session-result-csv.service.ts
@@ -146,15 +146,20 @@ export class SessionResultCsvService {
           recipientTeamName, recipientName, recipientLastName, recipientEmail, ...responseAnswer];
 
         if (isParticipantCommentsOnResponsesAllowed) {
-          const participantComment: string = response.participantComment ? response.participantComment.commentText : '';
-          currRow.push(participantComment);
+          const participantCommentHtml: string =
+              response.participantComment ? response.participantComment.commentText : '';
+          const participantComment: string = StringHelper.getTextFromHtml(participantCommentHtml);
+          const imgLinks: string = StringHelper.convertImageToLinkInHtml(participantCommentHtml);
+          currRow.push(participantComment + imgLinks);
         }
 
         if (isInstructorCommentsOnResponsesAllowed) {
           for (const commentOutput of response.instructorComments) {
             const instructorName: string = commentOutput.commentGiverName ? commentOutput.commentGiverName : '';
-            const instructorComment: string = commentOutput.commentText;
-            currRow.push(instructorName, instructorComment);
+            const instructorCommentHtml: string = commentOutput.commentText;
+            const instructorComment: string = StringHelper.getTextFromHtml(instructorCommentHtml);
+            const imgLinks: string = StringHelper.convertImageToLinkInHtml(instructorCommentHtml);
+            currRow.push(instructorName, instructorComment + imgLinks);
           }
         }
 

--- a/src/web/services/string-helper.spec.ts
+++ b/src/web/services/string-helper.spec.ts
@@ -24,6 +24,25 @@ describe('getTextFromHtml', () => {
   });
 });
 
+describe('convertImageToLinkInHtml', () => {
+  it('should return empty string if empty string is passed', () => {
+    expect(StringHelper.convertImageToLinkInHtml('')).toEqual('');
+  });
+
+  it('should return empty string if no img tags are present', () => {
+    expect(StringHelper.convertImageToLinkInHtml('<h1>header one</h1>')).toEqual('');
+  });
+
+  it('should return image links in img tags', () => {
+    expect(StringHelper.convertImageToLinkInHtml('<img src="http://www.example.com/test.jpg">Bob</img>'))
+        .toEqual(' Images Link: http://www.example.com/test.jpg ');
+  });
+
+  it('should return empty string for malformed img tags', () => {
+    expect(StringHelper.convertImageToLinkInHtml('Bob</img>')).toEqual('');
+  });
+});
+
 describe('removeExtraSpace', () => {
   it('should return empty string for empty string', () => {
     expect(StringHelper.removeExtraSpace('')).toEqual('');

--- a/src/web/services/string-helper.ts
+++ b/src/web/services/string-helper.ts
@@ -15,6 +15,28 @@ export class StringHelper {
   }
 
   /**
+   * Converts img tags in html to absolute links
+   */
+  static convertImageToLinkInHtml(html: string): string {
+    const domParser: DOMParser = new DOMParser();
+    const document: Document = domParser.parseFromString(html, 'text/html');
+    const imgElements: HTMLCollectionOf<HTMLImageElement> = document.getElementsByTagName('img');
+    if (!imgElements.length) {
+      return '';
+    }
+
+    let imgLinks: string = ' Images Link: ';
+    for (let i: number = 0; i < imgElements.length; i += 1) {
+      const img: HTMLImageElement | null = imgElements.item(i);
+      if (!img) {
+        continue;
+      }
+      imgLinks += `${img.src} `;
+    }
+    return imgLinks;
+  }
+
+  /**
    * Trims the string and reduces consecutive white spaces to only one space.
    * Example: " a   a  " --> "a a".
    * @return processed string, returns null if parameter is null


### PR DESCRIPTION
Part of #10156

**Outline of Solution**
Added in a method in `string-helper` to convert `img` to links for use in csv comment geenration