### PR TITLE
[#10523] Edit session button should open the sessions page in edit mode

### DIFF
--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -166,7 +166,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
             >
               
               <a
-                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review"
+                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
                 routerlink="/web/instructor/sessions/edit"
               >
                 
@@ -576,7 +576,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
             >
               
               <a
-                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review"
+                href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
                 routerlink="/web/instructor/sessions/edit"
               >
                 

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -61,7 +61,7 @@
           <tm-ajax-loading *ngIf="sessionsTableRowModel.isLoadingResponseRate" [useBlueSpinner]="true"></tm-ajax-loading>
         </td>
         <td class="actions-cell">
-          <a *ngIf="sessionsTableRowModel.instructorPrivilege.canModifySession; else editSessionBtn" routerLink="/web/instructor/sessions/edit" [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">
+          <a *ngIf="sessionsTableRowModel.instructorPrivilege.canModifySession; else editSessionBtn" routerLink="/web/instructor/sessions/edit" [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName, editingMode: true }">
             <ng-container *ngTemplateOutlet="editSessionBtn"></ng-container>
           </a>
           <ng-template #editSessionBtn>

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -799,7 +799,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                           >
                             
                             <a
-                              href="/web/instructor/sessions/edit?courseid=CS3281&fsname=Feedback"
+                              href="/web/instructor/sessions/edit?courseid=CS3281&fsname=Feedback&editingMode=true"
                               routerlink="/web/instructor/sessions/edit"
                             >
                               

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -79,7 +79,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   // url param
   courseId: string = '';
   feedbackSessionName: string = '';
-  isEditingMode: boolean = false;
+  isEditingMode: boolean = true;
 
   courseName: string = '';
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -79,7 +79,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   // url param
   courseId: string = '';
   feedbackSessionName: string = '';
-  isEditingMode: boolean = true;
+  isEditingMode: boolean = false;
 
   courseName: string = '';
 


### PR DESCRIPTION
Fixes #10523

**Old behavior**  
The user has to click on the edit button again to go into the edit mode.  
![image](https://gitlab.eecs.wsu.edu/2019080757/581teammates/uploads/195697872c92f62b8a275495636dd222/image.png)
![image](https://gitlab.eecs.wsu.edu/2019080757/581teammates/uploads/41c0ab8576fd18996fe6f65e0c53df56/image.png)

**New behavior**  
The page is opened in edit mode.  
![image](https://gitlab.eecs.wsu.edu/2019080757/581teammates/uploads/195697872c92f62b8a275495636dd222/image.png)
![image](https://gitlab.eecs.wsu.edu/2019080757/581teammates/uploads/7133702af28d4e79b19c24591bf360be/image.png)


**Outline of Solution**  
Set the parameter for editingMode to true in sessions-table.component.html and instructor-session-edit-page.component.ts.