### PR TITLE
[#10516] Features page: reduce indentation

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -63,7 +63,7 @@
               ],
               "index": {
                 "input": "src/web/index.prod.html",
-                "output": "index.html"
+                "output": "index.html",
               },
               "assets": [
                 "src/web/assets/",

--- a/angular.json
+++ b/angular.json
@@ -158,8 +158,5 @@
       }
     }
   },
-  "defaultProject": "teammates",
-  "cli": {
-    "analytics": "65249922-4f6e-433c-807e-02697cd7f415"
-  }
+  "defaultProject": "teammates"
 }

--- a/angular.json
+++ b/angular.json
@@ -63,7 +63,7 @@
               ],
               "index": {
                 "input": "src/web/index.prod.html",
-                "output": "index.html",
+                "output": "index.html"
               },
               "assets": [
                 "src/web/assets/",
@@ -158,5 +158,8 @@
       }
     }
   },
-  "defaultProject": "teammates"
+  "defaultProject": "teammates",
+  "cli": {
+    "analytics": "65249922-4f6e-433c-807e-02697cd7f415"
+  }
 }

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -9,7 +9,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Team peer evaluations</h2>
       <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations">
       <div class="col-xs-9 col-sm-9">
@@ -26,7 +26,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Flexible feedback paths</h2>
       <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
       <div class="col-xs-9 col-sm-9">
@@ -44,7 +44,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Powerful visibility control</h2>
       <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
       <div class="col-xs-9 col-sm-9">
@@ -62,7 +62,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Reports and statistics</h2>
       <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics">
       <div class="col-xs-9 col-sm-9">
@@ -79,7 +79,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Fine-grain access control</h2>
       <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
       <div class="col-xs-9 col-sm-9">
@@ -96,7 +96,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Different question types</h2>
       <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types">
       <div class="col-xs-9 col-sm-9">
@@ -113,7 +113,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Reuse past questions</h2>
       <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions">
       <div class="col-xs-9 col-sm-9">
@@ -130,7 +130,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">No signup required for students</h2>
       <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
       <div class="col-xs-9 col-sm-9">
@@ -147,7 +147,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Downloadable data</h2>
       <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data">
       <div class="col-xs-9 col-sm-9">
@@ -164,7 +164,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Shareable comments</h2>
       <img src="assets/images/feature-sharablecomments.png" alt="Sharable">
       <div class="col-xs-9 col-sm-9">
@@ -182,7 +182,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Student profiles</h2>
       <img src="assets/images/feature-studentprofiles.png" alt="Student profiles">
       <div class="col-xs-9 col-sm-9">
@@ -204,7 +204,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Powerful search</h2>
       <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search">
       <div class="col-xs-9 col-sm-9">
@@ -221,7 +221,7 @@
 
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
-    <div class="inner">
+    <div class="inner-content">
       <h2 class="color-orange col-xs-12">Support for big courses</h2>
       <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses">
       <div class="col-xs-9 col-sm-9">

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -8,9 +8,10 @@
 </div>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Team peer evaluations</h2>
-    <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations">
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Team peer evaluations</h2>
+      <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations">
       <div class="col-xs-9 col-sm-9">
         <div>
           Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer feedback to team members.
@@ -18,20 +19,23 @@
           Students can provide confidential peer evaluations to you too.
         </div>
       </div>
