### PR TITLE
[#10470] Add v6 instructor join link support

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
+++ b/src/main/java/teammates/ui/webapi/action/LegacyUrlMapper.java
@@ -6,8 +6,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import teammates.common.util.AppUrl;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
 
 /**
  * Maps some selected legacy URLs to new one. This is primarily for URLs send via email.
@@ -31,10 +33,16 @@ public class LegacyUrlMapper extends HttpServlet {
         switch (uri) {
         case Const.LegacyURIs.INSTRUCTOR_COURSE_JOIN:
             key = req.getParameter(Const.ParamsNames.REGKEY);
-            redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
+            String institute = req.getParameter(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
+            AppUrl newUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
                     .withRegistrationKey(key)
-                    .withParam(Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR)
-                    .toString();
+                    .withParam(Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR);
+            if (institute != null) {
+                newUrl = newUrl
+                        .withInstructorInstitution(institute)
+                        .withInstitutionMac(StringHelper.generateSignature(institute));
+            }
+            redirectUrl = newUrl.toString();
             break;
         case Const.LegacyURIs.STUDENT_COURSE_JOIN:
         case Const.LegacyURIs.STUDENT_COURSE_JOIN_NEW:


### PR DESCRIPTION
Fixes #10470 

**Outline of Solution**: Add institute mac when institute is present during routing from old join link to new one
