### PR TITLE
[#10374] Instructor course details page: loading spinner does not disappear

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -134,6 +134,10 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
 
         this.loadPrivilege(courseid, key, data);
       });
+
+      if (!sections.length) {
+        this.isStudentsLoading = false;
+      }
       this.courseDetails.stats = this.courseService.calculateCourseStatistics(students.students);
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);

--- a/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.ts
+++ b/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.ts
@@ -119,6 +119,10 @@ export class StudentCourseDetailsPageComponent implements OnInit {
     this.isLoadingTeammates = true;
     this.studentService.getStudentsFromCourseAndTeam(courseId, teamName)
       .subscribe((students: Students) => {
+        // No teammates
+        if (students.students.length === 1 && students.students[0].email === this.student.email) {
+          this.isLoadingTeammates = false;
+        }
         students.students.forEach((student: Student) => {
           // filter away current user
           if (student.email === this.student.email) {

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -81,6 +81,9 @@ export class StudentHomePageComponent implements OnInit {
   getStudentCourses(): void {
     this.isCoursesLoading = true;
     this.courseService.getAllCoursesAsStudent().subscribe((resp: Courses) => {
+      if (!resp.courses.length) {
+        this.isCoursesLoading = false;
+      }
       for (const course of resp.courses) {
         this.feedbackSessionsService.getFeedbackSessionsForStudent(course.courseId)
           .pipe(finalize(() => this.isCoursesLoading = false))


### PR DESCRIPTION
Fixes #10374

![c](https://user-images.githubusercontent.com/28994607/88166204-7d97ca00-cc49-11ea-8ece-2b30635a5102.gif)

**Outline of Solution**
- Added checks for empty arrays
- Issue exist in student home and details page. Same thing there. Added in checks
