### PR TITLE
[#10458] Make input fields more compact

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
@@ -1,8 +1,8 @@
 <div class="form-group row text-left" *ngFor="let option of questionDetails.constSumOptions; let i = index;">
-  <div class="col-12 col-sm-2 text-sm-right col-form-label">
+  <div class="col-md-2 col-xs-12 text-sm-right col-form-label">
     <strong>{{ option }}</strong>
   </div>
-  <div class="col-12 col-sm-5">
+  <div class="col-md-3 col-xs-12">
     <input type="number" class="form-control"
            [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
            (ngModelChange)="triggerResponse(i, $event)"

--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-5 col-sm-12">
+  <div class="col-lg-3 col-sm-6 col-xs-12">
     <select class="form-control"
             [ngClass]="{'color-positive': responseDetails.answer > 100,
               'color-negative': responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SURE && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED,
@@ -13,7 +13,7 @@
       <option *ngIf="questionDetails.isNotSureAllowed" [ngValue]="CONTRIBUTION_POINT_NOT_SURE" class="color-neutral">Not Sure</option>
     </select>
   </div>
-  <div class="col-md-7 col-sm-12" *ngIf="shouldShowHelpLink">
+  <div class="col-lg-9 col-sm-6 col-xs-12" *ngIf="shouldShowHelpLink">
     <button type="button" class="btn btn-link" (click)="openHelpModal(equalShareHelp)"><i class="fas fa-exclamation-circle"></i> More info about the <code>Equal Share</code> scale</button>
   </div>
   <ng-template #equalShareHelp>

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
@@ -1,9 +1,9 @@
 <div class="row text-left">
-  <div class="col-5">
+  <div class="col-md-3 col-xs-6">
     <input type="number" class="form-control" min="{{ questionDetails.minScale }}" max="{{ questionDetails.maxScale }}" step="{{ questionDetails.step }}"
            [ngModel]="responseDetails.answer == NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED ? '' : responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled">
   </div>
-  <div class="col-7">
+  <div class="col-md-9 col-xs-6">
     Possible Acceptable Values are: {{ possibleValues }}
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rank-options-question-edit-answer-form.component.html
@@ -1,8 +1,8 @@
 <div class="form-group row text-left" *ngFor="let num of questionDetails.options; let i = index;">
-  <div class="col-12 col-md-3 text-md-right col-form-label">
+  <div class="col-md-3 col-xs-6 text-md-right col-form-label">
     <strong>{{ questionDetails.options[i] }}</strong>
   </div>
-  <div class="col-12 col-md-9 text-md-left">
+  <div class="col-md-3 col-xs-6 text-md-left">
     <select class="form-control" [ngModel]="responseDetails.answers[i]"
             (ngModelChange)="triggerResponse(i, $event)" [disabled]="isDisabled">
       <option [ngValue]="RANK_OPTIONS_ANSWER_NOT_SUBMITTED"></option>

--- a/src/web/app/components/question-types/question-edit-answer-form/rank-recipients-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rank-recipients-question-edit-answer-form.component.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-sm-9">
+  <div class="col-md-3">
     <select class="form-control" [ngModel]="responseDetails.answer"
             (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled">
       <option [ngValue]="RANK_RECIPIENTS_ANSWER_NOT_SUBMITTED"></option>


### PR DESCRIPTION
Fixes #10458 

- Make input fields more compact
- Some mobile optimization

#### num-scale
![image](https://user-images.githubusercontent.com/32454748/88633396-86741a00-d0e7-11ea-90ac-f02e60a52844.png)
![image](https://user-images.githubusercontent.com/32454748/88633722-f84c6380-d0e7-11ea-9bfc-563c18a77add.png)

#### rank-options
![image](https://user-images.githubusercontent.com/32454748/88633420-925fdc00-d0e7-11ea-8563-096c6be024a5.png)
![image](https://user-images.githubusercontent.com/32454748/88633835-1ade7c80-d0e8-11ea-9186-b4ed33dd18e0.png)

#### rank-recipients
![image](https://user-images.githubusercontent.com/32454748/88633439-98ee5380-d0e7-11ea-9414-fac4fe616f71.png)
![image](https://user-images.githubusercontent.com/32454748/88633685-ebc80b00-d0e7-11ea-8c56-ee85b59e8122.png)

#### constsum-options
![image](https://user-images.githubusercontent.com/32454748/88634187-a22bf000-d0e8-11ea-921f-0148c5bab03c.png)
![image](https://user-images.githubusercontent.com/32454748/88634225-af48df00-d0e8-11ea-86bb-fd66a1bc190c.png)

#### team-contribution
![image](https://user-images.githubusercontent.com/32454748/88633511-b15e6e00-d0e7-11ea-9210-dbf601dc523e.png)
![image](https://user-images.githubusercontent.com/32454748/88634051-727ce800-d0e8-11ea-8c68-054633f31f45.png)
