### PR TITLE
[#10233] Compacting Student Related Pages

### DIFF
--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
@@ -6,7 +6,7 @@
     Giver: {{ response.giver }} ({{ response.giverTeam }})<br/>
     Recipient: {{ response.recipient }} ({{ response.recipientTeam }})
   </div>
-  <div class="offset-sm-6 col-sm-6">
+  <div class="col-6">
     <div class="float-right">
       <span>
         <button *ngIf="isVisibilityOptionEnabled" class="btn btn-info btn-sm" (click)="toggleVisibilityTable()">

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -1,4 +1,4 @@
-<div class="card border-{{ isSelfResponses ? 'info' : 'primary' }}" style="margin-top: 20px;">
+<div class="card border-{{ isSelfResponses ? 'info' : 'primary' }} mt-4">
   <div class="card-header bg-{{ isSelfResponses ? 'info' : 'primary' }} text-white">
     <b>To:</b> {{ recipient }}
   </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,8 +1,6 @@
-<div class="card margin-top-30px" xmlns="http://www.w3.org/1999/html">
+<div class="card mt-4" xmlns="http://www.w3.org/1999/html">
   <div class="card-header text-white question-header">
-    <b>Question {{ model.questionNumber }}</b>
-    <br/>
-    <span>{{ model.questionBrief }}</span>
+    <b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}
   </div>
 
   <div class="card-body">
@@ -12,8 +10,6 @@
       </div>
       <div class="card-body" [innerHTML]="model.questionDescription | safeHtml"></div>
     </div>
-
-    <br/>
 
     <p class="text-secondary">Only the following persons can see your responses: </p>
     <ul class="text-secondary">
@@ -49,24 +45,22 @@
 
     <div class="row">
       <div class="evaluee-col col-12">
-        <div class="row evaluee-row" *ngFor="let recipientSubmissionFormModel of model.recipientSubmissionForms; let i = index; trackBy: trackRecipientSubmissionFormByFn">
+        <div class="row" *ngFor="let recipientSubmissionFormModel of model.recipientSubmissionForms; let i = index; trackBy: trackRecipientSubmissionFormByFn">
           <div class="col-12 margin-top-10px" *ngIf="model.recipientType !== FeedbackParticipantType.SELF && model.recipientType !== FeedbackParticipantType.NONE">
             <div *ngIf="formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT">
               <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
             </div>
-            <div class="row align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
-              <div class="col-4">
-                <select class="form-control evaluee-select" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
-                        (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
-                        [disabled]="isDisabled">
-                  <option value=""></option>
-                  <ng-container *ngFor="let recipient of model.recipientList">
-                    <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ recipient.recipientName }}</option>
-                  </ng-container>
-                </select>
-              </div>
-              <div class="text-left">
-                ({{ model.recipientType | recipientTypeName:model.giverType }})
+            <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
+              <select class="form-control font-weight-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
+                      (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
+                      [disabled]="isDisabled">
+                <option value=""></option>
+                <ng-container *ngFor="let recipient of model.recipientList">
+                  <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ recipient.recipientName }}</option>
+                </ng-container>
+              </select>
+              <div class="col text-left">
+                ({{ model.recipientType | recipientTypeName: model.giverType }})
               </div>
             </div>
           </div>
@@ -165,12 +159,14 @@
       </div>
     </div>
 
-    <tm-rank-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS"
-                                            [recipientSubmissionForms]="model.recipientSubmissionForms"
-                                            [questionDetails]="model.questionDetails"></tm-rank-recipients-question-constraint>
-    <tm-constsum-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
-                                            [recipientSubmissionForms]="model.recipientSubmissionForms"
-                                            [questionDetails]="model.questionDetails"></tm-constsum-recipients-question-constraint>
+    <div class="col-12 constraint-margins">
+      <tm-rank-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS"
+                                              [recipientSubmissionForms]="model.recipientSubmissionForms"
+                                              [questionDetails]="model.questionDetails"></tm-rank-recipients-question-constraint>
+      <tm-constsum-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
+                                                  [recipientSubmissionForms]="model.recipientSubmissionForms"
+                                                  [questionDetails]="model.questionDetails"></tm-constsum-recipients-question-constraint>
+    </div>
 
     <div class="alert alert-warning" role="alert" *ngIf="model.recipientList.length === 0">
       <span *ngIf="model.recipientType === FeedbackParticipantType.OWN_TEAM_MEMBERS">This question is for team members and you don't have any team members. Therefore, you will not be able to answer this question.</span>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -1,9 +1,18 @@
