### PR TITLE
[#10573] Fix styling for error report modal

### DIFF
--- a/src/web/app/components/error-report/__snapshots__/error-report.component.spec.ts.snap
+++ b/src/web/app/components/error-report/__snapshots__/error-report.component.spec.ts.snap
@@ -15,7 +15,9 @@ exports[`ErrorReportComponent should snap with default view 1`] = `
   <div
     class="container"
   >
-    <h2>
+    <h2
+      id="error-report-header"
+    >
       Uh oh! Something went wrong.
     </h2>
     <hr />
@@ -80,6 +82,7 @@ exports[`ErrorReportComponent should snap with default view 1`] = `
     
     <button
       class="btn btn-success"
+      id="send-error-report-button"
     >
       Send Error Report
     </button>

--- a/src/web/app/components/error-report/error-report.component.html
+++ b/src/web/app/components/error-report/error-report.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <h2>Uh oh! Something went wrong.</h2>
+  <h2 id="error-report-header">Uh oh! Something went wrong.</h2>
   <hr>
   <div class="row">
     <div class="col-md-12">
@@ -25,7 +25,7 @@
     <label>Content:</label>
     <textarea [(ngModel)]="content" class="form-control" placeholder="Tell us the steps you took that led you to this error page"></textarea>
   </div>
-  <button class="btn btn-success" (click)="sendErrorReport()" [disabled]="!sendButtonEnabled" *ngIf="!errorReportSubmitted">Send Error Report</button>
+  <button id="send-error-report-button" class="btn btn-success" (click)="sendErrorReport()" [disabled]="!sendButtonEnabled" *ngIf="!errorReportSubmitted">Send Error Report</button>
   <div *ngIf="errorReportSubmitted">
     Your error report has been recorded. We will follow up with you in due course, usually, within 24 hours.
   </div>

--- a/src/web/app/components/error-report/error-report.component.scss
+++ b/src/web/app/components/error-report/error-report.component.scss
@@ -1,0 +1,7 @@
+#error-report-header {
+  margin-top: 3%;
+}
+
+#send-error-report-button {
+  margin-bottom: 3%;
+}


### PR DESCRIPTION
Fixes #10573 

**Outline of Solution**

- Added 3% padding to the top and bottom of the modal
- Updated snapshots using `npm run test` to match the new UI
