### PR TITLE
[#10462] CSV: Split rank received into multiple cells

### DIFF
--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -159,10 +159,10 @@ Summary Statistics
 Claimed Contribution (CC) = the contribution claimed by the student.
 Perceived Contribution (PC) = the average value of student's contribution as perceived by the team members.
 Team,Name,Email,CC,PC,Ratings Received
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,95,N/A,\\"N/A,N/A,N/A\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,Not Submitted,75,\\"75,N/A,N/A\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,Not Submitted,103,\\"103,N/A,N/A\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,Not Submitted,122,\\"122,N/A,N/A\\"
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,95,N/A,N/A,N/A,N/A
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,Not Submitted,75,75,N/A,N/A
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,Not Submitted,103,103,N/A,N/A
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,Not Submitted,122,122,N/A,N/A
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -68,9 +68,9 @@ Session Name,CONSTSUM Session
 Question 1,How important are the following factors to you? Give points accordingly.
 
 Summary Statistics
-Option,Points Received,Total Points,Average Points
-Fun,\\"20, 81\\",101,50.5
-Grades,\\"80, 19\\",99,49.5
+Option,Total Points,Average Points,Points Received
+Fun,101,50.5,20,81
+Grades,99,49.5,80,19
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Grades,Fun
@@ -84,7 +84,7 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,Team 1.2,studen
 Question 2,Split points among the teams
 
 Summary Statistics
-Team,Recipient,Points Received,Total Points,Average Points
+Team,Recipient,Total Points,Average Points,Points Received
 ,\\"Team 1.1</td></div>'\\"\\"\\",80,80,80
 ,Team 1.2,20,20,20
 
@@ -97,7 +97,7 @@ Instructors,Instructor1 Course1,Course1,instructor1@course1.tmt,Team 1.2,Team 1.
 Question 3,How much has each student worked?
 
 Summary Statistics
-Team,Recipient,Points Received,Total Points,Average Points
+Team,Recipient,Total Points,Average Points,Points Received
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",30,30,30
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,20,20,20
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,30,30,30
@@ -368,11 +368,11 @@ Session Name,RANK Session
 Question 1,Rank the other students.
 
 Summary Statistics
-Team,Recipient,Ranks Received,Self Rank,Overall Rank,Overall Rank Excluding Self
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",4,4,4,-
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,\\"3, 2\\",2,1,3
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,\\"2, 3\\",3,1,1
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,\\"4, 3, 1\\",3,3,2
+Team,Recipient,Self Rank,Overall Rank,Overall Rank Excluding Self,Ranks Received
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",4,4,-,4
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,2,1,3,3,2
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,3,1,1,2,3
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,3,3,2,4,3,1
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback
@@ -405,12 +405,12 @@ Team 1.2,student5 In Course1,Course1,student5InCourse1@gmail.tmt,\\"Team 1.1</td
 Question 2,Rank the areas of improvement you think your team should make progress in.
 
 Summary Statistics
-Option,Ranks Received,Overall Rank
-Friendliness of teammates,,
-Quality of progress reports,\\"2, 3\\",4
-Quality of work,\\"2, 3, 1, 4, 1\\",3
-Teamwork and communication,\\"1, 1, 4, 1\\",1
-Time management,\\"1, 2, 3, 2\\",2
+Option,Overall Rank,Ranks Received
+Friendliness of teammates,
+Quality of progress reports,4,2,3
+Quality of work,3,2,3,1,4,1
+Teamwork and communication,1,1,1,4,1
+Time management,2,1,2,3,2
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Feedback,Rank 1,Rank 2,Rank 3,Rank 4,Rank 5

--- a/src/web/types/question-details-impl/feedback-constsum-options-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-constsum-options-question-details.impl.ts
@@ -51,14 +51,14 @@ export class FeedbackConstantSumOptionsQuestionDetailsImpl extends AbstractFeedb
     }
     statsCalculation.calculateStatistics();
 
-    statsRows.push(['Option', 'Points Received', 'Total Points', 'Average Points']);
+    statsRows.push(['Option', 'Total Points', 'Average Points', 'Points Received']);
 
     Object.keys(statsCalculation.pointsPerOption).sort().forEach((option: string) => {
       statsRows.push([
         option,
-        statsCalculation.pointsPerOption[option].join(', '),
         String(statsCalculation.totalPointsPerOption[option]),
         String(statsCalculation.averagePointsPerOption[option]),
+        ...statsCalculation.pointsPerOption[option].map(String),
       ]);
     });
 

--- a/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
@@ -46,15 +46,15 @@ export class FeedbackConstantSumRecipientsQuestionDetailsImpl extends AbstractFe
     }
     statsCalculation.calculateStatistics();
 
-    statsRows.push(['Team', 'Recipient', 'Points Received', 'Total Points', 'Average Points']);
+    statsRows.push(['Team', 'Recipient', 'Total Points', 'Average Points', 'Points Received']);
 
     Object.keys(statsCalculation.pointsPerOption).sort().forEach((recipient: string) => {
       statsRows.push([
         statsCalculation.emailToTeamName[recipient],
         statsCalculation.emailToName[recipient],
-        statsCalculation.pointsPerOption[recipient].join(', '),
         String(statsCalculation.totalPointsPerOption[recipient]),
         String(statsCalculation.averagePointsPerOption[recipient]),
+        ...statsCalculation.pointsPerOption[recipient].map(String),
       ]);
     });
 

