### PR TITLE
[#10705] [#10718] Improve user flow for unregistered student and invalid registration key

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
@@ -29,28 +29,30 @@ public class GetRegkeyValidityAction extends Action {
         String regkey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
 
         if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
-            boolean isUsable = false;
             StudentAttributes student = logic.getStudentForRegistrationKey(regkey);
             boolean isValid = student != null;
+            boolean isUsed = false;
+            boolean isAllowedAccess = false;
 
             if (isValid) {
                 if (StringHelper.isEmpty(student.googleId)) {
                     // If registration key has not been used, always allow access
-                    isUsable = true;
+                    isAllowedAccess = true;
                 } else {
+                    isUsed = true;
                     // If the registration key has been used to register, the logged in user needs to match
                     // Block access to not logged in user and mismatched user
-                    isUsable = userInfo != null && student.googleId.equals(userInfo.id);
+                    isAllowedAccess = userInfo != null && student.googleId.equals(userInfo.id);
                 }
             }
 
-            return new JsonResult(new RegkeyValidityData(isValid, isUsable));
+            return new JsonResult(new RegkeyValidityData(isValid, isUsed, isAllowedAccess));
         }
 
         // Other intents are invalid for this purpose.
         // This includes instructor submission/result intents, because instructors are expected to be registered
         // in order to use the system.
-        return new JsonResult(new RegkeyValidityData(false, false));
+        return new JsonResult(new RegkeyValidityData(false, false, false));
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetRegkeyValidityAction.java
@@ -29,27 +29,28 @@ public class GetRegkeyValidityAction extends Action {
         String regkey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
 
         if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
-            boolean isValid = false;
+            boolean isUsable = false;
             StudentAttributes student = logic.getStudentForRegistrationKey(regkey);
+            boolean isValid = student != null;
 
-            if (student != null) {
+            if (isValid) {
                 if (StringHelper.isEmpty(student.googleId)) {
                     // If registration key has not been used, always allow access
-                    isValid = true;
+                    isUsable = true;
                 } else {
                     // If the registration key has been used to register, the logged in user needs to match
                     // Block access to not logged in user and mismatched user
-                    isValid = userInfo != null && student.googleId.equals(userInfo.id);
+                    isUsable = userInfo != null && student.googleId.equals(userInfo.id);
                 }
             }
 
-            return new JsonResult(new RegkeyValidityData(isValid));
+            return new JsonResult(new RegkeyValidityData(isValid, isUsable));
         }
 
         // Other intents are invalid for this purpose.
         // This includes instructor submission/result intents, because instructors are expected to be registered
         // in order to use the system.
-        return new JsonResult(new RegkeyValidityData(false));
+        return new JsonResult(new RegkeyValidityData(false, false));
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
+++ b/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
@@ -5,11 +5,13 @@ package teammates.ui.webapi.output;
  */
 public class RegkeyValidityData extends ApiOutput {
     private final boolean isValid;
-    private final boolean isUsable;
+    private final boolean isUsed;
+    private final boolean isAllowedAccess;
 
-    public RegkeyValidityData(boolean isValid, boolean isUsable) {
+    public RegkeyValidityData(boolean isValid, boolean isUsed, boolean isAllowedAccess) {
         this.isValid = isValid;
-        this.isUsable = isUsable;
+        this.isUsed = isUsed;
+        this.isAllowedAccess = isAllowedAccess;
     }
 
     /**
@@ -20,10 +22,17 @@ public class RegkeyValidityData extends ApiOutput {
     }
 
     /**
-     * Returns true if the registration key is usable, false otherwise.
+     * Returns true if the registration key has been used, false otherwise.
      */
-    public boolean isUsable() {
-        return isUsable;
+    public boolean isUsed() {
+        return isUsed;
+    }
+
+    /**
+     * Returns true if access is allowed for the requester by using the registration key, false otherwise.
+     */
+    public boolean isAllowedAccess() {
+        return isAllowedAccess;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
+++ b/src/main/java/teammates/ui/webapi/output/RegkeyValidityData.java
@@ -5,9 +5,11 @@ package teammates.ui.webapi.output;
  */
 public class RegkeyValidityData extends ApiOutput {
     private final boolean isValid;
+    private final boolean isUsable;
 
-    public RegkeyValidityData(boolean isValid) {
+    public RegkeyValidityData(boolean isValid, boolean isUsable) {
         this.isValid = isValid;
+        this.isUsable = isUsable;
     }
 
     /**
@@ -15,6 +17,13 @@ public class RegkeyValidityData extends ApiOutput {
      */
     public boolean isValid() {
         return isValid;
+    }
+
+    /**
+     * Returns true if the registration key is usable, false otherwise.
+     */
+    public boolean isUsable() {
+        return isUsable;
     }
 
 }

--- a/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
@@ -51,7 +51,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         verifyHttpParameterFailure(params);
 
-        ______TS("Normal case: No logged in user for a used regkey; should be valid/unusable");
+        ______TS("Normal case: No logged in user for a used regkey; should be valid/used/disallowed");
 
         gaeSimulation.logoutUser();
 
@@ -67,9 +67,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         RegkeyValidityData output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertFalse(output.isUsable());
+        assertTrue(output.isUsed());
+        assertFalse(output.isAllowedAccess());
 
-        ______TS("Normal case: Wrong logged in user for a used regkey; should be valid/unusable");
+        ______TS("Normal case: Wrong logged in user for a used regkey; should be valid/used/disallowed");
 
         loginAsStudent("student2InCourse1");
 
@@ -85,9 +86,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertFalse(output.isUsable());
+        assertTrue(output.isUsed());
+        assertFalse(output.isAllowedAccess());
 
-        ______TS("Normal case: Correct logged in user for a used regkey; should be valid/usable");
+        ______TS("Normal case: Correct logged in user for a used regkey; should be valid/used/allowed");
 
         loginAsStudent("student1InCourse1");
 
@@ -98,9 +100,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertTrue(output.isUsable());
+        assertTrue(output.isUsed());
+        assertTrue(output.isAllowedAccess());
 
-        ______TS("Normal case: No logged in user for an unused regkey; should be valid/usable");
+        ______TS("Normal case: No logged in user for an unused regkey; should be valid/unused/allowed");
 
         logic.resetStudentGoogleId("student1InCourse1@gmail.tmt", "idOfTypicalCourse1");
 
@@ -113,9 +116,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertTrue(output.isUsable());
+        assertFalse(output.isUsed());
+        assertTrue(output.isAllowedAccess());
 
-        ______TS("Normal case: Any logged in user for an unused regkey; should be valid/usable");
+        ______TS("Normal case: Any logged in user for an unused regkey; should be valid/unused/allowed");
 
         loginAsStudent("student2InCourse1");
 
@@ -126,7 +130,8 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertTrue(output.isUsable());
+        assertFalse(output.isUsed());
+        assertTrue(output.isAllowedAccess());
 
         loginAsStudent("student3InCourse1");
 
@@ -137,9 +142,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
-        assertTrue(output.isUsable());
+        assertFalse(output.isUsed());
+        assertTrue(output.isAllowedAccess());
 
-        ______TS("Normal case: Invalid regkey; should be invalid/unusable");
+        ______TS("Normal case: Invalid regkey; should be invalid/unused/disallowed");
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, StringHelper.encrypt("invalid-key"),
@@ -153,9 +159,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertFalse(output.isValid());
-        assertFalse(output.isUsable());
+        assertFalse(output.isUsed());
+        assertFalse(output.isAllowedAccess());
 
-        ______TS("Normal case: Invalid intent; should be invalid/unusable");
+        ______TS("Normal case: Invalid intent; should be invalid/unused/disallowed");
 
         gaeSimulation.logoutUser();
 
@@ -171,7 +178,8 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertFalse(output.isValid());
-        assertFalse(output.isUsable());
+        assertFalse(output.isUsed());
+        assertFalse(output.isAllowedAccess());
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetRegkeyValidityActionTest.java
@@ -51,7 +51,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         verifyHttpParameterFailure(params);
 
-        ______TS("Normal case: No logged in user for a used regkey; should be invalid");
+        ______TS("Normal case: No logged in user for a used regkey; should be valid/unusable");
 
         gaeSimulation.logoutUser();
 
@@ -66,9 +66,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
 
         RegkeyValidityData output = (RegkeyValidityData) r.getOutput();
-        assertFalse(output.isValid());
+        assertTrue(output.isValid());
+        assertFalse(output.isUsable());
 
-        ______TS("Normal case: Wrong logged in user for a used regkey; should be invalid");
+        ______TS("Normal case: Wrong logged in user for a used regkey; should be valid/unusable");
 
         loginAsStudent("student2InCourse1");
 
@@ -83,9 +84,10 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
 
         output = (RegkeyValidityData) r.getOutput();
-        assertFalse(output.isValid());
+        assertTrue(output.isValid());
+        assertFalse(output.isUsable());
 
-        ______TS("Normal case: Correct logged in user for a used regkey; should be valid");
+        ______TS("Normal case: Correct logged in user for a used regkey; should be valid/usable");
 
         loginAsStudent("student1InCourse1");
 
@@ -96,8 +98,9 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
+        assertTrue(output.isUsable());
 
-        ______TS("Normal case: No logged in user for an unused regkey; should be valid");
+        ______TS("Normal case: No logged in user for an unused regkey; should be valid/usable");
 
         logic.resetStudentGoogleId("student1InCourse1@gmail.tmt", "idOfTypicalCourse1");
 
@@ -110,8 +113,9 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
+        assertTrue(output.isUsable());
 
-        ______TS("Normal case: Any logged in user for an unused regkey; should be valid");
+        ______TS("Normal case: Any logged in user for an unused regkey; should be valid/usable");
 
         loginAsStudent("student2InCourse1");
 
@@ -122,6 +126,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
+        assertTrue(output.isUsable());
 
         loginAsStudent("student3InCourse1");
 
@@ -132,8 +137,25 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertTrue(output.isValid());
+        assertTrue(output.isUsable());
 
-        ______TS("Normal case: Invalid intent; should be invalid");
+        ______TS("Normal case: Invalid regkey; should be invalid/unusable");
+
+        params = new String[] {
+                Const.ParamsNames.REGKEY, StringHelper.encrypt("invalid-key"),
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
+        };
+
+        a = getAction(params);
+        r = getJsonResult(a);
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
+
+        output = (RegkeyValidityData) r.getOutput();
+        assertFalse(output.isValid());
+        assertFalse(output.isUsable());
+
+        ______TS("Normal case: Invalid intent; should be invalid/unusable");
 
         gaeSimulation.logoutUser();
 
@@ -149,6 +171,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
         output = (RegkeyValidityData) r.getOutput();
         assertFalse(output.isValid());
+        assertFalse(output.isUsable());
     }
 
     @Override

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -4,8 +4,14 @@
 <div class="row" *ngIf="regKey">
   <div class="col-12">
     <div class="alert alert-primary" role="alert">
-      You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to
-      <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">login using a Google account</a> (recommended).
+      <div *ngIf="loggedInUser">
+        You are viewing feedback results as {{ personName }}. If you wish to link your Google account ({{ loggedInUser }}) with this user,
+        <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">click here</a>.
+      </div>
+      <div *ngIf="!loggedInUser">
+        You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in.
+        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">login using a Google account</a> (recommended).
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -85,7 +85,7 @@ export class SessionResultPageComponent implements OnInit {
         if (this.regKey) {
           const intent: Intent = Intent.STUDENT_RESULT;
           this.authService.getAuthRegkeyValidity(this.regKey, intent).subscribe((resp: RegkeyValidity) => {
-            if (resp.isValid) {
+            if (resp.isUsable) {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
@@ -96,10 +96,17 @@ export class SessionResultPageComponent implements OnInit {
                 this.loadPersonName();
                 this.loadFeedbackSession();
               }
-            } else if (!auth.user) {
-              // If there is no logged in user for a valid, used registration key, redirect to login page
-              window.location.href = `${this.backendUrl}${auth.studentLoginUrl}`;
+            } else if (resp.isValid) {
+              if (auth.user) {
+                // Registration key belongs to another user who is not the logged in user
+                this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+                    'You are not authorized to view this page.');
+              } else {
+                // There is no logged in user for a valid, used registration key, redirect to login page
+                window.location.href = `${this.backendUrl}${auth.studentLoginUrl}`;
+              }
             } else {
+              // The registration key is invalid
               this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                   'You are not authorized to view this page.');
             }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -85,7 +85,7 @@ export class SessionResultPageComponent implements OnInit {
         if (this.regKey) {
           const intent: Intent = Intent.STUDENT_RESULT;
           this.authService.getAuthRegkeyValidity(this.regKey, intent).subscribe((resp: RegkeyValidity) => {
-            if (resp.isUsable) {
+            if (resp.isAllowedAccess) {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -55,6 +55,7 @@ export class SessionResultPageComponent implements OnInit {
   courseId: string = '';
   feedbackSessionName: string = '';
   regKey: string = '';
+  loggedInUser: string = '';
 
   isFeedbackSessionResultsLoading: boolean = false;
   hasFeedbackSessionResultsLoadingFailed: boolean = false;
@@ -82,6 +83,9 @@ export class SessionResultPageComponent implements OnInit {
 
       const nextUrl: string = `${window.location.pathname}${window.location.search}`;
       this.authService.getAuthUser(undefined, nextUrl).subscribe((auth: AuthInfo) => {
+        if (auth.user) {
+          this.loggedInUser = auth.user.id;
+        }
         if (this.regKey) {
           const intent: Intent = Intent.STUDENT_RESULT;
           this.authService.getAuthRegkeyValidity(this.regKey, intent).subscribe((resp: RegkeyValidity) => {
@@ -98,7 +102,7 @@ export class SessionResultPageComponent implements OnInit {
               }
             } else if (resp.isValid) {
               // At this point, registration key must already be used, otherwise access would be granted
-              if (auth.user) {
+              if (this.loggedInUser) {
                 // Registration key belongs to another user who is not the logged in user
                 this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                     'You are not authorized to view this page.');
@@ -115,7 +119,7 @@ export class SessionResultPageComponent implements OnInit {
             this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                 'You are not authorized to view this page.');
           });
-        } else if (auth.user) {
+        } else if (this.loggedInUser) {
           // Load information based on logged in user
           this.loadFeedbackSession();
         } else {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -86,17 +86,18 @@ export class SessionResultPageComponent implements OnInit {
           const intent: Intent = Intent.STUDENT_RESULT;
           this.authService.getAuthRegkeyValidity(this.regKey, intent).subscribe((resp: RegkeyValidity) => {
             if (resp.isAllowedAccess) {
-              if (auth.user) {
+              if (resp.isUsed) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
                 this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/result',
                     { courseid: this.courseId, fsname: this.feedbackSessionName });
               } else {
-                // There is no logged in user for valid, unused registration key; load information based on the key
+                // Valid, unused registration key; load information based on the key
                 this.loadPersonName();
                 this.loadFeedbackSession();
               }
             } else if (resp.isValid) {
+              // At this point, registration key must already be used, otherwise access would be granted
               if (auth.user) {
                 // Registration key belongs to another user who is not the logged in user
                 this.navigationService.navigateWithErrorMessage(this.router, '/web/front',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -30,8 +30,14 @@
 <div class="row" *ngIf="regKey">
   <div class="col-12">
     <div class="alert alert-primary" role="alert">
-      You are submitting feedback as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to
-      <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">login using a Google account</a> (recommended).
+      <div *ngIf="loggedInUser">
+        You are submitting feedback as {{ personName }}. If you wish to link your Google account ({{ loggedInUser }}) with this user,
+        <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">click here</a>.
+      </div>
+      <div *ngIf="!loggedInUser">
+        You are submitting feedback as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in.
+        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredStudent(); $event.preventDefault()">login using a Google account</a> (recommended).
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -153,7 +153,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         const isPreviewOrModeration: boolean = !!(auth.user && (this.moderatedPerson || this.previewAsPerson));
         if (this.regKey && !isPreviewOrModeration) {
           this.authService.getAuthRegkeyValidity(this.regKey, this.intent).subscribe((resp: RegkeyValidity) => {
-            if (resp.isUsable) {
+            if (resp.isAllowedAccess) {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -153,7 +153,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         const isPreviewOrModeration: boolean = !!(auth.user && (this.moderatedPerson || this.previewAsPerson));
         if (this.regKey && !isPreviewOrModeration) {
           this.authService.getAuthRegkeyValidity(this.regKey, this.intent).subscribe((resp: RegkeyValidity) => {
-            if (resp.isValid) {
+            if (resp.isUsable) {
               if (auth.user) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
@@ -161,14 +161,20 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                     { courseid: this.courseId, fsname: this.feedbackSessionName });
               } else {
                 // There is no logged in user for valid, unused registration key; load information based on the key
-
                 this.loadPersonName();
                 this.loadFeedbackSession();
               }
-            } else if (!auth.user) {
-              // If there is no logged in user for a valid, used registration key, redirect to login page
-              window.location.href = `${this.backendUrl}${auth.studentLoginUrl}`;
+            } else if (resp.isValid) {
+              if (auth.user) {
+                // Registration key belongs to another user who is not the logged in user
+                this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
+                    'You are not authorized to view this page.');
+              } else {
+                // There is no logged in user for a valid, used registration key, redirect to login page
+                window.location.href = `${this.backendUrl}${auth.studentLoginUrl}`;
+              }
             } else {
+              // The registration key is invalid
               this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                   'You are not authorized to view this page.');
             }

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -154,17 +154,18 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         if (this.regKey && !isPreviewOrModeration) {
           this.authService.getAuthRegkeyValidity(this.regKey, this.intent).subscribe((resp: RegkeyValidity) => {
             if (resp.isAllowedAccess) {
-              if (auth.user) {
+              if (resp.isUsed) {
                 // The logged in user matches the registration key; redirect to the logged in URL
 
                 this.navigationService.navigateByURLWithParamEncoding(this.router, '/web/student/sessions/submission',
                     { courseid: this.courseId, fsname: this.feedbackSessionName });
               } else {
-                // There is no logged in user for valid, unused registration key; load information based on the key
+                // Valid, unused registration key; load information based on the key
                 this.loadPersonName();
                 this.loadFeedbackSession();
               }
             } else if (resp.isValid) {
+              // At this point, registration key must already be used, otherwise access would be granted
               if (auth.user) {
                 // Registration key belongs to another user who is not the logged in user
                 this.navigationService.navigateWithErrorMessage(this.router, '/web/front',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -77,6 +77,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   courseId: string = '';
   feedbackSessionName: string = '';
   regKey: string = '';
+  loggedInUser: string = '';
 
   moderatedPerson: string = '';
   previewAsPerson: string = '';
@@ -151,6 +152,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       const nextUrl: string = `${window.location.pathname}${window.location.search}`;
       this.authService.getAuthUser(undefined, nextUrl).subscribe((auth: AuthInfo) => {
         const isPreviewOrModeration: boolean = !!(auth.user && (this.moderatedPerson || this.previewAsPerson));
+        if (auth.user) {
+          this.loggedInUser = auth.user.id;
+        }
         if (this.regKey && !isPreviewOrModeration) {
           this.authService.getAuthRegkeyValidity(this.regKey, this.intent).subscribe((resp: RegkeyValidity) => {
             if (resp.isAllowedAccess) {
@@ -166,7 +170,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               }
             } else if (resp.isValid) {
               // At this point, registration key must already be used, otherwise access would be granted
-              if (auth.user) {
+              if (this.loggedInUser) {
                 // Registration key belongs to another user who is not the logged in user
                 this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                     'You are not authorized to view this page.');
@@ -183,7 +187,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             this.navigationService.navigateWithErrorMessage(this.router, '/web/front',
                 'You are not authorized to view this page.');
           });
-        } else if (auth.user) {
+        } else if (this.loggedInUser) {
           // Load information based on logged in user
           // This will also cover moderation/preview cases
           this.loadPersonName();


### PR DESCRIPTION
Fixes #10705 
Fixes #10718 

Dealing with two issues at once since both deal with regkey check.

The root cause for both is the check for regkey's validity only stops at whether the regkey was usable by the current user or not. It did not specify further the different kinds of validity there can be, e.g. valid because the logged in user match, valid because it has not been used, etc.