### PR TITLE
[#11008] Add toJson with writer as input for JsonResult to reduce unnecessary

### DIFF
--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -75,6 +75,16 @@ public final class JsonUtils {
     }
 
     /**
+     * Serializes the specified object into its equivalent JSON string and stream into a writer.
+     * This is done to reduce the memory consumption when creating object across call stack.
+     *
+     * @see Gson#toJson(Object, Appendable)
+     */
+    public static void toCompactJson(Object src, Appendable writer) {
+        getGsonInstance(false).toJson(src, writer);
+    }
+
+    /**
      * Deserializes the specified JSON string into an object of the specified type.
      *
      * @see Gson#fromJson(String, Type)

--- a/src/main/java/teammates/ui/webapi/JsonResult.java
+++ b/src/main/java/teammates/ui/webapi/JsonResult.java
@@ -60,7 +60,7 @@ class JsonResult extends ActionResult {
         resp.setStatus(getStatusCode());
         resp.setContentType("application/json");
         PrintWriter pw = resp.getWriter();
-        pw.print(JsonUtils.toCompactJson(output));
+        JsonUtils.toCompactJson(output, pw);
     }
 
     List<Cookie> getCookies() {


### PR DESCRIPTION
Fixes #11008 

**Outline of Solution**

Utilize the `toJson(Object, Appendable)` function that allows streaming json output directly to writer to reduce memory consumption. Note that this memory consumption scales with the output size, which is of some concern when dealing with large size return.

**Before**
![image](https://user-images.githubusercontent.com/19870898/110110918-7c876780-7dea-11eb-9bd6-31d585f7abe4.png)

**After**
![image (1)](https://user-images.githubusercontent.com/19870898/110110927-801aee80-7dea-11eb-8a6e-7cf348ebd0cf.png)

