### PR TITLE
[#10782] Add a configurable banner

### DIFF
--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetailsTest.java
@@ -1,0 +1,41 @@
+package teammates.common.datatransfer.questions;
+
+import org.testng.annotations.Test;
+
+import teammates.test.BaseTestCase;
+
+/**
+ * SUT: {@link FeedbackRankQuestionDetails}.
+ */
+public class FeedbackRankQuestionDetailsTest extends BaseTestCase {
+    @Test
+    public void testValidateMinOptionsToBeRanked_sameValidValues_shouldReturnTrue() {
+        int testValue = 100;
+        FeedbackRankQuestionDetails feedbackRankQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackRankQuestionDetails.setMinOptionsToBeRanked(testValue);
+        assertEquals(feedbackRankQuestionDetails.minOptionsToBeRanked, testValue);
+    }
+    @Test
+    public void testValidateMinOptionsToBeRanked_differentValidValues_shouldReturnTrue() {
+        int testValue = 100;
+        int testDiffValue = 101;
+        FeedbackRankQuestionDetails feedbackRankQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackRankQuestionDetails.setMinOptionsToBeRanked(testValue);
+        assertNotEquals(feedbackRankQuestionDetails.minOptionsToBeRanked, testDiffValue);
+    }
+    @Test
+    public void testValidateMaxOptionsToBeRanked_sameValidValues_shouldReturnTrue() {
+        int testValue = 100;
+        FeedbackRankQuestionDetails feedbackRankQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackRankQuestionDetails.setMaxOptionsToBeRanked(testValue);
+        assertEquals(feedbackRankQuestionDetails.maxOptionsToBeRanked, testValue);
+    }
+    @Test
+    public void testValidateMaxOptionsToBeRanked_differentValidValues_shouldReturnTrue() {
+        int testValue = 100;
+        int testDiffValue = 101;
+        FeedbackRankQuestionDetails feedbackRankQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackRankQuestionDetails.setMaxOptionsToBeRanked(testValue);
+        assertNotEquals(feedbackRankQuestionDetails.maxOptionsToBeRanked, testDiffValue);
+    }
+}

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetailsTest.java
@@ -8,6 +8,7 @@ import teammates.test.BaseTestCase;
  * SUT: {@link FeedbackRankQuestionDetails}.
  */
 public class FeedbackRankQuestionDetailsTest extends BaseTestCase {
+
     @Test
     public void testValidateMinOptionsToBeRanked_sameValidValues_shouldReturnTrue() {
         int testValue = 100;
@@ -15,6 +16,7 @@ public class FeedbackRankQuestionDetailsTest extends BaseTestCase {
         feedbackRankQuestionDetails.setMinOptionsToBeRanked(testValue);
         assertEquals(feedbackRankQuestionDetails.minOptionsToBeRanked, testValue);
     }
+
     @Test
     public void testValidateMinOptionsToBeRanked_differentValidValues_shouldReturnTrue() {
         int testValue = 100;
@@ -23,6 +25,7 @@ public class FeedbackRankQuestionDetailsTest extends BaseTestCase {
         feedbackRankQuestionDetails.setMinOptionsToBeRanked(testValue);
         assertNotEquals(feedbackRankQuestionDetails.minOptionsToBeRanked, testDiffValue);
     }
+
     @Test
     public void testValidateMaxOptionsToBeRanked_sameValidValues_shouldReturnTrue() {
         int testValue = 100;
@@ -30,6 +33,7 @@ public class FeedbackRankQuestionDetailsTest extends BaseTestCase {
         feedbackRankQuestionDetails.setMaxOptionsToBeRanked(testValue);
         assertEquals(feedbackRankQuestionDetails.maxOptionsToBeRanked, testValue);
     }
+
     @Test
     public void testValidateMaxOptionsToBeRanked_differentValidValues_shouldReturnTrue() {
         int testValue = 100;

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetailsTest.java
@@ -1,0 +1,48 @@
+package teammates.common.datatransfer.questions;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.SanitizationHelper;
+import teammates.test.BaseTestCase;
+
+/**
+ * SUT: {@link FeedbackTextResponseDetails}.
+ */
+public class FeedbackTextResponseDetailsTest extends BaseTestCase {
+    @Test
+    public void testValidateResponseAnswer_sameValues_shouldReturnTrue() {
+        String testAnswer = "Hello World";
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testAnswer);
+        assertEquals(feedbackTextResponseDetails.getAnswer(), "Hello World");
+    }
+    @Test
+    public void testValidateResponseAnswer_differentValues_shouldReturnFalse() {
+        String testAnswer = "Hello World";
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testAnswer);
+        assertNotEquals(feedbackTextResponseDetails.getAnswer(), "World Hello");
+    }
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testValidateAttributesOfAnswer_nullValue_shouldThrowException() {
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(null);
+        int test = feedbackTextResponseDetails.getAnswer().length();
+    }
+    @Test
+    public void testValidateAttributesOfAnswer_validValue_shouldThrowException() {
+        String testValue = "Hello World";
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testValue);
+        int test = feedbackTextResponseDetails.getAnswer().length();
+    }
+    @Test
+    public void testValidateSanitizedAnswerString_nullValues_shouldReturnTrue() {
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(null);
+        assertEquals(feedbackTextResponseDetails.getAnswerString(),
+                SanitizationHelper.sanitizeForRichText(feedbackTextResponseDetails.getAnswer()));
+    }
+    @Test
+    public void testValidateSanitizedAnswerString_validValues_shouldReturnTrue() {
+        String testValue = "Hello World";
+        FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testValue);
+        assertEquals(feedbackTextResponseDetails.getAnswerString(),
+                SanitizationHelper.sanitizeForRichText(feedbackTextResponseDetails.getAnswer()));
+    }
+}

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetailsTest.java
@@ -15,29 +15,34 @@ public class FeedbackTextResponseDetailsTest extends BaseTestCase {
         FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testAnswer);
         assertEquals(feedbackTextResponseDetails.getAnswer(), "Hello World");
     }
+
     @Test
     public void testValidateResponseAnswer_differentValues_shouldReturnFalse() {
         String testAnswer = "Hello World";
         FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testAnswer);
         assertNotEquals(feedbackTextResponseDetails.getAnswer(), "World Hello");
     }
