### PR TITLE
[#10574] [#10575] [#10576] Fix back-end related issues

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -138,9 +138,9 @@ public final class FieldValidator {
             "The provided ${fieldName} is not acceptable to TEAMMATES as it contains only whitespace "
             + "or contains extra spaces at the beginning or at the end of the text.";
     public static final String NON_HTML_FIELD_ERROR_MESSAGE =
-            SanitizationHelper.sanitizeForHtml("The provided ${fieldName} is not acceptable to TEAMMATES "
-                                                + "as it cannot contain the following special html characters"
-                                                + " in brackets: (< > \" / ' &)");
+            "The provided ${fieldName} is not acceptable to TEAMMATES "
+                    + "as it cannot contain the following special html characters"
+                    + " in brackets: (< > \" / ' &)";
     public static final String NON_NULL_FIELD_ERROR_MESSAGE =
             "The provided ${fieldName} is not acceptable to TEAMMATES as it cannot be empty.";
 
@@ -246,7 +246,6 @@ public final class FieldValidator {
     public static String getInvalidityInfoForEmail(String email) {
 
         Assumption.assertNotNull("Non-null value expected", email);
-        String sanitizedValue = SanitizationHelper.sanitizeForHtml(email);
 
         if (email.isEmpty()) {
             return getPopulatedEmptyStringErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, EMAIL_FIELD_NAME,
@@ -254,10 +253,10 @@ public final class FieldValidator {
         } else if (isUntrimmed(email)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", EMAIL_FIELD_NAME);
         } else if (email.length() > EMAIL_MAX_LENGTH) {
-            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE, sanitizedValue, EMAIL_FIELD_NAME,
+            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE, email, EMAIL_FIELD_NAME,
                                             REASON_TOO_LONG, EMAIL_MAX_LENGTH);
         } else if (!isValidEmailAddress(email)) {
-            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE, sanitizedValue, EMAIL_FIELD_NAME,
+            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE, email, EMAIL_FIELD_NAME,
                                             REASON_INCORRECT_FORMAT, EMAIL_MAX_LENGTH);
         }
         return "";
@@ -287,7 +286,6 @@ public final class FieldValidator {
         Assumption.assertNotNull("Non-null value expected", googleId);
         Assumption.assertTrue("\"" + googleId + "\"" + "is not expected to be a gmail address.",
                 !googleId.toLowerCase().endsWith("@gmail.com"));
-        String sanitizedValue = SanitizationHelper.sanitizeForHtml(googleId);
 
         boolean isValidFullEmail = isValidEmailAddress(googleId);
         boolean isValidEmailWithoutDomain = StringHelper.isMatching(googleId, REGEX_GOOGLE_ID_NON_EMAIL);
@@ -298,10 +296,10 @@ public final class FieldValidator {
         } else if (isUntrimmed(googleId)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", GOOGLE_ID_FIELD_NAME);
         } else if (googleId.length() > GOOGLE_ID_MAX_LENGTH) {
-            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE, sanitizedValue, GOOGLE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE, googleId, GOOGLE_ID_FIELD_NAME,
                                             REASON_TOO_LONG, GOOGLE_ID_MAX_LENGTH);
         } else if (!(isValidFullEmail || isValidEmailWithoutDomain)) {
-            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE, sanitizedValue, GOOGLE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE, googleId, GOOGLE_ID_FIELD_NAME,
                                             REASON_INCORRECT_FORMAT, GOOGLE_ID_MAX_LENGTH);
         }
         return "";
@@ -325,13 +323,12 @@ public final class FieldValidator {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}",
                     COURSE_NAME_FIELD_NAME);
         }
-        String sanitizedValue = SanitizationHelper.sanitizeForHtml(courseId);
         if (courseId.length() > COURSE_ID_MAX_LENGTH) {
-            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE, sanitizedValue, COURSE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE, courseId, COURSE_ID_FIELD_NAME,
                                             REASON_TOO_LONG, COURSE_ID_MAX_LENGTH);
         }
         if (!StringHelper.isMatching(courseId, REGEX_COURSE_ID)) {
-            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE, sanitizedValue, COURSE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE, courseId, COURSE_ID_FIELD_NAME,
                                             REASON_INCORRECT_FORMAT, COURSE_ID_MAX_LENGTH);
         }
         return "";
