### PR TITLE
[#10354] [#10428] [#10511] [#10530] [#10545] UAT round 5 fixes: miscellaneous

### DIFF
--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -36,7 +36,7 @@
         </th>
         <th>Response</th>
         <th *ngIf="canResponseHasComment">Comment for Response</th>
-        <th class="text-center no-print">Actions</th>
+        <th class="text-center no-print actions-cell" [ngClass]="{ 'actions-cell-narrow': question.questionType === 'CONTRIB' }">Actions</th>
       </tr>
     </thead>
     <tbody>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
@@ -6,3 +6,18 @@
 .color-neutral {
   color: gray;
 }
+
+.actions-cell,
+.actions-cell-narrow {
+  min-width: 160px;
+}
+
+@media (min-width: 1000px) {
+  .actions-cell {
+    min-width: 300px;
+  }
+
+  .actions-cell-narrow {
+    min-width: 160px;
+  }
+}

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
@@ -106,8 +106,8 @@ export class McqQuestionStatisticsCalculation
 
         this.perRecipientResponses[recipient] = {
           recipient,
-          total,
-          average,
+          total: +total.toFixed(5),
+          average: +average.toFixed(2),
           recipientTeam: recipientToTeam[recipient],
           responses: perRecipientResponse[recipient],
         };

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
@@ -118,8 +118,8 @@ export class MsqQuestionStatisticsCalculation
 
       this.perRecipientResponses[recipient] = {
         recipient,
-        total,
-        average,
+        total: +total.toFixed(5),
+        average: +average.toFixed(2),
         recipientTeam: recipientToTeam[recipient],
         responses: perRecipientResponse[recipient],
       };

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/num-scale-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/num-scale-question-statistics-calculation.ts
@@ -42,14 +42,14 @@ export class NumScaleQuestionStatisticsCalculation
         stats.max = Math.max(...answersAsArray);
         stats.min = Math.min(...answersAsArray);
         const average: number = answersAsArray.reduce((a: number, b: number) => a + b, 0) / answersAsArray.length;
-        stats.average = Math.round(average * 100) / 100; // Show integers without dp, truncate fractions to 2dp
+        stats.average = +average.toFixed(2); // Show integers without dp, truncate fractions to 2dp
 
         const answersExcludingSelfAsArray: number[] = stats.responses.filter((resp: any) => !resp.isSelf)
             .map((resp: any) => resp.answer);
         if (answersExcludingSelfAsArray.length) {
           const averageExcludingSelf: number = answersExcludingSelfAsArray.reduce((a: number, b: number) => a + b, 0)
               / answersExcludingSelfAsArray.length;
-          stats.averageExcludingSelf = Math.round(averageExcludingSelf * 100) / 100;
+          stats.averageExcludingSelf = +averageExcludingSelf.toFixed(2);
         } else {
           stats.averageExcludingSelf = 0;
         }

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
@@ -113,7 +113,8 @@ export class RubricQuestionStatisticsCalculation
           continue;
         }
         this.perRecipientStatsMap[response.recipient].answers[i][subAnswer] += 1;
-        this.perRecipientStatsMap[response.recipient].subQuestionTotalChosenWeight[i] += this.weights[i][subAnswer];
+        this.perRecipientStatsMap[response.recipient].subQuestionTotalChosenWeight[i] +=
+            +this.weights[i][subAnswer].toFixed(5);
       }
     }
 
@@ -134,7 +135,7 @@ export class RubricQuestionStatisticsCalculation
       const weightAverage: number = sums[subQuestionIdx] === 0 ? 0
           : subQuestionAnswer.reduce((prevValue: number, currValue: number, currentIndex: number): number =>
               prevValue + currValue * this.weights[subQuestionIdx][currentIndex], 0) / sums[subQuestionIdx];
-      return Math.round(weightAverage * 100) / 100;
+      return +weightAverage.toFixed(2);
     });
   }
 
@@ -149,7 +150,7 @@ export class RubricQuestionStatisticsCalculation
     // Calculate the percentages based on the entry of each cell and the sum of each row
     for (let i: number = 0; i < answers.length; i += 1) {
       for (let j: number = 0; j < answers[i].length; j += 1) {
-        percentages[i][j] = sums[i] === 0 ? 0 : Math.round(percentages[i][j] / sums[i] * 1000) / 10;
+        percentages[i][j] = sums[i] === 0 ? 0 : +(percentages[i][j] / sums[i] * 100).toFixed(2);
       }
     }
 

--- a/src/web/app/components/sessions-table/sessions-table.component.scss
+++ b/src/web/app/components/sessions-table/sessions-table.component.scss
@@ -3,6 +3,12 @@
   text-align: center;
 }
 
