### PR TITLE
[#10950] Track student feedback session in frontend

### DIFF
--- a/src/main/java/teammates/ui/constants/LogTypes.java
+++ b/src/main/java/teammates/ui/constants/LogTypes.java
@@ -1,0 +1,27 @@
+package teammates.ui.constants;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import teammates.common.util.Const;
+
+/**
+ * Constant values for all the different log types.
+ */
+public enum LogTypes {
+    // CHECKSTYLE.OFF:JavadocVariable
+    FEEDBACK_SESSION_ACCESS(Const.FeedbackSessionLogTypes.ACCESS),
+    FEEDBACK_SESSION_SUBMISSION(Const.FeedbackSessionLogTypes.SUBMISSION);
+    // CHECKSTYLE.ON:JavadocVariable
+
+    @JsonValue
+    private final String value;
+
+    LogTypes(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -315,12 +315,13 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
         this.logService.createFeedbackSessionLog({
           courseId: this.courseId,
+          feedbackSessionName: this.feedbackSessionName,
           studentEmail: this.loggedInUser,
           logType: LogTypes.FEEDBACK_SESSION_ACCESS,
         }).subscribe(() => {
 
         }, () => {
-          this.simpleModalService.openInformationModal('Log Error', SimpleModalType.WARNING, '');
+          this.statusMessageService.showWarningToast('Failed to log feedback session access');
         });
 
         this.loadFeedbackQuestions();
@@ -554,12 +555,13 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
     this.logService.createFeedbackSessionLog({
       courseId: this.courseId,
+      feedbackSessionName: this.feedbackSessionName,
       studentEmail: this.loggedInUser,
       logType: LogTypes.FEEDBACK_SESSION_SUBMISSION,
     }).subscribe(() => {
 
     }, () => {
-      this.simpleModalService.openInformationModal('Log Error', SimpleModalType.WARNING, '');
+      this.statusMessageService.showWarningToast('Failed to log feedback session submission');
     });
 
     this.questionSubmissionForms.forEach((questionSubmissionFormModel: QuestionSubmissionFormModel) => {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -12,11 +12,13 @@ import { FeedbackResponseCommentService } from '../../../services/feedback-respo
 import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorService } from '../../../services/instructor.service';
+import { LogService } from '../../../services/log.service';
 import { NavigationService } from '../../../services/navigation.service';
 import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
+import { LogTypes } from '../../../types/api-const';
 import {
   AuthInfo,
   FeedbackParticipantType,
@@ -123,6 +125,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               private authService: AuthService,
               private navigationService: NavigationService,
               private commentService: FeedbackResponseCommentService,
+              private logService: LogService,
               @Inject(DOCUMENT) private document: any) {
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
   }
@@ -309,6 +312,16 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             default:
           }
         }
+
+        this.logService.createFeedbackSessionLog({
+          courseId: this.courseId,
+          studentEmail: this.loggedInUser,
+          logType: LogTypes.FEEDBACK_SESSION_ACCESS,
+        }).subscribe(() => {
+
+        }, () => {
+          this.simpleModalService.openInformationModal('Log Error', SimpleModalType.WARNING, '');
+        });
 
         this.loadFeedbackQuestions();
       }, (resp: ErrorMessageOutput) => {
@@ -538,6 +551,16 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     const answers: Record<string, FeedbackResponse[]> = {};
     const failToSaveQuestions: Record<number, string> = {}; // Map of question number to error message
     const savingRequests: Observable<any>[] = [];
+
+    this.logService.createFeedbackSessionLog({
+      courseId: this.courseId,
+      studentEmail: this.loggedInUser,
+      logType: LogTypes.FEEDBACK_SESSION_SUBMISSION,
+    }).subscribe(() => {
+
+    }, () => {
+      this.simpleModalService.openInformationModal('Log Error', SimpleModalType.WARNING, '');
+    });
 
     this.questionSubmissionForms.forEach((questionSubmissionFormModel: QuestionSubmissionFormModel) => {
       let isQuestionFullyAnswered: boolean = true;

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -217,7 +217,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   }
 
   /**
-   * Loads the name of the person invovled in the submission.
+   * Loads the name of the person involved in the submission.
    */
   loadPersonName(): void {
     switch (this.intent) {
@@ -229,6 +229,18 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         ).subscribe((student: Student) => {
           this.personName = student.name;
           this.personEmail = student.email;
+
+          this.logService.createFeedbackSessionLog({
+            courseId: this.courseId,
+            feedbackSessionName: this.feedbackSessionName,
+            studentEmail: this.personEmail,
+            logType: LogTypes.FEEDBACK_SESSION_ACCESS,
+          }).subscribe(() => {
+
+          }, () => {
+            this.statusMessageService.showWarningToast('Failed to log feedback session access');
+          });
+
         });
         break;
       case Intent.INSTRUCTOR_SUBMISSION:
@@ -312,17 +324,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             default:
           }
         }
-
-        this.logService.createFeedbackSessionLog({
-          courseId: this.courseId,
-          feedbackSessionName: this.feedbackSessionName,
-          studentEmail: this.loggedInUser,
-          logType: LogTypes.FEEDBACK_SESSION_ACCESS,
-        }).subscribe(() => {
-
-        }, () => {
-          this.statusMessageService.showWarningToast('Failed to log feedback session access');
-        });
 
         this.loadFeedbackQuestions();
       }, (resp: ErrorMessageOutput) => {

--- a/src/web/services/log.service.spec.ts
+++ b/src/web/services/log.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LogService } from './log.service';
+
+describe('LogService', () => {
+  let service: LogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/web/services/log.service.spec.ts
+++ b/src/web/services/log.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
-import { LogService } from './log.service';
 import { HttpRequestService } from './http-request.service';
+import { LogService } from './log.service';
 
 describe('LogService', () => {
   let service: LogService;

--- a/src/web/services/log.service.spec.ts
+++ b/src/web/services/log.service.spec.ts
@@ -1,12 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 
 import { LogService } from './log.service';
+import { HttpRequestService } from './http-request.service';
 
 describe('LogService', () => {
   let service: LogService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpRequestService },
+      ],
+    });
     service = TestBed.inject(LogService);
   });
 

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LogTypes, ResourceEndpoints } from '../types/api-const';
+import { HttpRequestService } from './http-request.service';
+
+/**
+ * Handles logging related logic provision.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class LogService {
+
+  constructor(private httpRequestService: HttpRequestService) { }
+
+  /**
+   * Creates a log for feedback session by calling API.
+   */
+  createFeedbackSessionLog(queryParams: {
+    courseId: string,
+    studentEmail: string,
+    logType: LogTypes }): Observable<string> {
+    const paramMap: Record<string, string> = {
+      courseId: queryParams.courseId,
+      studentEmail: queryParams.studentEmail,
+      fsltype: queryParams.logType.toString(),
+    };
+
+    return this.httpRequestService.get(ResourceEndpoints.TRACK_SESSION, paramMap);
+  }
+
+}

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -18,11 +18,13 @@ export class LogService {
    */
   createFeedbackSessionLog(queryParams: {
     courseId: string,
+    feedbackSessionName: string,
     studentEmail: string,
     logType: LogTypes }): Observable<string> {
     const paramMap: Record<string, string> = {
-      courseId: queryParams.courseId,
-      studentEmail: queryParams.studentEmail,
+      courseid: queryParams.courseId,
+      fsname: queryParams.feedbackSessionName,
+      studentemail: queryParams.studentEmail,
       fsltype: queryParams.logType.toString(),
     };
 


### PR DESCRIPTION
Part of #10950 

Outline of solution
- Added new log service in frontend and call the create logs API in the session submission page for access and submission
- Added the log types in `teammates.ui.constants` so that the type is generated for frontend use (and extensibility in case more log types apart from feedback session in future?)