@@ -412,7 +409,7 @@ public final class FieldValidator {
     public static String getInvalidityInfoForNationality(String nationality) {
         Assumption.assertNotNull("Non-null value expected", nationality);
         if (!NationalityHelper.getNationalities().contains(nationality)) {
-            return String.format(NATIONALITY_ERROR_MESSAGE, SanitizationHelper.sanitizeForHtml(nationality));
+            return String.format(NATIONALITY_ERROR_MESSAGE, nationality);
         }
         return "";
     }
@@ -447,9 +444,8 @@ public final class FieldValidator {
     public static String getInvalidityInfoForTimeZone(String timeZoneValue) {
         Assumption.assertNotNull("Non-null value expected", timeZoneValue);
         if (!ZoneId.getAvailableZoneIds().contains(timeZoneValue)) {
-            String sanitizedValue = SanitizationHelper.sanitizeForHtml(timeZoneValue);
             return getPopulatedErrorMessage(TIME_ZONE_ERROR_MESSAGE,
-                    sanitizedValue, TIME_ZONE_FIELD_NAME, REASON_UNAVAILABLE_AS_CHOICE);
+                    timeZoneValue, TIME_ZONE_FIELD_NAME, REASON_UNAVAILABLE_AS_CHOICE);
         }
         return "";
     }
@@ -462,10 +458,9 @@ public final class FieldValidator {
      */
     public static String getInvalidityInfoForRole(String role) {
         Assumption.assertNotNull("Non-null value expected", role);
-        String sanitizedValue = SanitizationHelper.sanitizeForHtml(role);
 
         if (!ROLE_ACCEPTED_VALUES.contains(role)) {
-            return String.format(ROLE_ERROR_MESSAGE, sanitizedValue);
+            return String.format(ROLE_ERROR_MESSAGE, role);
         }
         return "";
     }
@@ -501,25 +496,24 @@ public final class FieldValidator {
         if (isUntrimmed(value)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);
         }
-        String sanitizedValue = SanitizationHelper.sanitizeForHtml(value);
         if (value.length() > maxLength) {
-            return getPopulatedErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, sanitizedValue,
+            return getPopulatedErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, value,
                                             fieldName, REASON_TOO_LONG, maxLength);
         }
         if (!Character.isLetterOrDigit(value.codePointAt(0))) {
             boolean hasStartingBrace = value.charAt(0) == '{' && value.contains("}");
             if (!hasStartingBrace) {
-                return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, sanitizedValue,
+                return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, value,
                                                 fieldName, REASON_START_WITH_NON_ALPHANUMERIC_CHAR);
             }
             if (!StringHelper.isMatching(value.substring(1), REGEX_NAME)) {
-                return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, sanitizedValue, fieldName,
+                return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, value, fieldName,
                                                 REASON_CONTAINS_INVALID_CHAR);
             }
             return "";
         }
         if (!StringHelper.isMatching(value, REGEX_NAME)) {
-            return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, sanitizedValue, fieldName,
+            return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, value, fieldName,
                                             REASON_CONTAINS_INVALID_CHAR);
         }
         return "";
