### PR TITLE
[#10448] Add question to session: team-contribution questions should not inherit custom visibility from previous question

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -420,30 +420,30 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             </ul>
           </div>
         </div>
-      </div>
-      
-      <div
-        class="row margin-top-15px"
-        style=""
-      >
+        
         <div
-          class="col-12 text-right"
+          class="row margin-top-15px"
+          style=""
         >
-          
-          <button
-            class="btn btn-primary"
-            disabled=""
+          <div
+            class="col-12 text-right"
           >
             
-            
-            <span>
-              <i
-                class="fas fa-check"
-              />
-               Save Changes
-            </span>
-            
-          </button>
+            <button
+              class="btn btn-primary"
+              disabled=""
+            >
+              
+              
+              <span>
+                <i
+                  class="fas fa-check"
+                />
+                 Save Changes
+              </span>
+              
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -222,18 +222,18 @@
           </ul>
         </div>
       </div>
-    </div>
-    <div class="row margin-top-15px" *ngIf="!isDisplayOnly">
-      <div class="col-12 text-right">
-        <button type="button" class="btn btn-primary margin-right-5px" *ngIf="model.isEditable"
-                (click)="discardChangesHandler(false)" [disabled]="model.isSaving">
-          <i class="fas fa-ban"></i> Cancel
-        </button>
-        <button class="btn btn-primary" [disabled]="!model.isEditable || model.isSaving" (click)="saveQuestionHandler()">
-          <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>
-          <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>
-          <span *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Questions</span>
-        </button>
+      <div class="row margin-top-15px" *ngIf="!isDisplayOnly">
+        <div class="col-12 text-right">
+          <button type="button" class="btn btn-primary margin-right-5px" *ngIf="model.isEditable"
+                  (click)="discardChangesHandler(false)" [disabled]="model.isSaving">
+            <i class="fas fa-ban"></i> Cancel
+          </button>
+          <button class="btn btn-primary" [disabled]="!model.isEditable || model.isSaving" (click)="saveQuestionHandler()">
+            <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>
+            <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>
+            <span *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Questions</span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -706,7 +706,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           this.statusMessageService.showSuccessToast('The questions have been added to this feedback session.');
         }
       });
-    });
+    }, () => {});
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -5,7 +5,11 @@ import moment from 'moment-timezone';
 import { forkJoin, Observable, of } from 'rxjs';
 import { concatMap, finalize, flatMap, map, switchMap, tap } from 'rxjs/operators';
 import { CourseService } from '../../../services/course.service';
-import { FeedbackQuestionsService, NewQuestionModel } from '../../../services/feedback-questions.service';
+import {
+  CommonVisibilitySetting,
+  FeedbackQuestionsService,
+  NewQuestionModel,
+} from '../../../services/feedback-questions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { NavigationService } from '../../../services/navigation.service';
@@ -26,7 +30,7 @@ import {
   FeedbackSessionPublishStatus,
   FeedbackSessions,
   FeedbackSessionSubmissionStatus,
-  FeedbackTextQuestionDetails,
+  FeedbackTextQuestionDetails, FeedbackVisibilityType,
   HasResponses,
   Instructor,
   Instructors,
@@ -767,16 +771,48 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         SHOW_GIVER_NAME: lastQuestionEditFormModel.showGiverNameTo,
         SHOW_RECIPIENT_NAME: lastQuestionEditFormModel.showRecipientNameTo,
       });
-      this.newQuestionEditFormModel.showResponsesTo =
+      const newQuestionShowResponsesTo: FeedbackVisibilityType[]  =
           newQuestionVisibilityStateMachine.getVisibilityTypesUnderVisibilityControl(VisibilityControl.SHOW_RESPONSE);
-      this.newQuestionEditFormModel.showGiverNameTo =
+      const newQuestionShowGiverNameTo: FeedbackVisibilityType[] =
           newQuestionVisibilityStateMachine.getVisibilityTypesUnderVisibilityControl(VisibilityControl.SHOW_GIVER_NAME);
-      this.newQuestionEditFormModel.showRecipientNameTo =
-          newQuestionVisibilityStateMachine.getVisibilityTypesUnderVisibilityControl(
-              VisibilityControl.SHOW_RECIPIENT_NAME);
+      const newQuestionShowRecipientNameTo: FeedbackVisibilityType[] =
+          newQuestionVisibilityStateMachine
+              .getVisibilityTypesUnderVisibilityControl(VisibilityControl.SHOW_RECIPIENT_NAME);
+
+      let isAllowedToUseInheritedVisibility: boolean = false;
+      if (this.feedbackQuestionsService
+          .isCustomFeedbackVisibilitySettingAllowed(this.newQuestionEditFormModel.questionType)) {
+        isAllowedToUseInheritedVisibility = true;
+      } else {
+        const commonFeedbackVisibilitySettings: CommonVisibilitySetting[] =
+            this.feedbackQuestionsService.getCommonFeedbackVisibilitySettings(
+                newQuestionVisibilityStateMachine, this.newQuestionEditFormModel.questionType);
+        // new question is only allowed to have common visibility settings
+        // check whether the inherited settings fall into that or not
+        for (const commonVisibilityOption of commonFeedbackVisibilitySettings) {
+          if (this.isSameSet(newQuestionShowResponsesTo, commonVisibilityOption.visibilitySettings.SHOW_RESPONSE)
+              && this.isSameSet(newQuestionShowGiverNameTo,
+                  commonVisibilityOption.visibilitySettings.SHOW_GIVER_NAME)
+              && this.isSameSet(newQuestionShowRecipientNameTo,
+                  commonVisibilityOption.visibilitySettings.SHOW_RECIPIENT_NAME)) {
+            isAllowedToUseInheritedVisibility = true;
+            break;
+          }
+        }
+      }
+
+      if (isAllowedToUseInheritedVisibility) {
+        this.newQuestionEditFormModel.showResponsesTo = newQuestionShowResponsesTo;
+        this.newQuestionEditFormModel.showGiverNameTo = newQuestionShowGiverNameTo;
+        this.newQuestionEditFormModel.showRecipientNameTo = newQuestionShowRecipientNameTo;
+      }
     }
 
     this.scrollToNewEditForm();
+  }
+
+  private isSameSet(setA: FeedbackVisibilityType[], setB: FeedbackVisibilityType[]): boolean {
+    return setA.length === setB.length && setA.every((ele: FeedbackVisibilityType) => setB.includes(ele));
   }
 
   /**


### PR DESCRIPTION
Fixes #10448

There are two UAT fixes also.

The first is button alignment in the question edit form:

Before:
![image](https://user-images.githubusercontent.com/13977235/87900552-931eb100-ca09-11ea-84c1-6d3162eb18ad.png)
After:
![image](https://user-images.githubusercontent.com/13977235/87900590-ac276200-ca09-11ea-9609-e38cdd7b1fb4.png)

Looks like it is not fixed and I am wrong in my previous PR.

The second is the to add default empty handler when modal is closed (promise is rejected) (or there will be an error in the console)
