### PR TITLE
[#10838] Resolve PML has invalid URL path in eclipse

### DIFF
--- a/static-analysis/teammates-pmd.xml
+++ b/static-analysis/teammates-pmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+<ruleset xmlns="https://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          name=""
-         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+         xsi:schemaLocation="https://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
     <description>
         This is the PMD ruleset for all TEAMMATES Java code.
     </description>

--- a/static-analysis/teammates-pmdMain.xml
+++ b/static-analysis/teammates-pmdMain.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+<ruleset xmlns="https://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          name=""
-         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+         xsi:schemaLocation="https://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
     <description>
         This is the PMD additional ruleset for TEAMMATES production code.
     </description>


### PR DESCRIPTION
Eclipse: Referenced file contains errors (http://pmd.sourceforge.net/ruleset_2_0_0.xsd)

Fixes #10838

**Outline of Solution**

Used the SSL version of the URL  (https://pmd.sourceforge.net/ruleset_2_0_0.xsd)
