### PR TITLE
[#10844] Admin search page: show instructors and students in different colors

### DIFF
--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.html
@@ -14,7 +14,7 @@
 </div>
 
 <div class="card bg-light top-padded" *ngIf="instructors.length">
-  <div class="card-header bg-primary text-white">
+  <div class="card-header bg-info text-white">
     <strong>Instructors Found</strong>
     <div class="card-header-btn-toolbar">
       <button id="show-instructor-links" class="btn btn-light btn-sm" style="margin-right: 10px;" type="button" (click)="showAllInstructorsLinks()">Expand All</button>


### PR DESCRIPTION
Fixes #10844

**PR Checklist**

**Outline of Solution**

As the issue suggests, this PR basically changes the color of the instructor panel to `info` as in the below screenshot.

<img width="1672" alt="Screen Shot 2020-11-22 at 9 01 10 PM" src="https://user-images.githubusercontent.com/14261700/99924071-cd28f800-2d06-11eb-85ca-5d80db7d27b5.png">

