### PR TITLE
[#10245] Change status codes for non-required entities from 404 to 204

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/GetFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetFeedbackResponseCommentAction.java
@@ -85,7 +85,12 @@ public class GetFeedbackResponseCommentAction extends BasicCommentSubmissionActi
             FeedbackResponseCommentAttributes comment =
                     logic.getFeedbackResponseCommentForResponseFromParticipant(feedbackResponseId);
             if (comment == null) {
-                return new JsonResult("Comment not found", HttpStatus.SC_NOT_FOUND);
+                FeedbackResponseAttributes fr = logic.getFeedbackResponse(feedbackResponseId);
+                if (fr == null) {
+                    throw new EntityNotFoundException(
+                            new EntityDoesNotExistException("The feedback response does not exist."));
+                }
+                return new JsonResult("Comment not found", HttpStatus.SC_NO_CONTENT);
             }
             return new JsonResult(new FeedbackResponseCommentData(comment));
         default:

--- a/src/main/java/teammates/ui/webapi/action/GetStudentProfileAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetStudentProfileAction.java
@@ -74,7 +74,7 @@ public class GetStudentProfileAction extends Action {
 
         StudentProfileData output = new StudentProfileData(name, studentProfile);
         // If student requesting and is not the student's own profile, hide some fields
-        if (userInfo.isStudent && !studentId.equals(userInfo.id)) {
+        if (userInfo.isStudent && !userInfo.isInstructor && !studentId.equals(userInfo.id)) {
             output.hideInformationWhenViewedByOtherStudent();
         }
 

--- a/src/main/java/teammates/ui/webapi/action/GetStudentProfileAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetStudentProfileAction.java
@@ -56,6 +56,9 @@ public class GetStudentProfileAction extends Action {
             studentId = userInfo.id;
         } else {
             StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
+            if (student == null) {
+                return new JsonResult("No student found", HttpStatus.SC_NOT_FOUND);
+            }
             studentId = student.getGoogleId();
         }
 

--- a/src/main/java/teammates/ui/webapi/action/GetStudentProfilePictureAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetStudentProfilePictureAction.java
@@ -16,9 +16,6 @@ public class GetStudentProfilePictureAction extends Action {
     /** Indicates ACCESS is not given. */
     public static final String UNAUTHORIZED_ACCESS = "You are not allowed to view this resource!";
 
-    /** Indicates profile picture not found. */
-    public static final String PROFILE_PIC_NOT_FOUND = "Student has no profile picture";
-
     @Override
     protected AuthType getMinAuthLevel() {
         return AuthType.LOGGED_IN;
@@ -57,6 +54,9 @@ public class GetStudentProfilePictureAction extends Action {
             studentProfile = logic.getStudentProfile(userInfo.id);
         } else {
             StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
+            if (student == null) {
+                return new JsonResult("No student found", HttpStatus.SC_NOT_FOUND);
+            }
 
             if (!StringHelper.isEmpty(student.googleId)) {
                 studentProfile = logic.getStudentProfile(student.googleId);
@@ -64,7 +64,7 @@ public class GetStudentProfilePictureAction extends Action {
         }
 
         if (studentProfile == null || studentProfile.pictureKey.equals("")) {
-            return new JsonResult(PROFILE_PIC_NOT_FOUND, HttpStatus.SC_NOT_FOUND);
+            return new ImageResult();
         }
 
         return new ImageResult(studentProfile.pictureKey);

--- a/src/main/java/teammates/ui/webapi/action/ImageResult.java
+++ b/src/main/java/teammates/ui/webapi/action/ImageResult.java
@@ -16,6 +16,10 @@ public class ImageResult extends ActionResult {
     /** The blob key for the image. */
     public String blobKey;
 
+    public ImageResult() {
+        super(HttpStatus.SC_NO_CONTENT);
+    }
+
     public ImageResult(String blobKey) {
         super(HttpStatus.SC_OK);
         this.blobKey = blobKey;
@@ -24,7 +28,9 @@ public class ImageResult extends ActionResult {
     @Override
     public void send(HttpServletResponse resp) throws IOException {
         resp.setContentType("image/png");
-        GoogleCloudStorageHelper.serve(resp, blobKey);
+        if (blobKey != null) {
+            GoogleCloudStorageHelper.serve(resp, blobKey);
+        }
     }
 
 }

--- a/src/test/java/teammates/test/cases/webapi/GetFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetFeedbackResponseCommentActionTest.java
@@ -144,7 +144,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         assertEquals(actualComment.getFeedbackCommentText(), expected.getCommentText());
         assertEquals(actualComment.getCommentGiver(), expected.getCommentGiver());
 
-        ______TS("non-existent comment, should return 404");
+        ______TS("non-existent comment in existing response, should return 204");
 
         loginAsStudent(student1InCourse1.getGoogleId());
 
@@ -154,7 +154,16 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         };
         GetFeedbackResponseCommentAction action = getAction(submissionParams);
         JsonResult actualResult = getJsonResult(action);
-        assertEquals(HttpStatus.SC_NOT_FOUND, actualResult.getStatusCode());
+        assertEquals(HttpStatus.SC_NO_CONTENT, actualResult.getStatusCode());
+
+        ______TS("non-existent response, should return 404");
+
+        String[] nonExistentResponseSubmissionParams = new String[] {
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID, StringHelper.encrypt("randomresponseid"),
+        };
+
+        assertThrows(EntityNotFoundException.class, () -> getAction(nonExistentResponseSubmissionParams).execute());
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/GetStudentProfilePictureActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetStudentProfilePictureActionTest.java
@@ -107,13 +107,11 @@ public class GetStudentProfilePictureActionTest extends BaseActionTest<GetStuden
         };
 
         action = getAction(submissionParams);
-        JsonResult jsonResult = getJsonResult(action);
-        MessageOutput message = (MessageOutput) jsonResult.getOutput();
+        imageResult = getImageResult(action);
 
-        assertEquals(HttpStatus.SC_NOT_FOUND, jsonResult.getStatusCode());
-        assertEquals(GetStudentProfilePictureAction.PROFILE_PIC_NOT_FOUND, message.getMessage());
+        assertEquals(HttpStatus.SC_NO_CONTENT, imageResult.getStatusCode());
 
-        ______TS("Failure case: requested student has no profile picture");
+        ______TS("Success case: requested student has no profile picture");
 
         submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, student2InCourse1.getCourse(),
@@ -121,11 +119,24 @@ public class GetStudentProfilePictureActionTest extends BaseActionTest<GetStuden
         };
 
         action = getAction(submissionParams);
-        jsonResult = getJsonResult(action);
-        message = (MessageOutput) jsonResult.getOutput();
+        imageResult = getImageResult(action);
+
+        assertEquals(HttpStatus.SC_NO_CONTENT, imageResult.getStatusCode());
+
+        ______TS("Failure case: requesting image of a non-existing student");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student2InCourse1.getCourse(),
+                Const.ParamsNames.STUDENT_EMAIL, "non-existent@student.com",
+        };
+
+        action = getAction(submissionParams);
+        JsonResult jsonResult = getJsonResult(action);
+        MessageOutput message = (MessageOutput) jsonResult.getOutput();
 
         assertEquals(HttpStatus.SC_NOT_FOUND, jsonResult.getStatusCode());
-        assertEquals(GetStudentProfilePictureAction.PROFILE_PIC_NOT_FOUND, message.getMessage());
+        assertEquals("No student found", message.getMessage());
+
     }
 
     @Test

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -3,7 +3,7 @@ import { AfterViewInit, Component, Inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { PageScrollService } from 'ngx-page-scroll-core';
-import { forkJoin, Observable, of, throwError } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, finalize, switchMap, tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../../services/auth.service';
@@ -473,11 +473,11 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                 key: this.regKey,
                 moderatedperson: this.moderatedPerson,
               }).pipe(
-                  tap((comment: FeedbackResponseComment) => {
-                    recipientSubmissionFormModel.commentByGiver = this.getCommentModel(comment);
+                  tap((comment?: FeedbackResponseComment) => {
+                    if (comment) {
+                      recipientSubmissionFormModel.commentByGiver = this.getCommentModel(comment);
+                    }
                   }),
-                  // ignore 404 as comment does not exist
-                  catchError((err: any) => err.status === 404 ? of({}) : throwError(err)),
               ));
         });
     forkJoin(loadCommentRequests).subscribe(() => {

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
@@ -12,8 +12,7 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentProfileService } from '../../../services/student-profile.service';
 import { ErrorMessageOutput } from '../../error-message-output';
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { from, of, throwError } from 'rxjs';
+import { from, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { NationalitiesService } from '../../../services/nationalities.service';
 import {
@@ -116,17 +115,9 @@ export class StudentProfilePageComponent implements OnInit {
    */
   onUploadEdit(): void {
     const NO_IMAGE_UPLOADED: number = 600;
-    const NO_IMAGE_FOUND: number = 404;
 
     this.studentProfileService.getProfilePicture()
         .pipe(
-            // If no picture is found, return null
-            catchError((err: HttpErrorResponse) => {
-              if (err.status !== NO_IMAGE_FOUND) {
-                return throwError(status);
-              }
-              return of(null);
-            }),
             // Open Modal and wait for user to upload picture
             switchMap((image: Blob | null) => {
               const modalRef: NgbModalRef = this.ngbModal.open(UploadEditProfilePictureModalComponent);


### PR DESCRIPTION
Part of #10245 

- Endpoints like profile picture, student profile, and response comments return `404` when the corresponding items are not found. While not 100% wrong, it is not accurate because they may not be found because they simply are not or have not been made.
  - For those cases, the status should still be `200` with appropriate output, e.g. null profile picture (can use `204 NO CONTENT` status code here), empty student profile (_already implemented before this PR_), or empty list of comments.
  - `404`, on the other hand, will be accurate if the corresponding student (whose profile or profile picture) or feedback response (whose response comments) is not found.
- Student profile not showing shortname and personal email
  - Caused by misconfigured authentication when user is both student and instructor

**Discussion point**

Using `204` for the response comment may not be the best solution; another way is to construct a default response comment with default fields (like default, empty student profile). However, default response comment is not so straightforward to construct, as compared to default student profile.