@@ -545,8 +539,7 @@ public final class FieldValidator {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);
         }
         if (value.length() > maxLength) {
-            String sanitizedValue = SanitizationHelper.sanitizeForHtml(value);
-            return getPopulatedErrorMessage(SIZE_CAPPED_POSSIBLY_EMPTY_STRING_ERROR_MESSAGE, sanitizedValue,
+            return getPopulatedErrorMessage(SIZE_CAPPED_POSSIBLY_EMPTY_STRING_ERROR_MESSAGE, value,
                                             fieldName, REASON_TOO_LONG, maxLength);
         }
         return "";

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -15,7 +15,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.RegenerateStudentException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.SanitizationHelper;
 import teammates.storage.api.StudentsDb;
 
 /**
@@ -305,8 +304,8 @@ public final class StudentsLogic {
 
                 errorMessage.add(String.format(Const.StudentsLogicConst.ERROR_INVALID_TEAM_NAME,
                         currentStudent.team,
-                        SanitizationHelper.sanitizeForHtml(previousStudent.section),
-                        SanitizationHelper.sanitizeForHtml(currentStudent.section)));
+                        previousStudent.section,
+                        currentStudent.section));
 
                 invalidTeamList.add(currentStudent.team);
             }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -52,11 +52,18 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
                         Instant.ofEpochMilli(rangeStart.toEpochMilli()).minus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW))
                 .list();
 
-        // remove duplications
-        endEntities.removeAll(startEntities);
-        endEntities.addAll(startEntities);
+        List<String> startEntitiesIds = startEntities.stream()
+                .map(session -> session.getCourseId() + "::" + session.getFeedbackSessionName())
+                .collect(Collectors.toList());
 
-        return makeAttributes(endEntities);
+        List<FeedbackSession> ongoingSessions = endEntities.stream()
+                .filter(session -> {
+                    String id = session.getCourseId() + "::" + session.getFeedbackSessionName();
+                    return startEntitiesIds.contains(id);
+                })
+                .collect(Collectors.toList());
+
+        return makeAttributes(ongoingSessions);
     }
 
     /**

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -561,7 +561,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         assertEquals(
                 "The provided feedback session name is not acceptable to TEAMMATES "
                         + "as it cannot contain the following special html characters in brackets: "
-                        + "(&lt; &gt; &quot; &#x2f; &#39; &amp;)",
+                        + "(< > \" / ' &)",
                 e.getMessage());
 
         fs.setFeedbackSessionName("test %| test");

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -6,7 +6,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
-import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.test.cases.BaseTestCase;
 import teammates.test.driver.StringHelperExtension;
@@ -41,8 +40,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = FieldValidator.getValidityInfoForNonHtmlField(testFieldName, unsanitizedInput);
         assertEquals("Invalid unsanitized input should return error string",
                      "The provided Inconsequential test field name is not acceptable to TEAMMATES as it "
-                         + "cannot contain the following special html characters in brackets: (&lt; &gt; &quot; "
-                         + "&#x2f; &#39; &amp;)",
+                         + "cannot contain the following special html characters in brackets: (< > \" / ' &)",
                      actual);
     }
 
@@ -114,7 +112,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameContainInvalidChars = "Dr. Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"Dr. Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is "
+                     "\"Dr. Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)\" is "
                          + "not acceptable to TEAMMATES as a/an name field because it contains invalid "
                          + "characters. A/An name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
@@ -125,7 +123,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithNonAlphaNumChar = "!Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"!Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
+                     "\"!Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
                          + "non-alphanumeric character. A/An name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
@@ -136,7 +134,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithBracesButHasInvalidChar = "{Amy} -Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"{Amy} -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
+                     "\"{Amy} -Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it contains invalid "
                          + "characters. A/An name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
@@ -147,7 +145,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithCurlyBracketButHasNoEnd = "{Amy -Bén s/o O'&|% 2\t\n (~!@#$^*+_={[]\\:;\"<>?)";
         assertEquals("invalid: typical length started with non-alphanumeric character",
-                     "\"{Amy -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={[]\\:;&quot;&lt;&gt;?)\" is not "
+                     "\"{Amy -Bén s/o O'&|% 2\t\n (~!@#$^*+_={[]\\:;\"<>?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
                          + "non-alphanumeric character. A/An name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
@@ -230,8 +228,7 @@ public class FieldValidatorTest extends BaseTestCase {
         invalidNationality = "<script> alert('hi!'); </script>";
         actual = FieldValidator.getInvalidityInfoForNationality(invalidNationality);
         assertEquals("Unsanitized, invalid nationality should return sanitized error string",
-                     String.format(FieldValidator.NATIONALITY_ERROR_MESSAGE, SanitizationHelper.sanitizeForHtml(
-                     invalidNationality)), actual);
+                     String.format(FieldValidator.NATIONALITY_ERROR_MESSAGE, invalidNationality), actual);
     }
 
     @Test
@@ -309,8 +306,7 @@ public class FieldValidatorTest extends BaseTestCase {
         invalidRole = "<script> alert('hi!'); </script>";
         actual = FieldValidator.getInvalidityInfoForRole(invalidRole);
         assertEquals("Unsanitized, invalid role should return appropriate error string",
-                String.format(FieldValidator.ROLE_ERROR_MESSAGE, SanitizationHelper.sanitizeForHtml(invalidRole)),
-                actual);
+                String.format(FieldValidator.ROLE_ERROR_MESSAGE, invalidRole), actual);
     }
 
     @Test
@@ -387,7 +383,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String idWithInvalidHtmlChar = "invalid google id with HTML/< special characters";
         assertEquals("Invalid Google ID (contains HTML characters) should return appropriate error message",
-                     "\"invalid google id with HTML&#x2f;&lt; special characters\" is not acceptable to "
+                     "\"invalid google id with HTML/< special characters\" is not acceptable to "
                          + "TEAMMATES as a/an Google ID because it is not in the correct format. A Google ID "
                          + "must be a valid id already registered with Google. It cannot be longer than 254 "
                          + "characters, cannot be empty and cannot contain spaces.",

--- a/src/test/java/teammates/test/cases/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetOngoingSessionsActionTest.java
@@ -43,16 +43,17 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
 
         verifyNoExistingSession(r);
 
-        ______TS("Typical use case");
+        ______TS("Typical use case; one ongoing session, should be returned");
 
         InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         String courseId = instructor1OfCourse1.courseId;
+        String feedbackSessionName = "new-session";
 
         Instant startTime = Instant.now();
         Instant endTime = Instant.now().plus(5, ChronoUnit.DAYS);
 
         logic.createFeedbackSession(
-                FeedbackSessionAttributes.builder("new-session", courseId)
+                FeedbackSessionAttributes.builder(feedbackSessionName, courseId)
                         .withCreatorEmail(instructor1OfCourse1.email)
                         .withStartTime(startTime)
                         .withEndTime(endTime)
@@ -77,6 +78,37 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         assertEquals(1, response.getTotalOngoingSessions());
         assertEquals(1, response.getTotalInstitutes());
         assertEquals(1, response.getSessions().size());
+
+        ______TS("Typical use case; one future session, should not be returned");
+
+        startTime = Instant.now().minus(2, ChronoUnit.DAYS);
+        endTime = Instant.now().minus(1, ChronoUnit.DAYS);
+
+        params = new String[] {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(startTime.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(endTime.toEpochMilli()),
+        };
+
+        getOngoingSessionsAction = getAction(params);
+        r = getJsonResult(getOngoingSessionsAction);
+
+        verifyNoExistingSession(r);
+
+        ______TS("Typical use case; one past session, should not be returned");
+
+        startTime = Instant.now().plus(6, ChronoUnit.DAYS);
+        endTime = Instant.now().plus(7, ChronoUnit.DAYS);
+
+        params = new String[] {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(startTime.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(endTime.toEpochMilli()),
+        };
+
+        getOngoingSessionsAction = getAction(params);
+        r = getJsonResult(getOngoingSessionsAction);
+
+        verifyNoExistingSession(r);
+
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/GetStudentProfileActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetStudentProfileActionTest.java
@@ -93,7 +93,7 @@ public class GetStudentProfileActionTest extends BaseActionTest<GetStudentProfil
     }
 
     @Test
-    public void testExecute_getProfileOfUnregisteredStudent_shouldReturnNotFoundMessage() throws Exception {
+    public void testExecute_getProfileOfUnregisteredStudent_shouldReturnEmptyProfile() throws Exception {
         StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
         // Prepare an unregistered teammate
         StudentAttributes unregisteredStudentInCourse1 =
@@ -110,9 +110,19 @@ public class GetStudentProfileActionTest extends BaseActionTest<GetStudentProfil
                 Const.ParamsNames.COURSE_ID, unregisteredStudentInCourse1.getCourse(),
         };
         loginAsStudent(student1InCourse1.getGoogleId());
+        StudentProfileAttributes expectedProfile = StudentProfileAttributes.builder("").build();
+
         GetStudentProfileAction action = getAction(submissionParams);
         JsonResult result = getJsonResult(action);
-        assertEquals(HttpStatus.SC_NOT_FOUND, result.getStatusCode());
+        assertEquals(HttpStatus.SC_OK, result.getStatusCode());
+        StudentProfileData actualProfile = (StudentProfileData) result.getOutput();
+        assertEquals("unregistered student in course 1", actualProfile.getName());
+        assertNull(actualProfile.getEmail());
+        assertNull(expectedProfile.shortName, actualProfile.getShortName());
+        assertEquals(expectedProfile.institute, actualProfile.getInstitute());
+        assertEquals(expectedProfile.moreInfo, actualProfile.getMoreInfo());
+        assertEquals(expectedProfile.nationality, actualProfile.getNationality());
+        assertEquals(expectedProfile.gender, actualProfile.getGender());
     }
 
     private void testGetCorrectProfile(StudentProfileAttributes expectedProfile,

--- a/src/test/java/teammates/test/cases/webapi/UpdateStudentProfileActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateStudentProfileActionTest.java
@@ -96,25 +96,25 @@ public class UpdateStudentProfileActionTest extends BaseActionTest<UpdateStudent
 
         expectedErrorMessages.add(
                 getPopulatedErrorMessage(FieldValidator.INVALID_NAME_ERROR_MESSAGE,
-                        SanitizationHelper.sanitizeForHtml(req.getShortName()),
+                        req.getShortName(),
                         FieldValidator.PERSON_NAME_FIELD_NAME,
                         FieldValidator.REASON_CONTAINS_INVALID_CHAR,
                         FieldValidator.PERSON_NAME_MAX_LENGTH));
         expectedErrorMessages.add(
                 getPopulatedErrorMessage(FieldValidator.EMAIL_ERROR_MESSAGE,
-                        SanitizationHelper.sanitizeForHtml(req.getEmail()),
+                        req.getEmail(),
                         FieldValidator.EMAIL_FIELD_NAME,
                         FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.EMAIL_MAX_LENGTH));
         expectedErrorMessages.add(
                 getPopulatedErrorMessage(FieldValidator.INVALID_NAME_ERROR_MESSAGE,
-                        SanitizationHelper.sanitizeForHtml(req.getInstitute()),
+                        req.getInstitute(),
                         FieldValidator.INSTITUTE_NAME_FIELD_NAME,
                         FieldValidator.REASON_START_WITH_NON_ALPHANUMERIC_CHAR,
                         FieldValidator.INSTITUTE_NAME_MAX_LENGTH));
         expectedErrorMessages.add(
                 String.format(FieldValidator.NATIONALITY_ERROR_MESSAGE,
-                        SanitizationHelper.sanitizeForHtml(req.getNationality())));
+                        req.getNationality()));
 
         assertEquals(String.join(System.lineSeparator(), expectedErrorMessages), invalidOutput.getMessage());
     }


### PR DESCRIPTION
This fixes some back-end operations:
- Fixes #10574 
  - Change `404` to `200` (cannot use `204` because the response body will be stripped) and return empty student profile if the student has not registered. `404` is appropriate when the target student is not found.
- Fixes #10575 
  - This was due to HTML sanitization when constructing error message. HTML sanitization in the back-end is no longer necessary and in fact should not be done. The only place where HTML sanitization is still relevant is email content generation.
- Fixes #10576 
  - This was due to the sessions queried via start time and end time are combined with OR operation, not AND.
