### PR TITLE
[#9536] Improve E2E test stability and add test for searching response comments

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -96,16 +96,20 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
 
         ______TS("action: delete student");
 
-        StudentAttributes studentToDelete = testData.students.get("student2InCourse1");
+        StudentAttributes studentToDelete = testData.students.get("student2InCourse2");
 
-        searchPage.deleteStudent(course1, studentToDelete.getEmail());
+        searchPage.deleteStudent(course2, studentToDelete.getEmail());
 
         StudentAttributes[] studentsAfterDelete = {
-                testData.students.get("student2.2InCourse1"),
+                testData.students.get("student2.2InCourse2"),
         };
 
-        searchPage.verifyStudentDetails(course1, studentsAfterDelete);
+        searchPage.verifyStudentDetails(course2, studentsAfterDelete);
         verifyAbsentInDatastore(studentToDelete);
+
+        ______TS("search for response comments");
+
+        searchPage.search(false, true, "comment");
 
         // TODO add tests for search response comments
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -6,12 +6,15 @@ import java.util.Map;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.InstructorCourseStudentDetailsEditPage;
 import teammates.e2e.pageobjects.InstructorCourseStudentDetailsViewPage;
 import teammates.e2e.pageobjects.InstructorSearchPage;
+import teammates.e2e.pageobjects.InstructorSearchPage.CommentSearchResponseResult;
+import teammates.e2e.pageobjects.InstructorSearchPage.CommentSearchSessionResult;
 import teammates.e2e.pageobjects.InstructorStudentRecordsPage;
 
 /**
@@ -111,7 +114,29 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
 
         searchPage.search(false, true, "comment");
 
-        // TODO add tests for search response comments
+        CommentSearchSessionResult firstResult = new CommentSearchSessionResult();
+        firstResult.session = testData.feedbackSessions.get("First Session");
+
+        CommentSearchResponseResult firstResponse = new CommentSearchResponseResult();
+        firstResponse.question = testData.feedbackQuestions.get("qn1");
+        firstResponse.response = testData.feedbackResponses.get("qn1response1");
+        firstResponse.comments = new FeedbackResponseCommentAttributes[] {
+                testData.feedbackResponseComments.get("qn1Comment1"),
+                testData.feedbackResponseComments.get("qn1Comment2"),
+        };
+
+        CommentSearchResponseResult secondResponse = new CommentSearchResponseResult();
+        secondResponse.question = testData.feedbackQuestions.get("qn1");
+        secondResponse.response = testData.feedbackResponses.get("qn1response3");
+        secondResponse.comments = new FeedbackResponseCommentAttributes[] {
+                testData.feedbackResponseComments.get("qn1Comment3"),
+        };
+
+        firstResult.responses = new CommentSearchResponseResult[] { firstResponse, secondResponse };
+
+        CommentSearchSessionResult[] commentSearchSessionResults = { firstResult };
+        searchPage.verifyCommentSearchResults(commentSearchSessionResults, testData.students.values(),
+                testData.instructors.values());
 
     }
 

--- a/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
+++ b/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
@@ -53,6 +53,7 @@ public class TimezoneSyncerTest extends BaseE2ETestCase {
         String currentTzVersion = timezonePage.getMomentTimezoneVersion();
         IanaTimezonePage ianaPage = getNewPageInstance(
                 new AppUrl(IanaTimezonePage.IANA_TIMEZONE_DATABASE_URL), IanaTimezonePage.class);
+        ianaPage.waitForPageToLoad();
         String latestTzVersion = ianaPage.getVersion();
 
         if (!currentTzVersion.equals(latestTzVersion)) {

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -181,10 +181,6 @@ public abstract class AppPage {
         waitUntilAnimationFinish(browser);
     }
 
-    public void waitForLoadingElement() {
-        waitForElementStaleness(waitForElementPresence(By.className("loading-container")));
-    }
-
     /**
      * Waits until an element is no longer attached to the DOM or the timeout expires.
      * @param element the WebElement

--- a/src/e2e/java/teammates/e2e/pageobjects/Browser.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/Browser.java
@@ -131,6 +131,11 @@ public class Browser {
      * Visits the given URL.
      */
     public void goToUrl(String url) {
+        if (TestProperties.BROWSER.equals(TestProperties.BROWSER_CHROME)) {
+            // Recent chromedriver has bug in setting page load timeout, which can potentially cause infinitely long waits
+            ((JavascriptExecutor) driver).executeScript("window.location.href='" + url + "'");
+            return;
+        }
         try {
             driver.get(url);
         } catch (TimeoutException e) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -60,7 +61,15 @@ public class InstructorSearchPage extends AppPage {
             searchKeyword.clear();
             searchKeyword.sendKeys(searchTerm);
             click(searchButton);
-            waitForLoadingElement();
+            WebElement loadingContainer = null;
+            try {
+                loadingContainer = waitForElementPresence(By.className("loading-container"));
+            } catch (TimeoutException e) {
+                // loading has finished before this block is reached
+            }
+            if (loadingContainer != null) {
+                waitForElementStaleness(loadingContainer);
+            }
         } else {
             verifyUnclickable(searchButton);
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -3,6 +3,7 @@ package teammates.e2e.pageobjects;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -11,8 +12,15 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
 
 /**
@@ -176,6 +184,166 @@ public class InstructorSearchPage extends AppPage {
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
         return changePageType(InstructorStudentRecordsPage.class);
+    }
+
+    public void verifyCommentSearchResults(CommentSearchSessionResult[] commentSearchSessionResults,
+            Collection<StudentAttributes> students, Collection<InstructorAttributes> instructors) {
+        List<WebElement> sessionRows = browser.driver.findElements(By.className("comment-search-session"));
+        assertEquals(commentSearchSessionResults.length, sessionRows.size());
+
+        for (WebElement sessionRow : sessionRows) {
+            String sessionAndCourse = sessionRow.findElement(By.id("comment-search-session-name")).getText();
+
+            // Iterate as the result order may not be guaranteed
+            CommentSearchSessionResult matchedSession = null;
+            for (CommentSearchSessionResult sessionResult : commentSearchSessionResults) {
+                String expectedSessionAndCourse = String.format("Session: %s (%s)",
+                        sessionResult.session.getFeedbackSessionName(), sessionResult.session.getCourseId());
+                if (expectedSessionAndCourse.equals(sessionAndCourse)) {
+                    matchedSession = sessionResult;
+                    break;
+                }
+            }
+            if (matchedSession == null) {
+                fail("Session of comment is not found");
+            }
+
+            verifyResponsesAndComments(sessionRow, matchedSession, students, instructors);
+        }
+    }
+
+    private void verifyResponsesAndComments(WebElement sessionRow, CommentSearchSessionResult expectedSession,
+            Collection<StudentAttributes> students, Collection<InstructorAttributes> instructors) {
+        List<WebElement> responses = sessionRow.findElements(By.className("comment-search-response"));
+        assertEquals(expectedSession.responses.length, responses.size());
+
+        for (WebElement response : responses) {
+            String questionText = response.findElement(By.id("comment-search-question-text")).getText();
+            String responseGiverRecipient =
+                    response.findElement(By.id("comment-search-response-giver-recipient")).getText();
+
+            // Iterate as the result order may not be guaranteed
+            CommentSearchResponseResult matchedResponse = null;
+            for (CommentSearchResponseResult responseResult : expectedSession.responses) {
+                String expectedQuestionText = String.format("Question %d:%s%s",
+                        responseResult.question.questionNumber, System.lineSeparator(),
+                        responseResult.question.questionDetails.getQuestionText());
+
+                String giverName = getGiverName(responseResult.question.giverType,
+                        responseResult.response.giver, students, instructors);
+                String giverTeam = getGiverTeam(responseResult.question.giverType,
+                        responseResult.response.giver, students);
+
+                String expectedResponseGiverRecipient = String.format("From: %s (%s) To: %s",
+                        giverName, giverTeam, responseResult.response.recipient);
+
+                if (expectedQuestionText.equals(questionText)
+                        && expectedResponseGiverRecipient.equals(responseGiverRecipient)) {
+                    matchedResponse = responseResult;
+                    break;
+                }
+            }
+            if (matchedResponse == null) {
+                fail("Response of comment is not found");
+            }
+
+            verifyComments(response, matchedResponse, students, instructors);
+        }
+    }
+
+    private void verifyComments(WebElement response, CommentSearchResponseResult matchedResponse,
+            Collection<StudentAttributes> students, Collection<InstructorAttributes> instructors) {
+        List<WebElement> comments = response.findElements(By.className("comment-row"));
+        assertEquals(matchedResponse.comments.length, comments.size());
+
+        for (WebElement comment : comments) {
+            String commentGiverName = comment.findElement(By.id("comment-giver-name")).getText();
+            String commentText = comment.findElement(By.id("comment-text")).getText();
+
+            // Iterate as the result order may not be guaranteed
+            boolean hasMatch = false;
+            for (FeedbackResponseCommentAttributes frc : matchedResponse.comments) {
+                String expectedCommentGiverName = String.format("%s %s commented at",
+                        frc.isCommentFromFeedbackParticipant ? "Student" : "Instructor",
+                        getGiverName(frc.commentGiverType, frc.commentGiver, students, instructors));
+
+                // Normally, the comment text needs to be parsed for HTML and sanitized first.
+                // For E2E testing purpose, we will keep the comment simple and skip that step unless absolutely needed.
+                String expectedCommentText = frc.commentText;
+
+                if (expectedCommentGiverName.equals(commentGiverName)
+                        && expectedCommentText.equals(commentText)) {
+                    hasMatch = true;
+                    break;
+                }
+            }
+            if (!hasMatch) {
+                fail("Comment is not found");
+            }
+        }
+    }
+
+    private String getGiverName(FeedbackParticipantType giverType, String giverEmail,
+             Collection<StudentAttributes> students, Collection<InstructorAttributes> instructors) {
+        switch (giverType) {
+        case SELF:
+        case INSTRUCTORS:
+            InstructorAttributes matchedInstructor = instructors.stream()
+                    .filter(instructor -> instructor.email.equals(giverEmail))
+                    .findFirst()
+                    .orElse(null);
+            return matchedInstructor == null ? null : matchedInstructor.name;
+        case STUDENTS:
+            StudentAttributes matchedStudent = students.stream()
+                    .filter(student -> student.email.equals(giverEmail))
+                    .findFirst()
+                    .orElse(null);
+            return matchedStudent == null ? null : matchedStudent.name;
+        case TEAMS:
+            return giverEmail;
+        default:
+            throw new RuntimeException("Invalid giver type");
+        }
+    }
+
+    private String getGiverTeam(FeedbackParticipantType giverType, String giverEmail,
+            Collection<StudentAttributes> students) {
+        switch (giverType) {
+        case SELF:
+        case INSTRUCTORS:
+            return Const.USER_TEAM_FOR_INSTRUCTOR;
+        case STUDENTS:
+            StudentAttributes matchedStudent = students.stream()
+                    .filter(student -> student.email.equals(giverEmail))
+                    .findFirst()
+                    .orElse(null);
+            return matchedStudent == null ? null : matchedStudent.team;
+        case TEAMS:
+            return giverEmail;
+        default:
+            throw new RuntimeException("Invalid giver type");
+        }
+    }
+
+    /**
+     * Represents a session row (session + responses + comments) in the comment search result table.
+     */
+    public static class CommentSearchSessionResult {
+
+        public FeedbackSessionAttributes session;
+        public CommentSearchResponseResult[] responses;
+
+    }
+
+    /**
+     * Represents a response row (response + comments) in the comment search result table.
+     */
+    public static class CommentSearchResponseResult {
+
+        public FeedbackQuestionAttributes question;
+        public FeedbackResponseAttributes response;
+        public FeedbackResponseCommentAttributes[] comments;
+
     }
 
 }

--- a/src/e2e/resources/data/InstructorSearchPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorSearchPageE2ETest.json
@@ -170,20 +170,220 @@
       "section": "Section 1"
     }
   },
