### PR TITLE
[#10845] Fix observers cannot view session results

### DIFF
--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -42,9 +42,13 @@ class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(courseId, userInfo.getId()), feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-        case INSTRUCTOR_RESULT:
             InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
             checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSession);
+            break;
+        case INSTRUCTOR_RESULT:
+            gateKeeper.verifyLoggedInUserPrivileges();
+            gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(courseId, userInfo.getId()),
+                    feedbackSession, Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS);
             break;
         case STUDENT_RESULT:
             throw new InvalidHttpParameterException("Invalid intent for this action");

--- a/src/test/java/teammates/ui/webapi/GetFeedbackQuestionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackQuestionsActionTest.java
@@ -206,6 +206,17 @@ public class GetFeedbackQuestionsActionTest extends BaseActionTest<GetFeedbackQu
 
         verifyAccessibleForInstructorsOfTheSameCourse(params);
         verifyAccessibleForAdminToMasqueradeAsInstructor(params);
+
+        ______TS("observers of course can access result");
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, fs.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs.getFeedbackSessionName(),
+                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
+        };
+
+        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS, params);
     }
 
 }


### PR DESCRIPTION
Fixes #10845 

Separated result access control check from submission access control check.