### PR TITLE
[#10213] Fix clickable area / cursor related issues

### DIFF
--- a/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
+++ b/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
@@ -143,14 +143,14 @@ exports[`CopySessionModalComponent should snap with some session and courses can
         <div
           class="form-check"
         >
-          <input
-            class="form-check-input ng-untouched ng-pristine ng-valid"
-            name="copySessionChooseCourse"
-            type="radio"
-          />
           <label
             class="form-check-label"
           >
+            <input
+              class="form-check-input ng-untouched ng-pristine ng-valid"
+              name="copySessionChooseCourse"
+              type="radio"
+            />
              [
             <span
               class="text-danger"
@@ -158,32 +158,32 @@ exports[`CopySessionModalComponent should snap with some session and courses can
               Test01
             </span>
             ] : Sample Course 101 
+            
+            <span
+              class="text-danger"
+            >
+               {Session currently in this course} 
+            </span>
           </label>
-          
-          <div
-            class="text-danger"
-          >
-             {Session currently in this course} 
-          </div>
         </div>
         <div
           class="form-check"
         >
-          <input
-            class="form-check-input ng-untouched ng-pristine ng-valid"
-            name="copySessionChooseCourse"
-            type="radio"
-          />
           <label
             class="form-check-label"
           >
+            <input
+              class="form-check-input ng-untouched ng-pristine ng-valid"
+              name="copySessionChooseCourse"
+              type="radio"
+            />
              [
             <span>
               Test02
             </span>
             ] : Sample Course 202 
+            
           </label>
-          
         </div>
       </div>
     </div>

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -12,19 +12,19 @@
     <div class="col-12">
       <div class="form-group">
         <label><b>Name for copied session</b></label>
-        <input type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" maxlength="38">
+        <input type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH">
         <span>{{ FEEDBACK_SESSION_NAME_MAX_LENGTH - newFeedbackSessionName.length }} characters left</span>
       </div>
       <div class="form-check" *ngFor="let course of courseCandidates">
-        <input type="radio" name="copySessionChooseCourse" class="form-check-input"
-               [(ngModel)]="copyToCourseId" [value]="course.courseId">
         <label class="form-check-label">
+          <input type="radio" name="copySessionChooseCourse" class="form-check-input"
+                 [(ngModel)]="copyToCourseId" [value]="course.courseId">
           [<span [ngClass]="{ 'text-danger': sessionToCopyCourseId === course.courseId }">{{ course.courseId }}</span>]
           : {{ course.courseName }}
+          <span *ngIf="sessionToCopyCourseId === course.courseId" class="text-danger">
+            {{ "{Session currently in this course}" }}
+          </span>
         </label>
-        <div *ngIf="sessionToCopyCourseId === course.courseId" class="text-danger">
-          {{ "{Session currently in this course}" }}
-        </div>
       </div>
     </div>
   </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="groupByTeam">
   <div *ngFor="let teamInfo of teamsToUsers | keyvalue">
     <div class="card top-padded">
-      <div class="card-header bg-warning" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
+      <div class="card-header bg-warning cursor-pointer" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
         {{ teamInfo.key }}
         <div class="float-right">
           <i class="fas fa-chevron-down" *ngIf="!teamExpanded[teamInfo.key]"></i>
@@ -17,7 +17,7 @@
               <div class="card-header bg-info text-white">
                 <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber"
                                             [questionDetails]="question.feedbackQuestion.questionDetails"
-                                            (click)="$event.stopPropagation()"></tm-question-text-with-info>
+                ></tm-question-text-with-info>
               </div>
               <div class="card-body top-padded-small">
                 <tm-single-statistics [responses]="question.allResponses"
@@ -53,7 +53,7 @@
 
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
-    <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
+    <div class="card-header bg-primary text-white cursor-pointer" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
       {{ isGqr ? 'From' : 'To' }}:
       <tm-student-name-with-photo [name]="userInfo"
                        [email]="userToEmail[userInfo]"
@@ -73,10 +73,10 @@
     <div [ngbCollapse]="!userExpanded[userInfo]">
       <div class="card-body top-padded-0">
         <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo]">