+
     @Test(expectedExceptions = NullPointerException.class)
     public void testValidateAttributesOfAnswer_nullValue_shouldThrowException() {
         FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(null);
-        int test = feedbackTextResponseDetails.getAnswer().length();
+        feedbackTextResponseDetails.getAnswer().length();
     }
+
     @Test
     public void testValidateAttributesOfAnswer_validValue_shouldThrowException() {
         String testValue = "Hello World";
         FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(testValue);
-        int test = feedbackTextResponseDetails.getAnswer().length();
+        feedbackTextResponseDetails.getAnswer().length();
     }
+
     @Test
     public void testValidateSanitizedAnswerString_nullValues_shouldReturnTrue() {
         FeedbackTextResponseDetails feedbackTextResponseDetails = new FeedbackTextResponseDetails(null);
         assertEquals(feedbackTextResponseDetails.getAnswerString(),
                 SanitizationHelper.sanitizeForRichText(feedbackTextResponseDetails.getAnswer()));
     }
+
     @Test
     public void testValidateSanitizedAnswerString_validValues_shouldReturnTrue() {
         String testValue = "Hello World";

--- a/src/web/app/components/banner/banner.component.html
+++ b/src/web/app/components/banner/banner.component.html
@@ -1,0 +1,15 @@
+<div *ngIf="studentBannerContent === 1 || instructorBannerContent === 1" class="alert alert-primary alert-dismissible fade show" role="alert">
+    <div *ngIf="studentBannerContent === 1">
+        <h2>{{studentBannerData.title}}</h2>
+        <h5>{{studentBannerData.content}}</h5>
+        <h5 *ngFor="let link of studentBannerData.links">{{link.name + ': '}}<a [href]="link.link">{{link.link}}</a></h5>
+    </div>
+    <div *ngIf="instructorBannerContent === 1">
+        <h2>{{instructorBannerData.title}}</h2>
+        <h5>{{instructorBannerData.content}}</h5>
+        <h5 *ngFor="let link of instructorBannerData.links">{{link.name + ': '}}<a [href]="link.link">{{link.link}}</a></h5>
+    </div>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close" (click)="closeBanner()">
+        <span aria-hidden="true">&times;</span>
+    </button>
+</div>

--- a/src/web/app/components/banner/banner.component.html
+++ b/src/web/app/components/banner/banner.component.html
@@ -1,15 +1,29 @@
-<div *ngIf="studentBannerContent === 1 || instructorBannerContent === 1" class="alert alert-primary alert-dismissible fade show" role="alert">
-    <div *ngIf="studentBannerContent === 1">
-        <h2>{{studentBannerData?.title}}</h2>
-        <h5>{{studentBannerData?.content}}</h5>
-        <h5 *ngFor="let link of studentBannerData?.links">{{link?.name + ': '}}<a [href]="link?.link">{{link?.link}}</a></h5>
-    </div>
-    <div *ngIf="instructorBannerContent === 1">
-        <h2>{{instructorBannerData?.title}}</h2>
-        <h5>{{instructorBannerData?.content}}</h5>
-        <h5 *ngFor="let link of instructorBannerData?.links">{{link?.name + ': '}}<a [href]="link?.link">{{link?.link}}</a></h5>
-    </div>
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close" (click)="closeBanner()">
-        <span aria-hidden="true">&times;</span>
-    </button>
+<div
+  *ngIf="studentBannerContent === 1 || instructorBannerContent === 1"
+  class="alert alert-primary alert-dismissible fade show"
+  role="alert"
+>
+  <div *ngIf="studentBannerContent === 1">
+    <h2>{{ studentBannerData?.title }}</h2>
+    <h5>{{ studentBannerData?.content }}</h5>
+    <h5 *ngFor="let link of studentBannerData?.links">
+      {{ link?.name + ": " }}<a [href]="link?.link">{{ link?.link }}</a>
+    </h5>
+  </div>
+  <div *ngIf="instructorBannerContent === 1">
+    <h2>{{ instructorBannerData?.title }}</h2>
+    <h5>{{ instructorBannerData?.content }}</h5>
+    <h5 *ngFor="let link of instructorBannerData?.links">
+      {{ link?.name + ": " }}<a [href]="link?.link">{{ link?.link }}</a>
+    </h5>
+  </div>
+  <button
+    type="button"
+    class="close"
+    data-dismiss="alert"
+    aria-label="Close"
+    (click)="closeBanner()"
+  >
+    <span aria-hidden="true">&times;</span>
+  </button>
 </div>

--- a/src/web/app/components/banner/banner.component.html
+++ b/src/web/app/components/banner/banner.component.html
@@ -1,13 +1,13 @@
 <div *ngIf="studentBannerContent === 1 || instructorBannerContent === 1" class="alert alert-primary alert-dismissible fade show" role="alert">
     <div *ngIf="studentBannerContent === 1">
-        <h2>{{studentBannerData.title}}</h2>
-        <h5>{{studentBannerData.content}}</h5>
-        <h5 *ngFor="let link of studentBannerData.links">{{link.name + ': '}}<a [href]="link.link">{{link.link}}</a></h5>
+        <h2>{{studentBannerData?.title}}</h2>
+        <h5>{{studentBannerData?.content}}</h5>
+        <h5 *ngFor="let link of studentBannerData?.links">{{link?.name + ': '}}<a [href]="link?.link">{{link?.link}}</a></h5>
     </div>
     <div *ngIf="instructorBannerContent === 1">
-        <h2>{{instructorBannerData.title}}</h2>
-        <h5>{{instructorBannerData.content}}</h5>
-        <h5 *ngFor="let link of instructorBannerData.links">{{link.name + ': '}}<a [href]="link.link">{{link.link}}</a></h5>
+        <h2>{{instructorBannerData?.title}}</h2>
+        <h5>{{instructorBannerData?.content}}</h5>
+        <h5 *ngFor="let link of instructorBannerData?.links">{{link?.name + ': '}}<a [href]="link?.link">{{link?.link}}</a></h5>
     </div>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close" (click)="closeBanner()">
         <span aria-hidden="true">&times;</span>

--- a/src/web/app/components/banner/banner.component.spec.ts
+++ b/src/web/app/components/banner/banner.component.spec.ts
@@ -3,23 +3,22 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BannerComponent } from './banner.component';
 
 describe('BannerComponent', () => {
-    let component: BannerComponent;
-    let fixture: ComponentFixture<BannerComponent>;
+  let component: BannerComponent;
+  let fixture: ComponentFixture<BannerComponent>;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [BannerComponent],
-        })
-            .compileComponents();
-    }));
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [BannerComponent],
+    }).compileComponents();
+  }));
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(BannerComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });

