### PR TITLE
[#10931] Adding a new question typo in save button

### DIFF
--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -243,7 +243,7 @@
           <button class="btn btn-success" [disabled]="!model.isEditable || model.isSaving" (click)="saveQuestionHandler()">
             <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>
             <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>
-            <span id="btn-save-new" *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Questions</span>
+            <span id="btn-save-new" *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Question</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Fixes #10931

Fix typo in src/web/app/components/question-edit-form/question-edit-form.component.html
Line 246 change “Save Questions” button text to “Save Question” singular

<img width="1222" alt="Visibility (Who can see the responses)" src="https://user-images.githubusercontent.com/55817381/107129406-3a264580-6893-11eb-8020-ec3cdad57f48.png">
