### PR TITLE
[#10595] Instructor session results page: better label for questions without specific recipients

### DIFF
--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -57,8 +57,8 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
 
   get teamInfo(): Record<string, string> {
     const team: Record<string, string> = {};
-    let recipientTeamName = this.responses[0].allResponses[0].recipientTeam;
-    if (recipientTeamName != '') {
+    const recipientTeamName: string = this.responses[0].allResponses[0].recipientTeam;
+    if (recipientTeamName !== '') {
       team.recipient = (recipientTeamName === '-') ? '(No Specific Team)' : `(${recipientTeamName})`;
     } else {
       team.recipient = '';

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -57,8 +57,12 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
 
   get teamInfo(): Record<string, string> {
     const team: Record<string, string> = {};
-    team.recipient =  this.responses[0].allResponses[0].recipientTeam !== '' ?
-        `(${this.responses[0].allResponses[0].recipientTeam})` : '';
+    let recipientTeamName = this.responses[0].allResponses[0].recipientTeam;
+    if (recipientTeamName != '') {
+      team.recipient = (recipientTeamName === '-') ? '(No Specific Team)' : `(${recipientTeamName})`;
+    } else {
+      team.recipient = '';
+    }
     team.giver = `(${this.responses[0].allResponses[0].giverTeam})`;
     return team;
   }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -2,7 +2,7 @@
   <div *ngFor="let teamInfo of teamsToUsers | keyvalue">
     <div class="card top-padded">
       <div class="card-header alert-warning cursor-pointer" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
-        {{ teamInfo.key }}
+        {{ teamInfo.key == '-' ? 'No Specific Team': teamInfo.key }}
         <div class="card-header-btn-toolbar">
           <tm-panel-chevron [isExpanded]="teamExpanded[teamInfo.key]"></tm-panel-chevron>
         </div>
@@ -38,7 +38,12 @@
                          [email]="userToEmail[userInfo]"
                          [courseId]="session.courseId"
         ></tm-student-name-with-photo>
-        {{ usersToTeams[userInfo] !== '' ? '(' + usersToTeams[userInfo] + ')' : ''}}
+        {{ usersToTeams[userInfo] !== ''
+          ? '('
+            + (usersToTeams[userInfo] === '-' ? 'No Specific Team' : usersToTeams[userInfo])
+            + ')'
+          : ''
+        }}
         <a *ngIf="userToEmail[userInfo]" [href]="'mailto:' + userToEmail[userInfo]" class="text-white" (click)="$event.stopPropagation()">
           [{{ userToEmail[userInfo] }}]
         </a>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -48,7 +48,9 @@
                            [courseId]="session.courseId"
           ></tm-student-name-with-photo>
         </td>
-        <td *ngIf="showRecipient">{{ response.recipientTeam }}</td>
+        <td *ngIf="showRecipient">
+          {{ response.recipientTeam === '-' ? 'No Specific Team' : response.recipientTeam}}
+        </td>
         <td *ngIf="showRecipient">
           <tm-student-name-with-photo [name]="response.recipient"
                            [email]="response.recipientEmail"

--- a/src/web/app/components/teammates-common/student-name/student-name-with-photo.component.html
+++ b/src/web/app/components/teammates-common/student-name/student-name-with-photo.component.html
@@ -2,8 +2,8 @@
   <tm-view-photo-popover [photoUrl]="email | formatPhotoUrl: courseId" (showPhotoEvent)="clearTooltipTimer()">
     <i class="fa-user" [ngClass]="iconClass" (mouseover)="handleMouseover(t)" (mouseout)="handleMouseout(t)" triggers="manual" #t="ngbTooltip" ngbTooltip="Click to view student's profile picture"></i>
   </tm-view-photo-popover>
-  {{ name }}
+  {{ name === '-' ? 'No Specific User' : name}}
 </span>
 <ng-template #noPhoto>
-  {{ name }}
+  {{ name === '-' ? 'No Specific User' : name}}
 </ng-template>


### PR DESCRIPTION
Fixes #10595 

#### Outline of Solution
The following things were done in this PR - 
* In case the question is posed to no specific recipient, in the Recipient-Giver-Question view, instead of rendering - (-) as user, team under `No Specific Section`, render user (team) as `No Specific User (No Specific Team)`
* In per question view, in case the recipient user, team is marked as `-` render `No Specific User (No Specific Team)`

#### Testing
Attaching Screen shot for use cases

1. Use case fixed - 

<img width="1435" alt="No_Specific_User" src="https://user-images.githubusercontent.com/24290847/95021153-e7424480-068c-11eb-9f84-8b147e9e41c3.png">

2. Both Users are present in DB -

<img width="1435" alt="Both_Users_Present" src="https://user-images.githubusercontent.com/24290847/95021179-1062d500-068d-11eb-926f-693537216732.png">


