### PR TITLE
[#10708] Trim cell values of Enroll Students page

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -110,15 +110,15 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
         .filter((row: string[]) => (!row.every((cell: string) => cell === null || cell === '')))
         .forEach((row: string[]) => (studentsEnrollRequest.studentEnrollRequests.push({
           section: row[hotInstanceColHeaders.indexOf(this.colHeaders[0])] === null ?
-              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[0])],
+              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[0])].trim(),
           team: row[hotInstanceColHeaders.indexOf(this.colHeaders[1])] === null ?
-              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[1])],
+              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[1])].trim(),
           name: row[hotInstanceColHeaders.indexOf(this.colHeaders[2])] === null ?
-              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[2])],
+              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[2])].trim(),
           email: row[hotInstanceColHeaders.indexOf(this.colHeaders[3])] === null ?
-              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[3])],
+              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[3])].trim(),
           comments: row[hotInstanceColHeaders.indexOf(this.colHeaders[4])] === null ?
-              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[4])],
+              '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[4])].trim(),
         })));
 
     this.studentService.enrollStudents(
@@ -156,7 +156,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     for (const _ of statuses) {
       studentLists.push([]);
     }
-
+    console.log("hello");
     // Identify students not in the enroll list.
     for (const existingStudent of existingStudents) {
       const enrolledStudent: Student | undefined = enrolledStudents.find((student: Student) => {
@@ -189,8 +189,9 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       const enrolledStudent: Student | undefined = enrolledStudents.find((student: Student) => {
         return student.email === request.email;
       });
-
+      
       if (enrolledStudent === undefined) {
+        console.log("undefined", request);
         studentLists[EnrollStatus.ERROR].push({
           email: request.email,
           courseId: this.courseId,
@@ -201,6 +202,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
           joinState: JoinState.NOT_JOINED,
           lastName: '',
         });
+      } else {
+        console.log("okay", request);
       }
     }
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -156,7 +156,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     for (const _ of statuses) {
       studentLists.push([]);
     }
-    console.log("hello");
     // Identify students not in the enroll list.
     for (const existingStudent of existingStudents) {
       const enrolledStudent: Student | undefined = enrolledStudents.find((student: Student) => {
@@ -191,7 +190,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       });
       
       if (enrolledStudent === undefined) {
-        console.log("undefined", request);
         studentLists[EnrollStatus.ERROR].push({
           email: request.email,
           courseId: this.courseId,
@@ -202,8 +200,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
           joinState: JoinState.NOT_JOINED,
           lastName: '',
         });
-      } else {
-        console.log("okay", request);
       }
     }
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -156,6 +156,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     for (const _ of statuses) {
       studentLists.push([]);
     }
+
     // Identify students not in the enroll list.
     for (const existingStudent of existingStudents) {
       const enrolledStudent: Student | undefined = enrolledStudents.find((student: Student) => {
@@ -188,7 +189,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       const enrolledStudent: Student | undefined = enrolledStudents.find((student: Student) => {
         return student.email === request.email;
       });
-      
+
       if (enrolledStudent === undefined) {
         studentLists[EnrollStatus.ERROR].push({
           email: request.email,


### PR DESCRIPTION
Fixes #10708 

**Outline of Solution**

Trim all values before passing it to enrolling logic. Now enrolling students with trailing whitespace will be trimmed first and will not throw an error:

<img width="781" alt="Screenshot 2020-09-25 at 12 58 53 PM" src="https://user-images.githubusercontent.com/50471593/94228620-f4925d00-ff2f-11ea-97f3-9fbf4b491b81.png"> 

<img width="632" alt="Screenshot 2020-09-25 at 12 59 02 PM" src="https://user-images.githubusercontent.com/50471593/94228614-f0fed600-ff2f-11ea-97c2-13de1b0bef6d.png">