+    </div>
     <img src="assets/images/raised-edge.png">
   </div>
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Flexible feedback paths</h2>
-    <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        There are many other feedback paths available. Some examples:<br>
-        a) feedback between teams<br>
-        b) from instructors to students<br>
-        c) from each student to three other students
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Flexible feedback paths</h2>
+      <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          There are many other feedback paths available. Some examples:<br>
+          a) feedback between teams<br>
+          b) from instructors to students<br>
+          c) from each student to three other students
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -39,15 +43,17 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Powerful visibility control</h2>
-    <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can see the<br>
-        (i) response text,<br>
-        (ii) the identity of the feedback giver, and<br>
-        (iii) the identity of the feedback receiver.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Powerful visibility control</h2>
+      <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can see the<br>
+          (i) response text,<br>
+          (ii) the identity of the feedback giver, and<br>
+          (iii) the identity of the feedback receiver.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -55,14 +61,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Reports and statistics</h2>
-    <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
-        <br><br>
-        Some statistics for the responses are available too.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Reports and statistics</h2>
+      <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
+          <br><br>
+          Some statistics for the responses are available too.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -70,14 +78,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Fine-grain access control</h2>
-    <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different access levels.
-        <br><br>
-        If required, you can even set which sessions of which section of students are accessible to a particular instructor.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Fine-grain access control</h2>
+      <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different access levels.
+          <br><br>
+          If required, you can even set which sessions of which section of students are accessible to a particular instructor.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -85,14 +95,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Different question types</h2>
-    <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number of points among options' questions, questions measuring contribution in team projects, and more choices coming soon...
-        <br><br>
-        You can even generate MCQ options from student names, as illustrated in the above example.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Different question types</h2>
+      <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number of points among options' questions, questions measuring contribution in team projects, and more choices coming soon...
+          <br><br>
+          You can even generate MCQ options from student names, as illustrated in the above example.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -100,14 +112,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Reuse past questions</h2>
-    <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        Once you have a perfect set of questions configured for a session, you can reuse those questions later, without needing to configure the same questions from scratch again.
-        <br><br>
-        TEAMMATES also provides some session templates to choose from.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Reuse past questions</h2>
+      <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          Once you have a perfect set of questions configured for a session, you can reuse those questions later, without needing to configure the same questions from scratch again.
+          <br><br>
+          TEAMMATES also provides some session templates to choose from.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -115,14 +129,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">No signup required for students</h2>
-    <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to login or signup.
-        <br><br>
-        If they login to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">No signup required for students</h2>
+      <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to login or signup.
+          <br><br>
+          If they login to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -130,14 +146,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Downloadable data</h2>
-    <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        You can download the collected responses (and statistics) as spreadsheets.
-        <br><br>
-        The collected data belongs to you and you may delete your data from TEAMMATES any time.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Downloadable data</h2>
+      <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          You can download the collected responses (and statistics) as spreadsheets.
+          <br><br>
+          The collected data belongs to you and you may delete your data from TEAMMATES any time.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -145,15 +163,17 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Shareable comments</h2>
-    <img src="assets/images/feature-sharablecomments.png" alt="Sharable">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        You can add comments about responses collected. You can even share these comments with students/instructors.
-        <br><br>
-        Fine-grained visibility control is available for comments too.
-        For example, you can give a comment to a student that the receiving student can see while other students in the course can only see the comment text but cannot see the recipient name.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Shareable comments</h2>
+      <img src="assets/images/feature-sharablecomments.png" alt="Sharable">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          You can add comments about responses collected. You can even share these comments with students/instructors.
+          <br><br>
+          Fine-grained visibility control is available for comments too.
+          For example, you can give a comment to a student that the receiving student can see while other students in the course can only see the comment text but cannot see the recipient name.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -161,19 +181,21 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Student profiles</h2>
-    <img src="assets/images/feature-studentprofiles.png" alt="Student profiles">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        You can get students to upload more information about themselves, including a profile picture.
-        Such extra data can help you remember current/past students better.
-        <span class="tiny-text"> [<a href="https://www.flickr.com/photos/meatheadmovers">photo source</a>]</span>
-        <br><br>
-        You can access all data about a student in one page, just by typing a part of the student’s name in our search box. In a single page you can see,<br>
-        * Student’s profile<br>
-        * All feedback given/received by the student<br>
-        * All comments received by the student
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Student profiles</h2>
+      <img src="assets/images/feature-studentprofiles.png" alt="Student profiles">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          You can get students to upload more information about themselves, including a profile picture.
+          Such extra data can help you remember current/past students better.
+          <span class="tiny-text"> [<a href="https://www.flickr.com/photos/meatheadmovers">photo source</a>]</span>
+          <br><br>
+          You can access all data about a student in one page, just by typing a part of the student’s name in our search box. In a single page you can see,<br>
+          * Student’s profile<br>
+          * All feedback given/received by the student<br>
+          * All comments received by the student
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -181,14 +203,16 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Powerful search</h2>
-    <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        TEAMMATES has a powerful search feature to locate details about students or past comments.
-        <br><br>
-        Given above is an example of searching for a student whose name you are not very sure of.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Powerful search</h2>
+      <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          TEAMMATES has a powerful search feature to locate details about students or past comments.
+          <br><br>
+          Given above is an example of searching for a student whose name you are not very sure of.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">
@@ -196,13 +220,15 @@
 </section>
 
 <section class="row">
-  <div class="col-xs-12 col-sm-8 offset-sm-2">
-    <h2 class="color-orange col-xs-12">Support for big courses</h2>
-    <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses">
-    <div class="col-xs-9 col-sm-9">
-      <div>
-        TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into sections of no more than 100 students.
-        There is no limit on the number of courses or sessions you could have either.
+  <div class="col-xs-12 col-sm-8 offset-sm-1">
+    <div class="inner">
+      <h2 class="color-orange col-xs-12">Support for big courses</h2>
+      <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses">
+      <div class="col-xs-9 col-sm-9">
+        <div>
+          TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into sections of no more than 100 students.
+          There is no limit on the number of courses or sessions you could have either.
+        </div>
       </div>
     </div>
     <img src="assets/images/raised-edge.png">

--- a/src/web/app/pages-static/features-page/features-page.component.scss
+++ b/src/web/app/pages-static/features-page/features-page.component.scss
@@ -2,3 +2,7 @@ img {
   margin: 15px 0;
   max-width: 80%;
 }
+
+.inner {
+  margin: 0 20px;
+}

--- a/src/web/app/pages-static/features-page/features-page.component.scss
+++ b/src/web/app/pages-static/features-page/features-page.component.scss
@@ -3,6 +3,6 @@ img {
   max-width: 80%;
 }
 
-.inner {
+.inner-content {
   margin: 0 20px;
 }


### PR DESCRIPTION
Fixes #10516 

**Outline of Solution**

Added a wrapper div for each of the components to offset from the raise page img, and change the overall bootstrap offset class to one with smaller indentation.

Outcome:
![image](https://user-images.githubusercontent.com/19870898/90750569-93abaf80-e307-11ea-8f08-787a41ba91b1.png)
