### PR TITLE
[#10559] Pages with rich text editors cannot be displayed

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
             "main": "src/web/main.ts",
             "polyfills": "src/web/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "aot": false,
+            "aot": true,
             "assets": [
               "src/web/assets/",
               {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11175,9 +11175,9 @@
       "integrity": "sha512-h+j2xfbAwRkybjmx7I0jO+7f/MGkF/WwEqO7qudQwGAVF81Xw5LVfgZ8hTKTXPA+CeCS+3I/Rl99GFRhj0TYwA=="
     },
     "ng-in-viewport": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/ng-in-viewport/-/ng-in-viewport-6.1.1.tgz",
-      "integrity": "sha512-gw/p8Fhj5JIzzgkRcOHoR+34J2btidBx5Rt46/c4+CE89Ro/cLzaV1mIrr3TgOOuwSqMa5O7LG7m9V3KtFwMTQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ng-in-viewport/-/ng-in-viewport-6.1.0.tgz",
+      "integrity": "sha512-mJlsiGBhOLiqgM4S36zg9IWjv0YsOPuoVB1T4mKaq4NZ2aHB/8t5n5pB+pP93k1mmSUhp+cPscGua5o7gJrURg==",
       "requires": {
         "intersection-observer": ">=0.5.1",
         "tslib": ">=1.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11175,11 +11175,11 @@
       "integrity": "sha512-h+j2xfbAwRkybjmx7I0jO+7f/MGkF/WwEqO7qudQwGAVF81Xw5LVfgZ8hTKTXPA+CeCS+3I/Rl99GFRhj0TYwA=="
     },
     "ng-in-viewport": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ng-in-viewport/-/ng-in-viewport-6.1.0.tgz",
-      "integrity": "sha512-mJlsiGBhOLiqgM4S36zg9IWjv0YsOPuoVB1T4mKaq4NZ2aHB/8t5n5pB+pP93k1mmSUhp+cPscGua5o7gJrURg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/ng-in-viewport/-/ng-in-viewport-6.1.3.tgz",
+      "integrity": "sha512-REU59ZZE3er08obKvTpGN1B3/OTZ9TSRK7W6Yl6wC694FMfKW8YZrJo7ktoMw6cF13tegLoB/ojEPGruJ07EUA==",
       "requires": {
-        "intersection-observer": ">=0.5.1",
+        "intersection-observer": ">=0.11.0",
         "tslib": ">=1.9.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "intersection-observer": "^0.11.0",
     "moment-timezone": "^0.5.31",
     "ng-dynamic-component": "^6.1.0",
-    "ng-in-viewport": "^6.1.1",
+    "ng-in-viewport": "6.1.0",
     "ngx-captcha": "^8.0.1",
     "ngx-image-cropper": "^1.5.1",
     "ngx-page-scroll-core": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "intersection-observer": "^0.11.0",
     "moment-timezone": "^0.5.31",
     "ng-dynamic-component": "^6.1.0",
-    "ng-in-viewport": "6.1.0",
+    "ng-in-viewport": "^6.1.3",
     "ngx-captcha": "^8.0.1",
     "ngx-image-cropper": "^1.5.1",
     "ngx-page-scroll-core": "^7.0.1",

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,7 +4,7 @@
   <title>TEAMMATES - Online Peer Feedback/Evaluation System for Student Team Projects</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; frame-src 'self' docs.google.com https://www.google.com/recaptcha/; img-src 'self' data: http: https:; font-src 'self'; connect-src 'self' ws: http://localhost:*; form-action 'none'; base-uri 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; frame-src 'self' docs.google.com https://www.google.com/recaptcha/; img-src 'self' data: http: https:; font-src 'self'; connect-src 'self' ws: http://localhost:*; form-action 'none'; base-uri 'self'">
   <link rel="shortcut icon" href="assets/icons/icon-32x32.ico">
   <link rel="icon" href="assets/icons/icon-32x32.png">
   <link rel="apple-touch-icon" href="assets/icons/icon-152x152.png">


### PR DESCRIPTION
Fixes #10559 

Cause: one of the libraries recently added, `ng-in-viewport`, has `new Function` as part of its code, which is blocked under `unsafe-eval` CSP policy.

Solution:
- There is a very recent version that did not use any `unsafe-eval`-breaking code; use that version
- Change the local HTML file to also exclude `unsafe-eval` so that this kind of problem can be detected earlier

I have raised the issue to the library author: https://github.com/k3nsei/ng-in-viewport/issues/333