### PR TITLE
[#10597] Instructor edit session page: page refreshes by itself on first loading

### DIFF
--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -61,7 +61,7 @@
           <tm-ajax-loading *ngIf="sessionsTableRowModel.isLoadingResponseRate" [useBlueSpinner]="true"></tm-ajax-loading>
         </td>
         <td class="actions-cell">
-          <a *ngIf="sessionsTableRowModel.instructorPrivilege.canModifySession; else editSessionBtn" routerLink="/web/instructor/sessions/edit" [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">
+          <a *ngIf="sessionsTableRowModel.instructorPrivilege.canModifySession; else editSessionBtn" >
             <ng-container *ngTemplateOutlet="editSessionBtn"></ng-container>
           </a>
           <ng-template #editSessionBtn>


### PR DESCRIPTION
Fixes #10597
The page does not refresh a second time.
![image](https://user-images.githubusercontent.com/21325169/96058622-9080fb80-0e40-11eb-9ce1-f29c99e5d28e.png)

**Outline of Solution**
Remove edit button router link to prevent page refreshes by itself on first loading

