### PR TITLE
[#10176] UAT round 1 final fixes

### DIFF
--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -28,14 +28,14 @@
                 ></tm-single-statistics>
               </div>
             </div>
-            <h3>{{ teamInfo.key }} Detailed Responses</h3>
-            <hr>
-            <div *ngFor="let userInfo of teamInfo.value">
-              <ng-container
-                  [ngTemplateOutlet]="userTab"
-                  [ngTemplateOutletContext]="{userInfo:userInfo}">
-              </ng-container>
-            </div>
+          </div>
+          <h3>{{ teamInfo.key }} Detailed Responses</h3>
+          <hr>
+          <div *ngFor="let userInfo of teamInfo.value">
+            <ng-container
+                    [ngTemplateOutlet]="userTab"
+                    [ngTemplateOutletContext]="{userInfo:userInfo}">
+            </ng-container>
           </div>
         </div>
       </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -275,7 +275,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             break;
           case FeedbackSessionSubmissionStatus.OPEN:
             // closing in 15 minutes
-            if (Date.now() - feedbackSession.submissionEndTimestamp < 15 * 60 * 1000) {
+            if (feedbackSession.submissionEndTimestamp - Date.now() < 15 * 60 * 1000) {
               this.modalService.open(FeedbackSessionClosingSoonModalComponent);
             }
             break;


### PR DESCRIPTION
Part of #10176 

This fixes two critical bugs found after UAT round 1 that should be fixed before `V7.0.0-rc.0`:
- Instructor results page, GQR/RQG view: No response shown if all questions is either of text/contribution type (regression introduced in #10228)
- Session submission page: Wrong logic to determine whether there are only 15 minutes left before submission closing (regression introduced in #10246)
