### PR TITLE
[#10350] Change filename of csv file downloaded

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -223,7 +223,8 @@ export abstract class InstructorSessionBasePageComponent {
    * Downloads the result of a feedback session in csv.
    */
   downloadSessionResult(model: SessionsTableRowModel): void {
-    const filename: string = `${model.feedbackSession.feedbackSessionName.concat('_result')}.csv`;
+    const filename: string =
+        `${model.feedbackSession.courseId}_${model.feedbackSession.feedbackSessionName}_result.csv`;
     let blob: any;
 
     this.feedbackSessionsService.downloadSessionResults(

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -364,7 +364,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
    */
   downloadResultHandler(): void {
     this.isDownloadingResults = true;
-    const filename: string = `${this.session.feedbackSessionName.concat('_result')}.csv`;
+    const filename: string = `${this.session.courseId}_${this.session.feedbackSessionName}_result.csv`;
     let blob: any;
 
     this.feedbackSessionsService.downloadSessionResults(
@@ -384,9 +384,8 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   }
 
   downloadQuestionResultHandler(question: { questionNumber: number, questionId: string }): void {
-    const filename: string = `${
-      this.session.feedbackSessionName.concat('_question', String(question.questionNumber))
-    }.csv`;
+    const filename: string = `
+      ${this.session.courseId}_${this.session.feedbackSessionName}_question${question.questionNumber}.csv`;
 
     this.feedbackSessionsService.downloadSessionResults(
         this.session.courseId,


### PR DESCRIPTION
Fixes #10350

**Outline of Solution**

Make all filenames `${courseId}_${sessionName}_result.csv` or `${courseId}_${sessionName}_question1.csv`, same as V6.

Question: Why were there `.concat()` calls previously? I don't see their purpose and removed them.