### PR TITLE
[#10264] Encrypt Feedback Response ID

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
@@ -15,6 +15,7 @@ import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
 import teammates.ui.webapi.request.FeedbackResponseCommentCreateRequest;
 import teammates.ui.webapi.request.Intent;
@@ -31,7 +32,13 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
 
     @Override
     public void checkSpecificAccessControl() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);
 
@@ -91,7 +98,13 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
 
     @Override
     public ActionResult execute() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
 
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);

--- a/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseAction.java
@@ -11,8 +11,10 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.request.Intent;
 
 /**
@@ -27,7 +29,13 @@ public class DeleteFeedbackResponseAction extends BasicFeedbackSubmissionAction 
 
     @Override
     public void checkSpecificAccessControl() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes feedbackResponse = logic.getFeedbackResponse(feedbackResponseId);
         if (feedbackResponse == null) {
             throw new EntityNotFoundException(new EntityDoesNotExistException("The feedback response does not exist."));
@@ -76,7 +84,13 @@ public class DeleteFeedbackResponseAction extends BasicFeedbackSubmissionAction 
 
     @Override
     public ActionResult execute() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes feedbackResponse = logic.getFeedbackResponse(feedbackResponseId);
 
         logic.deleteFeedbackResponseCascade(feedbackResponse.getId());

--- a/src/main/java/teammates/ui/webapi/action/GetFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetFeedbackResponseCommentAction.java
@@ -11,7 +11,9 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
 import teammates.ui.webapi.request.Intent;
 
@@ -27,7 +29,13 @@ public class GetFeedbackResponseCommentAction extends BasicCommentSubmissionActi
 
     @Override
     public void checkSpecificAccessControl() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes feedbackResponseAttributes = logic.getFeedbackResponse(feedbackResponseId);
 
         if (feedbackResponseAttributes == null) {
@@ -62,7 +70,13 @@ public class GetFeedbackResponseCommentAction extends BasicCommentSubmissionActi
 
     @Override
     public ActionResult execute() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
 
         switch (intent) {

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
@@ -12,8 +12,10 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.InvalidHttpRequestBodyException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.output.FeedbackResponseData;
 import teammates.ui.webapi.request.FeedbackResponseUpdateRequest;
 import teammates.ui.webapi.request.Intent;
@@ -30,7 +32,13 @@ public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
 
     @Override
     public void checkSpecificAccessControl() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes feedbackResponse = logic.getFeedbackResponse(feedbackResponseId);
         if (feedbackResponse == null) {
             throw new EntityNotFoundException(new EntityDoesNotExistException("The feedback response does not exist."));
@@ -75,7 +83,13 @@ public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
 
     @Override
     public ActionResult execute() {
-        String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
+        String feedbackResponseId;
+        try {
+            feedbackResponseId = StringHelper.decrypt(
+                    getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID));
+        } catch (InvalidParametersException ipe) {
+            throw new InvalidHttpParameterException(ipe.getMessage(), ipe);
+        }
         FeedbackResponseAttributes feedbackResponse = logic.getFeedbackResponse(feedbackResponseId);
         FeedbackQuestionAttributes feedbackQuestion = logic.getFeedbackQuestion(feedbackResponse.feedbackQuestionId);
 

--- a/src/main/java/teammates/ui/webapi/output/FeedbackResponseData.java
+++ b/src/main/java/teammates/ui/webapi/output/FeedbackResponseData.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi.output;
 
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.util.StringHelper;
 
 /**
  * The API output format of {@link FeedbackResponseAttributes}.
@@ -17,7 +18,7 @@ public class FeedbackResponseData extends ApiOutput {
     private final FeedbackResponseDetails responseDetails;
 
     public FeedbackResponseData(FeedbackResponseAttributes feedbackResponseAttributes) {
-        this.feedbackResponseId = feedbackResponseAttributes.getId();
+        this.feedbackResponseId = StringHelper.encrypt(feedbackResponseAttributes.getId());
         this.giverIdentifier = feedbackResponseAttributes.giver;
         this.recipientIdentifier = feedbackResponseAttributes.recipient;
         this.responseDetails = feedbackResponseAttributes.getResponseDetails();

--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -20,6 +20,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 
 /**
  * API output format for session results, including statistics.
@@ -436,7 +437,6 @@ public class SessionResultsData extends ApiOutput {
 
         private boolean isMissingResponse;
 
-        // TODO: security risk: responseId can expose giver and recipient email
         private String responseId;
 
         private String giver;
@@ -564,7 +564,7 @@ public class SessionResultsData extends ApiOutput {
             }
 
             public Builder withResponseId(String responseId) {
-                responseOutput.responseId = responseId;
+                responseOutput.responseId = StringHelper.encrypt(responseId);
                 return this;
             }
 

--- a/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -19,6 +19,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.logic.core.FeedbackResponseCommentsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.storage.api.FeedbackResponseCommentsDb;
@@ -113,6 +114,13 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         ______TS("not enough parameters");
         verifyHttpParameterFailure();
+
+        ______TS("unencrypted responseId");
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+        };
+        verifyHttpParameterFailure(submissionParams);
     }
 
     @Test
@@ -122,7 +130,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         ______TS("successful case for unpublished session for INSTRUCTOR_RESULT");
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         FeedbackResponseCommentCreateRequest requestBody =
                 new FeedbackResponseCommentCreateRequest("Comment to first response",
@@ -151,7 +159,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         ______TS("typical successful case for unpublished session empty giver permissions");
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         FeedbackResponseCommentCreateRequest requestBody = new FeedbackResponseCommentCreateRequest(
@@ -168,7 +176,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         FeedbackResponseCommentCreateRequest requestBody = new FeedbackResponseCommentCreateRequest(
@@ -178,7 +186,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody = new FeedbackResponseCommentCreateRequest("Comment shown to giver",
@@ -188,7 +196,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody = new FeedbackResponseCommentCreateRequest("Comment shown to receiver",
@@ -198,7 +206,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody =
@@ -209,7 +217,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody = new FeedbackResponseCommentCreateRequest(
@@ -220,7 +228,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody = new FeedbackResponseCommentCreateRequest("Comment shown to students",
@@ -238,7 +246,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 session1InCourse1.getCourseId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         FeedbackResponseCommentCreateRequest requestBody = new FeedbackResponseCommentCreateRequest(
@@ -264,7 +272,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         ______TS("Unsuccessful case: empty comment text");
         String[] submissionParams = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         FeedbackResponseCommentCreateRequest requestBody = new FeedbackResponseCommentCreateRequest("",
@@ -291,7 +299,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
 
         FeedbackResponseCommentCreateRequest requestBody = new FeedbackResponseCommentCreateRequest(
@@ -312,7 +320,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         requestBody = new FeedbackResponseCommentCreateRequest(
@@ -335,14 +343,14 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         ______TS("invalid intent STUDENT_RESULT");
         String[] invalidIntent1 = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         verifyHttpParameterFailure(invalidIntent1);
 
         ______TS("invalid intent FULL_DETAIL");
         String[] invalidIntent2 = new String[] {
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         verifyHttpParameterFailure(invalidIntent2);
     }
@@ -357,7 +365,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     protected void testAccessControl_textTypeQuestionResponse_notAllowedToAddComment() {
         String[] submissionParamsInstructor = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ2.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ2.getId()),
         };
 
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
@@ -380,7 +388,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, contributionResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(contributionResponse.getId()),
         };
 
         loginAsInstructor(instructorAttributes.getGoogleId());
@@ -398,7 +406,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] submissionParamsStudent = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
 
         assertThrows(InvalidHttpParameterException.class,
@@ -411,7 +419,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
         String[] submissionParamsInstructor = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         assertThrows(InvalidHttpParameterException.class,
@@ -425,7 +433,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] submissionParamsStudentToStudents = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response2ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response2ForQ3.getId()),
         };
         verifyCannotAccess(submissionParamsStudentToStudents);
 
@@ -439,7 +447,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student3InCourse1.getGoogleId());
         String[] submissionParamsTeam = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response2ForQ4.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response2ForQ4.getId()),
         };
         verifyCannotAccess(submissionParamsTeam);
 
@@ -452,7 +460,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsInstructor(instructor2OfCourse1.getGoogleId());
         String[] submissionParamsInstructorToInstructor = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ5.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ5.getId()),
         };
         verifyCannotAccess(submissionParamsInstructorToInstructor);
 
@@ -469,14 +477,14 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] invalidIntent1 = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         assertThrows(InvalidHttpParameterException.class, () -> getAction(invalidIntent1).checkAccessControl());
 
         ______TS("invalid intent FULL_DETAIL");
         String[] invalidIntent2 = new String[] {
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         assertThrows(InvalidHttpParameterException.class, () -> getAction(invalidIntent2).checkAccessControl());
     }
@@ -487,7 +495,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsInstructor(helperOfCourse1.getGoogleId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         verifyCannotAccess(submissionParams);
     }
@@ -498,7 +506,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         gaeSimulation.logoutUser();
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         verifyCannotAccess(submissionParams);
     }
@@ -509,7 +517,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         verifyCannotAccess(submissionParams);
     }
@@ -520,7 +528,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsInstructor(instructor2OfCourse1.getGoogleId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         verifyCanAccess(submissionParams);
     }
@@ -531,7 +539,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         loginAsAdmin();
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         verifyCanMasquerade(instructor1OfCourse1.getGoogleId(), submissionParams);
     }
@@ -579,7 +587,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     private String[] getSubmissionParamsForCrossSectionResponse() {
         return new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ6.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ6.getId()),
         };
 
     }

--- a/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseActionTest.java
@@ -12,6 +12,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.action.DeleteFeedbackResponseAction;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.request.Intent;
@@ -96,11 +97,19 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
         verifyHttpParameterFailure();
         verifyHttpParameterFailure(Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString());
 
+        ______TS("Unencrypted responseId");
+
+        String[] invalidParams = new String[] {
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+        };
+        verifyHttpParameterFailure(invalidParams);
+
         ______TS("Typical success case, student");
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse.getId()),
         };
 
         DeleteFeedbackResponseAction a = getAction(params);
@@ -122,7 +131,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse3.getId()),
         };
 
         a = getAction(params);
@@ -149,7 +158,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] wrongGiverTypeParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse.getId()),
         };
 
         verifyCannotAccess(wrongGiverTypeParams);
@@ -160,7 +169,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] previewParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse.getId()),
                 Const.ParamsNames.PREVIEWAS, instructor1OfCourse1.email,
         };
 
@@ -174,7 +183,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] sessionNotOpenParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseInClosedSession.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(responseInClosedSession.getId()),
         };
 
         verifyCannotAccess(sessionNotOpenParams);
@@ -189,7 +198,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] invalidModeratedInstructorSubmissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse2.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse2.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, instructor1OfCourse1.getEmail(),
         };
 
@@ -206,7 +215,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] moderatedStudentSubmissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, testModerateResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(testModerateResponse.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, student1InCourse1.getEmail(),
         };
         verifyCannotAccess(moderatedStudentSubmissionParams);
@@ -217,7 +226,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] nonExistParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, "randomNonExistId",
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt("randomNonExistId"),
         };
 
         assertThrows(EntityNotFoundException.class, () -> getAction(nonExistParams).checkAccessControl());
@@ -232,7 +241,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] studentAccessOtherPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse.getId()),
         };
 
         verifyCannotAccess(studentAccessOtherPersonParams);
@@ -245,7 +254,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] studentAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse.getId()),
         };
 
         verifyCanAccess(studentAccessOwnPersonParams);
@@ -260,7 +269,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] studentAccessOSameTeamParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse2.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse2.getId()),
         };
 
         verifyCanAccess(studentAccessOSameTeamParams);
@@ -275,7 +284,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] studentAccessOtherTeamParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse2.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse2.getId()),
         };
 
         verifyCannotAccess(studentAccessOtherTeamParams);
@@ -290,7 +299,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] instructorAccessOtherPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse3.getId()),
         };
 
         verifyCannotAccess(instructorAccessOtherPersonParams);
@@ -303,7 +312,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] instructorAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse3.getId()),
         };
 
         verifyCanAccess(instructorAccessOwnPersonParams);
@@ -314,7 +323,7 @@ public class DeleteFeedbackResponseActionTest extends BaseActionTest<DeleteFeedb
 
         String[] unknownIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, typicalResponse3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(typicalResponse3.getId()),
         };
 
         assertThrows(InvalidHttpParameterException.class, () -> getAction(unknownIntentParams).checkAccessControl());

--- a/src/test/java/teammates/test/cases/webapi/GetFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetFeedbackResponseCommentActionTest.java
@@ -13,6 +13,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.action.GetFeedbackResponseCommentAction;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
@@ -74,11 +75,17 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     protected void testExecute_notEnoughParameters_shouldFail() {
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
         verifyHttpParameterFailure();
-        verifyHttpParameterFailure(Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId());
-        verifyHttpParameterFailure(Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString());
+        verifyHttpParameterFailure(Const.ParamsNames.FEEDBACK_RESPONSE_ID,
+                StringHelper.encrypt(response1ForQ1.getId()));
+        verifyHttpParameterFailure(Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString());
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+        };
+        verifyHttpParameterFailure(submissionParams);
     }
 
     @Test
@@ -89,7 +96,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         verifyHttpParameterFailure(submissionParams);
 
@@ -97,7 +104,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         loginAsStudent(student1InCourse1.getGoogleId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         verifyHttpParameterFailure(submissionParams);
     }
@@ -111,13 +118,12 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
 
         FeedbackResponseCommentData actualComment = getFeedbackResponseComments(submissionParams);
         FeedbackResponseCommentAttributes expected =
                 logic.getFeedbackResponseCommentForResponseFromParticipant(response1ForQ3.getId());
-        assertNotNull(actualComment.getFeedbackResponseCommentId());
         assertEquals(actualComment.getFeedbackCommentText(), expected.getCommentText());
         assertEquals(actualComment.getCommentGiver(), expected.getCommentGiver());
 
@@ -131,11 +137,10 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         actualComment = getFeedbackResponseComments(submissionParams);
         expected = logic.getFeedbackResponseCommentForResponseFromParticipant(response1ForQ1.getId());
-        assertNotNull(actualComment.getFeedbackResponseCommentId());
         assertEquals(actualComment.getFeedbackCommentText(), expected.getCommentText());
         assertEquals(actualComment.getCommentGiver(), expected.getCommentGiver());
 
@@ -145,7 +150,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response2ForQ4.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response2ForQ4.getId()),
         };
         GetFeedbackResponseCommentAction action = getAction(submissionParams);
         JsonResult actualResult = getJsonResult(action);
@@ -166,7 +171,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
 
         verifyCanAccess(submissionParams);
@@ -176,7 +181,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         verifyCanAccess(submissionParams);
     }
@@ -188,7 +193,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         loginAsStudent(student1InCourse1.getGoogleId());
         String[] studentInvalidIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
         assertThrows(InvalidHttpParameterException.class,
                 () -> getAction(studentInvalidIntentParams).checkSpecificAccessControl());
@@ -197,7 +202,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
         String[] instructorInvalidIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
         assertThrows(InvalidHttpParameterException.class,
                 () -> getAction(instructorInvalidIntentParams).checkSpecificAccessControl());
@@ -209,7 +214,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, "responseIdOfNonExistingResponse",
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt("responseIdOfNonExistingResponse"),
         };
 
         assertThrows(EntityNotFoundException.class, () -> getAction(submissionParams).checkSpecificAccessControl());
@@ -222,7 +227,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         loginAsInstructor(instructor1OfCourse2.getGoogleId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ1.getId()),
         };
 
         verifyCannotAccess(submissionParams);
@@ -231,7 +236,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         loginAsStudent(student1InCourse2.getGoogleId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, response1ForQ3.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(response1ForQ3.getId()),
         };
 
         verifyCannotAccess(submissionParams);

--- a/src/test/java/teammates/test/cases/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetFeedbackResponsesActionTest.java
@@ -13,8 +13,10 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.StringHelper;
 import teammates.ui.webapi.action.GetFeedbackResponsesAction;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.FeedbackResponseData;
@@ -85,7 +87,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
     }
 
     @Test
-    protected void testExecute_studentSubmission_shouldGetResponseSuccessfully() {
+    protected void testExecute_studentSubmission_shouldGetResponseSuccessfully() throws InvalidParametersException {
         loginAsStudent(student1InCourse1.getGoogleId());
 
         String[] params = {
@@ -104,7 +106,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
     }
 
     @Test
-    protected void testExecute_instructorSubmission_shouldGetResponseSuccessfully() {
+    protected void testExecute_instructorSubmission_shouldGetResponseSuccessfully() throws InvalidParametersException {
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
         String[] params = {
@@ -251,8 +253,9 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         return (FeedbackResponsesData) actualResult.getOutput();
     }
 
-    private void verifyFeedbackResponseEquals(FeedbackResponseAttributes expected, FeedbackResponseData actual) {
-        assertEquals(expected.getId(), actual.getFeedbackResponseId());
+    private void verifyFeedbackResponseEquals(FeedbackResponseAttributes expected, FeedbackResponseData actual)
+            throws InvalidParametersException {
+        assertEquals(expected.getId(), StringHelper.decrypt(actual.getFeedbackResponseId()));
         assertEquals(expected.getGiver(), actual.getGiverIdentifier());
         assertEquals(expected.getRecipient(), actual.getRecipientIdentifier());
         assertEquals(expected.getResponseDetails().getAnswerString(), actual.getResponseDetails().getAnswerString());

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseActionTest.java
@@ -17,6 +17,7 @@ import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 import teammates.test.driver.AssertHelper;
 import teammates.ui.webapi.action.UpdateFeedbackResponseAction;
 import teammates.ui.webapi.request.FeedbackResponseUpdateRequest;
@@ -69,31 +70,34 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
     }
 
     @Test
-    protected void testExecute_missingIntent_httpParameterFailure() {
+    protected void testExecute_invalidParams_httpParameterFailure() {
 
         ______TS("missing intent response parameters");
 
         loginAsStudent(student1InCourse1.getGoogleId());
 
         String[] missingIntentParams = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
         };
 
         verifyHttpParameterFailure(missingIntentParams);
-    }
-
-    @Test
-    protected void testExecute_missingResponseId_httpParameterFailure() {
 
         ______TS("missing response id parameters");
-
-        loginAsStudent(student1InCourse1.getGoogleId());
 
         String[] missingResponseIdParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
         verifyHttpParameterFailure(missingResponseIdParams);
+
+        ______TS("unencrypted response id parameters");
+
+        String[] unencryptedResponseId = new String[] {
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+        };
+
+        verifyHttpParameterFailure(unencryptedResponseId);
     }
 
     @Test
@@ -135,7 +139,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
         FeedbackResponseUpdateRequest updateRequest = getUpdateRequest(studentAttributes.getEmail());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, feedbackResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(feedbackResponse.getId()),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -188,7 +192,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
         FeedbackResponseUpdateRequest updateRequest = getUpdateRequest(instructorAttributes.getEmail());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, feedbackResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(feedbackResponse.getId()),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
 
@@ -225,7 +229,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] wrongGiverTypeParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
         };
 
         verifyCannotAccess(wrongGiverTypeParams);
@@ -240,7 +244,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] previewParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
                 Const.ParamsNames.PREVIEWAS, instructor1OfCourse1.email,
         };
 
@@ -265,7 +269,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] sessionNotOpenParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseInClosedSession.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(responseInClosedSession.getId()),
         };
 
         verifyCannotAccess(sessionNotOpenParams);
@@ -291,7 +295,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] invalidModeratedInstructorSubmissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student4ResponseToTeam.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student4ResponseToTeam.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, student4inCourse1.getEmail(),
         };
 
@@ -309,7 +313,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] nonExistParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, "randomNonExistId",
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt("randomNonExistId"),
         };
 
         assertThrows(EntityNotFoundException.class, () -> getAction(nonExistParams).checkAccessControl());
@@ -324,7 +328,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] unknownIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, instructor1ResponseToAll.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(instructor1ResponseToAll.getId()),
         };
 
         assertThrows(InvalidHttpParameterException.class, () -> getAction(unknownIntentParams).checkAccessControl());
@@ -354,7 +358,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] moderatedStudentSubmissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, testModerateResponse.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(testModerateResponse.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, student1InCourse1.getEmail(),
         };
 
@@ -378,7 +382,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessOtherPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
         };
 
         verifyCannotAccess(updateRequest, studentAccessOtherPersonParams);
@@ -407,7 +411,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessOtherTeamParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student4ResponseToTeam.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student4ResponseToTeam.getId()),
         };
 
         verifyCannotAccess(updateRequest, studentAccessOtherTeamParams);
@@ -430,7 +434,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] instructorAccessOtherPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, instructor1ResponseToAll.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(instructor1ResponseToAll.getId()),
         };
 
         verifyCannotAccess(updateRequest, instructorAccessOtherPersonParams);
@@ -449,7 +453,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] instructorAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, instructor1ResponseToAll.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(instructor1ResponseToAll.getId()),
         };
 
         verifyCanAccess(updateRequest, instructorAccessOwnPersonParams);
@@ -468,7 +472,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] instructorAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, instructor1ResponseToAll.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(instructor1ResponseToAll.getId()),
         };
 
         verifyCannotAccess(updateRequest, instructorAccessOwnPersonParams);
@@ -496,7 +500,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessSameTeamParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student4ResponseToTeam.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student4ResponseToTeam.getId()),
         };
 
         verifyCanAccess(updateRequest, studentAccessSameTeamParams);
@@ -515,7 +519,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
         };
 
         verifyCanAccess(updateRequest, studentAccessOwnPersonParams);
@@ -534,7 +538,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, student1InCourse1.getEmail(),
         };
 
@@ -557,7 +561,7 @@ public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedb
 
         String[] studentAccessOwnPersonParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_RESPONSE_ID, student1ResponseToStudent1.getId(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt(student1ResponseToStudent1.getId()),
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, student1InCourse1.getEmail(),
         };
 


### PR DESCRIPTION
Part of #10264 

Without any consideration for the front-end, my intent here is to encrypt all output of `responseId` and subsequently decrypt any receipt of `feedbackResponseId` from the API endpoints. 

This approach was taken because I believe `ResponseOutput` which is supposed to be the data output format for question responses is really just a superset of a `FeedbackResponseData` since the `responseId ` is really just the `feedbackResponseId`. Please do correct me if I'm wrong in my assumption. I'd like to clarify this assumption first before continuing to work on the tests and verify the impact of the encryption on the front-end.