### PR TITLE
[#10809] Instructor editing sessions: rename the 'done editing' button

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -153,7 +153,7 @@
         Save changes to the question when you have finished creating the question
       </li>
       <li>
-        When you are finished adding questions, click <button class="btn btn-primary">Done Editing</button>.
+        When you are finished adding questions, click <button class="btn btn-primary">Discard Unsaved edits</button>.
       </li>
     </ol>
     <tm-example-box *ngIf="questionsToCollapsed[SessionsSectionQuestions.SESSION_QUESTIONS]" @collapseAnim>
@@ -167,7 +167,7 @@
           </div>
           <button type="button" class="btn btn-link"><i class="fas fa-info-circle"></i></button>
           <button class="btn btn-primary">Copy Question</button>&nbsp;
-          <button class="btn btn-primary">Done Editing</button>
+          <button class="btn btn-primary">Discard Unsaved edits</button>
         </div>
       </div>
     </tm-example-box>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -39,7 +39,7 @@
       </div>
       <a type="button" class="btn btn-link" target="_blank" rel="noopener noreferrer" routerLink="/web/instructor/help" [queryParams]="{questionId: 'questions', section: 'questions'}"><i class="fas fa-info-circle"></i></a>
       <button id="btn-copy-question" class="btn btn-primary" (click)="copyQuestionsFromOtherSessionsHandler()" [disabled]="isCopyingQuestion"><tm-ajax-loading *ngIf="isCopyingQuestion"></tm-ajax-loading>&nbsp;Copy Question</button>
-      <button class="btn btn-primary btn-margin-left" (click)="doneEditingHandler()">Done Editing</button>
+      <button class="btn btn-primary btn-margin-left" (click)="doneEditingHandler()">Discard Unsaved edits</button>
     </div>
   </div>
   <tm-question-edit-form *ngIf="isAddingQuestionPanelExpanded"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -937,7 +937,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   }
 
   /**
-   * Handles 'Done Editing' click event.
+   * Handles 'Discard Unsaved edits' click event.
    */
   doneEditingHandler(): void {
     if (this.questionEditFormModels.some((q: QuestionEditFormModel) => q.isEditable)


### PR DESCRIPTION
Fixes #10809 

Found all files in the project which included the 'Done editing' text. I then replaced this text in each file with 'Discard unsaved edits'.

*Ready for review