+ul {
+  margin-bottom: 0.5rem;
+}
+
 .margin-top-30px {
   margin-top: 30px;
 }
 
 .margin-top-10px {
   margin-top: 10px;
+}
+
+.constraint-margins {
+  margin-top: 10px;
+  margin-left: 20px;
 }
 
 .question-header {
@@ -20,10 +29,7 @@
   padding-right: 50px;
 }
 
-.evaluee-row {
-  margin-bottom: 20px;
-}
-
 .evaluee-select {
-  font-weight: bold;
+  padding-left: 15px;
+  padding-right: 15px;
 }

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -1,7 +1,3 @@
-ul {
-  margin-bottom: 0.5rem;
-}
-
 .margin-top-30px {
   margin-top: 30px;
 }

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -25,6 +25,7 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
     Question 0:
   </b> MCQ question details
   <a
+    class="info-font-size"
     href="/"
     queryparamshandling="merge"
   >
@@ -45,12 +46,15 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
     Question 0:
   </b> MCQ question details
   <a
+    class="info-font-size"
     href="/"
     queryparamshandling="merge"
   >
      [less]
   
-  </a><div>
+  </a><div
+    class="info-font-size"
+  >
     
     
     

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,8 +1,8 @@
 <b>Question {{ questionNumber }}:</b> {{ questionDetails.questionText }}