-  "feedbackSessions": {},
-  "feedbackQuestions": {},
-  "feedbackResponses": {},
-  "feedbackResponseComments": {},
-  "profiles": {
-    "student1InCourse1": {
-      "googleId": "student1InCourse1",
-      "shortName": "Stud1",
-      "email": "i.m.stud1@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 3",
-      "nationality": "",
-      "gender": "MALE",
-      "moreInfo": "I am just a student :P",
-      "pictureKey": ""
+  "feedbackSessions": {
+    "First Session": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "creatorEmail": "ISearch.instructor1@gmail.tmt",
+      "instructions": "Instructions for first session",
+      "createdTime": "2012-04-01T23:59:00Z",
+      "startTime": "2012-04-01T23:59:00Z",
+      "endTime": "2026-04-30T23:59:00Z",
+      "sessionVisibleFromTime": "2012-04-01T23:59:00Z",
+      "resultsVisibleFromTime": "2012-05-01T23:59:00Z",
+      "timeZone": "UTC",
+      "gracePeriod": 10,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": true,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
     }
-  }
+  },
+  "feedbackQuestions": {
+    "qn1": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "questionDetails": {
+        "numOfMcqChoices": 2,
+        "mcqChoices": [
+          "UI",
+          "Algo"
+        ],
+        "questionText": "What part of the product did this teammate contribute most to?",
+        "questionType": "MCQ",
+        "otherEnabled": true,
+        "hasAssignedWeights": true,
+        "mcqWeights": [
+          1,
+          2
+        ],
+        "mcqOtherWeight": 3
+      },
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "OWN_TEAM_MEMBERS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "OWN_TEAM_MEMBERS",
+        "INSTRUCTORS"
+      ]
+    },
+    "qn2": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "questionDetails": {
+        "msqChoices": [],
+        "questionText": "Which students would you recommend to be a tutor?",
+        "questionType": "MSQ",
+        "otherEnabled": false,
+        "generateOptionsFor": "STUDENTS"
+      },
+      "questionNumber": 2,
+      "giverType": "STUDENTS",
+      "recipientType": "NONE",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ]
+    }
+  },
+  "feedbackResponses": {
+    "qn1response1": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackQuestionId": "1",
+      "giver": "ISearch.student1@gmail.tmt",
+      "recipient": "ISearch.student2@gmail.tmt",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1",
+      "responseDetails": {
+        "questionType": "MCQ",
+        "answer": "",
+        "isOther": true,
+        "otherFieldContent": "Answer from Alice."
+      }
+    },
+    "qn1response2": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackQuestionId": "1",
+      "giver": "ISearch.student1@gmail.tmt",
+      "recipient": "ISearch.student3@gmail.tmt",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1",
+      "responseDetails": {
+        "questionType": "MCQ",
+        "answer": "Algo"
+      }
+    },
+    "qn1response3": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackQuestionId": "1",
+      "giver": "ISearch.student3@gmail.tmt",
+      "recipient": "ISearch.student1@gmail.tmt",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1",
+      "responseDetails": {
+        "questionType": "MCQ",
+        "answer": "UI"
+      }
+    },
+    "qn2response1": {
+      "feedbackSessionName": "First Session",
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackQuestionId": "2",
+      "giver": "ISearch.student1@gmail.tmt",
+      "recipient": "%GENERAL%",
+      "giverSection": "Section 1",
+      "recipientSection": "None",
+      "responseDetails": {
+        "questionType": "MSQ",
+        "answers": [
+          "Benny Charles (Team 1)",
+          "Danny Engrid (Team 2)"
+        ]
+      }
+    }
+  },
+  "feedbackResponseComments": {
+    "qn1Comment1": {
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackSessionName": "First Session",
+      "feedbackQuestionId": "1",
+      "commentGiver": "ISearch.instructor1@gmail.tmt",
+      "giverSection": "None",
+      "receiverSection": "Section 1",
+      "feedbackResponseId": "1%ISearch.student1@gmail.tmt%ISearch.student2@gmail.tmt",
+      "showCommentTo": [
+        "INSTRUCTORS",
+        "STUDENTS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS",
+        "STUDENTS"
+      ],
+      "commentGiverType": "INSTRUCTORS",
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "createdAt": "2026-02-02T23:59:00Z",
+      "commentText": "Instructor first comment to student1"
+    },
+    "qn1Comment2": {
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackSessionName": "First Session",
+      "feedbackQuestionId": "1",
+      "commentGiver": "ISearch.instructor1@gmail.tmt",
+      "giverSection": "None",
+      "receiverSection": "Section 1",
+      "feedbackResponseId": "1%ISearch.student1@gmail.tmt%ISearch.student2@gmail.tmt",
+      "showCommentTo": [
+        "INSTRUCTORS",
+        "STUDENTS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS",
+        "STUDENTS"
+      ],
+      "commentGiverType": "INSTRUCTORS",
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "createdAt": "2026-03-01T23:59:00Z",
+      "lastEditorEmail": "ISearch.instructor1@gmail.tmt",
+      "lastEditedAt": "2026-03-02T23:59:00Z",
+      "commentText": "Instructor second comment to student1"
+    },
+    "qn1Comment3": {
+      "courseId": "tm.e2e.ISearch.course1",
+      "feedbackSessionName": "First Session",
+      "feedbackQuestionId": "1",
+      "commentGiver": "ISearch.student3@gmail.tmt",
+      "giverSection": "None",
+      "receiverSection": "None",
+      "feedbackResponseId": "1%ISearch.student3@gmail.tmt%ISearch.student1@gmail.tmt",
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "commentGiverType": "STUDENTS",
+      "isVisibilityFollowingFeedbackQuestion": true,
+      "isCommentFromFeedbackParticipant": true,
+      "createdAt": "2026-03-02T23:59:00Z",
+      "commentText": "student3 comment to student1"
+    }
+  },
+  "profiles": {}
 }

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -14,7 +14,7 @@
 
 <div class="card" *ngIf="!model.isEditing && mode == CommentRowMode.EDIT && model.originalComment">
   <div class="card-body">
