### PR TITLE
[#10352] Fix inconsistency in rubric question summary

### DIFF
--- a/src/web/app/components/question-types/question-response/rubric-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/rubric-question-response.component.html
@@ -17,7 +17,7 @@
   </table>
 </div>
 <div *ngIf="!isStudentPage">
-  <ul>
+  <ol type="a">
     <li *ngFor="let answer of answers">{{ answer.answer }} {{ answer.index ? '(Choice ' + answer.index + ')' : '' }}</li>
-  </ul>
+  </ol>
 </div>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -42,7 +42,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
 
   getTableData(): void {
     this.summaryColumnsData = [
-        { header: '' },
+        { header: 'Question', sortBy: SortBy.RUBRIC_SUBQUESTION },
       ...this.choices.map((choice: string) => ({ header: choice, sortBy: SortBy.RUBRIC_CHOICE })),
     ];
     if (this.hasWeights) {
@@ -51,7 +51,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
 
     this.summaryRowsData = this.subQuestions.map((subQuestion: string, questionIndex: number) => {
       const currRow: SortableTableCellData[] = [
-        { value: subQuestion },
+        { value: `${StringHelper.integerToLowerCaseAlphabeticalIndex(questionIndex + 1)}) ${subQuestion}` },
         ...this.choices.map((_: string, choiceIndex: number) => {
           if (this.excludeSelf) {
             return { value: `${ this.percentagesExcludeSelf[questionIndex][choiceIndex] }% \

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -432,8 +432,8 @@ Question 1,Please choose the best choice for the following sub-questions.
 
 Summary Statistics
 ,Yes,No,Average
-This student has done a good job.,67% (2) [1.25],33% (1) [-1.7],0.27649999999999997
-This student has tried his/her best.,75% (3) [1.25],25% (1) [-1.7],0.5125
+a) This student has done a good job.,67% (2) [1.25],33% (1) [-1.7],0.27649999999999997
+b) This student has tried his/her best.,75% (3) [1.25],25% (1) [-1.7],0.5125
 
 Per Recipient Statistics
 Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
@@ -475,8 +475,8 @@ Question 2,Please choose the best choice for the following sub-questions. Only f
 
 Summary Statistics
 ,Yes,No,Average
-This student has done a good job.,67% (2) [1.25],33% (1) [1],1.1675
-This student has tried his/her best.,0% (0) [1.25],0% (0) [1],0
+a) This student has done a good job.,67% (2) [1.25],33% (1) [1],1.1675
+b) This student has tried his/her best.,0% (0) [1.25],0% (0) [1],0
 
 Per Recipient Statistics
 Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average

--- a/src/web/services/table-comparator.service.ts
+++ b/src/web/services/table-comparator.service.ts
@@ -62,6 +62,7 @@ export class TableComparatorService {
   compare(sortBy: SortBy, order: SortOrder, strA: string, strB: string): number {
     switch (sortBy) {
       case SortBy.CONTRIBUTION_VALUE:
+      case SortBy.RUBRIC_SUBQUESTION:
       case SortBy.RUBRIC_CHOICE:
       case SortBy.RANK_RECIPIENTS_TEAM:
       case SortBy.RANK_RECIPIENTS_RECIPIENT:

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -62,7 +62,7 @@ export class FeedbackRubricQuestionDetailsImpl extends AbstractFeedbackQuestionD
 
     statsCalculation.subQuestions.forEach((subQuestion: string, questionIndex: number) => {
       const currRow: string[] = [
-        subQuestion,
+        `${StringHelper.integerToLowerCaseAlphabeticalIndex(questionIndex + 1)}) ${subQuestion}`,
         ...statsCalculation.choices.map((_: string, choiceIndex: number) => {
           return `${ statsCalculation.percentages[questionIndex][choiceIndex] }% \
 (${ statsCalculation.answers[questionIndex][choiceIndex] }) \

--- a/src/web/types/sort-properties.ts
+++ b/src/web/types/sort-properties.ts
@@ -278,6 +278,11 @@ export enum SortBy {
     RANK_RECIPIENTS_OVERALL_RANK_EXCLUDING_SELF,
 
     /**
+     * Rubric sub question
+     */
+    RUBRIC_SUBQUESTION,
+
+    /**
      * Frequency of choice
      */
     RUBRIC_CHOICE,


### PR DESCRIPTION
Fixes #10352 

**Outline of Solution**

- Add ordering prefix to rubric choices
    - Change to CSV generation `FeedbackRubricQuestionDetailsImpl`
    - Change to `RubricQuestionStatisticsComponent`
    - Change to `RubricQuestionResponseComponent`

Make initial sort to be the proper order

![image](https://user-images.githubusercontent.com/32454748/88048536-15cc7b00-cb86-11ea-93d3-b89dba90785f.png)

**Others**

~The solution is a little different from the original one as it uses number ordering instead of alphabet ordering. This is because it would be slightly more involved to roll out our alphabet ordering service and I don't see a reason for it.~

It turns out that there's currently a function implemented for alphabet ordering `StringHelper.integerToLowerCaseAlphabeticalIndex()`, so I'll use that instead.