### PR TITLE
[#10645] [#10688] Fix bugs in instructor results page

### DIFF
--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -9,7 +9,7 @@
       </div>
       <div *ngIf="teamExpanded[teamInfo.key]" @collapseAnim>
         <div class="card-body background-color-warning">
-          <div *ngIf="teamsToQuestions[teamInfo.key] && teamsToQuestions[teamInfo.key].length">
+          <div *ngIf="teamsToQuestions[teamInfo.key] && teamsToQuestions[teamInfo.key].length && showStatistics">
             <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
             <div class="card top-padded alert-primary-border" *ngFor="let question of teamsToQuestions[teamInfo.key]">
               <div class="card-header alert-primary">
@@ -81,7 +81,8 @@
           </div>
           <div *ngIf="question.isTabExpanded" @collapseAnim>
             <div class="card-body top-padded-small table-responsive">
-              <tm-single-statistics [responses]="question.questionOutput.allResponses"
+              <tm-single-statistics *ngIf="showStatistics"
+                                    [responses]="question.questionOutput.allResponses"
                                     [question]="question.questionOutput.feedbackQuestion.questionDetails"
                                     [statistics]="question.questionOutput.questionStatistics"
                                     [recipientType]="question.questionOutput.feedbackQuestion.recipientType"

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -2,7 +2,7 @@
   <div *ngFor="let teamInfo of teamsToUsers | keyvalue">
     <div class="card top-padded">
       <div class="card-header alert-warning cursor-pointer" (click)="teamExpanded[teamInfo.key] = !teamExpanded[teamInfo.key]">
-        {{ teamInfo.key }}
+        {{ teamInfo.key == '-' ? 'No Specific Team': teamInfo.key }}
         <div class="card-header-btn-toolbar">
           <tm-panel-chevron [isExpanded]="teamExpanded[teamInfo.key]"></tm-panel-chevron>
         </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -47,6 +47,9 @@
     </ng-container>
   </div>
 </div>
+<div *ngIf="(groupByTeam && !(teamsToUsers | keyvalue)?.length) || (!groupByTeam && !(userExpanded | keyvalue)?.length)">
+  <i>There are no responses for this section or you may not have the permission to see the response.</i>
+</div>
 
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded border-primary">

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -31,6 +31,7 @@ interface QuestionTab {
 export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase implements OnInit, OnChanges {
 
   @Input() responses: QuestionOutput[] = [];
+  @Input() sectionOfView: string = '';
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
@@ -94,9 +95,9 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
           continue;
         }
 
-        if (this.section) {
-          if (this.isGqr && response.giverSection !== this.section
-              || !this.isGqr && response.recipientSection !== this.section) {
+        if (this.sectionOfView) {
+          if (this.isGqr && response.giverSection !== this.sectionOfView
+              || !this.isGqr && response.recipientSection !== this.sectionOfView) {
             continue;
           }
         }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -28,6 +28,9 @@
     </ng-container>
   </div>
 </div>
+<div *ngIf="(groupByTeam && !(teamsToUsers | keyvalue)?.length) || (!groupByTeam && !(userExpanded | keyvalue)?.length)">
+  <i>There are no responses for this section or you may not have the permission to see the response.</i>
+</div>
 
 <ng-template #userTab let-userInfo='userInfo'>
   <div class="card top-padded border-primary">

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -27,6 +27,7 @@ import { InstructorResponsesViewBase } from '../instructor-responses-view-base';
 export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase implements OnInit, OnChanges {
 
   @Input() responses: QuestionOutput[] = [];
+  @Input() sectionOfView: string = '';
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
@@ -95,9 +96,9 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
           continue;
         }
 
-        if (this.section) {
-          if (this.isGrq && response.giverSection !== this.section
-              || !this.isGrq && response.recipientSection !== this.section) {
+        if (this.sectionOfView) {
+          if (this.isGrq && response.giverSection !== this.sectionOfView
+              || !this.isGrq && response.recipientSection !== this.sectionOfView) {
             continue;
           }
         }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -1,5 +1,5 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
-  <div class="card margin-bottom-15px alert-success-border" *ngIf="!section || (sectionInfo.key == section)">
+  <div class="card margin-bottom-15px alert-success-border">
     <div class="card-header alert-success cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="card-header-btn-toolbar">
@@ -8,7 +8,7 @@
     </div>
     <div *ngIf="sectionInfo.value.isTabExpanded" @collapseAnim>
       <div *tmIsLoading="!sectionInfo.value.hasPopulated" class="card-body">
-        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [sectionOfView]="sectionInfo.key" [section]="section" [sectionType]="sectionType"
                                    [indicateMissingResponses]="indicateMissingResponses"
                                    [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="true" [session]="session"
                                    [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -1,5 +1,5 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
-  <div class="card margin-bottom-15px alert-success-border" *ngIf="!section || (sectionInfo.key == section)">
+  <div class="card margin-bottom-15px alert-success-border">
     <div class="card-header alert-success cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="card-header-btn-toolbar">
@@ -8,7 +8,7 @@
     </div>
     <div *ngIf="sectionInfo.value.isTabExpanded" @collapseAnim>
       <div *tmIsLoading="!sectionInfo.value.hasPopulated" class="card-body">
-        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [sectionOfView]="sectionInfo.key" [section]="section" [sectionType]="sectionType"
                                    [indicateMissingResponses]="indicateMissingResponses"
                                    [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="true" [session]="session"
                                    [isExpandAll]="isExpandAll" [instructorCommentTableModel]="instructorCommentTableModel"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -1,5 +1,5 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
-  <div class="card margin-bottom-15px alert-success-border" *ngIf="!section || (sectionInfo.key == section)">
+  <div class="card margin-bottom-15px alert-success-border">
     <div class="card-header alert-success cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="card-header-btn-toolbar">
@@ -8,7 +8,7 @@
     </div>
     <div *ngIf="sectionInfo.value.isTabExpanded" @collapseAnim>
       <div *tmIsLoading="!sectionInfo.value.hasPopulated" class="card-body">
-        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+        <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [sectionOfView]="sectionInfo.key" [section]="section" [sectionType]="sectionType"
                                    [indicateMissingResponses]="indicateMissingResponses"
                                    [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="false" [session]="session"
                                    [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -1,5 +1,5 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
-  <div class="card margin-bottom-15px alert-success-border" *ngIf="!section || (sectionInfo.key == section)">
+  <div class="card margin-bottom-15px alert-success-border">
     <div class="card-header alert-success cursor-pointer" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key === 'None' ? 'No specific section' : sectionInfo.key }}
       <div class="card-header-btn-toolbar">
@@ -8,7 +8,7 @@
     </div>
     <div *ngIf="sectionInfo.value.isTabExpanded" @collapseAnim>
       <div class="card-body" *tmIsLoading="!sectionInfo.value.hasPopulated">
-        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="sectionInfo.key" [sectionType]="sectionType"
+        <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [sectionOfView]="sectionInfo.key" [section]="section" [sectionType]="sectionType"
                                    [indicateMissingResponses]="indicateMissingResponses"
                                    [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="false" [session]="session"
                                    [instructorCommentTableModel]="instructorCommentTableModel" [isExpandAll]="isExpandAll"


### PR DESCRIPTION
Fixes #10798
Fixes #10795

**Outline of Solution**
- Add `*ngIf = showStatistics` check to remove statistics element when statistics should not be shown
- Standardize naming for `No Specific Team` across views
    - Did not change naming for the titles as `No Specific Team Statistics` sounds weird to me.
- Add extra variable `sectionOfView` to differentiate filtering for the view and filtering because of the section.
    - It is not possible to filter the section headers as the data is only loaded when the headers are expanded. Thus, added a empty message for sections that are empty after filtering.

**Statistic not shown when show statistics is not selected**
![statistics](https://user-images.githubusercontent.com/31800234/96711526-482d8480-13d0-11eb-95a9-b4c05927f46f.PNG)

**Renamed to `No Specific Team` but titles are not renamed.**
![specific](https://user-images.githubusercontent.com/31800234/96711599-62676280-13d0-11eb-8b9b-9063e80a25bf.PNG)

**Filter by sections now shows other sections and has a message when the section is empty.**
![filter](https://user-images.githubusercontent.com/31800234/96711664-8034c780-13d0-11eb-8307-69b712ee6742.PNG)
