### PR TITLE
[#10702] Change status code to 400 for non-UTF8 inputs

### DIFF
--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -63,8 +63,20 @@ public class WebApiServlet extends HttpServlet {
         resp.setHeader("Cache-Control", "no-store");
         resp.setHeader("Pragma", "no-cache");
 
+        String requestParametersAsString;
+        try {
+            // Make sure that all parameters are valid UTF-8
+            requestParametersAsString = HttpRequestHelper.getRequestParametersAsString(req);
+        } catch (RuntimeException e) {
+            if (e.getClass().getSimpleName().equals("BadMessageException")) {
+                throwErrorBasedOnRequester(req, resp, e, HttpStatus.SC_BAD_REQUEST);
+                return;
+            }
+            throw e;
+        }
+
         log.info("Request received: [" + req.getMethod() + "] " + req.getRequestURL().toString()
-                + ", Params: " + HttpRequestHelper.getRequestParametersAsString(req)
+                + ", Params: " + requestParametersAsString
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(req)
                 + ", Request ID: " + Config.getRequestId());
 

--- a/src/main/java/teammates/ui/webapi/WebPageServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebPageServlet.java
@@ -8,11 +8,18 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
+
+import teammates.common.exception.TeammatesException;
+import teammates.common.util.Logger;
+
 /**
  * Servlet that handles the single web page.
  */
 @SuppressWarnings("serial")
 public class WebPageServlet extends HttpServlet {
+
+    private static final Logger log = Logger.getLogger();
 
     private static final String CSP_POLICY = String.join("; ", Arrays.asList(
             "default-src 'none'",
@@ -35,7 +42,16 @@ public class WebPageServlet extends HttpServlet {
         resp.setHeader("X-Frame-Options", "SAMEORIGIN");
         resp.setHeader("X-XSS-Protection", "1; mode=block");
         resp.setHeader("Strict-Transport-Security", "max-age=31536000");
-        req.getRequestDispatcher("/index.html").forward(req, resp);
+        try {
+            req.getRequestDispatcher("/index.html").forward(req, resp);
+        } catch (IllegalArgumentException e) {
+            if (e.getClass().getSimpleName().equals("NotUtf8Exception")) {
+                log.warning(TeammatesException.toStringWithStackTrace(e));
+                resp.setStatus(HttpStatus.SC_BAD_REQUEST);
+            } else {
+                throw e;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #10702 

We cannot access `org.eclipse.jetty.*` classes, so the next best thing we can do is to catch the immediate parent exception and match based on name. Adding the [jetty-http library](https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-http) doesn't help either because we don't know the exact version used by GAE's productions server (wrong version = different byte code = exception won't be caught even if we ask it to) (P.S. it's not 9.4.27 even though it's claimed as such).

Not sure how to add test (without putting in too much effort) because I don't see a good way to sneak in a non-UTF8 character.

References: [NotUtf8Exception](https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/util/Utf8Appendable.NotUtf8Exception.html), [BadMessageException](https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/http/BadMessageException.html)