### PR TITLE
[#10348] Add blue spinner to modal if data still being loaded

### DIFF
--- a/src/web/app/components/sessions-table/sessions-table-model.ts
+++ b/src/web/app/components/sessions-table/sessions-table-model.ts
@@ -7,7 +7,7 @@ export interface SessionsTableRowModel {
   feedbackSession: FeedbackSession;
   responseRate: string;
   isLoadingResponseRate: boolean;
-
+  isLoadingInstructorPrivilege: boolean;
   instructorPrivilege: InstructorPrivilege;
 }
 

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -99,6 +99,7 @@ describe('SessionsTableComponent', () => {
     feedbackSession: feedbackSession1,
     responseRate: '8 / 9',
     isLoadingResponseRate: false,
+    isLoadingInstructorPrivilege: false,
     instructorPrivilege: instructorCanEverything,
   };
 
@@ -106,6 +107,7 @@ describe('SessionsTableComponent', () => {
     feedbackSession: feedbackSession2,
     responseRate: '',
     isLoadingResponseRate: true,
+    isLoadingInstructorPrivilege: false,
     instructorPrivilege: instructorCannotEverything,
   };
 

--- a/src/web/app/components/sessions-table/sessions-table.component.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.ts
@@ -101,7 +101,9 @@ export class SessionsTableComponent implements OnInit {
     const modalContent: string = 'Session will be moved to the recycle bin.';
     const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
         `Delete session <strong>${ this.sessionsTableRowModels[rowIndex].feedbackSession.feedbackSessionName }</strong>?`,
-        SimpleModalType.WARNING, modalContent);
+        SimpleModalType.WARNING, modalContent, {
+          isLoadingData: this.sessionsTableRowModels[rowIndex].isLoadingInstructorPrivilege,
+        });
     modalRef.result.then(() => {
       this.moveSessionToRecycleBinEvent.emit(rowIndex);
     }, () => {});
@@ -133,7 +135,9 @@ export class SessionsTableComponent implements OnInit {
 
     const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
         `Publish session <strong>${ model.feedbackSession.feedbackSessionName }</strong>?`,
-        SimpleModalType.WARNING, 'An email will be sent to students to inform them that the responses are ready for viewing.');
+        SimpleModalType.WARNING, 'An email will be sent to students to inform them that the responses are ready for viewing.', {
+          isLoadingData: this.sessionsTableRowModels[rowIndex].isLoadingInstructorPrivilege,
+        });
 
     modalRef.result.then(() => {
       this.publishSessionEvent.emit(rowIndex);
@@ -150,7 +154,9 @@ export class SessionsTableComponent implements OnInit {
 
     const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
         `Unpublish session <strong>${ model.feedbackSession.feedbackSessionName }</strong>?`,
-        SimpleModalType.WARNING, modalContent);
+        SimpleModalType.WARNING, modalContent, {
+          isLoadingData: this.sessionsTableRowModels[rowIndex].isLoadingInstructorPrivilege,
+        });
 
     modalRef.result.then(() => {
       this.unpublishSessionEvent.emit(rowIndex);

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -34,6 +34,6 @@
           'btn-primary' : type === SimpleModalType.NEUTRAL }"
           (click)="activeModal.close()">{{ confirmMessage }}</button>
 </div>
-<div class="modal-footer" *ngIf="isLoadingData">
+<div class="modal-footer justify-content-center" *ngIf="isLoadingData">
   <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
 </div>

--- a/src/web/app/components/simple-modal/simple-modal.component.html
+++ b/src/web/app/components/simple-modal/simple-modal.component.html
@@ -22,7 +22,7 @@
   </div>
   <div *ngIf="!isTemplate" [innerHTML]="content"></div>
 </div>
-<div class="modal-footer">
+<div class="modal-footer" *ngIf="!isLoadingData">
   <button type="button" class="btn btn-light modal-btn-cancel" *ngIf="!isInformationOnly" (click)="activeModal.dismiss()">
     {{ cancelMessage }}
   </button>
@@ -33,4 +33,7 @@
           'btn-info' : type === SimpleModalType.INFO,
           'btn-primary' : type === SimpleModalType.NEUTRAL }"
           (click)="activeModal.close()">{{ confirmMessage }}</button>
+</div>
+<div class="modal-footer" *ngIf="isLoadingData">
+  <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
 </div>

--- a/src/web/app/components/simple-modal/simple-modal.component.spec.ts
+++ b/src/web/app/components/simple-modal/simple-modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { AjaxLoadingComponent } from '../ajax-loading/ajax-loading.component';
 import { SimpleModalComponent } from './simple-modal.component';
 
 describe('SimpleModalComponent', () => {
@@ -9,7 +10,7 @@ describe('SimpleModalComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SimpleModalComponent],
+      declarations: [SimpleModalComponent, AjaxLoadingComponent],
       providers: [NgbActiveModal],
     })
     .compileComponents();

--- a/src/web/app/components/simple-modal/simple-modal.component.ts
+++ b/src/web/app/components/simple-modal/simple-modal.component.ts
@@ -21,6 +21,7 @@ export class SimpleModalComponent implements OnInit {
   @Input() isInformationOnly: boolean =  false; // true will cause modal to only have 1 button
   @Input() confirmMessage: string = 'Yes'; // custom text message for confirm button
   @Input() cancelMessage: string = 'No, cancel the operation'; // custom text message for cancel button
+  @Input() isLoadingData: boolean = false; // true will cause loading spinner to display instead of buttons
 
   get isTemplate(): boolean {
     return this.content instanceof TemplateRef;

--- a/src/web/app/components/simple-modal/simple-modal.module.ts
+++ b/src/web/app/components/simple-modal/simple-modal.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { AjaxLoadingModule } from '../ajax-loading/ajax-loading.module';
 import { SimpleModalComponent } from './simple-modal.component';
 
 /**
@@ -10,6 +11,7 @@ import { SimpleModalComponent } from './simple-modal.component';
   exports: [SimpleModalComponent],
   imports: [
     CommonModule,
+    AjaxLoadingModule,
   ],
   entryComponents: [SimpleModalComponent],
 })

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -226,6 +226,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
                 feedbackSession,
                 responseRate: '',
                 isLoadingResponseRate: false,
+                isLoadingInstructorPrivilege: false,
                 instructorPrivilege: DEFAULT_INSTRUCTOR_PRIVILEGE,
               };
               model.sessionsTableRowModels.push(m);

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -159,13 +159,12 @@ export abstract class InstructorSessionBasePageComponent {
     this.instructorService.loadInstructorPrivilege({
       courseId: model.feedbackSession.courseId,
       feedbackSessionName: model.feedbackSession.feedbackSessionName,
-    },
-    ).subscribe((instructorPrivilege: InstructorPrivilege) => {
+    })
+    .pipe(finalize(() => model.isLoadingInstructorPrivilege = false))
+    .subscribe((instructorPrivilege: InstructorPrivilege) => {
       model.instructorPrivilege = instructorPrivilege;
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);
-    }, () => {
-      model.isLoadingInstructorPrivilege = false;
     });
   }
 

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -155,6 +155,7 @@ export abstract class InstructorSessionBasePageComponent {
    * Updates the instructor privilege in {@code SessionsTableRowModel}.
    */
   protected updateInstructorPrivilege(model: SessionsTableRowModel): void {
+    model.isLoadingInstructorPrivilege = true;
     this.instructorService.loadInstructorPrivilege({
       courseId: model.feedbackSession.courseId,
       feedbackSessionName: model.feedbackSession.feedbackSessionName,
@@ -163,6 +164,8 @@ export abstract class InstructorSessionBasePageComponent {
       model.instructorPrivilege = instructorPrivilege;
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorToast(resp.error.message);
+    }, () => {
+      model.isLoadingInstructorPrivilege = false;
     });
   }
 

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -385,7 +385,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
               feedbackSession: session,
               responseRate: '',
               isLoadingResponseRate: false,
-
+              isLoadingInstructorPrivilege: false,
               instructorPrivilege: DEFAULT_INSTRUCTOR_PRIVILEGE,
             };
             this.sessionsTableRowModels.push(model);
@@ -449,6 +449,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             feedbackSession,
             responseRate: '',
             isLoadingResponseRate: false,
+            isLoadingInstructorPrivilege: false,
             instructorPrivilege: DEFAULT_INSTRUCTOR_PRIVILEGE,
           };
           this.sessionsTableRowModels.push(m);
@@ -557,6 +558,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
           feedbackSession: session,
           responseRate: '',
           isLoadingResponseRate: false,
+          isLoadingInstructorPrivilege: false,
           instructorPrivilege: DEFAULT_INSTRUCTOR_PRIVILEGE,
         };
         this.sessionsTableRowModels.push(m);

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -72,6 +72,7 @@ describe('FeedbackSessionsService', () => {
       },
       responseRate: '',
       isLoadingResponseRate: false,
+      isLoadingInstructorPrivilege: false,
       instructorPrivilege: DEFAULT_INSTRUCTOR_PRIVILEGE,
     };
     mockFeedbackSession.submissionStartTimestamp = Date.now() - 100000;

--- a/src/web/services/simple-modal.service.ts
+++ b/src/web/services/simple-modal.service.ts
@@ -11,6 +11,7 @@ export interface SimpleModalOptions {
   isInformationOnly?: boolean;
   confirmMessage?: string; // custom text message for confirm button
   cancelMessage?: string; // custom text message for cancel button
+  isLoadingData?: boolean; // determines if a modal requires data that might still be loading
 }
 
 /**


### PR DESCRIPTION
Fixes #10348 

Display shown while data is being loaded (manually configured to be true for demo purposes):

![Jul-27-2020 15-53-56](https://user-images.githubusercontent.com/42177597/88517457-6e39c780-d021-11ea-88ed-436eaa0c9e3c.gif)