+@media (min-width: 1200px) {
+  .actions-cell {
+    min-width: 410px;
+  }
+}
+
 .actions-cell button:not(.dropdown-item) {
   margin-left: var(--btn-margin);
 }

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -380,9 +380,9 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
    * Loads all feedback sessions that can be accessed by current user.
    */
   loadFeedbackSessions(): void {
-    this.isFeedbackSessionsLoading = false;
+    this.isFeedbackSessionsLoading = true;
     this.feedbackSessionsService.getFeedbackSessionsForInstructor()
-        .pipe(finalize(() => this.isFeedbackSessionsLoading = true))
+        .pipe(finalize(() => this.isFeedbackSessionsLoading = false))
         .subscribe((response: FeedbackSessions) => {
           response.feedbackSessions.forEach((session: FeedbackSession) => {
             const model: SessionsTableRowModel = {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -621,10 +621,8 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                         recipientSubmissionFormModel.recipientIdentifier = resp.recipientIdentifier;
                       }),
                       switchMap(() => this.createCommentRequest(recipientSubmissionFormModel)),
-                      catchError((error: any) => {
-                        this.statusMessageService.showErrorToast((error as ErrorMessageOutput).error.message);
-                        failToSaveQuestions[questionSubmissionFormModel.questionNumber]
-                            = (error as ErrorMessageOutput).error.message;
+                      catchError((error: ErrorMessageOutput) => {
+                        failToSaveQuestions[questionSubmissionFormModel.questionNumber] = error.error.message;
                         return of(error);
                       }),
                   ));
@@ -640,19 +638,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     let hasSubmissionConfirmationError: boolean = false;
     forkJoin(savingRequests).pipe(
         switchMap(() => {
-          if (Object.keys(failToSaveQuestions).length === 0) {
-            this.statusMessageService.showSuccessToast('All responses submitted successfully!');
-          } else {
-            this.statusMessageService.showErrorToast('Some responses are not saved successfully');
-          }
-
-          if (notYetAnsweredQuestions.size !== 0) {
-            // TODO use showInfoMessage
-            this.statusMessageService.showSuccessToast(
-                `Note that some questions are yet to be answered. They are:
-                ${ Array.from(notYetAnsweredQuestions.values()) }.`);
-          }
-
           return this.feedbackSessionsService.confirmSubmission({
             courseId: this.courseId,
             feedbackSessionName: this.feedbackSessionName,

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -432,7 +432,7 @@ Question 1,Please choose the best choice for the following sub-questions.
 
 Summary Statistics
 ,Yes,No,Average
-a) This student has done a good job.,66.7% (2) [1.25],33.3% (1) [-1.7],0.27
+a) This student has done a good job.,66.67% (2) [1.25],33.33% (1) [-1.7],0.27
 b) This student has tried his/her best.,75% (3) [1.25],25% (1) [-1.7],0.51
 
 Per Recipient Statistics
@@ -475,7 +475,7 @@ Question 2,Please choose the best choice for the following sub-questions. Only f
 
 Summary Statistics
 ,Yes,No,Average
-a) This student has done a good job.,66.7% (2) [1.25],33.3% (1) [1],1.17
+a) This student has done a good job.,66.67% (2) [1.25],33.33% (1) [1],1.17
 b) This student has tried his/her best.,0% (0) [1.25],0% (0) [1],0
 
 Per Recipient Statistics

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -226,7 +226,7 @@ h6,
 }
 
 :root {
-  --btn-margin: 10px;
+  --btn-margin: 5px;
 }
 
 .btn-margin-left {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -91,7 +91,14 @@ h6,
   max-width: 70vw;
   min-width: 30vw;
   overflow-y: scroll;
+  scrollbar-width: none; // Firefox
+  -ms-overflow-style: none;  // IE10+
   vertical-align: middle;
+
+  &::-webkit-scrollbar { // Webkit-based browsers
+    width: 0;
+    height: 0;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
- Fixes #10511 
  - Note that I am not sure that the fix actually works, because the problem did not manifest in my environment. Likely to be specific to Win10 + Chrome.
- Fixes #10354 + fixes #10545 (similar issue)
  - Reduced the site-wide L/R margin of bottoms to 5px as 10px looks too wide.
- Fixes #10428 
  - The problem is not specific to MSQ; it applies to all question types.
- Fixes #10530 
  - Also standardized the way rounding is done, by using `+` and `toFixed`.

And fixed a regression in #10543 where a flipped condition caused feedback session table to never finish loading.