### PR TITLE
[#10421] Drop-down menus: allow opening in new tab

### DIFF
--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -145,12 +145,20 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
             <td
               class="actions-cell"
             >
-              <button
-                class="btn btn-light btn-sm"
-                type="button"
+              
+              <a
+                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review"
+                routerlink="/web/instructor/sessions/edit"
               >
-                Edit
-              </button>
+                
+                <button
+                  class="btn btn-light btn-sm"
+                  type="button"
+                >
+                   Edit 
+                </button>
+              </a>
+              
               <button
                 class="btn btn-light btn-sm"
                 type="button"
@@ -164,13 +172,22 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 Copy
               </button>
-              <button
-                class="btn btn-light btn-sm"
-                ngbtooltip="Start submitting feedback"
-                type="button"
+              
+              <a
+                href="/web/instructor/sessions/submission?courseid=GOT&fsname=Season%208%20Review"
+                routerlink="/web/instructor/sessions/submission"
               >
-                Submit
-              </button>
+                
+                <button
+                  class="btn btn-light btn-sm"
+                  ngbtooltip="Start submitting feedback"
+                  type="button"
+                >
+                  Submit
+                </button>
+                
+              </a>
+              
               <div
                 class="d-inline-block dropdown"
                 ngbdropdown=""
@@ -188,11 +205,13 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   ngbdropdownmenu=""
                   x-placement="bottom"
                 >
-                  <button
+                  <a
                     class="btn dropdown-item clickable"
+                    href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%208%20Review"
+                    routerlink="/web/instructor/sessions/result"
                   >
                     View Results
-                  </button>
+                  </a>
                   
                   <button
                     class="btn dropdown-item clickable"
@@ -270,13 +289,15 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
             <td
               class="actions-cell"
             >
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
                 type="button"
               >
-                Edit
+                 Edit 
               </button>
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
@@ -291,6 +312,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 Copy
               </button>
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
@@ -299,6 +321,8 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 Submit
               </button>
+              
+              
               <div
                 class="d-inline-block dropdown"
                 ngbdropdown=""
@@ -316,11 +340,13 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   ngbdropdownmenu=""
                   x-placement="bottom"
                 >
-                  <button
+                  <a
                     class="btn dropdown-item clickable"
+                    href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%207%20Review"
+                    routerlink="/web/instructor/sessions/result"
                   >
                     View Results
-                  </button>
+                  </a>
                   
                   <button
                     class="btn dropdown-item clickable"
@@ -492,12 +518,20 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
             <td
               class="actions-cell"
             >
-              <button
-                class="btn btn-light btn-sm"
-                type="button"
+              
+              <a
+                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review"
+                routerlink="/web/instructor/sessions/edit"
               >
-                Edit
-              </button>
+                
+                <button
+                  class="btn btn-light btn-sm"
+                  type="button"
+                >
+                   Edit 
+                </button>
+              </a>
+              
               <button
                 class="btn btn-light btn-sm"
                 type="button"
@@ -511,13 +545,22 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 Copy
               </button>
-              <button
-                class="btn btn-light btn-sm"
-                ngbtooltip="Start submitting feedback"
-                type="button"
+              
+              <a
+                href="/web/instructor/sessions/submission?courseid=GOT&fsname=Season%208%20Review"
+                routerlink="/web/instructor/sessions/submission"
               >
-                Submit
-              </button>
+                
+                <button
+                  class="btn btn-light btn-sm"
+                  ngbtooltip="Start submitting feedback"
+                  type="button"
+                >
+                  Submit
+                </button>
+                
+              </a>
+              
               <div
                 class="d-inline-block dropdown"
                 ngbdropdown=""
@@ -535,11 +578,13 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   ngbdropdownmenu=""
                   x-placement="bottom"
                 >
-                  <button
+                  <a
                     class="btn dropdown-item clickable"
+                    href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%208%20Review"
+                    routerlink="/web/instructor/sessions/result"
                   >
                     View Results
-                  </button>
+                  </a>
                   
                   <button
                     class="btn dropdown-item clickable"
@@ -610,13 +655,15 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
             <td
               class="actions-cell"
             >
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
                 type="button"
               >
-                Edit
+                 Edit 
               </button>
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
@@ -631,6 +678,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 Copy
               </button>
+              
               <button
                 class="btn btn-light btn-sm"
                 disabled=""
@@ -639,6 +687,8 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 Submit
               </button>
+              
+              
               <div
                 class="d-inline-block dropdown"
                 ngbdropdown=""
@@ -656,11 +706,13 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   ngbdropdownmenu=""
                   x-placement="bottom"
                 >
-                  <button
+                  <a
                     class="btn dropdown-item clickable"
+                    href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%207%20Review"
+                    routerlink="/web/instructor/sessions/result"
                   >
                     View Results
-                  </button>
+                  </a>
                   
                   <button
                     class="btn dropdown-item clickable"

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -53,18 +53,34 @@
           <tm-ajax-loading *ngIf="sessionsTableRowModel.isLoadingResponseRate" [useBlueSpinner]="true"></tm-ajax-loading>
         </td>
         <td class="actions-cell">
-          <button type="button" class="btn btn-light btn-sm" (click)="editSessionEvent.emit(idx)"
-                  [disabled]="!sessionsTableRowModel.instructorPrivilege.canModifySession">Edit</button>
+          <a *ngIf="sessionsTableRowModel.instructorPrivilege.canModifySession; else editSessionBtn" routerLink="/web/instructor/sessions/edit" [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">
+            <ng-container *ngTemplateOutlet="editSessionBtn"></ng-container>
+          </a>
+          <ng-template #editSessionBtn>
+            <button type="button" class="btn btn-light btn-sm" (click)="editSessionEvent.emit(idx)"
+                    [disabled]="!sessionsTableRowModel.instructorPrivilege.canModifySession">
+              Edit
+            </button>
+          </ng-template>
           <button type="button" class="btn btn-light btn-sm" (click)="moveSessionToRecycleBin(idx)"
                   [disabled]="!sessionsTableRowModel.instructorPrivilege.canModifySession">Delete</button>
           <button type="button" class="btn btn-light btn-sm" ngbTooltip="Copy feedback session details" (click)="copySession(idx)">Copy</button>
-          <button type="button" class="btn btn-light btn-sm" ngbTooltip="Start submitting feedback"
-                  [disabled]="sessionsTableRowModel.feedbackSession.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN
-                    || !sessionsTableRowModel.instructorPrivilege.canSubmitSessionInSections" (click)="submitSessionAsInstructorEvent.emit(idx)" >Submit</button>
+          <a *ngIf="sessionsTableRowModel.feedbackSession.submissionStatus === FeedbackSessionSubmissionStatus.OPEN && sessionsTableRowModel.instructorPrivilege.canSubmitSessionInSections; else submitBtn"
+             routerLink="/web/instructor/sessions/submission"
+             [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">
+            <ng-container *ngTemplateOutlet="submitBtn"></ng-container>
+          </a>
+          <ng-template #submitBtn>
+            <button type="button" class="btn btn-light btn-sm" ngbTooltip="Start submitting feedback"
+                    [disabled]="sessionsTableRowModel.feedbackSession.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN
+                      || !sessionsTableRowModel.instructorPrivilege.canSubmitSessionInSections" (click)="submitSessionAsInstructorEvent.emit(idx)">Submit</button>
+          </ng-template>
           <div ngbDropdown class="d-inline-block">
             <button class="btn btn-light btn-sm" ngbDropdownToggle>Results</button>
             <div ngbDropdownMenu>
-              <button class="btn dropdown-item clickable" (click)="viewSessionResultEvent.emit(idx)">View Results</button>
+              <a class="btn dropdown-item clickable" (click)="viewSessionResultEvent.emit(idx)"
+                      routerLink="/web/instructor/sessions/result"
+                      [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">View Results</a>
               <button class="btn dropdown-item clickable" ngbTooltip="Make responses no longer visible" placement="left" container="body"
                       *ngIf="![FeedbackSessionSubmissionStatus.NOT_VISIBLE, FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN].includes(sessionsTableRowModel.feedbackSession.submissionStatus)
                         && sessionsTableRowModel.feedbackSession.publishStatus === FeedbackSessionPublishStatus.PUBLISHED; else publishButton"

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
@@ -20,7 +21,7 @@ describe('SessionsTableComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SessionsTableModule, HttpClientTestingModule],
+      imports: [SessionsTableModule, HttpClientTestingModule, RouterTestingModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/components/sessions-table/sessions-table.module.ts
+++ b/src/web/app/components/sessions-table/sessions-table.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import {
   NgbDropdownModule,
   NgbTooltipModule,
@@ -37,6 +38,7 @@ import { SubmissionStatusTooltipPipe } from './submission-status-tooltip.pipe';
     NgbTooltipModule,
     FormsModule,
     CopySessionModalModule,
+    RouterModule,
   ],
   entryComponents: [
     ResendResultsLinkToRespondentModalComponent,

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -236,15 +236,15 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                   class="text-center actions-cell"
                 >
                   
-                  <button
+                  <a
                     class="btn btn-light btn-sm"
+                    href="/web/instructor/courses/enroll?courseid=CS3281"
                     id="btn-enroll-0"
                     ngbtooltip="Enroll student into the course"
                     routerlink="/web/instructor/courses/enroll"
-                    tabindex="0"
                   >
                      Enroll 
-                  </button>
+                  </a>
                   
                   
                   <div
@@ -265,20 +265,20 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3281"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3281"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-0"
@@ -371,20 +371,20 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3282"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3282"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-1"
@@ -695,15 +695,15 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                   class="text-center actions-cell"
                 >
                   
-                  <button
+                  <a
                     class="btn btn-light btn-sm"
+                    href="/web/instructor/courses/enroll?courseid=CS3281"
                     id="btn-enroll-0"
                     ngbtooltip="Enroll student into the course"
                     routerlink="/web/instructor/courses/enroll"
-                    tabindex="0"
                   >
                      Enroll 
-                  </button>
+                  </a>
                   
                   
                   <div
@@ -724,20 +724,20 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3281"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3281"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-0"
@@ -830,20 +830,20 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3282"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3282"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-1"
@@ -1245,15 +1245,15 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                   class="text-center actions-cell"
                 >
                   
-                  <button
+                  <a
                     class="btn btn-light btn-sm"
+                    href="/web/instructor/courses/enroll?courseid=CS3281"
                     id="btn-enroll-0"
                     ngbtooltip="Enroll student into the course"
                     routerlink="/web/instructor/courses/enroll"
-                    tabindex="0"
                   >
                      Enroll 
-                  </button>
+                  </a>
                   
                   
                   <div
@@ -1274,20 +1274,20 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3281"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3281"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-0"
@@ -1401,20 +1401,20 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                       ngbdropdownmenu=""
                       x-placement="bottom"
                     >
-                      <button
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/details?courseid=CS3282"
                         routerlink="/web/instructor/courses/details"
-                        tabindex="0"
                       >
                          View 
-                      </button>
-                      <button
+                      </a>
+                      <a
                         class="btn btn-primary btn-sm dropdown-item clickable"
+                        href="/web/instructor/courses/edit?courseid=CS3282"
                         routerlink="/web/instructor/courses/edit"
-                        tabindex="0"
                       >
                          Edit 
-                      </button>
+                      </a>
                       <button
                         class="btn btn-primary btn-sm dropdown-item clickable"
                         id="btn-archive-1"

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -99,30 +99,28 @@
               </span>
             </td>
             <td class="text-center actions-cell">
-              <button id="btn-enroll-{{ i }}" class="btn btn-light btn-sm" *ngIf="course.canModifyStudent"
+              <a id="btn-enroll-{{ i }}" class="btn btn-light btn-sm" *ngIf="course.canModifyStudent"
                       ngbTooltip="Enroll student into the course"
                       routerLink="/web/instructor/courses/enroll"
                       [queryParams]="{courseid: course.course.courseId}">
                 Enroll
-              </button>
+              </a>
               <button id="btn-enroll-disabled-{{ i }}" class="btn btn-light btn-sm disabled" *ngIf="!course.canModifyStudent">
                 Enroll
               </button>
               <div ngbDropdown class="d-inline-block">
                 <button id="btn-other-actions-{{ i }}" class="action-dropdown btn btn-light btn-sm" ngbDropdownToggle>Other Actions</button>
                 <div ngbDropdownMenu>
-                  <button class="btn btn-primary btn-sm dropdown-item clickable"
-
+                  <a class="btn btn-primary btn-sm dropdown-item clickable"
                           routerLink="/web/instructor/courses/details"
                           [queryParams]="{courseid: course.course.courseId}">
                     View
-                  </button>
-                  <button class="btn btn-primary btn-sm dropdown-item clickable"
-
+                  </a>
+                  <a class="btn btn-primary btn-sm dropdown-item clickable"
                           routerLink="/web/instructor/courses/edit"
                           [queryParams]="{courseid: course.course.courseId}">
                     Edit
-                  </button>
+                  </a>
                   <button id="btn-archive-{{ i }}" class="btn btn-primary btn-sm dropdown-item clickable" (click)="changeArchiveStatus(course.course.courseId, true)"
                           ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)">
                     Archive

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -767,12 +767,20 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                           <td
                             class="actions-cell"
                           >
-                            <button
-                              class="btn btn-light btn-sm"
-                              type="button"
+                            
+                            <a
+                              href="/web/instructor/sessions/edit?courseid=CS3281&fsname=Feedback"
+                              routerlink="/web/instructor/sessions/edit"
                             >
-                              Edit
-                            </button>
+                              
+                              <button
+                                class="btn btn-light btn-sm"
+                                type="button"
+                              >
+                                 Edit 
+                              </button>
+                            </a>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               type="button"
@@ -786,6 +794,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                             >
                               Copy
                             </button>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
@@ -794,6 +803,8 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                             >
                               Submit
                             </button>
+                            
+                            
                             <div
                               class="d-inline-block dropdown"
                               ngbdropdown=""
@@ -811,11 +822,13 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                 ngbdropdownmenu=""
                                 x-placement="bottom"
                               >
-                                <button
+                                <a
                                   class="btn dropdown-item clickable"
+                                  href="/web/instructor/sessions/result?courseid=CS3281&fsname=Feedback"
+                                  routerlink="/web/instructor/sessions/result"
                                 >
                                   View Results
-                                </button>
+                                </a>
                                 
                                 <button
                                   class="btn dropdown-item clickable"
@@ -1261,13 +1274,15 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                           <td
                             class="actions-cell"
                           >
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
                               type="button"
                             >
-                              Edit
+                               Edit 
                             </button>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
@@ -1282,6 +1297,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               Copy
                             </button>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
@@ -1290,6 +1306,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               Submit
                             </button>
+                            
+                            
                             <div
                               class="d-inline-block dropdown"
                               ngbdropdown=""
@@ -1307,11 +1325,13 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 ngbdropdownmenu=""
                                 x-placement="bottom"
                               >
-                                <button
+                                <a
                                   class="btn dropdown-item clickable"
+                                  href="/web/instructor/sessions/result?courseid=CS3281&fsname=Feedback%201"
+                                  routerlink="/web/instructor/sessions/result"
                                 >
                                   View Results
-                                </button>
+                                </a>
                                 
                                 <button
                                   class="btn dropdown-item clickable"
@@ -1389,13 +1409,15 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                           <td
                             class="actions-cell"
                           >
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
                               type="button"
                             >
-                              Edit
+                               Edit 
                             </button>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
@@ -1410,6 +1432,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               Copy
                             </button>
+                            
                             <button
                               class="btn btn-light btn-sm"
                               disabled=""
@@ -1418,6 +1441,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               Submit
                             </button>
+                            
+                            
                             <div
                               class="d-inline-block dropdown"
                               ngbdropdown=""
@@ -1435,11 +1460,13 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 ngbdropdownmenu=""
                                 x-placement="bottom"
                               >
-                                <button
+                                <a
                                   class="btn dropdown-item clickable"
+                                  href="/web/instructor/sessions/result?courseid=CS3281&fsname=Feedback%202"
+                                  routerlink="/web/instructor/sessions/result"
                                 >
                                   View Results
-                                </button>
+                                </a>
                                 
                                 <button
                                   class="btn dropdown-item clickable"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -61,25 +61,31 @@
           <select class="form-control preview-select" [(ngModel)]="emailOfStudentToPreview">
             <option *ngFor="let student of studentsOfCourse" [ngValue]="student.email">[{{ student.teamName }}] {{ student.name }}</option>
           </select>
-          <a routerLink="/web/sessions/submission"
+          <a *ngIf="emailOfStudentToPreview.length !== 0; else previewStudentBtn" routerLink="/web/sessions/submission"
              [queryParams]="{ courseid: courseId, fsname: feedbackSessionName, previewas: emailOfStudentToPreview }"
              target="_blank"
              rel="noopener noreferrer"
              [ngbTooltip]="emailOfStudentToPreview.length !== 0 ? 'View how this session would look like to a student who is submitting feedback.' : 'Preview is unavailable if the course has yet to have any student enrolled.'">
-            <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0">Preview as Student</button>
+            <ng-container *ngTemplateOutlet="previewStudentBtn"></ng-container>
           </a>
+          <ng-template #previewStudentBtn>
+            <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0">Preview as Student</button>
+          </ng-template>
         </div>
         <div class="col-lg-5">
           <select class="form-control preview-select" [(ngModel)]="emailOfInstructorToPreview">
             <option *ngFor="let instructor of instructorsCanBePreviewedAs" [ngValue]="instructor.email">{{ instructor.name }}</option>
           </select>
-          <a routerLink="/web/instructor/sessions/submission"
+          <a *ngIf="false; else previewInstructorBtn" routerLink="/web/instructor/sessions/submission"
              [queryParams]="{ courseid: courseId, fsname: feedbackSessionName, previewas: emailOfInstructorToPreview }"
              target="_blank"
              rel="noopener noreferrer"
              ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
-            <button class="btn btn-primary" [disabled]="emailOfInstructorToPreview.length === 0">Preview as Instructor</button>
+            <ng-container *ngTemplateOutlet="previewInstructorBtn"></ng-container>
           </a>
+          <ng-template #previewInstructorBtn>
+            <button class="btn btn-primary" [disabled]="false">Preview as Instructor</button>
+          </ng-template>
         </div>
       </div>
     </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -38,7 +38,7 @@
           </ng-container>
         </div>
       </div>
-      <button type="button" class="btn btn-link" (click)="questionsHelpHandler()"><i class="fas fa-info-circle"></i></button>
+      <a type="button" class="btn btn-link" target="_blank" rel="noopener noreferrer" routerLink="/web/instructor/help" [queryParams]="{questionId: 'questions', section: 'questions'}"><i class="fas fa-info-circle"></i></a>
       <button class="btn btn-primary" (click)="copyQuestionsFromOtherSessionsHandler()" [disabled]="isCopyingQuestion"><tm-ajax-loading *ngIf="isCopyingQuestion"></tm-ajax-loading>Copy Question</button>&nbsp;
       <button class="btn btn-primary" (click)="doneEditingHandler()">Done Editing</button>
     </div>
@@ -61,13 +61,25 @@
           <select class="form-control preview-select" [(ngModel)]="emailOfStudentToPreview">
             <option *ngFor="let student of studentsOfCourse" [ngValue]="student.email">[{{ student.teamName }}] {{ student.name }}</option>
           </select>
-          <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0" (click)="previewAsStudent()" [ngbTooltip]="emailOfStudentToPreview.length !== 0 ? 'View how this session would look like to a student who is submitting feedback.' : 'Preview is unavailable if the course has yet to have any student enrolled.'">Preview as Student</button>
+          <a routerLink="/web/sessions/submission"
+             [queryParams]="{ courseid: courseId, fsname: feedbackSessionName, previewas: emailOfStudentToPreview }"
+             target="_blank"
+             rel="noopener noreferrer"
+             [ngbTooltip]="emailOfStudentToPreview.length !== 0 ? 'View how this session would look like to a student who is submitting feedback.' : 'Preview is unavailable if the course has yet to have any student enrolled.'">
+            <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0">Preview as Student</button>
+          </a>
         </div>
         <div class="col-lg-5">
           <select class="form-control preview-select" [(ngModel)]="emailOfInstructorToPreview">
             <option *ngFor="let instructor of instructorsCanBePreviewedAs" [ngValue]="instructor.email">{{ instructor.name }}</option>
           </select>
-          <button class="btn btn-primary" [disabled]="emailOfInstructorToPreview.length === 0" (click)="previewAsInstructor()" ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">Preview as Instructor</button>
+          <a routerLink="/web/instructor/sessions/submission"
+             [queryParams]="{ courseid: courseId, fsname: feedbackSessionName, previewas: emailOfInstructorToPreview }"
+             target="_blank"
+             rel="noopener noreferrer"
+             ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
+            <button class="btn btn-primary" [disabled]="emailOfInstructorToPreview.length === 0">Preview as Instructor</button>
+          </a>
         </div>
       </div>
     </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -4,7 +4,6 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import moment from 'moment-timezone';
 import { forkJoin, Observable, of } from 'rxjs';
 import { concatMap, finalize, flatMap, map, switchMap, tap } from 'rxjs/operators';
-import { environment } from '../../../environments/environment';
 import { CourseService } from '../../../services/course.service';
 import { FeedbackQuestionsService, NewQuestionModel } from '../../../services/feedback-questions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
@@ -906,13 +905,6 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   }
 
   /**
-   * Handles question 'Help' link click event.
-   */
-  questionsHelpHandler(): void {
-    this.navigationService.openNewWindow(`${environment.frontendUrl}/web/instructor/help?questionId=questions&section=questions`);
-  }
-
-  /**
    * Gets all students of a course.
    */
   getAllStudentsOfCourse(): void {
@@ -960,23 +952,6 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             this.emailOfInstructorToPreview = this.instructorsCanBePreviewedAs[0].email;
           }
         }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
-  }
-
-  /**
-   * Previews the submission of the feedback session as a student.
-   */
-  previewAsStudent(): void {
-    this.navigationService.openNewWindow(`${environment.frontendUrl}/web/sessions/submission`,
-        { courseid: this.courseId, fsname: this.feedbackSessionName, previewas: this.emailOfStudentToPreview });
-  }
-
-  /**
-   * Previews the submission of the feedback session as an instructor.
-   */
-  previewAsInstructor(): void {
-    this.navigationService.openNewWindow(
-      `${environment.frontendUrl}/web/instructor/sessions/submission`,
-      { courseid: this.courseId, fsname: this.feedbackSessionName, previewas: this.emailOfInstructorToPreview });
   }
 
   expandAll(): void {

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -58,11 +58,11 @@
 
                   <hr/>
 
-                  <button class="btn btn-success"
+                  <a class="btn btn-success"
                     routerLink="/web/instructor/courses/enroll"
                     [queryParams]="{courseid: courseTab.course.courseId}">
                   Enroll Students
-                  </button>
+                  </a>
                   <br/><br/>
                   <tm-student-list
                       [courseId]="courseTab.course.courseId"


### PR DESCRIPTION
Fixes #10421 

**Outline of Solution**
![erere](https://user-images.githubusercontent.com/28994607/88621069-1a3aeb80-d0d2-11ea-9f69-771029a1b65a.gif)

- Added `routerLink` to `button` in `sessions-table`, `course-page`, `session-edit-page`
- Changed `button` tag to `a` tag to enable the `Open Link In New Tab`
- Removed unused code from `session-edit-page`