-    <div class="row">
+    <div class="row comment-row">
       <div class="col-12">
         <span id="by-response-giver" class="text-secondary" *ngIf="isFeedbackParticipantComment">
           Comment by response giver.

--- a/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
@@ -4,14 +4,14 @@
     <div class="font-weight-bold col-md-3">Session: {{ tableRow.feedbackSession.feedbackSessionName }} ({{ tableRow.feedbackSession.courseId }})</div>
     <div class="col-md-9">
       <div *ngFor="let question of tableRow.questions">
-        <div *ngFor="let response of question.allResponses" class="card p-0 border border-primary mb-3">
+        <div *ngFor="let response of question.allResponses" class="card p-0 border-light-blue border-primary mb-3">
           <div class="card-header bg-light-blue">
             <b>Question {{ question.feedbackQuestion.questionNumber }}:</b> {{ question.feedbackQuestion.questionDetails.questionText }}
           </div>
-          <div class="card-body border-bottom border-secondary">
+          <div class="card-body border-bottom">
             <b>From:</b> {{ response.giver }} <b>To:</b> {{ response.recipient }}
           </div>
-          <div class="card-body border-bottom border-secondary">
+          <div class="card-body border-bottom">
             <b>Response:</b>
             <tm-single-response
                 [isStudentPage]="false"
