### PR TITLE
[#10337] Fix instructor edit student details: form fields are not aligned

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
       class="card border-primary"
     >
       <div
-        class="card-body fill-plain text-center text-sm-left"
+        class="card-body fill-plain text-sm-left"
       >
         <form
           class="form form-horizontal ng-untouched ng-pristine ng-valid"
@@ -48,7 +48,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-form-label col-auto"
+              class="col-sm-2 col-form-label"
             >
               Student Name:
             </label>
@@ -67,7 +67,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-auto col-form-label"
+              class="col-sm-2 col-form-label"
             >
               Section Name:
             </label>
@@ -86,7 +86,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-auto col-form-label"
+              class="col-sm-2 col-form-label"
             >
               Team Name:
             </label>
@@ -106,7 +106,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-auto col-form-label"
+              class="col-sm-2 col-form-label"
             >
               E-mail Address:
             </label>
@@ -125,7 +125,7 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
             class="form-row"
           >
             <label
-              class="col-auto col-form-label"
+              class="col-sm-2 col-form-label"
             >
               Comments:
             </label>

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.html
@@ -1,12 +1,12 @@
 <div *ngIf="student">
   <div class="card border-primary">
-    <div class="card-body fill-plain text-center text-sm-left">
+    <div class="card-body fill-plain text-sm-left">
       <form
         id="instructor-student-edit-form"
         class="form form-horizontal"
         (ngSubmit)="onSubmit(confirmDelModal, resendPastLinksModal)" [formGroup]="editForm">
         <div class="form-row">
-          <label class="col-form-label col-auto">Student Name:</label>
+          <label class="col-sm-2 col-form-label">Student Name:</label>
           <div class="col-sm-10">
             <input
               class="form-control"
@@ -27,7 +27,7 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-auto col-form-label">Section Name:</label>
+          <label class="col-sm-2 col-form-label">Section Name:</label>
           <div class="col-sm-10">
             <input
               class="form-control"
@@ -48,7 +48,7 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-auto col-form-label">Team Name:</label>
+          <label class="col-sm-2 col-form-label">Team Name:</label>
           <div class="col-sm-10">
             <input
               class="form-control col-form-label"
@@ -70,7 +70,7 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-auto col-form-label">E-mail Address:</label>
+          <label class="col-sm-2 col-form-label">E-mail Address:</label>
           <div class="col-sm-10">
             <input
               class="form-control"
@@ -91,7 +91,7 @@
           </div>
         </div>
         <div class="form-row">
-          <label class="col-auto col-form-label">Comments:</label>
+          <label class="col-sm-2 col-form-label">Comments:</label>
           <div class="col-sm-10">
             <textarea
               class="form-control"


### PR DESCRIPTION
Fixes #10337

**Outline of Solution**

Regression introduced by #10042. Using `col-auto` does not enforce equal width across multiple rows. Changed to `col-sm-2`.

Desktop:
![image](https://user-images.githubusercontent.com/5328196/87895033-fd216f80-ca76-11ea-9793-b54db11c0504.png)

Mobile:
![image](https://user-images.githubusercontent.com/5328196/87895075-14605d00-ca77-11ea-92f6-c91d3acb2cbb.png)



