### PR TITLE
[#10343] Fix unnecessary bottom line for last response

### DIFF
--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -1,4 +1,4 @@
-<div class="row" [ngClass]="isLastResponse ? '' : 'border-bottom'"
+<div class="row" [class.border-bottom]="!isLastGroupedResponses"
     *ngIf="responses.length && responses[0].allResponses.length && hasRealResponses">
   <div class="col-md-3">
     <div>

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -1,4 +1,4 @@
-<div class="row" style="border-bottom: 1px solid #DDD;"
+<div class="row" [ngClass]="isLastResponse ? '' : 'border-bottom'"
     *ngIf="responses.length && responses[0].allResponses.length && hasRealResponses">
   <div class="col-md-3">
     <div>

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.scss
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.scss
@@ -15,6 +15,6 @@
   height: max-content;
 }
 
-.bottom-border {
+.border-bottom {
   border-bottom: 1px solid #DDD;
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.scss
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.scss
@@ -14,3 +14,7 @@
   margin-left: auto;
   height: max-content;
 }
+
+.bottom-border {
+  border-bottom: 1px solid #DDD;
+}

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -25,6 +25,7 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
   @Input() responses: QuestionOutput[] = [];
   @Input() userToEmail: Record<string, string> = {};
 
+  @Input() isLastResponse: boolean = false;
   @Input() isGrq: boolean = true;
   @Input() session: FeedbackSession = {
     courseId: '',

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -25,7 +25,7 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
   @Input() responses: QuestionOutput[] = [];
   @Input() userToEmail: Record<string, string> = {};
 
-  @Input() isLastResponse: boolean = false;
+  @Input() isLastGroupedResponses: boolean = false;
   @Input() isGrq: boolean = true;
   @Input() session: FeedbackSession = {
     courseId: '',

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -52,7 +52,7 @@
     <div *ngIf="userExpanded[userInfo]" @collapseAnim>
       <div class="card-body">
         <ng-container *ngIf="userHasRealResponses[userInfo]">
-          <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
+          <div class="top-padded" *ngFor="let last = last; let other of responsesToShow[userInfo] | keyvalue">
             <tm-grouped-responses [responses]="other.value"
                                   [isGrq]="isGrq" [session]="session"
                                   [instructorCommentTableModel]="instructorCommentTableModel"
@@ -60,7 +60,8 @@
                                   (instructorCommentTableModelChange)="triggerModelChange($event)"
                                   (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
-                                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"></tm-grouped-responses>
+                                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                                  [isLastResponse]="last"></tm-grouped-responses>
           </div>
         </ng-container>
         <div *ngIf="!userHasRealResponses[userInfo]" class="top-padded">

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -61,7 +61,7 @@
                                   (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
                                   (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
                                   (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                                  [isLastResponse]="last"></tm-grouped-responses>
+                                  [isLastGroupedResponses]="last"></tm-grouped-responses>
           </div>
         </ng-container>
         <div *ngIf="!userHasRealResponses[userInfo]" class="top-padded">


### PR DESCRIPTION
Fixes #10343 

Extract bottom border into css class, only displays if not last response

Multiple Responses (last response): 
![Screenshot 2020-07-23 at 10 49 48 AM](https://user-images.githubusercontent.com/42177597/88248608-5df9b380-ccd4-11ea-821d-df45c2b8aed9.png)

Single Response:
![Screenshot 2020-07-23 at 10 50 01 AM](https://user-images.githubusercontent.com/42177597/88248628-6e119300-ccd4-11ea-8242-121485c711ee.png)

