### PR TITLE
[#10950] Add base files for audit logs backend

### DIFF
--- a/src/client/java/teammates/client/scripts/MockCourseWithLargeResponseScript.java
+++ b/src/client/java/teammates/client/scripts/MockCourseWithLargeResponseScript.java
@@ -1,0 +1,239 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import teammates.client.remoteapi.RemoteApiClient;
+import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.attributes.AccountAttributes;
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.logic.api.Logic;
+
+/**
+ * Script to mock a course and populate large number of responses.
+ */
+public final class MockCourseWithLargeResponseScript extends RemoteApiClient {
+    // Change the following params for different course setup
+    private static final int NUMBER_OF_STUDENTS = 500;
+    private static final int NUMBER_OF_TEAMS = 100;
+    private static final int NUMBER_OF_FEEDBACK_QUESTIONS = 30;
+
+    // For each student, the number of responses depends on:
+    // number_of_students / number_of_teams * (per team feedback strategy)
+    private static final FeedbackParticipantType FEEDBACK_QUESTION_RECIPIENT_TYPE =
+            FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF;
+
+    // Change the course ID to be recognizable
+    private static final String COURSE_ID = "TestData.500S30Q100T";
+    private static final String COURSE_NAME = "MockLargeCourse";
+    private static final String COURSE_TIME_ZONE = "UTC";
+
+    private static final String INSTRUCTOR_ID = "LoadInstructor_id";
+    private static final String INSTRUCTOR_NAME = "LoadInstructor";
+    private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
+
+    private static final String STUDENT_ID = "LoadStudent.tmms";
+    private static final String STUDENT_NAME = "LoadStudent";
+    private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
+
+    private static final String TEAM_NAME = "Team ";
+    private static final String GIVER_SECTION_NAME = "Section 1";
+    private static final String RECEIVER_SECTION_NAME = "Section 1";
+
+    private static final String FEEDBACK_SESSION_NAME = "Test Feedback Session";
+
+    private static final String FEEDBACK_QUESTION_ID = "QuestionTest";
+    private static final String FEEDBACK_QUESTION_TEXT = "Test Question";
+
+    private static final String FEEDBACK_RESPONSE_ID = "ResponseForQ";
+
+    private MockCourseWithLargeResponseScript() {
+    }
+
+    @Override
+    protected void doOperation() {
+        try {
+            Logic logic = new Logic();
+            DataBundle data = generateDataBundle();
+            logic.removeDataBundle(data);
+            logic.persistDataBundle(data);
+            System.out.println(data.feedbackResponses.size());
+        } catch (InvalidParametersException e) {
+            System.err.println(e);
+        }
+    }
+
+    private static Map<String, AccountAttributes> generateAccounts() {
+        return new HashMap<>();
+    }
+
+    private static Map<String, CourseAttributes> generateCourses() {
+        Map<String, CourseAttributes> courses = new HashMap<>();
+
+        courses.put(COURSE_NAME, CourseAttributes.builder(COURSE_ID)
+                .withName(COURSE_NAME)
+                .withTimezone(ZoneId.of(COURSE_TIME_ZONE))
+                .build());
+
+        return courses;
+    }
+
+    private static Map<String, InstructorAttributes> generateInstructors() {
+        Map<String, InstructorAttributes> instructors = new HashMap<>();
+
+        instructors.put(INSTRUCTOR_NAME,
+                InstructorAttributes.builder(COURSE_ID, INSTRUCTOR_EMAIL)
+                        .withGoogleId(INSTRUCTOR_ID)
+                        .withName(INSTRUCTOR_NAME)
+                        .withRole("Co-owner")
+                        .withIsDisplayedToStudents(true)
+                        .withDisplayedName("Co-owner")
+                        .withPrivileges(new InstructorPrivileges(
+                                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER))
+                        .build()
+        );
+
+        return instructors;
+    }
+
+    private static Map<String, StudentAttributes> generateStudents() {
+        Map<String, StudentAttributes> students = new LinkedHashMap<>();
+        StudentAttributes studentAttribute;
+
+        for (int i = 1; i <= NUMBER_OF_STUDENTS; i++) {
+            studentAttribute = StudentAttributes.builder(COURSE_ID, i + STUDENT_EMAIL)
+                    .withGoogleId(STUDENT_ID + i)
+                    .withName(STUDENT_NAME + i)
+                    .withComment("This student's name is " + STUDENT_NAME + i)
+                    .withSectionName(GIVER_SECTION_NAME)
+                    .withTeamName(TEAM_NAME + i % NUMBER_OF_TEAMS)
+                    .build();
+
+            students.put(STUDENT_NAME + i, studentAttribute);
+        }
+
+        return students;
+    }
+
+    private static Map<String, FeedbackSessionAttributes> generateFeedbackSessions() {
+        Map<String, FeedbackSessionAttributes> feedbackSessions = new LinkedHashMap<>();
+
+        FeedbackSessionAttributes session = FeedbackSessionAttributes
+                .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
+                .withCreatorEmail(INSTRUCTOR_EMAIL)
+                .withStartTime(Instant.now())
+                .withEndTime(Instant.now().plusSeconds(500))
+                .withSessionVisibleFromTime(Instant.now())
+                .withResultsVisibleFromTime(Instant.now())
+                .build();
+
+        feedbackSessions.put(FEEDBACK_SESSION_NAME, session);
+
+        return feedbackSessions;
+    }
+
+    private static Map<String, FeedbackQuestionAttributes> generateFeedbackQuestions() {
+        List<FeedbackParticipantType> showResponses = new ArrayList<>();
+        showResponses.add(FeedbackParticipantType.RECEIVER);
+        showResponses.add(FeedbackParticipantType.INSTRUCTORS);
+
+        List<FeedbackParticipantType> showGiverName = new ArrayList<>();
+        showGiverName.add(FeedbackParticipantType.INSTRUCTORS);
+
+        List<FeedbackParticipantType> showRecepientName = new ArrayList<>();
+        showRecepientName.add(FeedbackParticipantType.INSTRUCTORS);
+
+        Map<String, FeedbackQuestionAttributes> feedbackQuestions = new LinkedHashMap<>();
+        FeedbackQuestionDetails details = new FeedbackTextQuestionDetails(FEEDBACK_QUESTION_TEXT);
+
+        for (int i = 1; i <= NUMBER_OF_FEEDBACK_QUESTIONS; i++) {
+            feedbackQuestions.put(FEEDBACK_QUESTION_ID + " " + i,
+                    FeedbackQuestionAttributes.builder()
+                            .withFeedbackSessionName(FEEDBACK_SESSION_NAME)
+                            .withQuestionDescription(FEEDBACK_QUESTION_TEXT)
+                            .withCourseId(COURSE_ID)
+                            .withQuestionDetails(details)
+                            .withQuestionNumber(i)
+                            .withGiverType(FeedbackParticipantType.STUDENTS)
+                            .withRecipientType(FEEDBACK_QUESTION_RECIPIENT_TYPE)
+                            .withShowResponsesTo(showResponses)
+                            .withShowGiverNameTo(showGiverName)
+                            .withShowRecipientNameTo(showRecepientName)
+                            .build()
+            );
+        }
+
+        return feedbackQuestions;
+    }
+
+    private static Map<String, FeedbackResponseAttributes> generateFeedbackResponses() {
+        Map<String, FeedbackResponseAttributes> feedbackResponses = new HashMap<>();
+
+        for (int i = 1; i <= NUMBER_OF_STUDENTS; i++) {
+            for (int j = 1; j <= NUMBER_OF_STUDENTS; j++) {
+                if (j % NUMBER_OF_TEAMS != i % NUMBER_OF_TEAMS) {
+                    continue;
+                }
+
+                for (int k = 1; k <= NUMBER_OF_FEEDBACK_QUESTIONS; k++) {
+                    String responseText = FEEDBACK_RESPONSE_ID + " " + k
+                            + " from student " + i + " to student " + j;
+                    FeedbackTextResponseDetails details =
+                            new FeedbackTextResponseDetails(responseText);
+
+                    feedbackResponses.put(responseText,
+                            FeedbackResponseAttributes.builder(
+                                    Integer.toString(k),
+                                    i + STUDENT_EMAIL,
+                                    j + STUDENT_EMAIL)
+                                    .withCourseId(COURSE_ID)
+                                    .withFeedbackSessionName(FEEDBACK_SESSION_NAME)
+                                    .withGiverSection(GIVER_SECTION_NAME)
+                                    .withRecipientSection(RECEIVER_SECTION_NAME)
+                                    .withResponseDetails(details)
+                                    .build());
+                }
+            }
+        }
+        System.out.println(feedbackResponses.size());
+
+        return feedbackResponses;
+    }
+
+    private static DataBundle generateDataBundle() {
+        DataBundle dataBundle = new DataBundle();
+
+        dataBundle.accounts = generateAccounts();
+        dataBundle.courses = generateCourses();
+        dataBundle.instructors = generateInstructors();
+        dataBundle.students = generateStudents();
+        dataBundle.feedbackSessions = generateFeedbackSessions();
+        dataBundle.feedbackQuestions = generateFeedbackQuestions();
+        dataBundle.feedbackResponses = generateFeedbackResponses();
+
+        return dataBundle;
+    }
+
+    public static void main(String[] args) throws IOException {
+        new MockCourseWithLargeResponseScript().doOperationRemotely();
+    }
+
+}

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -119,6 +119,9 @@ public final class Const {
 
         public static final String FEEDBACK_RESPONSE_COMMENT_ID = "responsecommentid";
 
+        public static final String FEEDBACK_SESSION_LOGS_STARTTIME = "fslstarttime";
+        public static final String FEEDBACK_SESSION_LOGS_ENDTIME = "fslendtime";
+
         public static final String FEEDBACK_RESULTS_GROUPBYSECTION = "frgroupbysection";
 
         public static final String PREVIEWAS = "previewas";
@@ -275,6 +278,7 @@ public final class Const {
         public static final String SESSION_STATS = URI_PREFIX + "/session/stats";
         public static final String SESSION_SUBMITTED_GIVER_SET = URI_PREFIX + "/session/submitted/giverset";
         public static final String SESSIONS = URI_PREFIX + "/sessions";
+        public static final String SESSION_ACCESS_LOGS = URI_PREFIX + "/sesion/accesslogs";
         public static final String SEARCH_COMMENTS = URI_PREFIX + "/search/comments";
         public static final String SEARCH_INSTRUCTORS = URI_PREFIX + "/search/instructors";
         public static final String SEARCH_STUDENTS = URI_PREFIX + "/search/students";

--- a/src/main/java/teammates/ui/output/FeedbackResponseAccessType.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseAccessType.java
@@ -1,0 +1,16 @@
+package teammates.ui.output;
+
+/**
+ * The feedback response access type.
+ */
+public enum FeedbackResponseAccessType {
+    /**
+     * General recipient.
+     */
+    VISIT,
+
+    /**
+     * Giver's team member.
+     */
+    SUBMISSION,
+}

--- a/src/main/java/teammates/ui/output/FeedbackResponseLog.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseLog.java
@@ -1,0 +1,26 @@
+package teammates.ui.output;
+
+import java.util.List;
+
+/**
+ * The response log of a single feedback session.
+ */
+public class FeedbackResponseLog {
+    private final FeedbackSessionData feedbackSessionData;
+
+    private final List<StudentResponseAccessLog> studentResponseAccessLogs;
+
+    public FeedbackResponseLog(FeedbackSessionData feedbackSessionData,
+                               List<StudentResponseAccessLog> studentResponseAccessLogs) {
+        this.feedbackSessionData = feedbackSessionData;
+        this.studentResponseAccessLogs = studentResponseAccessLogs;
+    }
+
+    public FeedbackSessionData getFeedbackSessionData() {
+        return feedbackSessionData;
+    }
+
+    public List<StudentResponseAccessLog> getStudentResponseAccessLogs() {
+        return studentResponseAccessLogs;
+    }
+}

--- a/src/main/java/teammates/ui/output/FeedbackResponseLogsData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseLogsData.java
@@ -1,0 +1,19 @@
+package teammates.ui.output;
+
+import java.util.List;
+
+/**
+ * The API output format for logs on student's feedback session access and response.
+ */
+public class FeedbackResponseLogsData extends ApiOutput {
+
+    private final List<FeedbackResponseLog> feedbackResponseLogs;
+
+    public FeedbackResponseLogsData(List<FeedbackResponseLog> feedbackResponseLogs) {
+        this.feedbackResponseLogs = feedbackResponseLogs;
+    }
+
+    public List<FeedbackResponseLog> getFeedbackResponseLogs() {
+        return feedbackResponseLogs;
+    }
+}

--- a/src/main/java/teammates/ui/output/StudentResponseAccessLog.java
+++ b/src/main/java/teammates/ui/output/StudentResponseAccessLog.java
@@ -1,0 +1,32 @@
+package teammates.ui.output;
+
+/**
+ * The response access log of a student for a single feedback response session.
+ */
+public class StudentResponseAccessLog {
+    private final StudentData studentData;
+
+    private final FeedbackResponseAccessType feedbackResponseAccessType;
+
+    private final long accessTimestamp;
+
+    public StudentResponseAccessLog(StudentData studentData,
+                                    FeedbackResponseAccessType feedbackResponseAccessType,
+                                    long accessTimestamp) {
+        this.studentData = studentData;
+        this.feedbackResponseAccessType = feedbackResponseAccessType;
+        this.accessTimestamp = accessTimestamp;
+    }
+
+    public StudentData getStudentData() {
+        return studentData;
+    }
+
+    public FeedbackResponseAccessType getFeedbackResponseAccessType() {
+        return feedbackResponseAccessType;
+    }
+
+    public long getAccessTimestamp() {
+        return accessTimestamp;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/GetSessionAccessLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionAccessLogsAction.java
@@ -1,0 +1,36 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.util.Const;
+
+/**
+ * Action: gets the session access logs of feedback sessions of a course.
+ */
+public class GetSessionAccessLogsAction extends Action {
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.PUBLIC;
+    }
+
+    @Override
+    void checkSpecificAccessControl() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+
+        CourseAttributes courseAttributes = logic.getCourse(courseId);
+
+        if (courseAttributes == null) {
+            throw new EntityNotFoundException(new EntityDoesNotExistException("Course is not found"));
+        }
+
+        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+        gateKeeper.verifyAccessible(instructor, courseAttributes);
+    }
+
+    @Override
+    ActionResult execute() {
+        return null;
+    }
+}

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
@@ -1,3 +1,22 @@
 .sortable-header {
   cursor: pointer;
 }
+
+#copy-question-modal {
+  table-layout: auto;
+  margin-bottom: 50px;
+}
+
+.modal-footer {
+  position: fixed;
+  bottom: 0;
+  height: 50px;
+  width: 69.8%;
+  justify-content: right;
+  background-color: white;
+}
+
+.form-control {
+  height: calc(.5em + 1.5vh);
+  width: calc(.5em + 1.5vw);
+}

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -22,7 +22,7 @@
           <tm-loading-retry [shouldShowRetry]="courseTab.hasLoadingFailed" [message]="'Failed to load students'" (retryEvent)="loadStudents(courseTab)">
             <div *tmIsLoading="!courseTab.hasStudentLoaded">
               <div *ngIf="!courseTab.hasLoadingFailed" class="card-body">
-                <ng-container *ngIf="courseTab.stats.numOfStudents > 0, else noStudentsTemplate">
+                <ng-container *ngIf="courseTab.hasStudentLoaded && courseTab.stats.numOfStudents > 0, else noStudentsTemplate">
                   <div class="card-deck text-center text-sm-left" *ngIf="courseTab.stats">
                     <div class="card">
                       <div class="card-body" id="num-students">


### PR DESCRIPTION
Part of #10950 

Added base files for the audit logs
- `FeedbackResponseAccessType`, `FeedbackResponseLog`, `FeedbackResponseLogsData`, `StudentResponseAccessLog` in the `output` package for API Output
- New endpoint `webapi/sesion/accesslogs` and `GetSessionAccessLogsAction`