### PR TITLE
[#10299] Fix some issues from UAT round 3

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -94,7 +94,7 @@ public class InstructorCourseEditPage extends AppPage {
         } else {
             assertEquals("(This instructor will NOT be displayed to students)", getInstructorDisplayName(instrNum));
         }
-        assertEquals(getRoleIndex(instructor.role), getInstructorAccessLevel(instrNum));
+        assertEquals(instructor.role, getInstructorRole(instrNum));
         if (instructor.role.equals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM)
                 && getEditInstructorButton(instrNum).isEnabled()) {
             verifyCustomPrivileges(instrNum, instructor.privileges);
@@ -235,7 +235,7 @@ public class InstructorCourseEditPage extends AppPage {
     }
 
     public void toggleCustomCourseLevelPrivilege(int instrNum, String privilege) {
-        if (getInstructorAccessLevel(instrNum) != INSTRUCTOR_TYPE_CUSTOM) {
+        if (!getInstructorRole(instrNum).equals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM)) {
             return;
         }
 
@@ -246,7 +246,7 @@ public class InstructorCourseEditPage extends AppPage {
 
     public void toggleCustomSectionLevelPrivilege(int instrNum, int panelNum, String section,
                                                 String privilege) {
-        if (getInstructorAccessLevel(instrNum) != INSTRUCTOR_TYPE_CUSTOM) {
+        if (!getInstructorRole(instrNum).equals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM)) {
             return;
         }
 
@@ -260,7 +260,7 @@ public class InstructorCourseEditPage extends AppPage {
 
     public void toggleCustomSessionLevelPrivilege(int instrNum, int panelNum, String section, String session,
                                                String privilege) {
-        if (getInstructorAccessLevel(instrNum) != INSTRUCTOR_TYPE_CUSTOM) {
+        if (!getInstructorRole(instrNum).equals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM)) {
             return;
         }
 
@@ -388,15 +388,9 @@ public class InstructorCourseEditPage extends AppPage {
         return browser.driver.findElement(By.id("displayed-name-instructor-" + instrNum)).getAttribute("value");
     }
 
-    public int getInstructorAccessLevel(int instrNum) {
-        List<WebElement> accessLevelCheckboxes = browser.driver.findElements(
-                By.cssSelector("#access-levels-instructor-" + instrNum + " input"));
-        for (int i = 0; i < accessLevelCheckboxes.size(); i++) {
-            if (accessLevelCheckboxes.get(i).isSelected()) {
-                return i;
-            }
-        }
-        return -1;
+    public String getInstructorRole(int instrNum) {
+        String roleAndDescription = browser.driver.findElement(By.id("role-instructor-" + instrNum)).getText();
+        return roleAndDescription.split(":")[0];
     }
 
     private WebElement getAccessLevels(int instrNum) {

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.ts
@@ -71,7 +71,11 @@ export class NumScaleQuestionEditAnswerFormComponent
       return false;
     }
 
-    return value >= minValue && value <= maxValue && (value - minValue) % increment === 0;
+    if (value < minValue || value > maxValue) {
+      return false;
+    }
+
+    return +((value - minValue) / increment).toFixed(6) % 1 === 0;
   }
 
 }

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
@@ -1,4 +1,4 @@
-<table class="table table-bordered">
+<table class="table table-bordered desktop-view">
   <tbody>
     <tr>
       <td></td>
@@ -10,9 +10,26 @@
       <td *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;" class="text-secondary answer-cell" (click)="selectAnswer(i, j)">
         <label>
           <input type="radio" [disabled]="isDisabled"
-                 [name]="id + i" [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j"/> {{ rubricDescriptionCell }}
+                 [name]="id + i + '-desktop'" [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j"/> {{ rubricDescriptionCell }}
         </label>
       </td>
     </tr>
   </tbody>
 </table>
+<div class="mobile-view">
+  <div class="card" *ngFor="let rubricDescriptionRow of questionDetails.rubricDescriptions; let i = index;">
+    <div class="card-header bg-light">
+      {{ questionDetails.rubricSubQuestions[i] }}
+    </div>
+    <div class="card-body"
+         [ngClass]="{ 'row-answered': i < responseDetails.answer.length && responseDetails.answer[i] !== RUBRIC_ANSWER_NOT_CHOSEN }">
+      <div *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;">
+        <label>
+          <input type="radio" [disabled]="isDisabled" (click)="selectAnswer(i, j)"
+                 [name]="id + i + '-mobile'" [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j">
+          {{ questionDetails.rubricChoices[j] }} - {{ rubricDescriptionCell }}
+        </label>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
@@ -5,3 +5,19 @@
 .answer-cell:hover {
   background-color: #D9EDF7 !important;
 }
+
+.mobile-view .card {
+  margin-bottom: 20px;
+}
+
+@media (max-width: 768px) {
+  .desktop-view {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .mobile-view {
+    display: none;
+  }
+}

--- a/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
@@ -94,6 +94,6 @@
     </label>
     <input type="number" class="form-control" [disabled]="!isMinSelectableChoicesEnabled || !isEditable"
            [ngModel]="displayValueForMinSelectableOption"
-           (ngModelChange)="triggerModelChange('minSelectableChoices', $event)" min="2" [max]="maxMinSelectableValue">
+           (ngModelChange)="triggerModelChange('minSelectableChoices', $event)" min="1" [max]="maxMinSelectableValue">
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
@@ -56,7 +56,7 @@
             <select id="time-zone" class="form-control" ngbTooltip="The time zone for the course. You should not need to change this as it is auto-detected based on your
               device settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time."
               [(ngModel)]="course.timeZone" #timeZone="ngModel" [disabled]="!isEditingCourse" required name="timeZone">
-              <option *ngFor="let timezone of timezones" [value]="timezone">{{ timezone }}</option>
+              <option *ngFor="let timezone of timezones" [value]="timezone.id">{{ timezone.id }} ({{ timezone.offset }})</option>
             </select>
             <span class="input-group-btn">
               <button class="btn btn-primary" type=button [disabled]="!isEditingCourse" (click)="detectTimezone()">

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -58,6 +58,18 @@ interface InstructorEditPanelDetail {
   editPanel: InstructorEditPanel;
 }
 
+interface Timezone {
+  id: string;
+  offset: string;
+}
+
+const formatTwoDigits: Function = (n: number): string => {
+  if (n < 10) {
+    return `0${n}`;
+  }
+  return String(n);
+};
+
 /**
  * Instructor course edit page.
  */
@@ -77,7 +89,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
   Sections: typeof Sections = Sections;
 
   courseId: string = '';
-  timezones: string[] = [];
+  timezones: Timezone[] = [];
   isEditingCourse: boolean = false;
   course: Course = {
     courseName: '',
@@ -175,7 +187,15 @@ export class InstructorCourseEditPageComponent implements OnInit {
       });
     });
 
-    this.timezones = Object.keys(this.timezoneService.getTzOffsets());
+    for (const [id, offset] of Object.entries(this.timezoneService.getTzOffsets())) {
+      const hourOffset: number = Math.floor(Math.abs(offset) / 60);
+      const minOffset: number = Math.abs(offset) % 60;
+      const sign: string = offset < 0 ? '-' : '+';
+      this.timezones.push({
+        id,
+        offset: offset === 0 ? 'UTC' : `UTC ${sign}${formatTwoDigits(hourOffset)}:${formatTwoDigits(minOffset)}`,
+      });
+    }
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
@@ -88,14 +88,21 @@
         Access Level:
       </label>
       <div id="access-levels-instructor-{{ instructorIndex + 1 }}" class="col-sm-9">
-        <div *ngFor="let role of InstructorPermissionRole | enumToArray" class="form-row">
-          <label>
-            <input id="{{role + instructorIndex + 1}}" type="radio" [checked]="role == instructor.role" (click)="triggerModelChange('role', role)" [disabled]="!instructor.isEditing">
-            {{ role | instructorRoleDescription }}
-            <button *ngIf="role != InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
-                    (click)="viewRolePrivilegeModel.emit(role); $event.stopPropagation();" type="button" class="btn btn-link padding-0">View Details</button>
-          </label>
-        </div>
+        <ng-container *ngIf="instructor.isEditing">
+          <div *ngFor="let role of InstructorPermissionRole | enumToArray" class="form-row">
+            <label>
+              <input id="{{role + instructorIndex + 1}}" type="radio" [checked]="role == instructor.role" (click)="triggerModelChange('role', role)" [disabled]="!instructor.isEditing">
+              {{ role | instructorRoleDescription }}
+              <button *ngIf="role != InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
+                      (click)="viewRolePrivilegeModel.emit(role); $event.stopPropagation();" type="button" class="btn btn-link padding-0">View Details</button>
+            </label>
+          </div>
+        </ng-container>
+        <ng-container *ngIf="!instructor.isEditing">
+          <span id="role-instructor-{{ instructorIndex + 1 }}">{{ instructor.role | instructorRoleDescription }}</span>
+          <button *ngIf="instructor.role != InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
+                  (click)="viewRolePrivilegeModel.emit(instructor.role); $event.stopPropagation();" type="button" class="btn btn-link padding-0">View Details</button>
+        </ng-container>
       </div>
     </div>
 

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -59,10 +59,10 @@ export class InstructorSearchPageComponent implements OnInit {
     forkJoin([
       this.searchParams.isSearchForComments
           ? this.searchService.searchComment(this.searchParams.searchKey)
-          : of() as Observable<InstructorSearchResult>,
+          : of({}) as Observable<InstructorSearchResult>,
       this.searchParams.isSearchForStudents
           ? this.searchService.searchInstructor(this.searchParams.searchKey)
-          : of() as Observable<InstructorSearchResult>,
+          : of({}) as Observable<InstructorSearchResult>,
     ]).pipe(
         finalize(() => this.loadingBarService.hideLoadingBar()),
     ).subscribe((resp: InstructorSearchResult[]) => {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -80,7 +80,7 @@ export class SessionResultPageComponent implements OnInit {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
-                this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/submission',
+                this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/result',
                     { courseid: this.courseId, fsname: this.feedbackSessionName });
               } else {
                 // There is no logged in user for valid, unused registration key; load information based on the key

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -77,7 +77,7 @@
 <tm-question-submission-form *ngFor="let questionSubmissionForm of questionSubmissionForms; let i = index; trackBy: trackQuestionSubmissionFormByFn"
                              [attr.id]="questionSubmissionForm.feedbackQuestionId"
                              [(formModel)]="questionSubmissionForms[i]" [formMode]="getQuestionSubmissionFormMode(questionSubmissionForm)"
-                             [isDisabled]="isSubmissionFormsDisabled"
+                             [isDisabled]="isSubmissionFormsDisabled && !this.previewAsPerson"
                              (deleteCommentEvent)="deleteParticipantComment(i, $event)"
                              (saveCommentEvent)="updateParticipantComment(i, $event)"
 ></tm-question-submission-form>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -158,7 +158,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
-                this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/result',
+                this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/submission',
                     { courseid: this.courseId, fsname: this.feedbackSessionName });
               } else {
                 // There is no logged in user for valid, unused registration key; load information based on the key


### PR DESCRIPTION
Part of #10299, fixes #10302, fixes #10303 

<img width="635" alt="Screen Shot 2020-07-13 at 10 09 53 PM" src="https://user-images.githubusercontent.com/7261051/87327357-8f50e180-c566-11ea-95a2-941ce435686a.png">

- Rubric question submission: V6 has different interface in mobile view

<img width="1044" alt="Screen Shot 2020-07-13 at 10 11 11 PM" src="https://user-images.githubusercontent.com/7261051/87327368-924bd200-c566-11ea-81bd-b6fccb428918.png">

- Instructor course edit: V6 has timezone offset information in the dropdown (
- Instructor course edit: for instructor access level, unless in "edit" mode, just show the existing access level name (i.e. no need to display all other access levels)
- Instructor search: Not working if not both "students" and "questions, responses, comments on responses" are selected.
- MSQ question: minimum selectable choice should be 1 instead of 2.
- Preview submission form as student shows the form in readonly mode. It shouldn’t be like that. Only the submission button should be disabled.