### PR TITLE
[#10305] CollapseAnim causing elements to be cut off 

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -106,7 +106,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
     
     <div
       class="ng-trigger ng-trigger-collapseAnim"
-      style="overflow:hidden;0:overflow;"
+      style=""
     >
       <div
         class="card-body"

--- a/src/web/app/components/teammates-common/collapse-anim.ts
+++ b/src/web/app/components/teammates-common/collapse-anim.ts
@@ -1,17 +1,15 @@
-import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from '@angular/animations';
+import { animate, AnimationTriggerMetadata, style, transition, trigger } from '@angular/animations';
 
 /**
  * Directive for collapsing of *ngIf columns.
  */
 export const collapseAnim: AnimationTriggerMetadata = trigger('collapseAnim', [
-  state('*', style({ overflow: 'hidden' })),
-  state('void', style({ overflow: 'hidden' })),
   transition(':leave', [
-    style({ height: '*' }),
+    style({ height: '*', overflow: 'hidden' }),
     animate('300ms ease-in-out', style({ height: 0, opacity: 0 })),
   ]),
   transition(':enter', [
-    style({ height: '0' }),
-    animate('300ms ease-in-out', style({ height: '*', opacity: 1 })),
+    style({ height: '0', overflow: 'hidden' }),
+    animate('300ms ease-in-out', style({ height: '*', opacity: 1, overflow: 'visible' })),
   ]),
 ]);

--- a/src/web/app/components/teammates-common/collapse-anim.ts
+++ b/src/web/app/components/teammates-common/collapse-anim.ts
@@ -10,6 +10,6 @@ export const collapseAnim: AnimationTriggerMetadata = trigger('collapseAnim', [
   ]),
   transition(':enter', [
     style({ height: '0', overflow: 'hidden' }),
-    animate('300ms ease-in-out', style({ height: '*', opacity: 1, overflow: 'visible' })),
+    animate('300ms ease-in-out', style({ height: '*', opacity: 1 })),
   ]),
 ]);


### PR DESCRIPTION
Fixes #10305

**Outline of Solution**

Set overflow to be set back to visible after animation ends instead of remaining as hidden in all states
Animation remains smooth and cut off problem is solved

**Screenshot**
![datepicker-fixed](https://user-images.githubusercontent.com/31800234/87248718-a1ab1c80-c48d-11ea-8dcc-331e38f17b29.PNG)
