### PR TITLE
[#10279] Restore all feedback sessions causes error 

### DIFF
--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -531,7 +531,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
     const restoreRequests: Observable<FeedbackSession>[] = [];
     this.recycleBinFeedbackSessionRowModels.forEach((model: RecycleBinFeedbackSessionRowModel) => {
       restoreRequests.push(
-          this.feedbackSessionsService.deleteFeedbackSession(
+          this.feedbackSessionsService.deleteSessionFromRecycleBin(
               model.feedbackSession.courseId,
               model.feedbackSession.feedbackSessionName,
           ));


### PR DESCRIPTION
Fixes #10279

**Outline of Solution**
`deleteFeedbackSession` mistakenly called instead of `deleteSessionFromRecycleBin` in `restoreAllRecycleBinFeedbackSession`

**Screenshot**
![fix](https://user-images.githubusercontent.com/31800234/86535734-1bcf2480-bf15-11ea-9131-4246b5fdeed7.PNG)
