### PR TITLE
[#10805] Browse by topic listing comes over the text

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <div class="side-nav container-fluid">
+  <div class="side-nav container-fluid" id="browse-by-topic">
     <p><b>
       Browse by topic:
       <br>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
@@ -18,3 +18,9 @@
 .section-body {
   padding-bottom: 5px;
 }
+
+@media only screen and (max-width: 500px) {
+  #browse-by-topic {
+    display: none;
+  }
+}


### PR DESCRIPTION
Fixes #10805 

**Outline of Solution**

- Gave an id "browse-by-topic" to the browse by topic listing.
- Added a media query that hides the browse by topic listing when the screen width goes below 500 px which is when it started to overlap the other elements on the webpage.

I gave it an id so that the media query does not affect any other element sharing the same class as browse by topic listing.

READY FOR REVIEW