### PR TITLE
[#10042] Improve UI for Mobile Compatibility 

### DIFF
--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
@@ -24,7 +24,7 @@
 <p *ngIf="isVisibilityOptionEnabled">You may change comment's visibility using the visibility options on the right hand side.</p>
 
 <div *ngIf="isVisibilityTableExpanded" @collapseAnim>
-  <table class="table margin-bottom-0 background-color-white table-striped">
+  <table class="table margin-bottom-0 background-color-white table-striped table-responsive-md">
     <thead>
     <tr>
       <th scope="col" class="text-center">User/Group</th>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -284,12 +284,12 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             style=""
           >
             <div
-              class="offset-1 col-4 text-right"
+              class="offset-1 col-md-4 text-md-right"
             >
                The maximum number of students each respondent should give feedback to: 
             </div>
             <div
-              class="col-2"
+              class="col-md-2"
             >
               <div
                 class="input-group"
@@ -316,7 +316,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
               </div>
             </div>
             <div
-              class="col-2"
+              class="col-md-2"
             >
               <div
                 class="form-check"

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -164,10 +164,10 @@
         </div>
         <div class="row margin-top-15px align-items-center"
              *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS || model.recipientType === FeedbackParticipantType.TEAMS || model.recipientType === FeedbackParticipantType.INSTRUCTORS">
-          <div class="offset-1 col-4 text-right">
+          <div class="offset-1 col-md-4 text-md-right">
             The maximum number of {{ model.recipientType | lowercase }} each respondent should give feedback to:
           </div>
-          <div class="col-2">
+          <div class="col-md-2">
             <div class="input-group">
               <div class="input-group-prepend">
                 <div class="input-group-text">
@@ -180,7 +180,7 @@
               <input type="number" min="1" class="form-control" [ngModel]="model.customNumberOfEntitiesToGiveFeedbackTo" (ngModelChange)="triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)" [disabled]="model.numberOfEntitiesToGiveFeedbackToSetting != NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM || !model.isEditable">
             </div>
           </div>
-          <div class="col-2">
+          <div class="col-md-2">
             <div class="form-check">
               <label class="form-check-label">
                 <input class="form-check-input" type="radio" [name]="model.feedbackQuestionId + 'numOfRecipients'"

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -83,7 +83,7 @@
             </div>
           </div>
           <div *ngIf="question.isTabExpanded" @collapseAnim>
-            <div class="card-body top-padded-small">
+            <div class="card-body top-padded-small table-responsive">
               <tm-single-statistics [responses]="question.questionOutput.allResponses"
                                     [question]="question.questionOutput.feedbackQuestion.questionDetails"
                                     [statistics]="question.questionOutput.questionStatistics"

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -56,7 +56,7 @@
         <td>
           <tm-response-moderation-button *ngIf="response.relatedGiverEmail" [session]="session" [relatedGiverEmail]="response.relatedGiverEmail"
                                          [moderatedQuestionId]="question.feedbackQuestionId" [isGiverInstructor]="question.giverType === 'INSTRUCTORS'"></tm-response-moderation-button>
-          <button class="btn btn-light btn-sm" style="margin-left: 5px; margin-top: 5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
+          <button class="btn btn-light btn-sm" style="margin-left: 5px; border: 1px solid #CCC;" [disabled]="isDisplayOnly"
                   *ngIf="!response.isMissingResponse && question.questionType !== 'CONTRIB'"
                   (click)="showCommentTableModel(response, commentTableModal)">Add Comment <span class="badge badge-secondary">
             {{this.instructorCommentTableModel[response.responseId].commentRows.length}}</span>

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -10,18 +10,22 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex"
+    class="d-inline-flex row no-gutters"
   >
     
     
     <span
-      class="mr-1"
+      class="col-auto"
     >
       <b>
         Question 0:
       </b>
     </span>
-     Text question details 
+    <span
+      class="col-auto"
+    >
+      Text question details
+    </span>
     
   </span>
 </tm-question-text-with-info>
@@ -37,18 +41,22 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex"
+    class="d-inline-flex row no-gutters"
   >
     
     
     <span
-      class="mr-1"
+      class="col-auto"
     >
       <b>
         Question 0:
       </b>
     </span>
-     MCQ question details 
+    <span
+      class="col-auto"
+    >
+      MCQ question details
+    </span>
     
     <a
       class="info-font-size ml-1"
@@ -71,18 +79,22 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex"
+    class="d-inline-flex row no-gutters"
   >
     
     
     <span
-      class="mr-1"
+      class="col-auto"
     >
       <b>
         Question 0:
       </b>
     </span>
-     MCQ question details 
+    <span
+      class="col-auto"
+    >
+      MCQ question details
+    </span>
     
     <a
       class="info-font-size ml-1"

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,14 +1,13 @@
-<span class="d-inline-flex">
-  <span *ngIf="shouldShowDownloadQuestionResult">
+<span class="d-inline-flex row no-gutters">
+  <span *ngIf="shouldShowDownloadQuestionResult" class="col-auto">
     <button ngbTooltip="Download Question Results" openDelay="500" type="button" class="btn btn-link text-white padding-0 mr-1" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
       <b>Question {{ questionNumber }}:</b>
     </button>
   </span>
-  <span *ngIf="!shouldShowDownloadQuestionResult" class="mr-1">
+  <span *ngIf="!shouldShowDownloadQuestionResult" class="col-auto">
     <b>Question {{ questionNumber }}:</b>
   </span>
-
-  {{ questionDetails.questionText }}
+  <span class="col-auto">{{ questionDetails.questionText }}</span>
   <a class="info-font-size ml-1" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [routerLink]="" queryParamsHandling="merge">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
   </a>

--- a/src/web/app/components/question-types/question-edit-details-form/contribution-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/contribution-question-edit-details-form.component.html
@@ -1,6 +1,6 @@
 <div class="row">
   <br>
-  <div class="col-6">
+  <div class="col-12">
     <div class="form-check form-check-inline">
       <label class="form-check-label" ngbTooltip="Ticking this allows a giver to select 'Not Sure' as his/her answer" container="body">
         <input class="form-check-input" type="checkbox" [ngModel]="model.isNotSureAllowed" (ngModelChange)="triggerModelChange('isNotSureAllowed', $event)" [disabled]="!isEditable">

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.scss
@@ -16,8 +16,10 @@
   border: 1px solid #CED4DA;
 }
 
