### PR TITLE
[#10697] Performance improvements when getting session result as students

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -639,8 +639,6 @@ public final class FeedbackSessionsLogic {
                 studentsLogic.getStudentsForCourse(courseId),
                 instructorsLogic.getInstructorsForCourse(courseId));
 
-        FeedbackSessionAttributes session = fsDb.getFeedbackSession(courseId, feedbackSessionName);
-
         // load question(s)
         List<FeedbackQuestionAttributes> allQuestions;
         Map<String, FeedbackQuestionAttributes> allQuestionsMap = new HashMap<>();
@@ -654,11 +652,27 @@ public final class FeedbackSessionsLogic {
         }
 
         // load response(s)
+        StudentAttributes student = getStudent(courseId, userEmail, role);
         List<FeedbackResponseAttributes> allResponses;
-        if (questionId == null) {
-            allResponses = frLogic.getFeedbackResponsesForSessionInSection(feedbackSessionName, courseId, section);
+        if (isInstructor(role)) {
+            // load all response for instructors and passively filter them later
+            if (questionId == null) {
+                allResponses = frLogic.getFeedbackResponsesForSessionInSection(feedbackSessionName, courseId, section);
+            } else {
+                allResponses = frLogic.getFeedbackResponsesForQuestionInSection(questionId, section);
+            }
         } else {
-            allResponses = frLogic.getFeedbackResponsesForQuestionInSection(questionId, section);
+            if (section != null) {
+                throw new UnsupportedOperationException("Specify section filtering is not supported for student result");
+            }
+            allResponses = new ArrayList<>();
+            // load viewable responses for students proactively
+            // this is cost-effective as in most of time responses for the whole session will not be viewable to students
+            for (FeedbackQuestionAttributes question : allQuestions) {
+                List<FeedbackResponseAttributes> viewableResponses =
+                        frLogic.getViewableFeedbackResponsesForStudentForQuestion(question, student, roster);
+                allResponses.addAll(viewableResponses);
+            }
         }
 
         // load comment(s)
@@ -682,7 +696,6 @@ public final class FeedbackSessionsLogic {
         }
 
         // consider the current viewing user
-        StudentAttributes student = getStudent(courseId, userEmail, role);
         Set<String> studentsEmailInTeam = getTeammateEmails(student, roster);
         InstructorAttributes instructor = getInstructor(courseId, userEmail, role);
 
@@ -734,6 +747,7 @@ public final class FeedbackSessionsLogic {
 
         List<FeedbackResponseAttributes> existingResponses = new ArrayList<>(relatedResponsesMap.values());
         List<FeedbackResponseAttributes> missingResponses = Collections.emptyList();
+        FeedbackSessionAttributes session = fsDb.getFeedbackSession(courseId, feedbackSessionName);
         if (role == UserRole.INSTRUCTOR) {
             missingResponses = buildMissingResponses(
                     instructor, responseVisibilityTable, session,

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -151,6 +151,17 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
     }
 
     /**
+     * Gets all responses received by a user for a question.
+     */
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForQuestion(
+            String feedbackQuestionId, String receiver) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, receiver);
+
+        return makeAttributes(getFeedbackResponseEntitiesForReceiverForQuestion(feedbackQuestionId, receiver));
+    }
+
+    /**
      * Checks whether a user has responses in a session.
      */
     public boolean hasResponsesFromGiverInSession(
@@ -361,6 +372,14 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
         return load()
                 .filter("feedbackQuestionId =", feedbackQuestionId)
                 .filter("giverEmail =", giverEmail)
+                .list();
+    }
+
+    private List<FeedbackResponse> getFeedbackResponseEntitiesForReceiverForQuestion(
+            String feedbackQuestionId, String receiver) {
+        return load()
+                .filter("feedbackQuestionId =", feedbackQuestionId)
+                .filter("receiver =", receiver)
                 .list();
     }
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -968,6 +968,21 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
+    public void testGetSessionResultsForUser_studentSpecificQuestionAndSection_shouldThrowOperationNotSupported() {
+        // extra test data used on top of typical data bundle
+        removeAndRestoreDataBundle(loadDataBundle("/SpecialCharacterTest.json"));
+
+        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                "First Session", "FQLogicPCT.CS2104", 1);
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            fsLogic.getSessionResultsForUser(
+                    "First Session", "FQLogicPCT.CS2104", "FQLogicPCT.alice.b@gmail.tmt",
+                    UserRole.STUDENT, question.getId(), Const.DEFAULT_SECTION);
+        });
+    }
+
+    @Test
     public void testGetSessionResultsForUser_studentSpecificQuestionNoSection_shouldHaveCorrectResponsesFiltered() {
         // extra test data used on top of typical data bundle
         removeAndRestoreDataBundle(loadDataBundle("/SpecialCharacterTest.json"));

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -517,6 +517,40 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
     }
 
     @Test
+    public void testGetFeedbackResponsesForReceiverForQuestion() {
+
+        ______TS("standard success case");
+
+        String questionId = fras.get("response1ForQ1S1C1").feedbackQuestionId;
+
+        List<FeedbackResponseAttributes> responses =
+                frDb.getFeedbackResponsesForReceiverForQuestion(questionId,
+                        "student1InCourse1@gmail.tmt");
+
+        assertEquals(1, responses.size());
+
+        ______TS("null params");
+
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestion(null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
+
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestion(questionId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
+
+        ______TS("non-existent feedback question");
+
+        assertTrue(frDb.getFeedbackResponsesForReceiverForQuestion(
+                "non-existent fq id", "student1InCourse1@gmail.tmt").isEmpty());
+
+        ______TS("non-existent receiver");
+
+        assertTrue(frDb.getFeedbackResponsesForReceiverForQuestion(
+                questionId, "non-existentStudentInCourse1@gmail.tmt").isEmpty());
+    }
+
+    @Test
     public void testGetFeedbackResponsesFromGiverForCourse() {
 
         ______TS("standard success case");


### PR DESCRIPTION
Fixes #10697 

**Outline of Solution**

Copy logic from V6 to proactively fetch the viewable response.

Tested for "Session with different question types" and unit tests cover most of the cases (see line coverage)
