### PR TITLE
[#9536] Fix AdminSessionsPageE2ETest due to wrong year pattern

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/AdminSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminSessionsPageE2ETest.java
@@ -29,7 +29,7 @@ public class AdminSessionsPageE2ETest extends BaseE2ETestCase {
 
     private String formatDateTime(Instant instant, String timeZone) {
         return DateTimeFormatter
-                .ofPattern("EEE, dd MMM YYYY, hh:mm a")
+                .ofPattern("EEE, dd MMM yyyy, hh:mm a")
                 .format(instant.atZone(ZoneId.of(timeZone)))
                 .replaceFirst(" AM$", " am")
                 .replaceFirst(" PM$", " pm");

--- a/src/e2e/java/teammates/e2e/pageobjects/AdminSessionsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AdminSessionsPage.java
@@ -96,7 +96,7 @@ public class AdminSessionsPage extends AppPage {
 
     private String formatDateTimeForFilter(Instant instant, ZoneId timeZone) {
         return DateTimeFormatter
-                .ofPattern("YYYY-MM-dd")
+                .ofPattern("yyyy-MM-dd")
                 .format(instant.atZone(timeZone));
     }
 


### PR DESCRIPTION
Part of #9536 

Reference: https://rules.sonarsource.com/java/RSPEC-3986