### PR TITLE
[#9536] Fix various issues in E2E tests

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/e2e/AdminSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/AdminSearchPageE2ETest.java
@@ -32,7 +32,6 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createUrl(Const.WebPageURIs.ADMIN_SEARCH_PAGE);
         searchPage = loginAdminToPage(url, AdminSearchPage.class);
 
-        searchPage.waitForPageToLoad();
         StudentAttributes student = testData.students.get("student1InCourse1");
         AccountAttributes studentAccount = testData.accounts.get("student1InCourse1");
         InstructorAttributes instructor = testData.instructors.get("instructor1OfCourse1");

--- a/src/e2e/java/teammates/e2e/cases/e2e/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/BaseE2ETestCase.java
@@ -103,6 +103,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithBackDoorApiAccess 
 
         if (browser.isAdminLoggedIn) {
             browser.driver.get(url.toAbsoluteString());
+            browser.waitForPageLoad();
             try {
                 return AppPage.getNewPageInstance(browser, typeOfPage);
             } catch (Exception e) {

--- a/src/e2e/java/teammates/e2e/cases/e2e/FeedbackSubmitPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/FeedbackSubmitPageE2ETest.java
@@ -55,7 +55,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName());
         FeedbackSubmitPage submitPage = loginAdminToPage(url, FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
 
         ______TS("verify loaded session data");
         submitPage.verifyFeedbackSessionDetails(openSession);
@@ -66,7 +65,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
 
         ______TS("questions with giver type students");
         submitPage = loginAdminToPage(getStudentSubmitPageUrl(student, openSession), FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
 
         submitPage.verifyNumQuestions(4);
         submitPage.verifyQuestionDetails(1, testData.feedbackQuestions.get("qn1InSession1"));
@@ -98,7 +96,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         ______TS("can submit in grace period");
         AppUrl gracePeriodSessionUrl = getStudentSubmitPageUrl(student, gracePeriodSession);
         submitPage = AppPage.getNewPageInstance(browser, gracePeriodSessionUrl, FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
         FeedbackQuestionAttributes question = testData.feedbackQuestions.get("qn1InGracePeriodSession");
         String questionId = getFeedbackQuestion(question).getId();
         String recipient = "Team 2";
@@ -145,7 +142,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
                 .withSessionName(openSession.getFeedbackSessionName())
                 .withParam("previewas", student.getEmail());
         submitPage = AppPage.getNewPageInstance(browser, url, FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
 
         submitPage.verifyFeedbackSessionDetails(openSession);
         submitPage.verifyNumQuestions(4);
@@ -162,7 +158,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
                 .withSessionName(openSession.getFeedbackSessionName())
                 .withParam("previewas", instructor.getEmail());
         submitPage = AppPage.getNewPageInstance(browser, url, FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
 
         submitPage.verifyFeedbackSessionDetails(openSession);
         submitPage.verifyNumQuestions(1);
@@ -177,7 +172,6 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
                 .withParam("moderatedperson", student.getEmail())
                 .withParam("moderatedquestionId", questionId);
         submitPage = AppPage.getNewPageInstance(browser, url, FeedbackSubmitPage.class);
-        submitPage.waitForPageToLoad();
 
         submitPage.verifyFeedbackSessionDetails(gracePeriodSession);
         // One out of two questions in grace period session should not be visible

--- a/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/InstructorCourseEditPageE2ETest.java
@@ -8,7 +8,6 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
-import teammates.common.util.ThreadHelper;
 import teammates.e2e.pageobjects.AppPage;
 import teammates.e2e.pageobjects.InstructorCourseEditPage;
 
@@ -90,14 +89,10 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS, true);
 
         editPage.editInstructor(1, instructors[0]);
-        ThreadHelper.waitFor(100);
         editPage.toggleCustomCourseLevelPrivilege(1, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
-        ThreadHelper.waitFor(100);
         editPage.toggleCustomCourseLevelPrivilege(1, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT);
-        ThreadHelper.waitFor(100);
         editPage.toggleCustomSectionLevelPrivilege(1, 1, "Section 2",
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS);
-        ThreadHelper.waitFor(100);
         editPage.toggleCustomSessionLevelPrivilege(1, 2, "Section 1", "First feedback session",
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
         editPage.verifyStatusMessage("The instructor " + instructors[0].name + " has been updated.");

--- a/src/e2e/java/teammates/e2e/cases/e2e/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/InstructorCoursesPageE2ETest.java
@@ -49,7 +49,6 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE)
                 .withUserId(instructorId);
         InstructorCoursesPage coursesPage = loginAdminToPage(url, InstructorCoursesPage.class);
-        coursesPage.waitForPageToLoad();
 
         ______TS("verify loaded data");
         CourseAttributes[] activeCourses = { courses[0] };

--- a/src/e2e/java/teammates/e2e/cases/e2e/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/InstructorFeedbackSessionsPageE2ETest.java
@@ -97,7 +97,6 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
                 + "Click the \"Add New Question\" button below to begin adding questions for the feedback session.");
         feedbackSessionsPage = AppPage.getNewPageInstance(browser, url,
                 InstructorFeedbackSessionsPage.class);
-        feedbackSessionsPage.waitForPageToLoad();
         feedbackSessionsPage.sortBySessionsName();
         feedbackSessionsPage.verifySessionsTable(sessionsForAdded);
         verifyPresentInDatastore(newSession);
@@ -114,7 +113,6 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
                         + "Please modify settings/questions as necessary.");
         feedbackSessionsPage = AppPage.getNewPageInstance(browser, url,
                 InstructorFeedbackSessionsPage.class);
-        feedbackSessionsPage.waitForPageToLoad();
         feedbackSessionsPage.verifySessionDetails(copiedSession);
         verifyPresentInDatastore(copiedSession);
 
@@ -130,7 +128,6 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
                 + "Please modify settings/questions as necessary.");
         feedbackSessionsPage = AppPage.getNewPageInstance(browser, url,
                 InstructorFeedbackSessionsPage.class);
-        feedbackSessionsPage.waitForPageToLoad();
         feedbackSessionsPage.verifySessionDetails(copiedSession2);
         verifyPresentInDatastore(copiedSession2);
 

--- a/src/e2e/java/teammates/e2e/cases/e2e/StudentHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/StudentHomePageE2ETest.java
@@ -30,8 +30,6 @@ public class StudentHomePageE2ETest extends BaseE2ETestCase {
         AppUrl url = createUrl(Const.WebPageURIs.STUDENT_HOME_PAGE).withUserId("SHomeUiT.student");
         loginAdminToPage(url, StudentHomePage.class);
 
-        browser.waitForPageLoad();
-
         List<String> courseIds = getAllVisibleCourseIds();
 
         for (int i = 0; i < courseIds.size(); i++) {

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -194,6 +194,7 @@ public abstract class AppPage {
     public void waitUntilAnimationFinish() {
         WebDriverWait wait = new WebDriverWait(browser.driver, 2);
         wait.until(ExpectedConditions.invisibilityOfElementLocated(By.className("ng-animating")));
+        ThreadHelper.waitFor(500);
     }
 
     /**

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -114,6 +114,7 @@ public abstract class AppPage {
      */
     public static <T extends AppPage> T getNewPageInstance(Browser currentBrowser, Url url, Class<T> typeOfPage) {
         currentBrowser.driver.get(url.toAbsoluteString());
+        currentBrowser.waitForPageLoad();
         return getNewPageInstance(currentBrowser, typeOfPage);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/Browser.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/Browser.java
@@ -10,6 +10,7 @@ import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.ScriptTimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -95,12 +96,16 @@ public class Browser {
      *         as criteria for page load's completion.
      */
     public void waitForPageLoad(boolean excludeToast) {
-        WebDriverWait wait = new WebDriverWait(driver, TestProperties.TEST_TIMEOUT);
-        wait.until(driver -> {
-            return "complete".equals(
-                    ((JavascriptExecutor) driver).executeAsyncScript(PAGE_LOAD_SCRIPT, excludeToast ? 1 : 0)
-            );
-        });
+        try {
+            WebDriverWait wait = new WebDriverWait(driver, TestProperties.TEST_TIMEOUT);
+            wait.until(driver -> {
+                return "complete".equals(
+                        ((JavascriptExecutor) driver).executeAsyncScript(PAGE_LOAD_SCRIPT, excludeToast ? 1 : 0)
+                );
+            });
+        } catch (ScriptTimeoutException e) {
+            System.out.println("Page could not load completely. Trying to continue test.");
+        }
     }
 
     /**

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -16,6 +16,7 @@ import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
+import teammates.common.util.ThreadHelper;
 
 /**
  * Represents the instructor course edit page of the website.
@@ -307,7 +308,7 @@ public class InstructorCourseEditPage extends AppPage {
 
     private void clickSaveInstructorButton(int instrNum) {
         click(getSaveInstructorButton(instrNum));
-        waitForPageToLoad(true);
+        ThreadHelper.waitFor(1000);
     }
 
     private void clickAddSectionPrivilegeLink(int instrNum) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEnrollPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEnrollPage.java
@@ -51,6 +51,7 @@ public class InstructorCourseEnrollPage extends AppPage {
 
     public void clickToggleExistingStudentsHeader() {
         click(toggleExistingStudentsHeader);
+        waitUntilAnimationFinish();
     }
 
     public void clickEnrollButton() {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
@@ -154,7 +154,7 @@ public class InstructorCoursesPage extends AppPage {
         click(otherActionButton);
         click(getArchiveButton(courseId));
 
-        waitForElementStaleness(otherActionButton);
+        waitUntilAnimationFinish();
     }
 
     public void moveCourseToRecycleBin(String courseId) {
@@ -162,21 +162,21 @@ public class InstructorCoursesPage extends AppPage {
         click(otherActionButton);
         clickAndConfirm(getMoveToRecycleBinButton(courseId));
 
-        waitForElementStaleness(otherActionButton);
+        waitUntilAnimationFinish();
     }
 
     public void unarchiveCourse(String courseId) {
         WebElement unarchiveButton = getUnarchiveButton(courseId);
         click(unarchiveButton);
 
-        waitForElementStaleness(unarchiveButton);
+        waitUntilAnimationFinish();
     }
 
     public void moveArchivedCourseToRecycleBin(String courseId) {
         WebElement moveArchivedToRecycleBinButton = getMoveArchivedToRecycleBinButton(courseId);
         clickAndConfirm(moveArchivedToRecycleBinButton);
 
-        waitForElementStaleness(moveArchivedToRecycleBinButton);
+        waitUntilAnimationFinish();
     }
 
     public void showDeleteTable() {
@@ -195,28 +195,28 @@ public class InstructorCoursesPage extends AppPage {
         WebElement restoreButton = getRestoreButton(courseId);
         click(restoreButton);
 
-        waitForElementStaleness(restoreButton);
+        waitUntilAnimationFinish();
     }
 
     public void deleteCourse(String courseId) {
         WebElement deleteButton = getDeleteButton(courseId);
         clickAndConfirm(deleteButton);
 
-        waitForElementStaleness(deleteButton);
+        waitUntilAnimationFinish();
     }
 
     public void restoreAllCourses() {
         WebElement restoreAllButton = getRestoreAllButton();
         click(restoreAllButton);
 
-        waitForElementStaleness(restoreAllButton);
+        waitUntilAnimationFinish();
     }
 
     public void deleteAllCourses() {
         WebElement deleteAllButton = getDeleteAllButton();
         clickAndConfirm(deleteAllButton);
 
-        waitForElementStaleness(deleteAllButton);
+        waitUntilAnimationFinish();
     }
 
     public void sortByCourseName() {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -810,7 +810,7 @@ public class InstructorFeedbackEditPage extends AppPage {
     private void clickSaveQuestionButton(int questionNum) {
         WebElement saveButton = getQuestionForm(questionNum).findElement(By.id("btn-save-question"));
         click(saveButton);
-        waitForElementStaleness(saveButton);
+        ThreadHelper.waitFor(1000);
     }
 
     private void setQuestionVisibility(int questionNum, FeedbackQuestionAttributes feedbackQuestion) {


### PR DESCRIPTION
Part of #9536

**Outline of Solution**

- **Add some delay to `waitUntilAnimationFinish`:** 
    - tests are failing due to elements being not found/having empty values because animation has not completely finished. 
    - Added a slight delay to ensure animation is completed and elements are loaded.
- **Allow test to continue even if page cannot load completely:** 
    - using `waitForPageToLoad` results in many timeouts despite the page being 99% loaded. We should allow the test to continue even if something irrelevant to the critical functionality is not loaded properly. 
    - Add try catch block to ignore exception thrown by `waitForPageToLoad`.
- **Add `waitForPageToLoad` to all page loading methods**: 
    - Wait for pages to fully load before proceeding with test, which minimizes chance of any elements being missing. 
    - These page loading methods are `getNewPageInstance` and `loginAdminToPage`
- **Add delay after saving methods**: 
    - For some test, toggling too quickly between edit mode and normal mode causes `StaleElementReferenceException`. 
    - Add some delay after pressing save to prevent such unrealistically quick toggling.
