### PR TITLE
[#10465] Instructor enroll students: error message should be a modal

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEnrollPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEnrollPageE2ETest.java
@@ -66,14 +66,7 @@ public class InstructorCourseEnrollPageE2ETest extends BaseE2ETestCase {
         // student2 included to test modified without change table
         StudentAttributes[] studentsEnrollingToExistingCourse = {student2, student3, student4, student5};
         enrollPage.enroll(studentsEnrollingToExistingCourse);
-        enrollPage.verifyStatusMessage("Some students failed to be enrolled, see the summary below."
-                + " You may check that: "
-                + "\"Section\" and \"Comment\" are optional while \"Team\", \"Name\", and \"Email\" must be filled. "
-                + "\"Section\", \"Team\", \"Name\", and \"Comment\" should start with an alphabetical character, "
-                + "unless wrapped by curly brackets \"{}\", "
-                + "and should not contain vertical bar \"|\" and percentage sign\"%\". "
-                + "\"Email\" should contain some text followed by one '@' sign followed by some more text. "
-                + "\"Team\" should not have same format of email to avoid mis-interpretation.");
+        enrollPage.verifyStatusMessage("Some students failed to be enrolled, see the summary below.");
 
         StudentAttributes[] newStudentsData = {student4};
         StudentAttributes[] modifiedStudentsData = {student3};

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -47,6 +47,14 @@
               [hidden]="isExistingStudentsPanelCollapsed" @collapseAnim>
           </hot-table>
         </div>
+
+        <div *ngIf="showGeneralErrorMessage" class="card card-default">
+          <div class="card-body bg-danger text-white">
+            <button class="float-right fas fa-times close" (click)="showGeneralErrorMessage = false"></button>
+            You may check that: "Section" and "Comment" are optional while "Team", "Name", and "Email" must be filled. "Section", "Team", "Name", and "Comment" should start with an alphabetical character, unless wrapped by curly brackets {{'"{}"'}}, and should not contain vertical bar "|" and percentage sign "%". "Email" should contain some text followed by one "@" sign followed by some more text. "Team" should not have the same format as email to avoid mis-interpretation.
+          </div>
+        </div>
+
         <div class="card card-default">
           <div class="card-header cursor-pointer" (click)="toggleNewStudentsPanel()">
             <div class="float-right margin-left-7px">

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -20,7 +20,7 @@
             <tm-status-message [messages]="statusMessage"></tm-status-message>
             <div class="card card-default">
               <div id="toggle-existing-students" class="card-header cursor-pointer"
-               (click)="toggleExistingStudentsPanel()">
+                   (click)="toggleExistingStudentsPanel()">
                 <b class="existing-students-status-message">Existing Students</b>
                 <div class="float-right margin-left-7px">
                   <tm-ajax-preload *ngIf="loading"></tm-ajax-preload>
@@ -50,9 +50,9 @@
               </hot-table>
             </div>
 
-            <div *ngIf="showEnrollErrorMessage && enrollErrorMessage" class="card card-default">
+            <div *ngIf="enrollErrorMessage" class="card card-default">
               <div class="card-body bg-danger text-white">
-                <button class="float-right fas fa-times close" (click)="showEnrollErrorMessage = false"></button>
+                <button class="float-right fas fa-times close" (click)="enrollErrorMessage = ''"></button>
                 {{ enrollErrorMessage }}
               </div>
             </div>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -50,10 +50,10 @@
               </hot-table>
             </div>
 
-            <div *ngIf="showGeneralErrorMessage" class="card card-default">
+            <div *ngIf="showEnrollErrorMessage && enrollErrorMessage" class="card card-default">
               <div class="card-body bg-danger text-white">
-                <button class="float-right fas fa-times close" (click)="showGeneralErrorMessage = false"></button>
-                You may check that: "Section" and "Comment" are optional while "Team", "Name", and "Email" must be filled. "Section", "Team", "Name", and "Comment" should start with an alphabetical character, unless wrapped by curly brackets {{'"{}"'}}, and should not contain vertical bar "|" and percentage sign "%". "Email" should contain some text followed by one "@" sign followed by some more text. "Team" should not have the same format as email to avoid mis-interpretation.
+                <button class="float-right fas fa-times close" (click)="showEnrollErrorMessage = false"></button>
+                {{ enrollErrorMessage }}
               </div>
             </div>
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="coursePresent">
     <h1>Enroll Students for {{ courseId }}</h1>
     <tm-loading-retry [shouldShowRetry]="hasLoadingStudentsFailed" [message]="'Failed to load students'" (retryEvent)="getCourseEnrollPageData(courseId)">
-      <div *ngIf='!hasLoadingStudentsFailed'class="card card-primary">
+      <div *ngIf='!hasLoadingStudentsFailed' class="card card-primary">
         <div class="card-body fill-plain">
           <p class="text-muted">
             <i class="fas fa-info-circle"></i>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -132,8 +132,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
           this.populateEnrollResultPanelList(this.existingStudents, enrolledStudents,
               studentsEnrollRequest.studentEnrollRequests);
     }, (resp: ErrorMessageOutput) => {
-      this.statusMessage.pop(); // removes any existing error status message
-      this.statusMessageService.showErrorToast(resp.error.message);
       this.enrollErrorMessage = resp.error.message;
       this.showEnrollErrorMessage = true;
     }, () => {

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -38,7 +38,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   courseId: string = '';
   coursePresent?: boolean;
   showEnrollResults?: boolean = false;
-  showEnrollErrorMessage: boolean = false;
   enrollErrorMessage: string = '';
   statusMessage: StatusMessage[] = [];
 
@@ -93,7 +92,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    */
   submitEnrollData(): void {
     this.isEnrolling = true;
-    this.showEnrollErrorMessage = false;
+    this.enrollErrorMessage = '';
     const newStudentsHOTInstance: Handsontable =
         this.hotRegisterer.getInstance(this.newStudentsHOT);
 
@@ -133,7 +132,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
               studentsEnrollRequest.studentEnrollRequests);
     }, (resp: ErrorMessageOutput) => {
       this.enrollErrorMessage = resp.error.message;
-      this.showEnrollErrorMessage = true;
     }, () => {
       this.studentService.getStudentsFromCourse({ courseId: this.courseId }).subscribe((resp: Students) => {
         this.existingStudents = resp.students;
@@ -222,7 +220,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     }
 
     if (studentLists[EnrollStatus.ERROR].length > 0) {
-      this.showEnrollErrorMessage = true;
       this.enrollErrorMessage = `You may check that: "Section" and "Comment" are optional while "Team", "Name",
         and "Email" must be filled. "Section", "Team", "Name", and "Comment" should start with an
         alphabetical character, unless wrapped by curly brackets "{}", and should not contain vertical bar "|" and

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -38,7 +38,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   courseId: string = '';
   coursePresent?: boolean;
   showEnrollResults?: boolean = false;
-  showGeneralErrorMessage: boolean = false;
+  showEnrollErrorMessage: boolean = false;
+  enrollErrorMessage: string = '';
   statusMessage: StatusMessage[] = [];
 
   @ViewChild('moreInfo') moreInfo?: ElementRef;
@@ -92,7 +93,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    */
   submitEnrollData(): void {
     this.isEnrolling = true;
-    this.showGeneralErrorMessage = false;
+    this.showEnrollErrorMessage = false;
     const newStudentsHOTInstance: Handsontable =
         this.hotRegisterer.getInstance(this.newStudentsHOT);
 
@@ -133,6 +134,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     }, (resp: ErrorMessageOutput) => {
       this.statusMessage.pop(); // removes any existing error status message
       this.statusMessageService.showErrorToast(resp.error.message);
+      this.enrollErrorMessage = resp.error.message;
+      this.showEnrollErrorMessage = true;
     }, () => {
       this.studentService.getStudentsFromCourse({ courseId: this.courseId }).subscribe((resp: Students) => {
         this.existingStudents = resp.students;
@@ -221,7 +224,12 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     }
 
     if (studentLists[EnrollStatus.ERROR].length > 0) {
-      this.showGeneralErrorMessage = true;
+      this.showEnrollErrorMessage = true;
+      this.enrollErrorMessage = `You may check that: "Section" and "Comment" are optional while "Team", "Name",
+        and "Email" must be filled. "Section", "Team", "Name", and "Comment" should start with an
+        alphabetical character, unless wrapped by curly brackets "{}", and should not contain vertical bar "|" and
+        percentage sign "%". "Email" should contain some text followed by one "@" sign followed by some
+        more text. "Team" should not have the same format as email to avoid mis-interpretation.`;
       this.statusMessageService.showErrorToast('Some students failed to be enrolled, see the summary below.');
     }
     return panels;

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -38,6 +38,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   courseid: string = '';
   coursePresent?: boolean;
   showEnrollResults?: boolean = false;
+  showGeneralErrorMessage: boolean = false;
   statusMessage: StatusMessage[] = [];
 
   @ViewChild('moreInfo') moreInfo?: ElementRef;
@@ -89,6 +90,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    */
   submitEnrollData(): void {
     this.isEnrolling = true;
+    this.showGeneralErrorMessage = false;
     const newStudentsHOTInstance: Handsontable =
         this.hotRegisterer.getInstance(this.newStudentsHOT);
 
@@ -217,14 +219,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     }
 
     if (studentLists[EnrollStatus.ERROR].length > 0) {
-      const generalEnrollErrorMessage: string = 'You may check that: ' +
-          '"Section" and "Comment" are optional while "Team", "Name", and "Email" must be filled. ' +
-          '"Section", "Team", "Name", and "Comment" should start with an alphabetical character, ' +
-          'unless wrapped by curly brackets "{}", and should not contain vertical bar "|" and percentage sign"%". ' +
-          '"Email" should contain some text followed by one \'@\' sign followed by some more text. ' +
-          '"Team" should not have same format of email to avoid mis-interpretation. ';
-      this.statusMessageService.showErrorToast(`Some students failed to be enrolled, see the summary below.
-       ${generalEnrollErrorMessage}`);
+      this.showGeneralErrorMessage = true;
+      this.statusMessageService.showErrorToast('Some students failed to be enrolled, see the summary below.');
     }
     return panels;
   }


### PR DESCRIPTION
Fixes #10465, #10038 

**Outline of Solution**

![erere](https://user-images.githubusercontent.com/28994607/88653934-4ae54a00-d0ff-11ea-96e6-9086f6bf2ae0.gif)

- Added in card for long error message