### PR TITLE
[#10805][Help for instructions page][small screen mode]Browse my topic listing comes over the text #10805

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <div class="side-nav container-fluid">
+  <div class="side-nav container-fluid" id="browse-by-topics">
     <p><b>
       Browse by topic:
       <br>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
@@ -18,3 +18,9 @@
 .section-body {
   padding-bottom: 5px;
 }
+
+@media only screen and (max-width: 500px) {
+  #fadeshow1 {
+    display: none;
+  }
+}


### PR DESCRIPTION
Added a media query that hides browse by topic listing whenever the
width is lower than 500 px which is when it started to overlap the
otherelements on the webpage.

Resolves: #10805

Fixes #10805 

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [x] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr
  - [ ] Added the issue number to the "Fixes" keyword above
  - [ ] Titled the PR as specified in the abovementioned document
- [ ] Made your changes on a branch other than `master` and `release`
- [ ] Gone through all the changes in this PR and ensured that:
  - [ ] They addressed one (and only one) issue
  - [ ] No unintended changes were made
- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [ ] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
