### PR TITLE
[#10615] added space between download label and load icon

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -44,6 +44,7 @@
           </button>
           <button class="btn btn-primary action-btn no-print" [ngbTooltip]="downloadTooltip" (click)="downloadResultHandler()" [disabled]="isDownloadingResults">
             <tm-ajax-loading *ngIf="isDownloadingResults"></tm-ajax-loading>
+            &nbsp;
             <i class="fas fa-file-download"></i> Download Results
           </button>
           <button class="btn btn-primary action-btn no-print" (click)="printViewHandler()">


### PR DESCRIPTION
Fixes #10615
Code is Ready for review 
I added this space in html before the loading icon before icon is displayed

**After Fix**

![image](https://user-images.githubusercontent.com/47011340/96052845-2e6dc980-0e33-11eb-870e-d466c8f3a4bb.png)

