### PR TITLE
[#3810] Create a new 'under maintenance' version

### DIFF
--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -78,6 +78,9 @@ public final class Config {
     /** The value of the "app.enable.datastore.backup" in build.properties file. */
     public static final boolean ENABLE_DATASTORE_BACKUP;
 
+    /** The value of the "app.maintenance" in build.properties file. */
+    public static final boolean MAINTENANCE;
+
     static {
         APP_URL = readAppUrl();
         Properties properties = new Properties();
@@ -106,6 +109,7 @@ public final class Config {
         MAILJET_APIKEY = properties.getProperty("app.mailjet.apikey");
         MAILJET_SECRETKEY = properties.getProperty("app.mailjet.secretkey");
         ENABLE_DATASTORE_BACKUP = Boolean.parseBoolean(properties.getProperty("app.enable.datastore.backup", "false"));
+        MAINTENANCE = Boolean.parseBoolean(properties.getProperty("app.maintenance", "false"));
     }
 
     private Config() {

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -80,6 +80,12 @@ public class WebApiServlet extends HttpServlet {
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(req)
                 + ", Request ID: " + Config.getRequestId());
 
+        if (Config.MAINTENANCE) {
+            throwError(resp, HttpStatus.SC_SERVICE_UNAVAILABLE,
+                    "The server is currently undergoing some maintenance.");
+            return;
+        }
+
         try {
             Action action = new ActionFactory().getAction(req, req.getMethod());
             action.checkAccessControl();

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -35,6 +35,10 @@ app.backup.gcs.bucketname=teammates-john-backup
 # It does not have any effect in dev server.
 app.enable.datastore.backup=false
 
+# This flag sets whether the server is in maintenance mode.
+# Under maintenance mode, all API requests will return a 503 error.
+app.maintenance=false
+
 # This is the key used to bypass origin check for web API endpoints.
 # It can be any random string you choose.
 # Make sure that this key is secure.

--- a/src/web/app/app.module.ts
+++ b/src/web/app/app.module.ts
@@ -15,6 +15,7 @@ import { LoadingSpinnerModule } from './components/loading-spinner/loading-spinn
 import { SimpleModalModule } from './components/simple-modal/simple-modal.module';
 import { ToastModule } from './components/toast/toast.module';
 import { CustomUrlSerializer } from './custom-url-serializer';
+import { MaintenancePageComponent } from './maintenance-page.component';
 import { ClickOutsideDirective, PageComponent } from './page.component';
 import { AdminPageComponent } from './pages-admin/admin-page.component';
 import { InstructorPageComponent } from './pages-instructor/instructor-page.component';
@@ -27,7 +28,7 @@ const customUrlSerializerProvider: Provider = {
   provide: UrlSerializer,
   useValue: customUrlSerializer,
 };
-const routes: Routes = [
+let routes: Routes = [
   {
     path: 'web',
     children: [
@@ -91,6 +92,31 @@ const routes: Routes = [
   },
 ];
 
+if (environment.maintenance) {
+  routes = [
+    {
+      path: 'web',
+      component: PublicPageComponent,
+      children: [
+        {
+          path: '',
+          component: MaintenancePageComponent,
+        },
+        {
+          path: '**',
+          pathMatch: 'full',
+          redirectTo: '',
+        },
+      ],
+    },
+    {
+      path: '**',
+      pathMatch: 'full',
+      redirectTo: 'web',
+    },
+  ];
+}
+
 /**
  * Root module.
  */
@@ -104,6 +130,7 @@ const routes: Routes = [
     StudentPageComponent,
     InstructorPageComponent,
     AdminPageComponent,
+    MaintenancePageComponent,
   ],
   imports: [
     SimpleModalModule,

--- a/src/web/app/maintenance-page.component.html
+++ b/src/web/app/maintenance-page.component.html
@@ -1,0 +1,6 @@
+<p>
+  TEAMMATES server is currently undergoing some maintenance.
+</p>
+<p>
+  We apologize for the inconveniences caused.
+</p>

--- a/src/web/app/maintenance-page.component.spec.ts
+++ b/src/web/app/maintenance-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MaintenancePageComponent } from './maintenance-page.component';
+
+describe('MaintenancePageComponent', () => {
+  let component: MaintenancePageComponent;
+  let fixture: ComponentFixture<MaintenancePageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [MaintenancePageComponent],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MaintenancePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/maintenance-page.component.ts
+++ b/src/web/app/maintenance-page.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+/**
+ * Maintenance page component.
+ */
+@Component({
+  selector: 'tm-maintenance-page',
+  templateUrl: './maintenance-page.component.html',
+  styleUrls: ['./maintenance-page.component.scss'],
+})
+export class MaintenancePageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/web/app/public-page.component.ts
+++ b/src/web/app/public-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { environment } from '../environments/environment';
 import { AuthService } from '../services/auth.service';
 import { MasqueradeModeService } from '../services/masquerade-mode.service';
 import { AuthInfo } from '../types/api-output';
@@ -16,6 +17,9 @@ export class PublicPageComponent {
   constructor(private route: ActivatedRoute,
               private authService: AuthService,
               private masqueradeModeService: MasqueradeModeService) {
+    if (environment.maintenance) {
+      return;
+    }
     this.route.queryParams.subscribe((queryParams: any) => {
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user && res.masquerade) {

--- a/src/web/environments/config.template.ts
+++ b/src/web/environments/config.template.ts
@@ -23,4 +23,10 @@ export const config: any = {
    * e.g. "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI" is a site key for test environments.
    */
   captchaSiteKey: '',
+
+  /**
+   * This flag determines if the system is in maintenance mode.
+   * Under maintenance mode, all requests to the front-end will be routed to the "under maintenance" page.
+   */
+  maintenance: false,
 };


### PR DESCRIPTION
Fixes #3810 

API server and front-end are configured differently. The former returns `503 Service Unavailable` for all requests, the latter reroutes all requests to maintenance page. Technically speaking, with the way the system works right now (i.e. we don't offer standalone API services), only the latter needs to be done.