### PR TITLE
[#10955] Configure CI for 'objectify-v6-migration' branch

### DIFF
--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -3,11 +3,13 @@ name: Component Tests
 on:
   push:
     branches:
-      - master 
+      - master
+      - objectify-v6-migration
       - release
   pull_request:
     branches:
-      - master 
+      - master
+      - objectify-v6-migration
       - release
   schedule:
     - cron: "0 0 * * *" #end of every day

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,11 +3,13 @@ name: E2E Tests
 on:
   push:
     branches:
-      - master 
+      - master
+      - objectify-v6-migration
       - release
   pull_request:
     branches:
-      - master 
+      - master
+      - objectify-v6-migration
       - release
   schedule:
     - cron: "0 0 * * *" #end of every day

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -3,7 +3,8 @@ name: L&P Tests
 on:
   push:
     branches:
-      - master 
+      - master
+      - objectify-v6-migration
       - release
 jobs:
   LnP-testing:


### PR DESCRIPTION
Part of #10955 

**Outline of Solution**
* included `objectify-v6-migration` branch trigger for GitHub Actions
* CI included: `lint`, `component-testing`, `E2E-testing` and `LnP-testing`

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->