### PR TITLE
[#10307] Status message timeout does not reset 

### DIFF
--- a/src/web/app/components/toast/toast.component.html
+++ b/src/web/app/components/toast/toast.component.html
@@ -1,4 +1,4 @@
-<ngb-toast *ngIf="toast" [delay]="toast.delay || 5000" (hide)="removeToast()" [class]="toast.classes">
+<ngb-toast *ngIf="toast" [delay]="toast.delay || 5000" (hide)="removeToast()" [class]="toast.classes" [autohide]="toast.autohide">
   <ng-template [ngIf]="isTemplate()">
     <ng-template [ngTemplateOutlet]="toast.message"></ng-template>
   </ng-template>

--- a/src/web/app/components/toast/toast.component.ts
+++ b/src/web/app/components/toast/toast.component.ts
@@ -19,6 +19,20 @@ export class ToastComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  ngOnChanges(): void {
+    // reset autohide timing
+    this.setAutohide(false);
+    setTimeout(() => {
+      this.setAutohide(true);
+    }, 100);
+  }
+
+  setAutohide(status: boolean): void {
+    if (this.toast) {
+      this.toast.autohide = status;
+    }
+  }
+
   /**
    * Removes the toast from view.
    */

--- a/src/web/app/components/toast/toast.ts
+++ b/src/web/app/components/toast/toast.ts
@@ -7,4 +7,5 @@ export interface Toast {
   message: string | TemplateRef<any>;
   delay?: number;
   classes: string;
+  autohide: boolean;
 }

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -49,6 +49,7 @@ export class StatusMessageService {
       message,
       classes,
       delay,
+      autohide: true,
     });
   }
 
@@ -64,6 +65,7 @@ export class StatusMessageService {
       classes,
       delay,
       message: template,
+      autohide: true,
     });
   }
 


### PR DESCRIPTION
Fixes #10307

**Outline of Solution**

- Toggle the autohide status when the toast is changed to ensure timer is reset if there is already a toast present
- Timeout is needed as toggling without it does not get registered