@@ -22,7 +22,7 @@
                 [responseDetails]="response.responseDetails">
             </tm-single-response>
           </div>
-          <div class="card p-0">
+          <div class="card p-0" style="border-width: 0;">
             <div class="card-body bg-secondary text-white font-weight-bold">Comment(s):</div>
             <tm-comment-table *ngIf="response.instructorComments.length"
                 [model]="response.instructorComments | commentsToCommentTableModel: true: tableRow.feedbackSession.timeZone"

--- a/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
@@ -1,14 +1,14 @@
 <div class="card border border-primary mb-4">
   <div class="card-header text-white bg-primary font-weight-bold">Questions, responses, comments on responses</div>
-  <div class="card-body p-4 row" *ngFor="let tableRow of commentTables">
-    <div class="font-weight-bold col-md-3">Session: {{ tableRow.feedbackSession.feedbackSessionName }} ({{ tableRow.feedbackSession.courseId }})</div>
+  <div class="card-body p-4 row comment-search-session" *ngFor="let tableRow of commentTables">
+    <div class="font-weight-bold col-md-3" id="comment-search-session-name">Session: {{ tableRow.feedbackSession.feedbackSessionName }} ({{ tableRow.feedbackSession.courseId }})</div>
     <div class="col-md-9">
-      <div *ngFor="let question of tableRow.questions">
-        <div *ngFor="let response of question.allResponses" class="card p-0 border-light-blue border-primary mb-3">
-          <div class="card-header bg-light-blue">
+      <div class="comment-search-question" *ngFor="let question of tableRow.questions">
+        <div *ngFor="let response of question.allResponses" class="card p-0 border-light-blue border-primary mb-3 comment-search-response">
+          <div class="card-header bg-light-blue" id="comment-search-question-text">
             <b>Question {{ question.feedbackQuestion.questionNumber }}:</b> {{ question.feedbackQuestion.questionDetails.questionText }}
           </div>
