### PR TITLE
[#10340] Add loading indicators to instructor course details page

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -8,7 +8,10 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
   instructorService={[Function InstructorService]}
   instructors={[Function Array]}
   isAjaxSuccess={[Function Boolean]}
-  loading={[Function Boolean]}
+  isCourseLoading={[Function Boolean]}
+  isInstructorsLoading={[Function Boolean]}
+  isStudentListDownloaded={[Function Boolean]}
+  isStudentsLoading={[Function Boolean]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -43,11 +46,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                CS101
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -62,11 +67,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
               class="col-sm-6 text-sm-left"
               id="coursename"
             >
-              <p
-                class="form-control-static"
-              >
-                Introduction to CS
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -80,11 +87,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -98,11 +107,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -116,11 +127,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
         </div>
@@ -139,6 +152,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div>
                Co-owner: Hodor (hodor@gmail.com) 
             </div>
+            
+            <tm-ajax-loading>
+              <img
+                src="assets/images/ajax-loader.gif"
+              />
+            </tm-ajax-loading>
           </div>
         </div>
         
@@ -175,7 +194,10 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
   instructorService={[Function InstructorService]}
   instructors={[Function Array]}
   isAjaxSuccess="false"
-  loading="false"
+  isCourseLoading={[Function Boolean]}
+  isInstructorsLoading={[Function Boolean]}
+  isStudentListDownloaded="false"
+  isStudentsLoading={[Function Boolean]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -210,11 +232,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                CS101
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -229,11 +253,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
               class="col-sm-6 text-sm-left"
               id="coursename"
             >
-              <p
-                class="form-control-static"
-              >
-                Introduction to CS
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -247,11 +273,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -265,11 +293,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -283,11 +313,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
         </div>
@@ -306,6 +338,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             <div>
                Co-owner: Bran (bran@gmail.com) 
             </div>
+            
+            <tm-ajax-loading>
+              <img
+                src="assets/images/ajax-loader.gif"
+              />
+            </tm-ajax-loading>
           </div>
         </div>
         
@@ -555,7 +593,10 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
   instructorService={[Function InstructorService]}
   instructors={[Function Array]}
   isAjaxSuccess={[Function Boolean]}
-  loading="false"
+  isCourseLoading={[Function Boolean]}
+  isInstructorsLoading={[Function Boolean]}
+  isStudentListDownloaded="false"
+  isStudentsLoading={[Function Boolean]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
   route={[Function ActivatedRoute]}
@@ -590,11 +631,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -609,11 +652,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
               class="col-sm-6 text-sm-left"
               id="coursename"
             >
-              <p
-                class="form-control-static"
-              >
-                
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -627,11 +672,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                0
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -645,11 +692,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                0
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
           <div
@@ -663,11 +712,13 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             <div
               class="col-sm-6 text-sm-left"
             >
-              <p
-                class="form-control-static"
-              >
-                0
-              </p>
+              
+              
+              <tm-ajax-loading>
+                <img
+                  src="assets/images/ajax-loader.gif"
+                />
+              </tm-ajax-loading>
             </div>
           </div>
         </div>
@@ -683,6 +734,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="col-sm-6 text-sm-left"
           >
             
+            
+            <tm-ajax-loading>
+              <img
+                src="assets/images/ajax-loader.gif"
+              />
+            </tm-ajax-loading>
           </div>
         </div>
         

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.html
@@ -6,31 +6,36 @@
         <div class="form-group row">
           <label class="col-sm-3 text-sm-right">Course ID:</label>
           <div class="col-sm-6 text-sm-left">
-            <p class="form-control-static">{{courseDetails.course.courseId}}</p>
+            <p *ngIf="!isCourseLoading" class="form-control-static">{{courseDetails.course.courseId}}</p>
+            <tm-ajax-loading *ngIf="isCourseLoading"></tm-ajax-loading>
           </div>
         </div>
         <div class="form-group row">
           <label class="col-sm-3 text-sm-right">Course name:</label>
           <div class="col-sm-6 text-sm-left" id="coursename">
-            <p class="form-control-static">{{courseDetails.course.courseName}}</p>
+            <p *ngIf="!isCourseLoading" class="form-control-static">{{courseDetails.course.courseName}}</p>
+            <tm-ajax-loading *ngIf="isCourseLoading"></tm-ajax-loading>
           </div>
         </div>
         <div class="form-group row">
           <label class="col-sm-3 text-sm-right">Sections:</label>
           <div class="col-sm-6 text-sm-left">
-            <p class="form-control-static">{{courseDetails.stats.numOfSections}}</p>
+            <p *ngIf="!isStudentsLoading" class="form-control-static">{{courseDetails.stats.numOfSections}}</p>
+            <tm-ajax-loading *ngIf="isStudentsLoading"></tm-ajax-loading>
           </div>
         </div>
         <div class="form-group row">
           <label class="col-sm-3 text-sm-right">Teams:</label>
           <div class="col-sm-6 text-sm-left">
-            <p class="form-control-static">{{courseDetails.stats.numOfTeams}}</p>
+            <p *ngIf="!isStudentsLoading" class="form-control-static">{{courseDetails.stats.numOfTeams}}</p>
+            <tm-ajax-loading *ngIf="isStudentsLoading"></tm-ajax-loading>
           </div>
         </div>
         <div class="form-group row">
           <label class="col-sm-3 text-sm-right">Total students:</label>
           <div class="col-sm-6 text-sm-left">
-            <p class="form-control-static">{{courseDetails.stats.numOfStudents}}</p>
+            <p *ngIf="!isStudentsLoading" class="form-control-static">{{courseDetails.stats.numOfStudents}}</p>
+            <tm-ajax-loading *ngIf="isStudentsLoading"></tm-ajax-loading>
           </div>
         </div>
       </div>
@@ -40,6 +45,7 @@
           <div *ngFor="let instructor of instructors">
             {{instructor.role | instructorRoleName}}: {{instructor.name}} ({{instructor.email}})
           </div>
+          <tm-ajax-loading *ngIf="isInstructorsLoading"></tm-ajax-loading>
         </div>
       </div>
       <div *ngIf="students.length > 0">

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
@@ -77,7 +77,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
     component.courseDetails = courseDetails;
     component.instructors = [coOwner];
     component.courseStudentListAsCsv = 'a,b';
-    component.loading = true;
+    component.isStudentListDownloaded = true;
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
   });

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -57,8 +57,11 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
   students: StudentListRowModel[] = [];
   courseStudentListAsCsv: string = '';
 
-  loading: boolean = false;
+  isCourseLoading: boolean = true;
+  isStudentsLoading: boolean = true;
+  isInstructorsLoading: boolean = true;
   isAjaxSuccess: boolean = true;
+  isStudentListDownloaded: boolean = false;
 
   constructor(private route: ActivatedRoute, private router: Router,
               private statusMessageService: StatusMessageService,
@@ -88,6 +91,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
   private loadCourseName(courseid: string): void {
     this.courseService.getCourseAsInstructor(courseid).subscribe((course: Course) => {
       this.courseDetails.course = course;
+      this.isCourseLoading = false;
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);
     });
@@ -100,6 +104,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
     this.instructorService.loadInstructors({ courseId: courseid, intent: Intent.FULL_DETAIL })
     .subscribe((instructors: Instructors) => {
       this.instructors = instructors.instructors;
+      this.isInstructorsLoading = false;
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);
     });
@@ -130,6 +135,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
         this.loadPrivilege(courseid, key, data);
       });
       this.courseDetails.stats = this.courseService.calculateCourseStatistics(students.students);
+      this.isStudentsLoading = false;
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);
     });
@@ -190,7 +196,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
     let blob: any;
 
     // Calling REST API only the first time to load the downloadable data
-    if (this.loading) {
+    if (this.isStudentListDownloaded) {
       blob = new Blob([this.courseStudentListAsCsv], { type: 'text/csv' });
       saveAs(blob, filename);
     } else {
@@ -199,7 +205,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
           blob = new Blob([resp], { type: 'text/csv' });
           saveAs(blob, filename);
           this.courseStudentListAsCsv = resp;
-          this.loading = false;
+          this.isStudentListDownloaded = true;
         }, (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
         });

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
 import { StudentListModule } from '../../components/student-list/student-list.module';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
@@ -28,6 +29,7 @@ const routes: Routes = [
     TeammatesCommonModule,
     RouterModule.forChild(routes),
     StudentListModule,
+    AjaxLoadingModule,
     AjaxPreloadModule,
   ],
 })


### PR DESCRIPTION
Fixes #10340

**Outline of Solution**

Add loading separated indicators for loading course info, students and instructors.

![ezgif-1-9772db480cbb](https://user-images.githubusercontent.com/5328196/87893402-563ad480-ca72-11ea-9a3b-e837cea6f1c8.gif)

