### PR TITLE
[#10950] Add base files for audit logs backend

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -113,6 +113,8 @@ public final class Const {
         public static final String FEEDBACK_SESSION_ENDTIME = "endtime";
         public static final String FEEDBACK_SESSION_MODERATED_PERSON = "moderatedperson";
         public static final String FEEDBACK_SESSION_LOG_TYPE = "fsltype";
+        public static final String FEEDBACK_SESSION_LOG_STARTTIME = "fslstarttime";
+        public static final String FEEDBACK_SESSION_LOG_ENDTIME = "fslendtime";
 
         public static final String FEEDBACK_QUESTION_ID = "questionid";
 
@@ -298,6 +300,7 @@ public final class Const {
         public static final String NATIONALITIES = URI_PREFIX + "/nationalities";
         public static final String EMAIL = URI_PREFIX + "/email";
         public static final String TRACK_SESSION = URI_PREFIX + "/track/session";
+        public static final String SESSION_LOGS = URI_PREFIX + "/logs/session";
 
         public static final String STUDENT_PROFILE_PICTURE = URI_PREFIX + "/student/profilePic";
         public static final String STUDENT_PROFILE = URI_PREFIX + "/student/profile";

--- a/src/main/java/teammates/ui/output/FeedbackSessionLog.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLog.java
@@ -1,0 +1,26 @@
+package teammates.ui.output;
+
+import java.util.List;
+
+/**
+ * The response log of a single feedback session.
+ */
+public class FeedbackSessionLog {
+    private final FeedbackSessionData feedbackSessionData;
+
+    private final List<FeedbackSessionLogEntry> feedbackSessionLogEntries;
+
+    public FeedbackSessionLog(FeedbackSessionData feedbackSessionData,
+                              List<FeedbackSessionLogEntry> feedbackSessionLogEntries) {
+        this.feedbackSessionData = feedbackSessionData;
+        this.feedbackSessionLogEntries = feedbackSessionLogEntries;
+    }
+
+    public FeedbackSessionData getFeedbackSessionData() {
+        return feedbackSessionData;
+    }
+
+    public List<FeedbackSessionLogEntry> getStudentResponseAccessLogs() {
+        return feedbackSessionLogEntries;
+    }
+}

--- a/src/main/java/teammates/ui/output/FeedbackSessionLogEntry.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogEntry.java
@@ -1,0 +1,33 @@
+package teammates.ui.output;
+
+/**
+ * The session log of a student for a single feedback session.
+ */
+public class FeedbackSessionLogEntry {
+    private final StudentData studentData;
+
+    private final String feedbackSessionLogType;
+
+    private final long timestamp;
+
+    public FeedbackSessionLogEntry(StudentData studentData,
+                                   String feedbackSessionLogType,
+                                   long timestamp) {
+        this.studentData = studentData;
+        this.feedbackSessionLogType = feedbackSessionLogType;
+        this.timestamp = timestamp;
+    }
+
+    public StudentData getStudentData() {
+        return studentData;
+    }
+
+    public String getFeedbackSessionLogType() {
+        // TODO: change type from String to LogType
+        return feedbackSessionLogType;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/teammates/ui/output/FeedbackSessionLogsData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogsData.java
@@ -1,0 +1,19 @@
+package teammates.ui.output;
+
+import java.util.List;
+
+/**
+ * The API output format for logs on all feedback sessions in a course.
+ */
+public class FeedbackSessionLogsData extends ApiOutput {
+
+    private final List<FeedbackSessionLog> feedbackSessionLogs;
+
+    public FeedbackSessionLogsData(List<FeedbackSessionLog> feedbackSessionLogs) {
+        this.feedbackSessionLogs = feedbackSessionLogs;
+    }
+
+    public List<FeedbackSessionLog> getFeedbackResponseLogs() {
+        return feedbackSessionLogs;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -120,6 +120,7 @@ public class ActionFactory {
 
         // Logging and tracking
         map(ResourceURIs.TRACK_SESSION, GET, CreateFeedbackSessionLogAction.class);
+        map(ResourceURIs.SESSION_LOGS, GET, GetFeedbackSessionLogsAction.class);
 
         // Cron jobs; use GET request
         // Reference: https://cloud.google.com/appengine/docs/standard/java/config/cron

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -1,0 +1,36 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.util.Const;
+
+/**
+ * Action: gets the feedback session logs of feedback sessions of a course.
+ */
+public class GetFeedbackSessionLogsAction extends Action {
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    void checkSpecificAccessControl() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+
+        CourseAttributes courseAttributes = logic.getCourse(courseId);
+
+        if (courseAttributes == null) {
+            throw new EntityNotFoundException(new EntityDoesNotExistException("Course is not found"));
+        }
+
+        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+        gateKeeper.verifyAccessible(instructor, courseAttributes);
+    }
+
+    @Override
+    ActionResult execute() {
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #10950 

Added base files for the audit logs
- `FeedbackResponseAccessType`, `FeedbackResponseLog`, `FeedbackResponseLogsData`, `StudentResponseAccessLog` in the `output` package for API Output
- New endpoint `webapi/sesion/accesslogs` and `GetSessionAccessLogsAction`