-          <div class="card-body border-bottom">
+          <div class="card-body border-bottom" id="comment-search-response-giver-recipient">
             <b>From:</b> {{ response.giver }} <b>To:</b> {{ response.recipient }}
           </div>
           <div class="card-body border-bottom">

--- a/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/comment-result-table/comment-result-table.component.html
@@ -24,9 +24,13 @@
           </div>
           <div class="card p-0">
             <div class="card-body bg-secondary text-white font-weight-bold">Comment(s):</div>
-            <tm-comment-table
+            <tm-comment-table *ngIf="response.instructorComments.length"
                 [model]="response.instructorComments | commentsToCommentTableModel: true: tableRow.feedbackSession.timeZone"
                 [shouldHideClosingButtonForNewComment]="true">
+            </tm-comment-table>
+            <tm-comment-table *ngIf="response.participantComment"
+                              [model]="[response.participantComment] | commentsToCommentTableModel: true: tableRow.feedbackSession.timeZone"
+                              [shouldHideClosingButtonForNewComment]="true">
             </tm-comment-table>
           </div>
         </div>


### PR DESCRIPTION
This will be an extended part of #9536 

- Resolved the high failure rate of Chrome-based E2E tests. It seems that a somewhat recent version of Chromedriver has a bug in setting page load timeout, so it is resolved by using native JS method. There may be other places where that bug occurs, but `driver.get` is the most obvious and by far most widely used call site.
- Separated `InstructorFeedbackResultsPageE2ETest` to multiple test cases. This is preferable because:
  - The entire test runs in 5.5 mins, so if anything breaks in the middle, everything has to be run all over again
  - The different view types of the results page technically create "different pages"
- Improved stability of `InstructorSearchPageE2ETest` sllightly
- Added some minor fixes to the search comments functionality: minor UI improvement and show participant comment on top of instructor comments
- Added E2E test portion for search response comments (another box ticked in the original issue!)