### PR TITLE
[#10922] Added top padding to Add All Instructors button

### DIFF
--- a/src/web/app/pages-admin/admin-home-page/__snapshots__/admin-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-home-page/__snapshots__/admin-home-page.component.spec.ts.snap
@@ -320,7 +320,7 @@ exports[`AdminHomePageComponent should snap with disabled adding instructor butt
           </tbody>
         </table>
         <button
-          class="btn btn-primary"
+          class="btn btn-primary top-padded"
           disabled=""
           id="add-all-instructors"
         >
@@ -612,7 +612,7 @@ exports[`AdminHomePageComponent should snap with some instructors details 1`] = 
           </tbody>
         </table>
         <button
-          class="btn btn-primary"
+          class="btn btn-primary top-padded"
           id="add-all-instructors"
         >
           

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -80,10 +80,10 @@
         </tbody>
       </table>
       <div class="top-padded">
-      <button class="btn btn-primary" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">
-        <tm-ajax-loading *ngIf="isAddingInstructors"></tm-ajax-loading>
-        Add All Instructors
-      </button>
+        <button class="btn btn-primary" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">
+          <tm-ajax-loading *ngIf="isAddingInstructors"></tm-ajax-loading>
+          Add All Instructors
+        </button>
       </div>
     </div>
   </div>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -79,12 +79,10 @@
           </tr>
         </tbody>
       </table>
-      <div class="top-padded">
-        <button class="btn btn-primary" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">
-          <tm-ajax-loading *ngIf="isAddingInstructors"></tm-ajax-loading>
-          Add All Instructors
-        </button>
-      </div>
+      <button class="btn btn-primary top-padded" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">
+        <tm-ajax-loading *ngIf="isAddingInstructors"></tm-ajax-loading>
+        Add All Instructors
+      </button>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -79,10 +79,12 @@
           </tr>
         </tbody>
       </table>
+      <div class="top-padded">
       <button class="btn btn-primary" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">
         <tm-ajax-loading *ngIf="isAddingInstructors"></tm-ajax-loading>
         Add All Instructors
       </button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #10922

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:

- [x]  Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr

  - [x] Added the issue number to the "Fixes" keyword above
  - [x] Titled the PR as specified in the abovementioned document
- [x] Made your changes on a branch other than `master` and `release`
- [x] Gone through all the changes in this PR and ensured that:
  - [x] They addressed one (and only one) issue
  - [x] No unintended changes were made
- [x] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [ ] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
Surrounded 'Add All Instructors' button with div containing class="top-padded" in /teammates/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html

Changed top padding of 'Add All Instructors' button form this -
![image](https://user-images.githubusercontent.com/53873549/105030246-8858dd80-5a79-11eb-84c6-fe8cd1b3c058.png)
To this -
![image](https://user-images.githubusercontent.com/53873549/105030299-9ad31700-5a79-11eb-9afb-22c52ea9d40f.png)