--- a/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
@@ -52,7 +52,7 @@ export class FeedbackContributionQuestionDetailsImpl extends AbstractFeedbackQue
       email: string,
       claimedStr: string,
       perceivedStr: string,
-      ratingsReceivedStr: string,
+      ratingsReceivedStr: string[],
     }[] = [];
     for (const email of Object.keys(statsCalculation.emailToName)) {
       const teamName: string = statsCalculation.emailToTeamName[email];
@@ -61,15 +61,14 @@ export class FeedbackContributionQuestionDetailsImpl extends AbstractFeedbackQue
       const claimedStr: string = this.getContributionPointToText(claimed);
       const perceived: number = statsCalculation.questionOverallStatistics.results[email].perceived;
       const perceivedStr: string = this.getContributionPointToText(perceived);
-      let ratingsReceivedStr: string =
+      const ratingsReceivedStr: string[] =
           statsCalculation.questionOverallStatistics.results[email].perceivedOthers
               .concat()
               .sort()
               .reverse()
-              .map(this.getContributionPointToText)
-              .join(',');
+              .map(this.getContributionPointToText);
       if (ratingsReceivedStr.length === 0) {
-        ratingsReceivedStr = 'N/A';
+        ratingsReceivedStr[0] = 'N/A';
       }
       stats.push({
         teamName,
@@ -91,10 +90,10 @@ export class FeedbackContributionQuestionDetailsImpl extends AbstractFeedbackQue
       email: string,
       claimedStr: string,
       perceivedStr: string,
-      ratingsReceivedStr: string,
+      ratingsReceivedStr: string[],
     }) => {
       statsRows.push([value.teamName, value.name, value.email,
-        value.claimedStr, value.perceivedStr, value.ratingsReceivedStr]);
+        value.claimedStr, value.perceivedStr, ...value.ratingsReceivedStr]);
     });
 
     return statsRows;

--- a/src/web/types/question-details-impl/feedback-rank-options-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rank-options-question-details.impl.ts
@@ -46,13 +46,13 @@ export class FeedbackRankOptionsQuestionDetailsImpl extends AbstractFeedbackQues
     }
     statsCalculation.calculateStatistics();
 
-    statsRows.push(['Option', 'Ranks Received', 'Overall Rank']);
+    statsRows.push(['Option', 'Overall Rank', 'Ranks Received']);
 
     Object.keys(statsCalculation.ranksReceivedPerOption).sort().forEach((option: string) => {
       statsRows.push([
         option,
-        statsCalculation.ranksReceivedPerOption[option].join(', '),
         statsCalculation.rankPerOption[option] ? String(statsCalculation.rankPerOption[option]) : '',
+        ...statsCalculation.ranksReceivedPerOption[option].map(String),
       ]);
     });
 

--- a/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
@@ -42,21 +42,21 @@ export class FeedbackRankRecipientsQuestionDetailsImpl extends AbstractFeedbackQ
     statsRows.push([
       'Team',
       'Recipient',
-      'Ranks Received',
       'Self Rank',
       'Overall Rank',
       'Overall Rank Excluding Self',
+      'Ranks Received',
     ]);
 
     Object.keys(statsCalculation.ranksReceivedPerOption).sort().forEach((recipient: string) => {
       statsRows.push([
         statsCalculation.emailToTeamName[recipient],
         statsCalculation.emailToName[recipient],
-        statsCalculation.ranksReceivedPerOption[recipient].join(', '),
         statsCalculation.selfRankPerOption[recipient] ? String(statsCalculation.selfRankPerOption[recipient]) : '-',
         statsCalculation.rankPerOption[recipient] ? String(statsCalculation.rankPerOption[recipient]) : '-',
         statsCalculation.rankPerOptionExcludeSelf[recipient] ?
             String(statsCalculation.rankPerOptionExcludeSelf[recipient]) : '-',
+        ...statsCalculation.ranksReceivedPerOption[recipient].map(String),
       ]);
     });
 


### PR DESCRIPTION
Fixes #10462 
Fixes #10436 
Fixes #10453 

- Set `Ranks Received` to be the last column to be shown, and spread out the values to multiple cells
    - For both rank-options and rank-recipients
![image](https://user-images.githubusercontent.com/32454748/88621090-27f07100-d0d2-11ea-8048-515c10d7715d.png)

- Set "Points Received" to be the last column to be shown, and spread out the values to multiple cells
    - For both constsum-options and constsum-recipients
![image](https://user-images.githubusercontent.com/32454748/88626164-b9fd7700-d0dc-11ea-8489-596266f7c18e.png)

- Set "Ratings Received" to be the last column to be shown, and spread out the values to multiple cells
    - For contribution-question
![image](https://user-images.githubusercontent.com/32454748/88642395-0358c100-d0f3-11ea-9d61-da546bdf6f72.png)

