### PR TITLE
[#10651] Fix broken links at Instructor help page

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
@@ -25,7 +25,7 @@
                             headerText="Is there a size limit for a course?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.SIZE_LIMIT]">
     <p>
-      No. However, if courses with an enrollment of more than 100 students need to be <a (click)="jumpTo(CoursesSectionQuestions.ENROLL_SECTIONS); questionsToCollapsed[CoursesSectionQuestions.ENROLL_SECTIONS] = true" [tmRouterLink]="">divided into sections</a>.<br>
+      No. However, if courses with an enrollment of more than 100 students need to be <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.ENROLL_SECTIONS); questionsToCollapsed[CoursesSectionQuestions.ENROLL_SECTIONS] = true">divided into sections</a>.<br>
       TEAMMATES uses section information to organize the results of your sessions into a downloadable report.
     </p>
   </tm-instructor-help-panel>
@@ -123,7 +123,7 @@
                             headerText="How do I set an instructor's access level?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.COURSE_INSTRUCTOR_ACCESS]">
     <p>
-      When <a (click)="jumpTo(CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR); questionsToCollapsed[CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR] = true" [tmRouterLink]="">adding an instructor</a> or <a (click)="jumpTo(CoursesSectionQuestions.COURSE_EDIT_INSTRUCTOR); questionsToCollapsed[CoursesSectionQuestions.COURSE_EDIT_INSTRUCTOR] = true" [tmRouterLink]="">editing an instructor's information</a>, you can set the instructor's access level.
+      When <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR); questionsToCollapsed[CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR] = true">adding an instructor</a> or <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_EDIT_INSTRUCTOR); questionsToCollapsed[CoursesSectionQuestions.COURSE_EDIT_INSTRUCTOR] = true">editing an instructor's information</a>, you can set the instructor's access level.
       There are 4 pre-defined privilege options for you to choose from:
     </p>
     <ul>
@@ -199,7 +199,7 @@
         Click the <button class="btn btn-secondary btn-sm">Edit</button> button in the last column of the row corresponding to Student A.
       </li>
       <li>
-        A new page will open that allows you to <button class="btn btn-link" (click)="collapseStudentEditDetails.emit(true);">edit the student's profile</button>, including a field to edit the student's section.<br>
+        A new page will open that allows you to <a role = "button" class = "modal-button"  (click)="collapseStudentEditDetails.emit(true);">edit the student's profile</a>, including a field to edit the student's section.<br>
       </li>
       <li>
         After editing the section name, click <button class="btn btn-primary btn-sm">Save Changes</button> to confirm Student A's new section.
@@ -226,7 +226,7 @@
     </p>
     <ol>
       <li>
-        <a (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_STUDENTS); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_STUDENTS] = true" [tmRouterLink]="">View the student list</a> of Course B.
+        <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_STUDENTS); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_STUDENTS] = true">View the student list</a> of Course B.
       </li>
       <li>
         In the row corresponding to Student A, click the <button class="btn btn-secondary btn-sm">Delete</button> button.
@@ -267,7 +267,7 @@
     </p>
     <p>
       The courses you have previously archived are listed here.
-      In order to access information in an archived course, <a (click)="jumpTo(CoursesSectionQuestions.COURSE_UNARCHIVE); questionsToCollapsed[CoursesSectionQuestions.COURSE_UNARCHIVE] = true" [tmRouterLink]="">unarchive the course</a>.
+      In order to access information in an archived course, <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_UNARCHIVE); questionsToCollapsed[CoursesSectionQuestions.COURSE_UNARCHIVE] = true">unarchive the course</a>.
     </p>
   </tm-instructor-help-panel>
   <!--Question-->
@@ -276,7 +276,7 @@
                             headerText="How do I unarchive an archived course?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.COURSE_UNARCHIVE]">
     <p>
-      To unarchive a course, first <a (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_ARCHIVED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_ARCHIVED] = true" [tmRouterLink]="">view the course</a> that you would like to unarchive in the <b>Courses</b> page.<br>
+      To unarchive a course, first <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_ARCHIVED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_ARCHIVED] = true">view the course</a> that you would like to unarchive in the <b>Courses</b> page.<br>
       Then, click on the <button href="#" class="btn btn-secondary btn-sm" type="button">Unarchive</button> button corresponding to the course you want to unarchive.
     </p>
   </tm-instructor-help-panel>
