### PR TITLE
[#9936] Add logging and swap if condition order for expensive operation

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -173,28 +173,35 @@ public final class FeedbackSessionsLogic {
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent() {
         List<FeedbackSessionAttributes> sessions = fsDb.getFeedbackSessionsPossiblyNeedingPublishedEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
         List<FeedbackSessionAttributes> sessionsToSendEmailsFor = new ArrayList<>();
 
         for (FeedbackSessionAttributes session : sessions) {
             // automated emails are required only for custom publish times
-            if (!coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()
-                    && session.isPublished()
-                    && !TimeHelper.isSpecialTime(session.getResultsVisibleFromTime())) {
+            if (session.isPublished()
+                    && !TimeHelper.isSpecialTime(session.getResultsVisibleFromTime())
+                    && !coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()) {
                 sessionsToSendEmailsFor.add(session);
             }
         }
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                sessionsToSendEmailsFor.size()));
         return sessionsToSendEmailsFor;
     }
 
     public List<FeedbackSessionAttributes> getFeedbackSessionsWhichNeedOpenEmailsToBeSent() {
         List<FeedbackSessionAttributes> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpenEmail();
         List<FeedbackSessionAttributes> sessionsToSendEmailsFor = new ArrayList<>();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
 
         for (FeedbackSessionAttributes session : sessions) {
-            if (!coursesLogic.getCourse(session.getCourseId()).isCourseDeleted() && session.isOpened()) {
+            if (session.isOpened() && !coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()) {
                 sessionsToSendEmailsFor.add(session);
             }
         }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                sessionsToSendEmailsFor.size()));
         return sessionsToSendEmailsFor;
     }
 
@@ -506,14 +513,17 @@ public final class FeedbackSessionsLogic {
         List<FeedbackSessionAttributes> requiredSessions = new ArrayList<>();
 
         List<FeedbackSessionAttributes> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
 
         for (FeedbackSessionAttributes session : sessions) {
-            if (!coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()
-                    && session.isClosingWithinTimeLimit(SystemParams.NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)) {
+            if (session.isClosingWithinTimeLimit(SystemParams.NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
+                    && !coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()) {
                 requiredSessions.add(session);
             }
         }
 
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
         return requiredSessions;
     }
 
@@ -523,13 +533,17 @@ public final class FeedbackSessionsLogic {
     public List<FeedbackSessionAttributes> getFeedbackSessionsClosedWithinThePastHour() {
         List<FeedbackSessionAttributes> requiredSessions = new ArrayList<>();
         List<FeedbackSessionAttributes> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosedEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
 
         for (FeedbackSessionAttributes session : sessions) {
             // is session closed in the past 1 hour
-            if (!coursesLogic.getCourse(session.getCourseId()).isCourseDeleted() && session.isClosedWithinPastHour()) {
+            if (session.isClosedWithinPastHour()
+                    && !coursesLogic.getCourse(session.getCourseId()).isCourseDeleted()) {
                 requiredSessions.add(session);
             }
         }
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
         return requiredSessions;
     }
 


### PR DESCRIPTION
Part of #9936

This is just a temp fix for OutOfMemory error. We put the expensive DB check as the last condition, hoping that many session will be filtered out by the first several cheap checks. The underlying issue where:

1. We are still fetching associated course for every session under consideration
1. We only make use of the `isDeleted` of the course (other fields are not used and result in extra works for GC or just result in OOM)

We should strike to think of permanent fix for the issue. Right now, as reported in V6, this fix works for a while.