-<a (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
+<a class="info-text" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
   [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
 </a>
-<div *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
+<div class="info-text" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
   <tm-contribution-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="questionDetails"></tm-contribution-question-additional-info>
   <tm-text-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.TEXT" [questionDetails]="questionDetails"></tm-text-question-additional-info>
   <tm-mcq-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.MCQ" [questionDetails]="questionDetails"></tm-mcq-question-additional-info>

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,8 +1,8 @@
 <b>Question {{ questionNumber }}:</b> {{ questionDetails.questionText }}
-<a class="info-text" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
+<a class="info-font-size" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
   [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
 </a>
-<div class="info-text" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
+<div class="info-font-size" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
   <tm-contribution-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="questionDetails"></tm-contribution-question-additional-info>
   <tm-text-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.TEXT" [questionDetails]="questionDetails"></tm-text-question-additional-info>
   <tm-mcq-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.MCQ" [questionDetails]="questionDetails"></tm-mcq-question-additional-info>

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -1,4 +1,4 @@
-.info-text {
+.info-font-size {
   font-size: 1rem;
 }
 

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -1,4 +1,3 @@
 .info-font-size {
   font-size: 1rem;
 }
-

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -1,0 +1,4 @@
+.info-text {
+  font-size: 1rem;
+}
+

--- a/src/web/app/components/question-types/question-constraint/rank-recipients-question-constraint.component.html
+++ b/src/web/app/components/question-types/question-constraint/rank-recipients-question-constraint.component.html
@@ -1,6 +1,6 @@
-<div class="constraint-box">
+<div>
   <p *ngIf="!questionDetails.areDuplicatesAllowed && isSameRanksAssigned" class="text-danger">The same rank should not be given multiple times.</p>
-  <p *ngIf="isNoRecipientRanked" style="color: blue;">Please rank the above recipients.</p>
+  <p *ngIf="isNoRecipientRanked" class="text-info">Please rank the above recipients.</p>
   <p *ngIf="isMinRecipientsEnabled && isRecipientsRankedLessThanMin" class="text-danger">You need to rank at least {{ questionDetails.minOptionsToBeRanked }} recipients.</p>
   <p *ngIf="isMaxRecipientsEnabled && isRecipientsRankedMoreThanMax" class="text-danger">Rank no more than {{questionDetails.maxOptionsToBeRanked}} recipients.</p>
 </div>

--- a/src/web/app/components/question-types/question-constraint/rank-recipients-question-constraint.component.scss
+++ b/src/web/app/components/question-types/question-constraint/rank-recipients-question-constraint.component.scss
@@ -1,3 +1,0 @@
-.constraint-box {
-  margin-left: 35px;
-}

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
@@ -1,20 +1,18 @@
-<div class="col-sm-9">
-  <div class="form-group row" *ngFor="let option of questionDetails.constSumOptions; let i = index;">
-    <div class="col-sm-2 text-right align-self-center">
-      <strong>{{ option }}</strong>
-    </div>
-    <div class="col-sm-3">
-      <input type="number" class="form-control"
-             [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
-             (ngModelChange)="triggerResponse(i, $event)"
-             [disabled]="isDisabled"
-             min="0" step="1">
-    </div>
+<div class="form-group row text-left" *ngFor="let option of questionDetails.constSumOptions; let i = index;">
+  <div class="col-12 col-sm-2 text-sm-right col-form-label">
+    <strong>{{ option }}</strong>
   </div>
-  <div class="form-group row" *ngIf="responseDetails.answers.length !== 0">
-    <div class="col-sm-5 text-right">
-      <button type="button" class="btn btn-light btn-sm" (click)="triggerResponseDetailsChange('answers', [])" [disabled]="isDisabled">Clear Points</button>
-    </div>
+  <div class="col-12 col-sm-5">
+    <input type="number" class="form-control"
+           [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
+           (ngModelChange)="triggerResponse(i, $event)"
+           [disabled]="isDisabled"
+           min="0" step="1">
+  </div>
+</div>
+<div class="form-group row" *ngIf="responseDetails.answers.length !== 0">
+  <div class="col-12 col-sm-5 offset-sm-2">
+    <button type="button" class="btn btn-light btn-sm" (click)="triggerResponseDetailsChange('answers', [])" [disabled]="isDisabled">Clear Points</button>
   </div>
 </div>
 <div class="row" *ngIf="responseDetails.answers.length !== 0">

--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-5-md col-12-sm">
+  <div class="col-md-5 col-sm-12">
     <select class="form-control"
             [ngClass]="{'color-positive': responseDetails.answer > 100,
               'color-negative': responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SURE && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED,
@@ -13,7 +13,7 @@
       <option *ngIf="questionDetails.isNotSureAllowed" [ngValue]="CONTRIBUTION_POINT_NOT_SURE" class="color-neutral">Not Sure</option>
     </select>
   </div>
-  <div class="col-7-md col-12-sm" *ngIf="shouldShowHelpLink">
+  <div class="col-md-7 col-sm-12" *ngIf="shouldShowHelpLink">
     <button type="button" class="btn btn-link" (click)="openModal(helpModal)"><i class="fas fa-exclamation-circle"></i> More info about the <code>Equal Share</code> scale</button>
   </div>
   <ng-template #helpModal let-modal>

--- a/src/web/app/components/question-types/question-edit-answer-form/mcq-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/mcq-question-edit-answer-form.component.scss
@@ -5,6 +5,4 @@
 .option-text {
   display: inline-block;
   vertical-align: top;
-  max-width: 95%;
-  min-width: 300px;
 }

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
@@ -1,13 +1,15 @@
-<div class="row">
+<div class="row text-left">
   <div class="col-5">
     <input type="number" class="form-control" min="{{ questionDetails.minScale }}" max="{{ questionDetails.maxScale }}" step="{{ questionDetails.step }}"
            [ngModel]="responseDetails.answer == NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED ? '' : responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled">
   </div>
-  <div>
+  <div class="col-7">
     Possible Acceptable Values are: {{ possibleValues }}
   </div>
-  <div>
-    <p *ngIf="!isValidPossibleValue(responseDetails.answer) && responseDetails.answer != NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED" style="margin-left: 1em;" class="text-danger">The scale entered is not a possible value.</p>
-    <p *ngIf="responseDetails.answer == NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED" style="margin-left: 1em; color: blue;">Please enter a scale number.</p>
+</div>
+<div class="row mt-1">
+  <div class="col-12">
+    <p *ngIf="!isValidPossibleValue(responseDetails.answer) && responseDetails.answer != NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED" class="text-danger">The scale entered is not a possible value.</p>
+    <p *ngIf="responseDetails.answer == NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED" class="text-info">Please enter a scale number.</p>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.scss
@@ -1,0 +1,3 @@
+p {
+  margin-bottom: 0;
+}

--- a/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.html
@@ -1,21 +1,19 @@
-<div class="col-sm-9">
-  <div>
-    <div class="form-group row" *ngFor="let num of questionDetails.options; let i = index;">
-      <label class="col-sm-2 control-label margin-left-45px">
-        <strong>{{ questionDetails.options[i] }}</strong>
-      </label>
-      <div class="col-sm-3">
-        <select class="form-control" [ngModel]="responseDetails.answers[i]"
-                (ngModelChange)="triggerResponse(i, $event)" [disabled]="isDisabled">
-          <option [ngValue]="RANK_OPTIONS_ANSWER_NOT_SUBMITTED"></option>
-          <option *ngFor="let rank of ranksToBeAssigned" [ngValue]="rank">{{ rank }}</option>
-        </select>
-        <br>
-      </div>
-    </div>
-    <p *ngIf="!questionDetails.areDuplicatesAllowed && isSameRanksAssigned" class="text-danger">The same rank should not be given multiple times.</p>
-    <p *ngIf="isNoOptionRanked" style="color: blue;">Please rank the above options.</p>
-    <p *ngIf="isMinOptionsEnabled && isOptionsRankedLessThanMin" class="text-danger">You need to rank at least {{ questionDetails.minOptionsToBeRanked }} options.</p>
-    <p *ngIf="isMaxOptionsEnabled && isOptionsRankedMoreThanMax" class="text-danger">Rank no more than {{questionDetails.maxOptionsToBeRanked}} options.</p>
+<div class="form-group row text-left" *ngFor="let num of questionDetails.options; let i = index;">
+  <div class="col-12 col-md-3 text-md-right col-form-label">
+    <strong>{{ questionDetails.options[i] }}</strong>
   </div>
+  <div class="col-12 col-md-9 text-md-left">
+    <select class="form-control" [ngModel]="responseDetails.answers[i]"
+            (ngModelChange)="triggerResponse(i, $event)" [disabled]="isDisabled">
+      <option [ngValue]="RANK_OPTIONS_ANSWER_NOT_SUBMITTED"></option>
+      <option *ngFor="let rank of ranksToBeAssigned" [ngValue]="rank">{{ rank }}</option>
+    </select>
+  </div>
+</div>
+
+<div class="col-md-9 offset-md-3">
+  <p *ngIf="!questionDetails.areDuplicatesAllowed && isSameRanksAssigned" class="text-danger">The same rank should not be given multiple times.</p>
+  <p *ngIf="isNoOptionRanked" class="text-info">Please rank the above options.</p>
+  <p *ngIf="isMinOptionsEnabled && isOptionsRankedLessThanMin" class="text-danger">You need to rank at least {{ questionDetails.minOptionsToBeRanked }} options.</p>
+  <p *ngIf="isMaxOptionsEnabled && isOptionsRankedMoreThanMax" class="text-danger">Rank no more than {{questionDetails.maxOptionsToBeRanked}} options.</p>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.scss
@@ -1,3 +1,7 @@
-.margin-left-25px {
+.margin-left-45px {
   margin-left: 45px;
+}
+
+.margin-top-20px {
+  margin-top: 20px;
 }

--- a/src/web/app/components/question-types/question-instruction/constsum-options-question-instruction.component.html
+++ b/src/web/app/components/question-types/question-instruction/constsum-options-question-instruction.component.html
@@ -1,12 +1,12 @@
-<div class="constraints-1">
-  <p class="text-color-blue text-left font-weight-bold">Note:</p>
-  <p class="text-color-blue padding-left-35px">
+<div class="text-info">
+  <p class="text-left font-weight-bold">Note:</p>
+  <p>
     <span class="fa fa-info-circle"></span> Total points distributed should add up to {{ totalPoints }}.
   </p>
-  <p class="text-color-blue padding-left-35px" *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY">
+  <p *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY">
     <span class="fa fa-info-circle"></span> At least one option should be allocated different number of points.
   </p>
-  <p class="text-color-blue padding-left-35px" *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY">
+  <p *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY">
     <span class="fa fa-info-circle"></span> Every option should be allocated different number of points.
   </p>
   <hr class="margin-top-0 border-top-dark-gray">

--- a/src/web/app/components/question-types/question-instruction/constsum-options-question-instruction.component.scss
+++ b/src/web/app/components/question-types/question-instruction/constsum-options-question-instruction.component.scss
@@ -1,9 +1,9 @@
-.text-color-blue {
-  color: blue;
+span {
+  margin-left: 25px;
 }
 
-.padding-left-35px {
-  padding-left: 35px;
+.text-color-blue {
+  color: blue;
 }
 
 .margin-top-0 {
@@ -12,8 +12,4 @@
 
 .border-top-dark-gray {
   border-top: 1px solid #CCC;
-}
-
-.padding-right-10px {
-  padding-right: 10px;
 }

--- a/src/web/app/components/question-types/question-instruction/constsum-recipients-question-instruction.component.html
+++ b/src/web/app/components/question-types/question-instruction/constsum-recipients-question-instruction.component.html
@@ -1,12 +1,12 @@
-<div>
-  <p class="text-color-blue text-left font-weight-bold">Note:</p>
-  <p class="text-color-blue padding-left-35px">
+<div class="text-info">
+  <p class="text-left font-weight-bold">Note:</p>
+  <p>
     <span class="fa fa-info-circle"></span> Total points distributed should add up to {{ totalPoints }}.
   </p>
-  <p class="text-color-blue padding-left-35px" *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY">
+  <p *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY">
     <span class="fa fa-info-circle"></span> At least one recipient should be allocated different number of points.
   </p>
-  <p class="text-color-blue padding-left-35px" *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY">
+  <p *ngIf="questionDetails.forceUnevenDistribution && questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY">
     <span class="fa fa-info-circle"></span> Every recipient should be allocated different number of points.
   </p>
   <hr class="margin-top-0 border-top-dark-gray">

--- a/src/web/app/components/question-types/question-instruction/constsum-recipients-question-instruction.component.scss
+++ b/src/web/app/components/question-types/question-instruction/constsum-recipients-question-instruction.component.scss
@@ -1,9 +1,9 @@
-.text-color-blue {
-  color: blue;
+span {
+  margin-left: 25px;
 }
 
-.padding-left-35px {
-  padding-left: 35px;
+.text-color-blue {
+  color: blue;
 }
 
 .margin-top-0 {
@@ -12,8 +12,4 @@
 
 .border-top-dark-gray {
   border-top: 1px solid #CCC;
-}
-
-.padding-right-10px {
-  padding-right: 10px;
 }

--- a/src/web/app/components/question-types/question-instruction/rank-options-question-instruction.component.html
+++ b/src/web/app/components/question-types/question-instruction/rank-options-question-instruction.component.html
@@ -1,4 +1,4 @@
-<p *ngIf="questionDetails.minOptionsToBeRanked !== NO_VALUE || questionDetails.maxOptionsToBeRanked ! == NO_VALUE"
+<p *ngIf="questionDetails.minOptionsToBeRanked !== NO_VALUE || questionDetails.maxOptionsToBeRanked !== NO_VALUE"
    class="text-muted">Instructions:</p>
 <ul>
   <li *ngIf="questionDetails.minOptionsToBeRanked !== NO_VALUE" class="text-muted">You need to rank at least {{ questionDetails.minOptionsToBeRanked }} options.</li>

--- a/src/web/app/components/question-types/question-statistics/constsum-options-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/constsum-options-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent && hasAnswers">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rank-options-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rank-recipients-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length && !isStudent">
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div>
   <div class="row">
-    <div class="col-sm-4 text-color-gray">
+    <div class="col-sm-4 text-color-gray mt-2">
       <strong>
         Response Summary
       </strong>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -9,7 +9,7 @@
     </div>
   </div>
 </div>
-<div class="card card-plain">
+<div class="card card-plain mt-3">
   <div class="card-body">
     <br/>
     <div class="row text-center">
@@ -35,9 +35,9 @@
   </div>
 </div>
 
-<div class="card bg-light top-padded" *ngFor="let question of questions">
-  <div class="card-body" style="padding: 20px;">
-    <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" style="font-size: 20px;"></tm-question-text-with-info>
+<div class="card bg-light mt-4" *ngFor="let question of questions">
+  <div class="card-body">
+    <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" class="question-text"></tm-question-text-with-info>
     <tm-single-statistics [question]="question.feedbackQuestion.questionDetails"
                           [responses]="question.responsesToSelf"
                           [statistics]="question.questionStatistics"
@@ -46,7 +46,7 @@
     <div *ngFor="let responsesForOtherRecipient of question.otherResponses">
       <tm-student-view-responses *ngIf="responsesForOtherRecipient.length" [responses]="responsesForOtherRecipient" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone"></tm-student-view-responses>
     </div>
-    <div *ngIf="question.responsesFromSelf.length" style="margin-top: 10px;">
+    <div class="mt-4" *ngIf="question.responsesFromSelf.length">
       <strong>Your own responses:</strong>
       <div *ngFor="let responseFromSelf of question.responsesFromSelf">
         <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone"></tm-student-view-responses>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.scss
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.scss
@@ -1,10 +1,10 @@
-.top-padded {
-  margin-top: 20px;
-}
-
 .card-plain {
   background-color: #EAEFF5;
   background-image: none;
   border: 0;
   box-shadow: 0 0 0 0;
+}
+
+.question-text {
+  font-size: 18px;
 }

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -9,6 +9,10 @@ body {
   font-size: 15px;
 }
 
+ul {
+  margin-bottom: 0;
+}
+
 .btn {
   font-size: .8rem;
 }


### PR DESCRIPTION
Part of #10233

**Outline of Solution**
Using V6 student pages as a guideline, the following were implemented: 

- General removal/shrinking of margins and paddings in the components

Before
![reduce-spacing-original](https://user-images.githubusercontent.com/28994607/86102800-900d6080-baee-11ea-97a6-c1bd3e9b4ec4.PNG)
After
![reduce-spacing-changed](https://user-images.githubusercontent.com/28994607/86102793-8e439d00-baee-11ea-9a34-af3383fd527d.PNG)

- Changed font size for more/less text

Before
![view-original](https://user-images.githubusercontent.com/28994607/86102285-e5953d80-baed-11ea-97ee-bac6a6645ef6.PNG)
After
![view changed](https://user-images.githubusercontent.com/28994607/86102502-2db46000-baee-11ea-9d54-6535663db590.PNG)

- Changed structure of some pages to better save space

Before
![rank original](https://user-images.githubusercontent.com/28994607/86102663-63f1df80-baee-11ea-856a-2a5c10deb0d1.PNG)
After
![rank-changed](https://user-images.githubusercontent.com/28994607/86102672-65230c80-baee-11ea-84a5-11df815ebd1f.PNG)

- Instructions for questions were compacted

Before
![constsum-rank-original](https://user-images.githubusercontent.com/28994607/86103051-dcf13700-baee-11ea-80c9-eac2f58b0875.PNG)
After
![constum-rank-changed](https://user-images.githubusercontent.com/28994607/86103046-db277380-baee-11ea-8757-6784be46a953.PNG)