--- a/src/web/app/components/banner/banner.component.spec.ts
+++ b/src/web/app/components/banner/banner.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BannerComponent } from './banner.component';
+
+describe('BannerComponent', () => {
+    let component: BannerComponent;
+    let fixture: ComponentFixture<BannerComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [BannerComponent],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(BannerComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/web/app/components/banner/banner.component.ts
+++ b/src/web/app/components/banner/banner.component.ts
@@ -1,42 +1,46 @@
 import { Component } from '@angular/core';
 import { environment } from '../../../environments/environment';
-import StudentBannerContent, { StudentBannerContentType } from './student.banner-content';
-import InstructorBannerContent,{ InstructorBannerContentType } from './instructor.banner-content';
+import InstructorBannerContent, {
+  InstructorBannerContentType,
+} from './instructor.banner-content';
+import StudentBannerContent, {
+  StudentBannerContentType,
+} from './student.banner-content';
 /**
  * Version redirect banner.
  */
 @Component({
-    selector: 'tm-banner',
-    templateUrl: './banner.component.html',
-    styleUrls: ['./banner.component.scss'],
+  selector: 'tm-banner',
+  templateUrl: './banner.component.html',
+  styleUrls: ['./banner.component.scss'],
 })
 export class BannerComponent {
-    studentBannerContent: number;
-    instructorBannerContent: number;
-    studentBannerData: StudentBannerContentType | undefined;
-    instructorBannerData: InstructorBannerContentType | undefined;
+  studentBannerContent: number;
+  instructorBannerContent: number;
+  studentBannerData: StudentBannerContentType | undefined;
+  instructorBannerData: InstructorBannerContentType | undefined;
 
-    constructor() {
-        this.studentBannerContent = environment.studentBannerContent;
-        this.instructorBannerContent = environment.instructorBannerContent;
+  constructor() {
+    this.studentBannerContent = environment.studentBannerContent;
+    this.instructorBannerContent = environment.instructorBannerContent;
 
-        if (this.studentBannerContent == 1) {
-            try {
-                this.studentBannerData = StudentBannerContent;
-            } catch (e) {
-                this.studentBannerData = undefined;
-            }
-        }
-        if (this.instructorBannerContent == 1) {
-            try {
-                this.instructorBannerData = InstructorBannerContent;
-            } catch (e) {
-                this.instructorBannerData = undefined;
-            }
-        }
+    if (this.studentBannerContent === 1) {
+      try {
+        this.studentBannerData = StudentBannerContent;
+      } catch (e) {
+        this.studentBannerData = undefined;
+      }
     }
-    closeBanner = () => {
-        this.studentBannerContent = 0;
-        this.instructorBannerContent = 0;
+    if (this.instructorBannerContent === 1) {
+      try {
+        this.instructorBannerData = InstructorBannerContent;
+      } catch (e) {
+        this.instructorBannerData = undefined;
+      }
     }
+  }
+  closeBanner = () => {
+    this.studentBannerContent = 0;
+    this.instructorBannerContent = 0;
+  }
 }

--- a/src/web/app/components/banner/banner.component.ts
+++ b/src/web/app/components/banner/banner.component.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import StudentBannerContent, { StudentBannerContentType } from './student.banner-content';
+import InstructorBannerContent,{ InstructorBannerContentType } from './instructor.banner-content';
+/**
+ * Version redirect banner.
+ */
+@Component({
+    selector: 'tm-banner',
+    templateUrl: './banner.component.html',
+    styleUrls: ['./banner.component.scss'],
+})
+export class BannerComponent {
+    studentBannerContent: number;
+    instructorBannerContent: number;
+    studentBannerData: StudentBannerContentType | undefined;
+    instructorBannerData: InstructorBannerContentType | undefined;
+
+    constructor() {
+        this.studentBannerContent = environment.studentBannerContent;
+        this.instructorBannerContent = environment.instructorBannerContent;
+
+        if (this.studentBannerContent == 1) {
+            try {
+                this.studentBannerData = StudentBannerContent;
+            } catch (e) {
+                this.studentBannerData = undefined;
+            }
+        }
+        if (this.instructorBannerContent == 1) {
+            try {
+                this.instructorBannerData = InstructorBannerContent;
+            } catch (e) {
+                this.instructorBannerData = undefined;
+            }
+        }
+    }
+    closeBanner = () => {
+        this.studentBannerContent = 0;
+        this.instructorBannerContent = 0;
+    }
+}

--- a/src/web/app/components/banner/banner.module.ts
+++ b/src/web/app/components/banner/banner.module.ts
@@ -6,12 +6,8 @@ import { BannerComponent } from './banner.component';
  * Module for redirect banner.
  */
 @NgModule({
-    declarations: [BannerComponent],
-    exports: [
-        BannerComponent,
-    ],
-    imports: [
-        CommonModule,
-    ],
+  declarations: [BannerComponent],
+  exports: [BannerComponent],
+  imports: [CommonModule],
 })
-export class BannerModule { }
+export class BannerModule {}

--- a/src/web/app/components/banner/banner.module.ts
+++ b/src/web/app/components/banner/banner.module.ts
@@ -1,0 +1,17 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { BannerComponent } from './banner.component';
+
+/**
+ * Module for redirect banner.
+ */
+@NgModule({
+    declarations: [BannerComponent],
+    exports: [
+        BannerComponent,
+    ],
+    imports: [
+        CommonModule,
+    ],
+})
+export class BannerModule { }

--- a/src/web/app/components/banner/instructor.banner-content.ts
+++ b/src/web/app/components/banner/instructor.banner-content.ts
@@ -1,0 +1,20 @@
+interface Link {
+    name: string;
+    link: string;
+}
+export interface InstructorBannerContentType {
+    title: string;
+    content: string;
+    links: Link[];
+}
+const InstructorBannerContent : InstructorBannerContentType = {
+    title: "Instructor Banner Title",
+    content: "Instructor Banner Content",
+    links: [
+        {
+            name: "Email",
+            link: "something@something.com"
+        }
+    ]
+}
+export default InstructorBannerContent;

--- a/src/web/app/components/banner/instructor.banner-content.ts
+++ b/src/web/app/components/banner/instructor.banner-content.ts
@@ -1,20 +1,25 @@
 interface Link {
-    name: string;
-    link: string;
+  name: string;
+  link: string;
 }
+
+/**
+ * Type for instructor banner content
+ */
 export interface InstructorBannerContentType {
-    title: string;
-    content: string;
-    links: Link[];
+  title: string;
+  content: string;
+  links: Link[];
 }
-const InstructorBannerContent : InstructorBannerContentType = {
-    title: "Instructor Banner Title",
-    content: "Instructor Banner Content",
-    links: [
-        {
-            name: "Email",
-            link: "something@something.com"
-        }
-    ]
-}
-export default InstructorBannerContent;
+
+const instructorBannerContent: InstructorBannerContentType = {
+  title: 'Instructor Banner Title',
+  content: 'Instructor Banner Content',
+  links: [
+    {
+      name: 'Email',
+      link: 'something@something.com',
+    },
+  ],
+};
+export default instructorBannerContent;

--- a/src/web/app/components/banner/student.banner-content.ts
+++ b/src/web/app/components/banner/student.banner-content.ts
@@ -1,20 +1,25 @@
 interface Link {
-    name: string;
-    link: string;
+  name: string;
+  link: string;
 }
+
+/**
+ * Type for student banner content
+ */
 export interface StudentBannerContentType {
-    title: string;
-    content: string;
-    links: Link[];
+  title: string;
+  content: string;
+  links: Link[];
 }
-const StudentBannerContent : StudentBannerContentType = {
-    title: "Student Banner Title",
-    content: "Student Banner Content",
-    links: [
-        {
-            name: "Email",
-            link: "something@something.com"
-        }
-    ]
+
+const studentBannerContent: StudentBannerContentType = {
+  title: 'Student Banner Title',
+  content: 'Student Banner Content',
+  links: [
+    {
+      name: 'Email',
+      link: 'something@something.com',
+    },
+  ],
 };
-export default StudentBannerContent;
+export default studentBannerContent;

--- a/src/web/app/components/banner/student.banner-content.ts
+++ b/src/web/app/components/banner/student.banner-content.ts
@@ -1,0 +1,20 @@
+interface Link {
+    name: string;
+    link: string;
+}
+export interface StudentBannerContentType {
+    title: string;
+    content: string;
+    links: Link[];
+}
+const StudentBannerContent : StudentBannerContentType = {
+    title: "Student Banner Title",
+    content: "Student Banner Content",
+    links: [
+        {
+            name: "Email",
+            link: "something@something.com"
+        }
+    ]
+};
+export default StudentBannerContent;

--- a/src/web/app/pages-static/index-page/index-page.component.html
+++ b/src/web/app/pages-static/index-page/index-page.component.html
@@ -1,4 +1,5 @@
 <main>
+  <tm-banner></tm-banner>
   <p class="h2 color-orange text-center">
     Student peer evaluations/feedback, shareable instructor comments, and more...
   </p>

--- a/src/web/app/pages-static/index-page/index-page.component.spec.ts
+++ b/src/web/app/pages-static/index-page/index-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IndexPageComponent } from './index-page.component';
+import { BannerComponent } from '../../components/banner/banner.component';
 
 describe('IndexPageComponent', () => {
   let component: IndexPageComponent;
@@ -7,7 +8,7 @@ describe('IndexPageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [IndexPageComponent],
+      declarations: [IndexPageComponent, BannerComponent],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-static/index-page/index-page.component.spec.ts
+++ b/src/web/app/pages-static/index-page/index-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { IndexPageComponent } from './index-page.component';
 import { BannerComponent } from '../../components/banner/banner.component';
+import { IndexPageComponent } from './index-page.component';
 
 describe('IndexPageComponent', () => {
   let component: IndexPageComponent;

--- a/src/web/app/pages-static/index-page/index-page.module.ts
+++ b/src/web/app/pages-static/index-page/index-page.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { BannerModule } from '../../components/banner/banner.module';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
 import { IndexPageComponent } from './index-page.component';
-import { BannerModule } from '../../components/banner/banner.module';
 
 const routes: Routes = [
   {
@@ -26,7 +26,7 @@ const routes: Routes = [
     CommonModule,
     RouterModule.forChild(routes),
     TeammatesRouterModule,
-    BannerModule
+    BannerModule,
   ],
 })
 export class IndexPageModule { }

--- a/src/web/app/pages-static/index-page/index-page.module.ts
+++ b/src/web/app/pages-static/index-page/index-page.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
 import { IndexPageComponent } from './index-page.component';
+import { BannerModule } from '../../components/banner/banner.module';
 
 const routes: Routes = [
   {
@@ -25,6 +26,7 @@ const routes: Routes = [
     CommonModule,
     RouterModule.forChild(routes),
     TeammatesRouterModule,
+    BannerModule
   ],
 })
 export class IndexPageModule { }


### PR DESCRIPTION
Fixes #10782 
**Outline of Solution**
![image](https://user-images.githubusercontent.com/53283766/101870045-cda50800-3bbb-11eb-9614-5257caeae590.png)

Based on the implementation from  #10471
Banner content can be set in ```student.banner-content.ts``` and ```instructor.banner-content.ts```. To hide/show banners, set the ```studentBannerContent``` or ```instructorBannerContent``` in ```config.ts``` (1 to show, 0 to hide).
Banner content has the form:
 - Title
 - Content
 - Links: each link has a name and a clickable link

