### PR TITLE
[#10614][#10616] Fix session results page issues

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -38,7 +38,9 @@
         <div class="action-btn-group col-sm-12 col-md-12 col-lg-3">
           <button class="btn btn-primary action-btn no-print" ngbTooltip="{{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED? 'Make responses no longer visible': 'Make session responses available for viewing' }}"
              placement="top" (click)="publishResultHandler()">
-            {{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED? "&#x2717; Unpublish": "&#x2713; Publish"}} Results
+            <i *ngIf="session.publishStatus == FeedbackSessionPublishStatus.NOT_PUBLISHED" class="fas fa-eye"></i>
+            <i *ngIf="session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED" class="fas fa-eye-slash"></i>
+            {{session.publishStatus == FeedbackSessionPublishStatus.PUBLISHED ? "Unpublish" : "Publish"}} Results
           </button>
           <button class="btn btn-primary action-btn no-print" [ngbTooltip]="downloadTooltip" (click)="downloadResultHandler()" [disabled]="isDownloadingResults">
             <tm-ajax-loading *ngIf="isDownloadingResults"></tm-ajax-loading>
@@ -111,8 +113,8 @@
     </div>
   </div>
   <div *tmIsLoading="!isSectionsLoaded || !isQuestionsLoaded">
-    <div class="top-padded col-md-2 offset-md-10">
-      <button class="btn action-btn btn-light" (click)="toggleExpandAllHandler()">
+    <div class="top-padded offset-md-10 margin-vertical-20px">
+      <button class="btn expand-btn btn-light" (click)="toggleExpandAllHandler()">
         {{this.isExpandAll ? "Collapse": "Expand"}} All
       </button>
     </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
@@ -18,6 +18,15 @@
   padding-right: 40px;
 }
 
+.expand-btn {
+  width: 100%
+}
+
+.margin-vertical-20px {
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
 .report-config-item {
   margin-bottom: 6px;
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.scss
@@ -19,7 +19,7 @@
 }
 
 .expand-btn {
-  width: 100%
+  width: 100%;
 }
 
 .margin-vertical-20px {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -109,6 +109,8 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   FeedbackSessionPublishStatus: typeof FeedbackSessionPublishStatus = FeedbackSessionPublishStatus;
   isExpandAll: boolean = false;
 
+  readonly TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
+
   session: FeedbackSession = {
     courseId: '',
     timeZone: '',
@@ -164,15 +166,14 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       feedbackSessionName,
       intent: Intent.INSTRUCTOR_RESULT,
     }).subscribe((feedbackSession: FeedbackSession) => {
-      const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
       this.session = feedbackSession;
       this.formattedSessionOpeningTime = this.timezoneService
-          .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, TIME_FORMAT);
+          .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, this.TIME_FORMAT);
       this.formattedSessionClosingTime = this.timezoneService
-          .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, TIME_FORMAT);
+          .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, this.TIME_FORMAT);
       if (this.session.resultVisibleFromTimestamp) {
         this.formattedResultVisibleFromTime = this.timezoneService
-            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
+            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, this.TIME_FORMAT);
       } else {
         this.formattedResultVisibleFromTime = 'Not applicable';
       }
@@ -241,24 +242,6 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       this.isFeedbackSessionLoading = false;
       this.hasFeedbackSessionLoadingFailed = true;
       this.statusMessageService.showErrorToast(resp.error.message);
-    });
-  }
-
-  loadFeedbackSessionVisibleFromTime(courseId: string, feedbackSessionName: string): void {
-    this.feedbackSessionsService.getFeedbackSession({
-      courseId,
-      feedbackSessionName,
-      intent: Intent.INSTRUCTOR_RESULT,
-    }).subscribe((feedbackSession: FeedbackSession) => {
-      this.session = feedbackSession;
-      const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
-      this.session = feedbackSession;
-      if (this.session.resultVisibleFromTimestamp) {
-        this.formattedResultVisibleFromTime = this.timezoneService
-          .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
-      } else {
-        this.formattedResultVisibleFromTime = 'Not applicable';
-      }
     });
   }
 
@@ -401,8 +384,14 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
           )
       ;
 
-      response.subscribe(() => {
-        this.loadFeedbackSessionVisibleFromTime(this.courseId, this.fsName);
+      response.subscribe((res: FeedbackSession) => {
+        this.session = res;
+        if (this.session.resultVisibleFromTimestamp) {
+          this.formattedResultVisibleFromTime = this.timezoneService
+            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, this.TIME_FORMAT);
+        } else {
+          this.formattedResultVisibleFromTime = 'Not applicable';
+        }
         if (isPublished) {
           this.statusMessageService.showSuccessToast('The feedback session has been unpublished.');
         } else {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -60,6 +60,8 @@ export interface QuestionTabModel {
   isTabExpanded: boolean;
 }
 
+const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
+
 /**
  * Instructor feedback session result page.
  */
@@ -108,8 +110,6 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
 
   FeedbackSessionPublishStatus: typeof FeedbackSessionPublishStatus = FeedbackSessionPublishStatus;
   isExpandAll: boolean = false;
-
-  readonly TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
 
   session: FeedbackSession = {
     courseId: '',
@@ -168,12 +168,12 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     }).subscribe((feedbackSession: FeedbackSession) => {
       this.session = feedbackSession;
       this.formattedSessionOpeningTime = this.timezoneService
-          .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, this.TIME_FORMAT);
+          .formatToString(this.session.submissionStartTimestamp, this.session.timeZone, TIME_FORMAT);
       this.formattedSessionClosingTime = this.timezoneService
-          .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, this.TIME_FORMAT);
+          .formatToString(this.session.submissionEndTimestamp, this.session.timeZone, TIME_FORMAT);
       if (this.session.resultVisibleFromTimestamp) {
         this.formattedResultVisibleFromTime = this.timezoneService
-            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, this.TIME_FORMAT);
+            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
       } else {
         this.formattedResultVisibleFromTime = 'Not applicable';
       }
@@ -388,15 +388,12 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
         this.session = res;
         if (this.session.resultVisibleFromTimestamp) {
           this.formattedResultVisibleFromTime = this.timezoneService
-            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, this.TIME_FORMAT);
-        } else {
-          this.formattedResultVisibleFromTime = 'Not applicable';
-        }
-        if (isPublished) {
-          this.statusMessageService.showSuccessToast('The feedback session has been unpublished.');
-        } else {
+            .formatToString(this.session.resultVisibleFromTimestamp, this.session.timeZone, TIME_FORMAT);
           this.statusMessageService.showSuccessToast('The feedback session has been published. '
             + 'Please allow up to 1 hour for all the notification emails to be sent out.');
+        } else {
+          this.formattedResultVisibleFromTime = 'Not applicable';
+          this.statusMessageService.showSuccessToast('The feedback session has been unpublished.');
         }
       }, (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorToast(resp.error.message);


### PR DESCRIPTION
Fixes #10614 
Fixes #10616
![image](https://user-images.githubusercontent.com/5328196/90330262-f1758a00-dfdd-11ea-93d0-841546103a96.png)
Other fixes:
- Add "not applicable" for results visible from time for unpublished sessions
- Make the style of merge/expand all button consistent with edit session page