### PR TITLE
[#10809] Instructor editing sessions: Remove 'Done Editing' button

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -152,7 +152,6 @@
       <li>
         Save changes to the question when you have finished creating the question
       </li>
-
     </ol>
     <tm-example-box *ngIf="questionsToCollapsed[SessionsSectionQuestions.SESSION_QUESTIONS]" @collapseAnim>
       <div class="card">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -152,9 +152,7 @@
       <li>
         Save changes to the question when you have finished creating the question
       </li>
-      <li>
-        When you are finished adding questions, click <button class="btn btn-primary">Done Editing</button>.
-      </li>
+
     </ol>
     <tm-example-box *ngIf="questionsToCollapsed[SessionsSectionQuestions.SESSION_QUESTIONS]" @collapseAnim>
       <div class="card">
@@ -166,8 +164,7 @@
             </div>
           </div>
           <button type="button" class="btn btn-link"><i class="fas fa-info-circle"></i></button>
-          <button class="btn btn-primary">Copy Question</button>&nbsp;
-          <button class="btn btn-primary">Done Editing</button>
+          <button class="btn btn-primary">Copy Question</button>
         </div>
       </div>
     </tm-example-box>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -39,7 +39,6 @@
       </div>
       <a type="button" class="btn btn-link" target="_blank" rel="noopener noreferrer" tmRouterLink="/web/instructor/help" [queryParams]="{questionId: 'questions', section: 'questions'}"><i class="fas fa-info-circle"></i></a>
       <button id="btn-copy-question" class="btn btn-primary" (click)="copyQuestionsFromOtherSessionsHandler()" [disabled]="isCopyingQuestion"><tm-ajax-loading *ngIf="isCopyingQuestion"></tm-ajax-loading>Copy Question</button>
-      <button class="btn btn-primary btn-margin-left" (click)="doneEditingHandler()">Done Editing</button>
     </div>
   </div>
   <tm-question-edit-form *ngIf="isAddingQuestionPanelExpanded"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -938,24 +938,6 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   }
 
   /**
-   * Handles 'Done Editing' click event.
-   */
-  doneEditingHandler(): void {
-    if (this.questionEditFormModels.some((q: QuestionEditFormModel) => q.isEditable)
-        || this.sessionEditFormModel.isEditable) {
-      const modalContent: string = `<p>There exists unsaved field(s), this operation will cause all the changes to be lost.</p>
-          <p>Are you sure you want to continue?</p>`;
-      this.simpleModalService.openConfirmationModal(
-          'Discard unsaved field(s)?', SimpleModalType.WARNING, modalContent).result.then(() => {
-            this.navigationService.navigateByURL(this.router, '/web/instructor/sessions');
-          }, () => {});
-    } else {
-      this.navigationService.navigateByURL(this.router, '/web/instructor/sessions');
-    }
-    // TODO focus on the row of current feedback session in the sessions page
-  }
-
-  /**
    * Gets all students of a course.
    */
   getAllStudentsOfCourse(): void {


### PR DESCRIPTION
This PR fixes #10809 by:
- removing all instances of 'Done Editing' button
- removing the instruction related to the button
- removing `doneEditingHandler`
