### PR TITLE
[#10959] Add endpoint to fetch pagination metadata

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -265,6 +265,7 @@ public final class Const {
         public static final String INSTRUCTOR = URI_PREFIX + "/instructor";
         public static final String INSTRUCTOR_PRIVILEGE = URI_PREFIX + "/instructor/privilege";
         public static final String RESULT = URI_PREFIX + "/result";
+        public static final String PAGINATION_META_DATA = URI_PREFIX + "/pagination/metadata";
         public static final String STUDENTS = URI_PREFIX + "/students";
         public static final String STUDENT = URI_PREFIX + "/student";
         public static final String SESSIONS_ONGOING = URI_PREFIX + "/sessions/ongoing";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1387,4 +1387,8 @@ public class Logic {
         return feedbackQuestionsLogic.getNumOfGeneratedChoicesForParticipantType(courseId, generateOptionsFor);
     }
 
+    public int getSubmittedResponseCountForQuestion(String questionId) {
+        return feedbackResponsesLogic.getSubmittedResponseCountForQuestion(questionId);
+    }
+
 }

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -615,6 +615,13 @@ public final class FeedbackResponsesLogic {
     }
 
     /**
+     * Get the total number of submitted responses for a question.
+     */
+    public int getSubmittedResponseCountForQuestion(String questionId) {
+        return frDb.getSubmittedResponseCountForQuestion(questionId);
+    }
+
+    /**
      * Set contains only unique response.
      */
     private static class UniqueResponsesSet {

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -399,6 +399,15 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
                 .list();
     }
 
+    /**
+     * Get number of submitted responses for a question.
+     */
+    public int getSubmittedResponseCountForQuestion(String questionId) {
+        return load()
+                .filter("feedbackQuestionId =", questionId)
+                .count();
+    }
+
     @Override
     LoadType<FeedbackResponse> load() {
         return ofy().load().type(FeedbackResponse.class);

--- a/src/main/java/teammates/ui/output/PaginationMetaData.java
+++ b/src/main/java/teammates/ui/output/PaginationMetaData.java
@@ -1,0 +1,22 @@
+package teammates.ui.output;
+
+/**
+ * Pagination metadata.
+ */
+public class PaginationMetaData extends ApiOutput {
+    private final int noResponses;
+    private final String questionId;
+
+    public PaginationMetaData(int noResponses, String questionId) {
+        this.noResponses = noResponses;
+        this.questionId = questionId;
+    }
+
+    public int getNoResponses() {
+        return noResponses;
+    }
+
+    public String getQuestionId() {
+        return questionId;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -65,6 +65,7 @@ public class ActionFactory {
         map(ResourceURIs.RESPONSE_COMMENT, PUT, UpdateFeedbackResponseCommentAction.class);
         map(ResourceURIs.RESPONSE_COMMENT, DELETE, DeleteFeedbackResponseCommentAction.class);
         map(ResourceURIs.RESULT, GET, GetSessionResultsAction.class);
+        map(ResourceURIs.PAGINATION_META_DATA, GET, GetPaginationMetaDataAction.class);
 
         //STUDENTS APIs
         map(ResourceURIs.STUDENTS, GET, GetStudentsAction.class);

--- a/src/main/java/teammates/ui/webapi/GetPaginationMetaDataAction.java
+++ b/src/main/java/teammates/ui/webapi/GetPaginationMetaDataAction.java
@@ -1,0 +1,52 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.ui.output.PaginationMetaData;
+
+/**
+ * Get pagination metadata.
+ */
+public class GetPaginationMetaDataAction extends Action {
+
+    private static final String MESSAGE_NOT_INSTRUCTOR_ACCOUNT = "You did not login as an instructor,"
+            + " so you cannot view your profile";
+    private static final String MESSAGE_INSTRUCTOR_NOT_FOUND = "The instructor is not in the course you are given,"
+            + " so you cannot access the profile.";
+
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    void checkSpecificAccessControl() {
+        if (userInfo.isAdmin) {
+            return;
+        }
+        if (!userInfo.isInstructor) {
+            throw new UnauthorizedAccessException(MESSAGE_NOT_INSTRUCTOR_ACCOUNT);
+        }
+
+        String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+        String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
+
+        InstructorAttributes instructor = logic.getInstructorForEmail(courseId, instructorEmail);
+        if (instructor == null) {
+            throw new UnauthorizedAccessException(MESSAGE_INSTRUCTOR_NOT_FOUND);
+        }
+        gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+    }
+
+    @Override
+    ActionResult execute() {
+        String feedbackQuestionId = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+
+        int submittedResponseCount = logic.getSubmittedResponseCountForQuestion(feedbackQuestionId);
+        PaginationMetaData data = new PaginationMetaData(submittedResponseCount, feedbackQuestionId);
+
+        return new JsonResult(data);
+    }
+}


### PR DESCRIPTION
Part of #10959

Endpoint to fetch the total number of responses for a question in order to prepare pagination calls.
Path: ```/webapi/pagination/metadata```
Params: course ID, instructor email, question ID
Response: number of submitted responses, question ID