-          <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
+          <div class="card-header bg-info text-white cursor-pointer" (click)="question.isTabExpanded = !question.isTabExpanded">
             <tm-question-text-with-info [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
                                         [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
-                                        (click)="$event.stopPropagation()"></tm-question-text-with-info>
+            ></tm-question-text-with-info>
             <div class="float-right">
               <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
               <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="groupByTeam">
   <div *ngFor="let teamInfo of teamsToUsers | keyvalue">
     <div class="card top-padded">
-      <div class="card-header bg-warning" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
+      <div class="card-header bg-warning cursor-pointer" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
         {{ teamInfo.key }}
         <div class="float-right">
           <i class="fas fa-chevron-down" *ngIf="!teamExpanded[teamInfo.key]"></i>
@@ -32,7 +32,7 @@
 
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded">
-    <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
+    <div class="card-header bg-primary text-white cursor-pointer" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
       {{ isGrq ? 'From' : 'To' }}:
       <tm-student-name-with-photo [name]="userInfo"
                        [email]="userToEmail[userInfo]"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -17,7 +17,7 @@
       <div class="col-md-12">
         <tm-status-message [messages]="statusMessage"></tm-status-message>
         <div class="card card-default">
-          <div id="toggle-existing-students" class="card-header"
+          <div id="toggle-existing-students" class="card-header cursor-pointer"
                (click)="toggleExistingStudentsPanel()">
             <b class="existing-students-status-message">Existing Students</b>
             <div class="float-right margin-left-7px">
@@ -48,7 +48,7 @@
           </hot-table>
         </div>
         <div class="card card-default">
-          <div class="card-header" (click)="toggleNewStudentsPanel()">
+          <div class="card-header cursor-pointer" (click)="toggleNewStudentsPanel()">
             <div class="float-right margin-left-7px">
               <i class="fas fa-chevron-{{ isNewStudentsPanelCollapsed ? 'down' : 'up' }}"></i>
             </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.html
@@ -6,12 +6,12 @@
 </div>
 <div class="modal-body">
   <div class="card margin-top-20px" *ngFor="let templateQuestionModel of templateQuestionModels">
-    <div class="card-header">
+    <div class="card-header cursor-pointer"
+         (click)="templateQuestionModel.isShowDetails = !templateQuestionModel.isShowDetails">
       <label>
-        <input type="checkbox" [(ngModel)]="templateQuestionModel.isSelected">
+        <input type="checkbox" [(ngModel)]="templateQuestionModel.isSelected" (click)="$event.stopPropagation()">
       </label>&nbsp;
-      <span [innerHTML]="templateQuestionModel.description" class="template-description"
-            (click)="templateQuestionModel.isShowDetails = !templateQuestionModel.isShowDetails"></span>
+      <span [innerHTML]="templateQuestionModel.description" class="template-description"></span>
     </div>
     <div [ngbCollapse]="!templateQuestionModel.isShowDetails">
       <div class="card-body">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -1,4 +1,4 @@
-<div class="card-header bg-info text-dark course-tab-header" (click)="toggleTab()">
+<div class="card-header bg-info text-dark cursor-pointer" (click)="toggleTab()">
   Participants who have not responded to any question
   <div class="float-right">
     <i class="fas fa-chevron-down" *ngIf="!isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
+    <div class="card-header bg-info text-white cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
+    <div class="card-header bg-info text-white cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
+    <div class="card-header bg-info text-white cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
+    <div class="card-header bg-info text-white cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -9,7 +9,7 @@
 <ng-container>
   <div *ngFor="let courseTab of courseTabList">
     <div class="card">
-      <div class="card-header justify-content-between course-card-header"
+      <div class="card-header justify-content-between course-card-header cursor-pointer"
         (click)="toggleCard(courseTab)">
         <div class="row course-card-content">
           <div class="col-sm-11">


### PR DESCRIPTION
Part of #10213 

Mostly change cursors to pointers on clickable surfaces, with some other fixes:

- Courses -> Enroll - Existing students
    - Fix cursor not pointers on clickable surface
- Courses -> Enroll - New students
    - Fix cursor not pointers on clickable surface
- Sessions -> Edit -> Add New Questions -> Choose from template questions
    - Fix cursor not pointers on clickable surface
    - Fixed not expanding on clicking outside of text as well
- Sessions -> View Results -  Participants who have not responded to any question
    - Fix cursor not pointers on clickable surface
- Sessions -> View Results -> GRQ / RGQ / GQR / RQG: All header cursors are not pointer
    - Fix cursor not pointers on clickable surface
- GQR / RQG - Questions
    - Fixed not expanding on clicking outside of text as well
- Sessions -> Copy
    - Fix session label unclickable
    - Align labels to fit onto one line instead of 2
- Students -> View -> All Records - Response From / To
    - Fix cursor not pointers on clickable surface
- Students List
    - Fix cursor not pointers on clickable surface