### PR TITLE
[#10245] UAT Fix: Instructor Search Page

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchStudentsAction.java
@@ -6,6 +6,7 @@ import java.util.List;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
@@ -27,13 +28,6 @@ public class SearchStudentsAction extends Action {
         // Only instructors and admins can search for student
         if (!userInfo.isInstructor && !userInfo.isAdmin) {
             throw new UnauthorizedAccessException("Instructor or Admin privilege is required to access this resource.");
-        }
-        String entity = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
-        if (!userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
-            throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
-        }
-        if (!userInfo.isInstructor && entity.equals(Const.EntityType.INSTRUCTOR)) {
-            throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
     }
 
@@ -81,16 +75,18 @@ public class SearchStudentsAction extends Action {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.SEARCH_KEY);
         String entity = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
         List<StudentAttributes> students;
-        List<StudentData> studentDataList = new ArrayList<>();
 
         // Search for students
-        if (userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
-            students = logic.searchStudentsInWholeSystem(searchKey).studentList;
-        } else {
+        if (userInfo.isInstructor && entity.equals(Const.EntityType.INSTRUCTOR)) {
             List<InstructorAttributes> instructors = logic.getInstructorsForGoogleId(userInfo.id);
             students = logic.searchStudents(searchKey, instructors).studentList;
+        } else if (userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
+            students = logic.searchStudentsInWholeSystem(searchKey).studentList;
+        } else {
+            throw new InvalidHttpParameterException("Invalid entity type for search");
         }
 
+        List<StudentData> studentDataList = new ArrayList<>();
         for (StudentAttributes s : students) {
             StudentData studentData = new StudentData(s);
 

--- a/src/main/java/teammates/ui/webapi/action/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchStudentsAction.java
@@ -28,6 +28,13 @@ public class SearchStudentsAction extends Action {
         if (!userInfo.isInstructor && !userInfo.isAdmin) {
             throw new UnauthorizedAccessException("Instructor or Admin privilege is required to access this resource.");
         }
+        String entity = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
+        if (!userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
+            throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
+        }
+        if (!userInfo.isInstructor && entity.equals(Const.EntityType.INSTRUCTOR)) {
+            throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
+        }
     }
 
     private String getInstituteFromCourseId(String courseId) {
@@ -72,11 +79,12 @@ public class SearchStudentsAction extends Action {
     @Override
     public ActionResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.SEARCH_KEY);
+        String entity = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
         List<StudentAttributes> students;
         List<StudentData> studentDataList = new ArrayList<>();
 
         // Search for students
-        if (userInfo.isAdmin) {
+        if (userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
             students = logic.searchStudentsInWholeSystem(searchKey).studentList;
         } else {
             List<InstructorAttributes> instructors = logic.getInstructorsForGoogleId(userInfo.id);
@@ -86,7 +94,7 @@ public class SearchStudentsAction extends Action {
         for (StudentAttributes s : students) {
             StudentData studentData = new StudentData(s);
 
-            if (userInfo.isAdmin) {
+            if (userInfo.isAdmin && entity.equals(Const.EntityType.ADMIN)) {
                 studentData.addAdditionalInformationForAdminSearch(
                         StringHelper.encrypt(s.getKey()),
                         getInstituteFromCourseId(s.getCourse()));

--- a/src/test/java/teammates/test/cases/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/SearchStudentsActionTest.java
@@ -48,6 +48,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsAdmin();
         String[] accNameParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, acc.getName(),
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
         SearchStudentsAction a = getAction(accNameParams);
         JsonResult result = getJsonResult(a);
@@ -61,6 +62,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsAdmin();
         String[] accCourseIdParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, acc.getCourse(),
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
         SearchStudentsAction a = getAction(accCourseIdParams);
         JsonResult result = getJsonResult(a);
@@ -73,6 +75,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsAdmin();
         String[] accNameParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "Course2",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
         SearchStudentsAction a = getAction(accNameParams);
         JsonResult result = getJsonResult(a);
@@ -87,6 +90,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         StudentAttributes acc = typicalBundle.students.get("student1InCourse1");
         String[] emailParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, acc.getEmail(),
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
 
         SearchStudentsAction a = getAction(emailParams);
@@ -101,6 +105,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsAdmin();
         String[] accNameParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "minuscoronavirus",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
         SearchStudentsAction a = getAction(accNameParams);
         JsonResult result = getJsonResult(a);
@@ -114,6 +119,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsAdmin();
         String[] googleIdParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "Course",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
         };
         SearchStudentsAction a = getAction(googleIdParams);
         JsonResult result = getJsonResult(a);
@@ -127,6 +133,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsInstructor("idOfInstructor1OfCourse1");
         String[] googleIdParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "Course",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
         };
 
         SearchStudentsAction a = getAction(googleIdParams);
@@ -139,7 +146,17 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
     @Override
     @Test
     protected void testAccessControl() {
-        verifyAccessibleForAdmin();
-        verifyOnlyInstructorsCanAccess();
+        String[] adminParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
+        };
+        String[] instructorParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
+        };
+        verifyAccessibleForAdmin(adminParams);
+        verifyOnlyInstructorsCanAccess(instructorParams);
+        verifyInaccessibleForAdmin(instructorParams);
+        verifyInaccessibleForInstructors(adminParams);
     }
 }

--- a/src/test/java/teammates/test/cases/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/SearchStudentsActionTest.java
@@ -37,9 +37,35 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
     }
 
     @Test
-    public void execute_notEnoughParameters_parameterFailure() {
+    public void execute_invalidParameters_parameterFailure() {
         loginAsAdmin();
         verifyHttpParameterFailure();
+
+        String[] notEnoughParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+        };
+        verifyHttpParameterFailure(notEnoughParams);
+
+        String[] invalidEntityParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+                Const.ParamsNames.ENTITY_TYPE, "dummy",
+        };
+        verifyHttpParameterFailure(invalidEntityParams);
+
+        String[] adminParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
+        };
+        String[] instructorParams = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "dummy",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
+        };
+
+        loginAsAdmin();
+        verifyHttpParameterFailure(instructorParams);
+
+        loginAsInstructor("idOfInstructor1OfCourse1");
+        verifyHttpParameterFailure(adminParams);
     }
 
     @Test
@@ -146,17 +172,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
     @Override
     @Test
     protected void testAccessControl() {
-        String[] adminParams = new String[] {
-                Const.ParamsNames.SEARCH_KEY, "dummy",
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
-        };
-        String[] instructorParams = new String[] {
-                Const.ParamsNames.SEARCH_KEY, "dummy",
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
-        };
-        verifyAccessibleForAdmin(adminParams);
-        verifyOnlyInstructorsCanAccess(instructorParams);
-        verifyInaccessibleForAdmin(instructorParams);
-        verifyInaccessibleForInstructors(adminParams);
+        verifyAccessibleForAdmin();
+        verifyOnlyInstructorsCanAccess();
     }
 }

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -168,9 +168,10 @@ describe('SearchService', () => {
   });
 
   it('should execute GET when searching for students', () => {
-    service.searchStudents('Alice');
+    service.searchStudents('Alice', 'instructor');
     const paramMap: { [key: string]: string } = {
       searchkey: 'Alice',
+      entitytype: 'instructor',
     };
     expect(spyHttpRequestService.get).toHaveBeenCalledWith(
       '/search/students',

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -45,7 +45,7 @@ export class SearchService {
   ) {}
 
   searchInstructor(searchKey: string): Observable<InstructorSearchResult> {
-    return this.searchStudents(searchKey).pipe(
+    return this.searchStudents(searchKey, 'instructor').pipe(
       map((studentsRes: Students) => this.getCoursesWithSections(studentsRes)),
       mergeMap((coursesWithSections: SearchStudentsTable[]) =>
         forkJoin([
@@ -69,7 +69,7 @@ export class SearchService {
 
   searchAdmin(searchKey: string): Observable<AdminSearchResult> {
     return forkJoin([
-      this.searchStudents(searchKey),
+      this.searchStudents(searchKey, 'admin'),
       this.searchInstructors(searchKey),
     ]).pipe(
       map((value: [Students, Instructors]): [Student[], Instructor[]] =>
@@ -92,9 +92,10 @@ export class SearchService {
     );
   }
 
-  searchStudents(searchKey: string): Observable<Students> {
+  searchStudents(searchKey: string, entityType: string): Observable<Students> {
     const paramMap: { [key: string]: string } = {
       searchkey: searchKey,
+      entitytype: entityType,
     };
     return this.httpRequestService.get(ResourceEndpoints.SEARCH_STUDENTS, paramMap);
   }


### PR DESCRIPTION
Part of #10245 

> Instructor search page: If an instructor who is admin searches for students, s/he will get all the matching students in the system. This is not accurate as the intention of this page is not for system-wide search.

Added new param `entitytype` for student search