@@ -293,7 +293,7 @@
     </p>
     <p>
       The courses you have previously deleted are listed here.
-      In order to access information in a deleted course, <a (click)="jumpTo(CoursesSectionQuestions.COURSE_RESTORE); questionsToCollapsed[CoursesSectionQuestions.COURSE_RESTORE] = true" [tmRouterLink]="">restore the course</a>.
+      In order to access information in a deleted course, <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_RESTORE); questionsToCollapsed[CoursesSectionQuestions.COURSE_RESTORE] = true">restore the course</a>.
     </p>
   </tm-instructor-help-panel>
   <!--Question-->
@@ -302,7 +302,7 @@
                             headerText="How do I restore a deleted course?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.COURSE_RESTORE]">
     <p>
-      To restore a deleted course, first <a (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true" [tmRouterLink]="">view the course</a> that you would like to restore in the <b>Courses</b> page.<br>
+      To restore a deleted course, first <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true">view the course</a> that you would like to restore in the <b>Courses</b> page.<br>
       Then, click on the <button href="#" class="btn btn-secondary btn-sm" type="button">Restore</button> button corresponding to the course you want to restore.
     </p>
     <p>
@@ -315,7 +315,7 @@
                             headerText="How do I permanently delete a course?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.PERM_DEL]">
     <p>
-      To permanently delete a course, first <a (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true" [tmRouterLink]="">view the course</a> that you would like to permanently delete in the <b>Courses</b> page.<br>
+      To permanently delete a course, first <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true">view the course</a> that you would like to permanently delete in the <b>Courses</b> page.<br>
       Then, click on the <button href="#" class="btn btn-secondary btn-sm color-negative" type="button">Delete Permanently</button> button corresponding to the course you want to delete.
     </p>
     <p>
@@ -328,7 +328,7 @@
                             headerText="How do I restore/delete all courses from Recycle Bin?"
                             [(isPanelExpanded)]="questionsToCollapsed[CoursesSectionQuestions.RESTORE_ALL]">
     <p>
-      First <a (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true" [tmRouterLink]="">view the course</a> and check for courses in Recycle Bin.<br>
+      First <a role = "button" class = "modal-button" (click)="jumpTo(CoursesSectionQuestions.COURSE_VIEW_DELETED); questionsToCollapsed[CoursesSectionQuestions.COURSE_VIEW_DELETED] = true">view the course</a> and check for courses in Recycle Bin.<br>
       To restore all courses, click on the <a class="btn btn-secondary btn-sm" data-toggle="tooltip" data-placement="top"><span class="fa fa-check"></span><strong> Restore All</strong></a> button in <b>Deleted courses</b> heading;
       to delete all courses, click on the <a class="btn btn-secondary btn-sm color-negative" data-toggle="tooltip" data-placement="top"><span class="fa fa-times"></span><strong> Delete All</strong></a> button in <b>Deleted courses</b> heading.
     </p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.scss
@@ -9,3 +9,13 @@
 button {
   text-align: left;
 }
+
+.modal-button {
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.modal-button:hover {
+  text-decoration: underline;
+  color: #0056B3;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -8,12 +8,12 @@
     For more help, browse the answers to some <a [tmRouterLink]="instructorHelpPath">frequently asked questions</a>.
   </p>
   <ol>
-    <li><a (click)="jumpTo('course-setup')" [tmRouterLink]="">Set up a course</a></li>
-    <li><a (click)="jumpTo('session-setup')" [tmRouterLink]="">Create a session</a></li>
-    <li><a (click)="jumpTo('session-invites')" [tmRouterLink]="">Wait for your session to open</a></li>
-    <li><a (click)="jumpTo('session-results')" [tmRouterLink]="">View and publish session results</a></li>
-    <li><a (click)="jumpTo('other-actions')" [tmRouterLink]="">Learn about other actions you can perform</a></li>
-    <li><a (click)="jumpTo('contact-us')" [tmRouterLink]="">Contact us</a></li>
+    <li><a role = "button" class = "modal-button"(click)="jumpTo('course-setup')">Set up a course</a></li>
+    <li><a role = "button" class = "modal-button" (click)="jumpTo('session-setup')">Create a session</a></li>
+    <li><a role = "button" class = "modal-button" (click)="jumpTo('session-invites')">Wait for your session to open</a></li>
+    <li><a role = "button" class = "modal-button" (click)="jumpTo('session-results')">View and publish session results</a></li>
+    <li><a role = "button" class = "modal-button" (click)="jumpTo('other-actions')">Learn about other actions you can perform</a></li>
+    <li><a role = "button" class = "modal-button" (click)="jumpTo('contact-us')">Contact us</a></li>
   </ol>
   <div class="separate-content-holder">
     <hr>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.scss
@@ -3,3 +3,13 @@
   padding-top: 1em;
   width: 100%;
 }
+
+.modal-button {
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.modal-button:hover {
+  text-decoration: underline;
+  color: #0056B3;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -48,22 +48,22 @@
     </b></p>
     <ul class="nav nav-pills flex-column">
       <li class="nav-item">
-        <a (click)="scroll(Sections.students)" [tmRouterLink]="">Students</a>
+        <a role = "button" class = "modal-button" (click)="scroll(Sections.students)">Students</a>
       </li>
       <li class="nav-item">
-        <a (click)="scroll(Sections.courses)" [tmRouterLink]="">Courses</a>
+        <a role = "button" class = "modal-button" (click)="scroll(Sections.courses)">Courses</a>
       </li>
       <li class="nav-item">
-        <a (click)="scroll(Sections.sessions)" [tmRouterLink]="">Sessions</a>
+        <a role = "button" class = "modal-button" (click)="scroll(Sections.sessions)">Sessions</a>
       </li>
       <li class="nav-item">
-        <a (click)="scroll(Sections.questions)" [tmRouterLink]="">Questions</a>
+        <a role = "button" class = "modal-button" (click)="scroll(Sections.questions)">Questions</a>
       </li>
     </ul>
     <br>
     <ul class="nav nav-pills flex-column">
       <li class="nav-item">
-        <a (click)="scroll(Sections.body)" [tmRouterLink]="">Back to Top <i class="fas fa-arrow-up"></i> </a>
+        <a role = "button" class = "modal-button" (click)="scroll(Sections.body)">Back to Top <i class="fas fa-arrow-up"></i> </a>
       </li>
     </ul>
   </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.scss
@@ -18,3 +18,13 @@
 .section-body {
   padding-bottom: 5px;
 }
+
+.modal-button {
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.modal-button:hover {
+  text-decoration: underline;
+  color: #0056B3;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -96,7 +96,7 @@
     <p>
       Multiple-choice (multiple answers) question are similar to the single answer version, except that respondents are able to select multiple options as their response.
       <br> The setup and result statistics is similar to the single answer version. See
-      <a (click)="jumpTo(QuestionsSectionQuestions.SINGLE_ANSWER_MCQ); questionsToCollapsed[QuestionsSectionQuestions.SINGLE_ANSWER_MCQ] = true" [tmRouterLink]="">above</a> for details.
+      <a role = "button" class = "modal-button" (click)="jumpTo(QuestionsSectionQuestions.SINGLE_ANSWER_MCQ); questionsToCollapsed[QuestionsSectionQuestions.SINGLE_ANSWER_MCQ] = true">above</a> for details.
     </p>
     <p>
       <strong>Note:</strong> Multiple-choice (multiple answers) question allow respondents to select 'None of the above' option as an answer,
@@ -292,7 +292,7 @@
     </ol>
     <p>
       In the calculation, we do not allow (1) to affect (2). We use (2) to calculate the average perceived contribution for each student. A more detailed version of this calculation can be found
-      <a (click)="openContribInfoModal(contributionTemplateBody)" [tmRouterLink]="">here</a>.
+      <a role = "button" class = "modal-button" (click)="openContribInfoModal(contributionTemplateBody)">here</a>.
       <ng-template #contributionTemplateBody>
         <div class="modal-body">
           <ul>
@@ -470,7 +470,7 @@
     <p>
       The ratings in a contribution question can be used to identify relative contribution levels of students in a team.
       If you use these values for grading, also refer the ‘Interpret contribution numbers with care’ caveat in the
-      <button class="btn btn-link" (click)="collapsePeerEvalTips.emit()">tips for conducting 'team peer evaluation' sessions</button> section.
+      <a role = "button" class = "modal-button" (click)="collapsePeerEvalTips.emit()">tips for conducting 'team peer evaluation' sessions</a> section.
     </p>
     <p>
       The actual contribution values entered by the student may appear different from the values shown in the results because the system ‘normalizes’ those values so that there is no artificial inflation of contribution.
@@ -660,7 +660,7 @@
       </li>
     </ul>
     <p>
-      Technical details about how ranks are calculated are available <a (click)="openRankInfoModal(rankInfoHelp)" [tmRouterLink]="">here</a>.
+      Technical details about how ranks are calculated are available <a role = "button" class = "modal-button" (click)="openRankInfoModal(rankInfoHelp)">here</a>.
     </p>
     <ng-template #rankInfoHelp>
       <ul>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.scss
@@ -9,3 +9,13 @@
 button {
   text-align: left;
 }
+
+.modal-button {
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.modal-button:hover {
+  text-decoration: underline;
+  color: #0056B3;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -146,7 +146,7 @@
         Scroll to the bottom of the page.
       </li>
       <li>
-        Select between adding a question from our predefined <a (click)="jumpTo('questions')" [tmRouterLink]="">question types</a> or
+        Select between adding a question from our predefined <a role = "button" class = "modal-button" (click)="jumpTo('questions')">question types</a> or
         copying a question from an existing feedback session.
       </li>
       <li>
@@ -173,7 +173,7 @@
     </tm-example-box>
     <p>
       TEAMMATES gives you fine-grained control of each question. In addition to providing a range of different
-      <a (click)="jumpTo('questions')" [tmRouterLink]="">question types</a>,
+      <a role = "button" class = "modal-button" (click)="jumpTo('questions')">question types</a>,
       you can also customize your desired:
     </p>
     <ul>
@@ -274,7 +274,7 @@
         Ask the student to view the submission page and send you his/her answers to the session questions.
       </li>
       <li>
-        <a (click)="jumpTo(SessionsSectionQuestions.SESSION_VIEW_RESULTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_VIEW_RESULTS] = true" [tmRouterLink]="">View the results</a> of the session.
+        <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.SESSION_VIEW_RESULTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_VIEW_RESULTS] = true">View the results</a> of the session.
       </li>
       <li>
         Scroll to the panel titled <b>Participants who have not responded to any question</b>. Click on the panel to expand it.
@@ -438,7 +438,7 @@
                             headerText="How do I create a comment on a response?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SESSION_ADD_COMMENTS]">
     <p>
-      While <a (click)="jumpTo(SessionsSectionQuestions.SESSION_VIEW_RESULTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_VIEW_RESULTS] = true" [tmRouterLink]="">viewing the results</a> of a session, you can add comments to respondents' answers.
+      While <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.SESSION_VIEW_RESULTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_VIEW_RESULTS] = true">viewing the results</a> of a session, you can add comments to respondents' answers.
     </p>
     <p>
       To create comments on a response in a session:
@@ -483,7 +483,7 @@
     </p>
     <ol>
       <li>
-        Navigate to the page where you <a (click)="jumpTo(SessionsSectionQuestions.SESSION_ADD_COMMENTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_ADD_COMMENTS] = true" [tmRouterLink]="">added the comment</a> that you want to edit or delete.
+        Navigate to the page where you <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.SESSION_ADD_COMMENTS); questionsToCollapsed[SessionsSectionQuestions.SESSION_ADD_COMMENTS] = true">added the comment</a> that you want to edit or delete.
       </li>
       <li>
         Hover over the comment which you want to edit or delete.
@@ -547,7 +547,7 @@
     </tm-example-box>
     <p>
       The feedback sessions you have previously deleted are listed here.
-      In order to access information in a deleted session, <a (click)="jumpTo(SessionsSectionQuestions.RESTORE_SESSION); questionsToCollapsed[SessionsSectionQuestions.RESTORE_SESSION] = true" [tmRouterLink]="">restore the session</a>.
+      In order to access information in a deleted session, <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.RESTORE_SESSION); questionsToCollapsed[SessionsSectionQuestions.RESTORE_SESSION] = true">restore the session</a>.
     </p>
   </tm-instructor-help-panel>
   <!-- Question -->
@@ -556,7 +556,7 @@
                             headerText="How do I restore a deleted session?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.RESTORE_SESSION]">
     <p>
-      To restore a deleted feedback session, first <a (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true" [tmRouterLink]="">view the session</a> that you would like to restore in the <b>Sessions</b> page.<br>
+      To restore a deleted feedback session, first <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true">view the session</a> that you would like to restore in the <b>Sessions</b> page.<br>
       Then, click on the <button href="#" class="btn btn-secondary btn-sm" type="button">Restore</button> button corresponding to the session you want to restore.
     </p>
     <tm-example-box *ngIf="questionsToCollapsed[SessionsSectionQuestions.RESTORE_SESSION]" @collapseAnim>
@@ -575,7 +575,7 @@
                             headerText="How do I permanently delete a session?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.PERMANENT_DEL_SESSION]">
     <p>
-      To permanently delete a feedback session, first <a (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true" [tmRouterLink]="">view the session</a> that you would like to permanently delete in the <b>Sessions</b> page.<br>
+      To permanently delete a feedback session, first <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true">view the session</a> that you would like to permanently delete in the <b>Sessions</b> page.<br>
       Then, click on the <button href="#" class="btn btn-sm btn-danger" type="button">Delete Permanently</button> button corresponding to the session you want to delete.
     </p>
     <tm-example-box *ngIf="questionsToCollapsed[SessionsSectionQuestions.PERMANENT_DEL_SESSION]" @collapseAnim>
@@ -594,7 +594,7 @@
                             headerText="How do I restore/delete all sessions from Recycle Bin?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.RESTORE_DEL_ALL]">
     <p>
-      First <a (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true" [tmRouterLink]="">view the session</a> and check for sessions in Recycle Bin.<br>
+      First <a role = "button" class = "modal-button" (click)="jumpTo(SessionsSectionQuestions.VIEW_DELETED_SESSION); questionsToCollapsed[SessionsSectionQuestions.VIEW_DELETED_SESSION] = true">view the session</a> and check for sessions in Recycle Bin.<br>
       To restore all sessions, click on the <button href="#" class="btn btn-sm btn-secondary"><i class="fas fa-check"></i><strong> Restore All</strong></button> button in <b>Deleted feedback sessions</b> heading;
       to delete all sessions, click on the <button href="#" class="btn btn-sm btn-danger"><i class="fas fa-times"></i><strong> Delete All</strong></button> button in <b>Deleted feedback sessions</b> heading.
     </p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
@@ -38,3 +38,13 @@
 button {
   text-align: left;
 }
+
+.modal-button {
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.modal-button:hover {
+  text-decoration: underline;
+  color: #0056B3;
+}


### PR DESCRIPTION
Fixes #10651 

Let's
* remove `[tmRouterLink]=""` in `<a>` elements
* style the elements such that it still looks the same as a link
* change relevant `<button>` elements to `<a>` elements

The bug lies in `[tmRouterLink] = ""` which gives `<a>` the link behaviour, additionally it only links back to the home page which is incorrect. To remain consistent with the current styling, links that trigger in-page-functionality are made to look the same as the original while not being able to be opened at a new tab. 

Using a `<button>` element with `class = "btn btn-link"` would achieve the same outcome, however I decided not to use it to improve user experience as there is a padding around the button (shown below)

![image](https://user-images.githubusercontent.com/43613036/101811247-d1ea0a80-3b54-11eb-9e1d-4eaab56e6d31.png)

I also did not follow the MarkBind to use dashed underlines as there are other places (e.g. the side panel) that we still want to look like links. Hence I gave all trigger in-page links a common class and styled it using `scss`.
![image](https://user-images.githubusercontent.com/43613036/101811680-59377e00-3b55-11eb-8948-14c58c8e8f21.png)


Refer to the use of button classes to trigger in-page-functionality
https://getbootstrap.com/docs/4.0/components/buttons/#button-tags

