### PR TITLE
[#10517] Preview as instructor link not working 

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -76,7 +76,7 @@
           <select class="form-control preview-select" [(ngModel)]="emailOfInstructorToPreview">
             <option *ngFor="let instructor of instructorsCanBePreviewedAs" [ngValue]="instructor.email">{{ instructor.name }}</option>
           </select>
-          <a *ngIf="false; else previewInstructorBtn" routerLink="/web/instructor/sessions/submission"
+          <a *ngIf="emailOfInstructorToPreview.length !== 0; else previewInstructorBtn" routerLink="/web/instructor/sessions/submission"
              [queryParams]="{ courseid: courseId, fsname: feedbackSessionName, previewas: emailOfInstructorToPreview }"
              target="_blank"
              rel="noopener noreferrer"
@@ -84,7 +84,7 @@
             <ng-container *ngTemplateOutlet="previewInstructorBtn"></ng-container>
           </a>
           <ng-template #previewInstructorBtn>
-            <button class="btn btn-primary" [disabled]="false">Preview as Instructor</button>
+            <button class="btn btn-primary" [disabled]="emailOfInstructorToPreview.length === 0">Preview as Instructor</button>
           </ng-template>
         </div>
       </div>


### PR DESCRIPTION
Fixes #10517

**Outline of Solution**

- ngIf was set to false, causing the link to always not be present
- change back to using `emailOfInstructorToPreview` as the check