-.padding-left-300px {
-  padding-left: 300px;
+@media (min-width: 576px) {
+  .padding-left-300px {
+    padding-left: 300px;
+  }
 }
 
 .margin-top-22px {

--- a/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.scss
@@ -16,8 +16,10 @@
   border: 1px solid #CED4DA;
 }
 
-.padding-left-300px {
-  padding-left: 300px;
+@media (min-width: 576px) {
+  .padding-left-300px {
+    padding-left: 300px;
+  }
 }
 
 .margin-top-22px {

--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-sm-12">
+    <div class="col-sm-12 table-responsive">
       <tm-sortable-table [rows]="rowsData" [columns]="columnsData"></tm-sortable-table>
     </div>
   </div>

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
@@ -6,10 +6,10 @@
       <div class="card bg-light top-padded">
         <div class="card-header bg-secondary recycle-bin-header" (click)="recycleBinExpandEvent.emit()">
           <div class="row align-items-center">
-            <div class="col-6 text-white">
+            <div class="col-4 text-white">
               <b>Recycle Bin</b>
             </div>
-            <div class="col-6 text-right bin-header-button">
+            <div class="col-8 text-right bin-header-button">
               <button type="button" class="btn btn-light btn-sm" ngbTooltip="Restore all feedback sessions"
                       (click)="$event.stopPropagation(); restoreAllRecycleBinFeedbackSessionEvent.emit()"><i class="fas fa-check"></i> Restore All</button>
               <button type="button" class="btn btn-light btn-sm text-danger" ngbTooltip="Permanently delete all feedback sessions"

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
@@ -81,14 +81,14 @@
   <div class="card bg-light border-info top-margin" *ngFor="let sectionLevel of permission.sectionLevel; let i = index">
     <div class="card-header bg-info text-white">
       <div class="row">
-        <div class="col-sm-2">
+        <div class="col col-sm-2">
           <p>
             <strong>
               But in section(s)
             </strong>
           </p>
         </div>
-        <div class="col-sm-9">
+        <div class="col-6 col-sm-9">
           <div id="custom-sections" class="row">
             <div *ngFor="let section of this.allSections" class="col">
               <label>
@@ -100,7 +100,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-1">
+        <div class="col col-sm-1">
           <button id="btn-custom-sections-cancel" type="button" class="btn btn-danger" (click)="removeSectionLevelPermission(i)"><i class="fa fa-trash" aria-hidden="true"></i></button>
         </div>
       </div>
@@ -149,7 +149,7 @@
       <button *ngIf="sectionLevel.sessionLevel.length != 0"
               class="btn btn-link" (click)="deleteSessionLevelPermission(i)">Delete session-level permissions</button>
 
-      <table id="custom-sessions" class="table table-striped" *ngIf="sectionLevel.sessionLevel.length != 0">
+      <table id="custom-sessions" class="table table-striped table-responsive" *ngIf="sectionLevel.sessionLevel.length != 0">
         <thead>
         <tr>
           <th scope="col">Session Name</th>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
@@ -1,10 +1,10 @@
-<div class="card bg-light top-padded">
-  <div class="card-header bg-primary text-white text-center">
+<div class="card bg-light top-padded text-center">
+  <div class="card-header bg-primary text-white">
     <div class="row">
-      <div class="col-md-6 text-md-left align-self-center">
+      <div class="col-3 col-md-6 text-md-left align-self-center">
         <strong>Course</strong>
       </div>
-      <div class="col-md-6 text-md-right">
+      <div class="col-9 col-md-6 text-right">
         <button id="btn-edit-course" class="btn btn-light btn-sm btn-course" ngbTooltip="Edit course name" placement="top-right"
                 [disabled]="!currInstructorCoursePrivilege.canModifyCourse"
                 *ngIf="!isEditingCourse" (click)="this.isEditingCourse = true">

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.html
@@ -1,10 +1,10 @@
 <div class="card bg-light top-padded">
   <div class="card-header bg-primary text-white text-center">
     <div class="row">
-      <div class="col-md-6 text-left align-self-center">
+      <div class="col-4 col-md-6 text-left align-self-center">
         <strong>Instructor {{ instructorIndex + 1 }}</strong>
       </div>
-      <div class="col-md-6 text-right">
+      <div class="col-8 col-md-6 text-right">
         <button id="btn-resend-invite-{{ instructorIndex + 1 }}" class="btn btn-light btn-sm" ngbTooltip="Send invitation email to the instructor" placement="top-right"
                 *ngIf="instructor.joinState == JoinState.NOT_JOINED && editMode == EditMode.EDIT"
                 [disabled]="!currInstructorCoursePrivilege.canModifyInstructor"
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <div class="card-body" [ngClass]="{'fill-plain': editMode == EditMode.ADD}">
+  <div class="card-body text-center" [ngClass]="{'fill-plain': editMode == EditMode.ADD}">
     <div class="form-row form-group" *ngIf="editMode == EditMode.EDIT && currInstructorCoursePrivilege.canModifyInstructor">
       <label class="col-sm-3 control-label">
         Google ID:
@@ -83,8 +83,8 @@
                [ngModel]="instructor.isDisplayedToStudents ? instructor.displayedToStudentsAs : '(This instructor will NOT be displayed to students)'">
       </div>
     </div>
-    <div class="form-row form-group align-items-start">
-      <label class="col-sm-3 control-label">
+    <div class="form-row form-group align-items-start text-left">
+      <label class="col-sm-3 control-label text-center text-md-right">
         Access Level:
       </label>
       <div id="access-levels-instructor-{{ instructorIndex + 1 }}" class="col-sm-9">
@@ -106,11 +106,11 @@
       </div>
     </div>
 
-    <tm-custom-privilege-setting-panel id="custom-access-instructor-{{ instructorIndex + 1 }}" *ngIf="instructor.isEditing && instructor.role == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
+    <tm-custom-privilege-setting-panel class="text-left" id="custom-access-instructor-{{ instructorIndex + 1 }}" *ngIf="instructor.isEditing && instructor.role == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM"
                                        [permission]="this.instructor.permission" (permissionChange)="triggerModelChange('permission', $event)"
                                        [allSections]="this.allSections" [allSessions]="this.allSessions"></tm-custom-privilege-setting-panel>
 
-    <div class="text-center" *ngIf="instructor.isEditing">
+    <div *ngIf="instructor.isEditing">
       <button id="btn-save-instructor-{{ instructorIndex + 1 }}" class="btn btn-primary" tabindex="6" type="button" (click)="saveInstructor.emit()">
         <span *ngIf="editMode == EditMode.EDIT">Save changes</span>
         <span *ngIf="editMode == EditMode.ADD">Add Instructor</span>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -270,7 +270,7 @@
        EnrollStatus.NEW || enrollResultPanel.status === EnrollStatus.MODIFIED_UNCHANGED ? 'white' : 'black' ">
         {{ enrollResultPanel.messageForEnrollmentStatus }}
       </div>
-      <table class="table table-striped table-bordered">
+      <table class="table table-striped table-bordered table-responsive">
         <thead>
           <tr>
             <th>Section</th>

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
       class="card border-primary"
     >
       <div
-        class="card-body fill-plain"
+        class="card-body fill-plain text-center text-sm-left"
       >
         <form
           class="form form-horizontal ng-untouched ng-pristine ng-valid"
@@ -48,12 +48,12 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-sm-1"
+              class="col-form-label col-auto"
             >
               Student Name:
             </label>
             <div
-              class="col-sm-11"
+              class="col-sm-10"
             >
               <input
                 class="form-control ng-untouched ng-pristine ng-valid"
@@ -67,12 +67,12 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-sm-1"
+              class="col-auto col-form-label"
             >
               Section Name:
             </label>
             <div
-              class="col-sm-11"
+              class="col-sm-10"
             >
               <input
                 class="form-control ng-untouched ng-pristine ng-valid"
@@ -86,14 +86,12 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-sm-1"
+              class="col-auto col-form-label"
             >
-              Team
-              <br />
-              Name:
+              Team Name:
             </label>
             <div
-              class="col-sm-11"
+              class="col-sm-10"
             >
               <input
                 class="form-control col-form-label ng-untouched ng-pristine ng-valid"
@@ -108,12 +106,12 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-sm-1"
+              class="col-auto col-form-label"
             >
               E-mail Address:
             </label>
             <div
-              class="col-sm-11"
+              class="col-sm-10"
             >
               <input
                 class="form-control ng-untouched ng-pristine ng-valid"
@@ -127,12 +125,12 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-sm-1"
+              class="col-auto col-form-label"
             >
               Comments:
             </label>
             <div
-              class="col-sm-11"
+              class="col-sm-10"
             >
               <textarea
                 class="form-control ng-untouched ng-pristine ng-valid"

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.html
@@ -1,13 +1,13 @@
 <div *ngIf="student">
   <div class="card border-primary">
-    <div class="card-body fill-plain">
+    <div class="card-body fill-plain text-center text-sm-left">
       <form
         id="instructor-student-edit-form"
         class="form form-horizontal"
         (ngSubmit)="onSubmit(confirmDelModal, resendPastLinksModal)" [formGroup]="editForm">
         <div class="form-row">
-          <label class="col-sm-1">Student Name:</label>
-          <div class="col-sm-11">
+          <label class="col-form-label col-auto">Student Name:</label>
+          <div class="col-sm-10">
             <input
               class="form-control"
               id="studentname"
@@ -27,8 +27,8 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-sm-1">Section Name:</label>
-          <div class="col-sm-11">
+          <label class="col-auto col-form-label">Section Name:</label>
+          <div class="col-sm-10">
             <input
               class="form-control"
               id="sectionname"
@@ -48,8 +48,8 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-sm-1">Team<br>Name:</label>
-          <div class="col-sm-11">
+          <label class="col-auto col-form-label">Team Name:</label>
+          <div class="col-sm-10">
             <input
               class="form-control col-form-label"
               name="teamname"
@@ -70,8 +70,8 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-sm-1">E-mail Address:</label>
-          <div class="col-sm-11">
+          <label class="col-auto col-form-label">E-mail Address:</label>
+          <div class="col-sm-10">
             <input
               class="form-control"
               id="newstudentemail"
@@ -91,8 +91,8 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-sm-1">Comments:</label>
-          <div class="col-sm-11">
+          <label class="col-auto col-form-label">Comments:</label>
+          <div class="col-sm-10">
             <textarea
               class="form-control"
               rows="6"

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -402,14 +402,14 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
             class="row align-items-center"
           >
             <div
-              class="col-6 text-white"
+              class="col-4 text-white"
             >
               <b>
                 Recycle Bin
               </b>
             </div>
             <div
-              class="col-6 text-right bin-header-button"
+              class="col-8 text-right bin-header-button"
             >
               
               
@@ -848,14 +848,14 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
             class="row align-items-center"
           >
             <div
-              class="col-6 text-white"
+              class="col-4 text-white"
             >
               <b>
                 Recycle Bin
               </b>
             </div>
             <div
-              class="col-6 text-right bin-header-button"
+              class="col-8 text-right bin-header-button"
             >
               
               <button

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -210,10 +210,10 @@
     <div class="card bg-light top-padded">
       <div id="deleted-table-heading" class="card-header recycle-bin-header" (click)="isRecycleBinExpanded = !isRecycleBinExpanded">
         <div class="row align-items-center">
-          <div class="col-6 text-white">
+          <div class="col-4 text-white">
             <b>Recycle Bin</b>
           </div>
-          <div class="col-6 text-right bin-header-button">
+          <div class="col-8 text-right bin-header-button">
             <button id="btn-restore-all" class="btn btn-light btn-sm" *ngIf="canRestoreAll" (click)="$event.stopPropagation(); onRestoreAll()"
                     ngbTooltip="Restore all deleted courses and their corresponding students and sessions">
               <i class="fas fa-check"></i> Restore All

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -49,16 +49,16 @@
 <div class="card">
   <div class="card-body background-color-light-blue text-center">
     <div class="row align-items-center">
-      <div class="col-2 text-right">
+      <div class="col-lg-2 text-lg-right">
         <b>Preview Session:</b>
       </div>
-      <div class="col-5" ngbTooltip="View how this session would look like to a student who is submitting feedback. Preview is unavailable if the course has yet to have any student enrolled.">
+      <div class="col-lg-5" ngbTooltip="View how this session would look like to a student who is submitting feedback. Preview is unavailable if the course has yet to have any student enrolled.">
         <select class="form-control preview-select" [(ngModel)]="emailOfStudentToPreview">
           <option *ngFor="let student of studentsOfCourse" [ngValue]="student.email">[{{ student.teamName }}] {{ student.name }}</option>
         </select>
         <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0" (click)="previewAsStudent()">Preview as Student</button>
       </div>
-      <div class="col-5" ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
+      <div class="col-lg-5" ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
         <select class="form-control preview-select" [(ngModel)]="emailOfInstructorToPreview">
           <option *ngFor="let instructor of instructorsCanBePreviewedAs" [ngValue]="instructor.email">{{ instructor.name }}</option>
         </select>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -2,7 +2,7 @@
   Feedback Session Results
 </h1>
 
-<div class="card bg-light top-padded" *ngIf="session">
+<div class="card bg-light top-padded text-center text-sm-left" *ngIf="session">
   <div class="card-body row info-card-padding">
     <div class="col-sm-12 col-md-12 col-lg-4">
       <div class="form-group row">
@@ -49,7 +49,7 @@
   </div>
 </div>
 
-<div class="card bg-light top-padded" *ngIf="session">
+<div class="card bg-light top-padded text-center text-sm-left" *ngIf="session">
   <div class="card-body row">
     <div class="col-md-6">
       <div ngbTooltip="View results in different formats">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -1,7 +1,7 @@
 <div class="card margin-bottom-15px" *ngFor="let question of questionsOrder">
   <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(question.question.feedbackQuestionId)">
     <div class="row">
-      <tm-question-text-with-info class="col-md-11"
+      <tm-question-text-with-info class="col-11"
         [questionNumber]="question.question.questionNumber"
         [questionDetails]="question.question.questionDetails"
         [shouldShowDownloadQuestionResult]="true"
@@ -9,7 +9,7 @@
         questionNumber: question.question.questionNumber,
         questionId: question.question.feedbackQuestionId})"
       ></tm-question-text-with-info>
-      <div class="text-md-right col-md-1">
+      <div class="text-md-right col-1">
         <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
         <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
       </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -12,13 +12,13 @@
       <div class="card-header justify-content-between course-card-header cursor-pointer"
         (click)="toggleCard(courseTab)">
         <div class="row course-card-content">
-          <div class="col-sm-11">
+          <div class="col-11">
             <div class="course-card-header-text">
               <i class="fas fa-chalkboard-teacher"
                 style="color: white;"></i>&nbsp;[{{courseTab.course.courseId}}]: {{courseTab.course.courseName}}
             </div>
           </div>
-          <div class="col-sm-1">
+          <div class="col-1">
             <button *ngIf="!courseTab.hasTabExpanded"
               class="btn float-right"><i class="fas fa-chevron-circle-down fa-lg"
               style="color: white;"></i></button>
@@ -31,7 +31,7 @@
       <div *ngIf="courseTab.hasTabExpanded" @collapseAnim>
         <div class="card-body">
           <ng-container *ngIf="courseTab.stats.numOfStudents > 0, else noStudentsTemplate">
-            <div class="card-deck" *ngIf="courseTab.stats">
+            <div class="card-deck text-center text-sm-left" *ngIf="courseTab.stats">
               <div class="card">
                 <div class="card-body">
                   <h3 class="card-title">{{courseTab.stats.numOfStudents}}</h3>

--- a/src/web/app/pages-instructor/student-profile/course-related-info/course-related-info.component.html
+++ b/src/web/app/pages-instructor/student-profile/course-related-info/course-related-info.component.html
@@ -1,50 +1,50 @@
 <div class="card border-primary">
   <div class="card-body fill-plain">
-    <div class="form form-horizontal">
+    <div class="form form-horizontal text-center">
       <div class="form-group">
-        <div class="col-sm-12">
+        <div class="col-sm-12 text-md-left">
           <h4 class="font-weight-bold">Enrollment Details</h4>
         </div>
       </div>
       <div class="form-group student-info-row row">
-        <div class="col-4 text-right">
+        <div class="col-md-4 text-md-right">
           <label>Course</label>
         </div>
-        <div class="col-8">
+        <div class="col-md-8 text-md-left">
           <a routerLink="/web/instructor/courses/details" [queryParams]="{courseid: student?.courseId}">
             <span>{{student?.courseId}}</span>
           </a>
         </div>
       </div>
       <div class="form-group student-info-row row" *ngIf="student?.sectionName">
-        <div class="col-4 text-right">
+        <div class="col-md-4 text-md-right">
           <label>Section Name</label>
         </div>
-        <div class="col-8">
+        <div class="col-md-8 text-md-left">
           <span>{{student?.sectionName}}</span>
         </div>
       </div>
       <div class="form-group student-info-row row">
-        <div class="col-4 text-right">
+        <div class="col-md-4 text-md-right">
           <label>Team Name</label>
         </div>
-        <div class="col-8">
+        <div class="col-md-8 text-md-left">
           <span>{{student?.teamName}}</span>
         </div>
       </div>
       <div class="form-group student-info-row row">
-        <div class="col-4 text-right">
+        <div class="col-md-4 text-md-right">
           <label>Official Email</label>
         </div>
-        <div class="col-8">
+        <div class="col-md-8 text-md-left">
           <span>{{student?.email}}</span>
         </div>
       </div>
       <div class="form-group student-info-row row">
-        <div class="col-4 text-right">
+        <div class="col-md-4 text-md-right">
           <label>Comments</label>
         </div>
-        <div class="col-8">
+        <div class="col-md-8 text-md-left">
           <span>{{student?.comments}}</span>
         </div>
       </div>

--- a/src/web/app/pages-instructor/student-profile/student-profile.component.html
+++ b/src/web/app/pages-instructor/student-profile/student-profile.component.html
@@ -3,10 +3,10 @@
   <div class="row">
     <div class="col-12">
       <div class="row">
-        <div class="col-md-2 col-3">
+        <div class="col-md-2 col-4">
           <img src="{{this.photoUrl}}" class="profile-pic float-right" (error)="setDefaultPic()">
         </div>
-        <div class="col-md-10 col-sm-9 col-8">
+        <div class="col-md-10 col-8">
           <table class="table table-striped">
             <thead>
               <tr>

--- a/src/web/app/pages-student/student-profile-page/__snapshots__/student-profile-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-profile-page/__snapshots__/student-profile-page.component.spec.ts.snap
@@ -14,7 +14,9 @@ exports[`StudentProfilePageComponent should snap with a student field without in
   student={[Function Object]}
   studentProfileService={[Function StudentProfileService]}
 >
-  <div>
+  <div
+    class="text-center text-sm-left"
+  >
     <h1>
       Student Profile
     </h1>
@@ -31,7 +33,7 @@ exports[`StudentProfilePageComponent should snap with a student field without in
           class="row profile-pic-row"
         >
           <div
-            class="col-3 cursor-pointer"
+            class="col cursor-pointer"
           >
             <img
               class="profile-pic"
@@ -246,7 +248,9 @@ exports[`StudentProfilePageComponent should snap with values and a profile photo
   student={[Function Object]}
   studentProfileService={[Function StudentProfileService]}
 >
-  <div>
+  <div
+    class="text-center text-sm-left"
+  >
     <h1>
       Student Profile
     </h1>
@@ -263,7 +267,7 @@ exports[`StudentProfilePageComponent should snap with values and a profile photo
           class="row profile-pic-row"
         >
           <div
-            class="col-3 cursor-pointer"
+            class="col cursor-pointer"
           >
             <img
               class="profile-pic"

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.html
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.html
@@ -1,10 +1,10 @@
-<div *ngIf="student">
+<div *ngIf="student" class="text-center text-sm-left">
   <h1>Student Profile</h1>
   <div class="card">
     <div class="card-body fill-plain">
       <h1>{{ name }}</h1>
       <div class="row profile-pic-row">
-        <div class="col-3 cursor-pointer">
+        <div class="col cursor-pointer">
           <img
               src="{{ profilePicLink }}"
               class="profile-pic"


### PR DESCRIPTION
Fixes #10042 

Went through the app in mobile view as a whole one more time and did minor fixes to the mobile UI. 99% of pages are mobile optimized now

**Outline of Solution**
- Table responsive in mobile view
- Make question text with info more mobile friendly
![table responsive](https://user-images.githubusercontent.com/28994607/87776537-8576f900-c85a-11ea-8485-4c0b31d282d0.gif)

- Make headers show buttons/text in one row in mobile
![deleted](https://user-images.githubusercontent.com/28994607/87776516-7abc6400-c85a-11ea-9375-42514a4ddfba.PNG)

- Make most labels centralised in mobile view. Some examples
![student list](https://user-images.githubusercontent.com/28994607/87776757-d71f8380-c85a-11ea-9f40-b33b36652f85.gif)
![student profile](https://user-images.githubusercontent.com/28994607/87776758-d850b080-c85a-11ea-944e-d110e6ca15b2.gif)
![preview](https://user-images.githubusercontent.com/28994607/87776875-0e8e3000-c85b-11ea-8185-eed5ae17c617.PNG)

