### PR TITLE
[#11001] Migrate App Engine Text datastore type

### DIFF
--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.appengine.api.datastore.Text;
+import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -39,10 +39,10 @@ public class FeedbackQuestion extends BaseEntity {
      * @see teammates.common.datatransfer.attributes.FeedbackQuestionAttributes#getQuestionDetails()
      */
     @Unindex
-    private Text questionText;
+    private StringValue questionText;
 
     @Unindex
-    private Text questionDescription;
+    private StringValue questionDescription;
 
     private int questionNumber;
 
@@ -145,19 +145,19 @@ public class FeedbackQuestion extends BaseEntity {
     }
 
     public String getQuestionMetaData() {
-        return questionText == null ? null : questionText.getValue();
+        return questionText == null ? null : questionText.get();
     }
 
     public void setQuestionText(String questionText) {
-        this.questionText = questionText == null ? null : new Text(questionText);
+        this.questionText = questionText == null ? null : new StringValue(questionText);
     }
 
     public String getQuestionDescription() {
-        return questionDescription == null ? null : questionDescription.getValue();
+        return questionDescription == null ? null : questionDescription.get();
     }
 
     public void setQuestionDescription(String questionDescription) {
-        this.questionDescription = questionDescription == null ? null : new Text(questionDescription);
+        this.questionDescription = questionDescription == null ? null : new StringValue(questionDescription);
     }
 
     public FeedbackQuestionType getQuestionType() {

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -39,10 +38,10 @@ public class FeedbackQuestion extends BaseEntity {
      * @see teammates.common.datatransfer.attributes.FeedbackQuestionAttributes#getQuestionDetails()
      */
     @Unindex
-    private StringValue questionText;
+    private String questionText;
 
     @Unindex
-    private StringValue questionDescription;
+    private String questionDescription;
 
     private int questionNumber;
 
@@ -145,19 +144,19 @@ public class FeedbackQuestion extends BaseEntity {
     }
 
     public String getQuestionMetaData() {
-        return questionText == null ? null : questionText.get();
+        return questionText == null ? null : questionText;
     }
 
     public void setQuestionText(String questionText) {
-        this.questionText = questionText == null ? null : new StringValue(questionText);
+        this.questionText = questionText == null ? null : questionText;
     }
 
     public String getQuestionDescription() {
-        return questionDescription == null ? null : questionDescription.get();
+        return questionDescription == null ? null : questionDescription;
     }
 
     public void setQuestionDescription(String questionDescription) {
-        this.questionDescription = questionDescription == null ? null : new StringValue(questionDescription);
+        this.questionDescription = questionDescription == null ? null : questionDescription;
     }
 
     public FeedbackQuestionType getQuestionType() {

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -144,19 +144,19 @@ public class FeedbackQuestion extends BaseEntity {
     }
 
     public String getQuestionMetaData() {
-        return questionText == null ? null : questionText;
+        return questionText;
     }
 
     public void setQuestionText(String questionText) {
-        this.questionText = questionText == null ? null : questionText;
+        this.questionText = questionText;
     }
 
     public String getQuestionDescription() {
-        return questionDescription == null ? null : questionDescription;
+        return questionDescription;
     }
 
     public void setQuestionDescription(String questionDescription) {
-        this.questionDescription = questionDescription == null ? null : questionDescription;
+        this.questionDescription = questionDescription;
     }
 
     public FeedbackQuestionType getQuestionType() {

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -226,11 +226,11 @@ public class FeedbackResponseComment extends BaseEntity {
     }
 
     public String getCommentText() {
-        return commentText == null ? null : commentText;
+        return commentText;
     }
 
     public void setCommentText(String commentText) {
-        this.commentText = commentText == null ? null : commentText;
+        this.commentText = commentText;
     }
 
     public String getGiverSection() {

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -73,7 +72,7 @@ public class FeedbackResponseComment extends BaseEntity {
 
     /** The comment from giver about the feedback response. */
     @Unindex
-    private StringValue commentText;
+    private String commentText;
 
     /** The e-mail of the account that last edited the comment. */
     private String lastEditorEmail;
@@ -227,11 +226,11 @@ public class FeedbackResponseComment extends BaseEntity {
     }
 
     public String getCommentText() {
-        return commentText == null ? null : commentText.get();
+        return commentText == null ? null : commentText;
     }
 
     public void setCommentText(String commentText) {
-        this.commentText = commentText == null ? null : new StringValue(commentText);
+        this.commentText = commentText == null ? null : commentText;
     }
 
     public String getGiverSection() {

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.appengine.api.datastore.Text;
+import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -73,7 +73,7 @@ public class FeedbackResponseComment extends BaseEntity {
 
     /** The comment from giver about the feedback response. */
     @Unindex
-    private Text commentText;
+    private StringValue commentText;
 
     /** The e-mail of the account that last edited the comment. */
     private String lastEditorEmail;
@@ -227,11 +227,11 @@ public class FeedbackResponseComment extends BaseEntity {
     }
 
     public String getCommentText() {
-        return commentText == null ? null : commentText.getValue();
+        return commentText == null ? null : commentText.get();
     }
 
     public void setCommentText(String commentText) {
-        this.commentText = commentText == null ? null : new Text(commentText);
+        this.commentText = commentText == null ? null : new StringValue(commentText);
     }
 
     public String getGiverSection() {

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -141,11 +141,11 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public String getInstructions() {
-        return instructions == null ? null : instructions;
+        return instructions;
     }
 
     public void setInstructions(String instructions) {
-        this.instructions = instructions == null ? null : instructions;
+        this.instructions = instructions;
     }
 
     public Instant getCreatedTime() {

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -2,7 +2,7 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 
-import com.google.appengine.api.datastore.Text;
+import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -34,7 +34,7 @@ public class FeedbackSession extends BaseEntity {
     private String creatorEmail;
 
     @Unindex
-    private Text instructions;
+    private StringValue instructions;
 
     @Unindex
     @Translate(InstantTranslatorFactory.class)
@@ -142,11 +142,11 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public String getInstructions() {
-        return instructions == null ? null : instructions.getValue();
+        return instructions == null ? null : instructions.get();
     }
 
     public void setInstructions(String instructions) {
-        this.instructions = instructions == null ? null : new Text(instructions);
+        this.instructions = instructions == null ? null : new StringValue(instructions);
     }
 
     public Instant getCreatedTime() {

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 
-import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -34,7 +33,7 @@ public class FeedbackSession extends BaseEntity {
     private String creatorEmail;
 
     @Unindex
-    private StringValue instructions;
+    private String instructions;
 
     @Unindex
     @Translate(InstantTranslatorFactory.class)
@@ -142,11 +141,11 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public String getInstructions() {
-        return instructions == null ? null : instructions.get();
+        return instructions == null ? null : instructions;
     }
 
     public void setInstructions(String instructions) {
-        this.instructions = instructions == null ? null : new StringValue(instructions);
+        this.instructions = instructions == null ? null : instructions;
     }
 
     public Instant getCreatedTime() {

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -2,7 +2,7 @@ package teammates.storage.entity;
 
 import java.security.SecureRandom;
 
-import com.google.appengine.api.datastore.Text;
+import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -52,7 +52,7 @@ public class Instructor extends BaseEntity {
     @Unindex
     private String displayedName;
 
-    private Text instructorPrivilegesAsText;
+    private StringValue instructorPrivilegesAsText;
 
     @SuppressWarnings("unused")
     private Instructor() {
@@ -205,10 +205,10 @@ public class Instructor extends BaseEntity {
         if (instructorPrivilegesAsText == null) {
             return null;
         }
-        return instructorPrivilegesAsText.getValue();
+        return instructorPrivilegesAsText.get();
     }
 
     public void setInstructorPrivilegeAsText(String instructorPrivilegesAsText) {
-        this.instructorPrivilegesAsText = new Text(instructorPrivilegesAsText);
+        this.instructorPrivilegesAsText = new StringValue(instructorPrivilegesAsText);
     }
 }

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -202,9 +202,6 @@ public class Instructor extends BaseEntity {
      * Gets the instructor privileges stored in JSON format.
      */
     public String getInstructorPrivilegesAsText() {
-        if (instructorPrivilegesAsText == null) {
-            return null;
-        }
         return instructorPrivilegesAsText;
     }
 

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.security.SecureRandom;
 
-import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
@@ -52,7 +51,8 @@ public class Instructor extends BaseEntity {
     @Unindex
     private String displayedName;
 
-    private StringValue instructorPrivilegesAsText;
+    @Unindex
+    private String instructorPrivilegesAsText;
 
     @SuppressWarnings("unused")
     private Instructor() {
@@ -205,10 +205,10 @@ public class Instructor extends BaseEntity {
         if (instructorPrivilegesAsText == null) {
             return null;
         }
-        return instructorPrivilegesAsText.get();
+        return instructorPrivilegesAsText;
     }
 
     public void setInstructorPrivilegeAsText(String instructorPrivilegesAsText) {
-        this.instructorPrivilegesAsText = new StringValue(instructorPrivilegesAsText);
+        this.instructorPrivilegesAsText = instructorPrivilegesAsText;
     }
 }

--- a/src/main/java/teammates/storage/entity/StudentProfile.java
+++ b/src/main/java/teammates/storage/entity/StudentProfile.java
@@ -146,11 +146,11 @@ public class StudentProfile extends BaseEntity {
     }
 
     public String getMoreInfo() {
-        return this.moreInfo == null ? null : this.moreInfo;
+        return moreInfo;
     }
 
     public void setMoreInfo(String moreInfo) {
-        this.moreInfo = moreInfo == null ? null : moreInfo;
+        this.moreInfo = moreInfo;
     }
 
     public Instant getModifiedDate() {

--- a/src/main/java/teammates/storage/entity/StudentProfile.java
+++ b/src/main/java/teammates/storage/entity/StudentProfile.java
@@ -2,7 +2,7 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 
-import com.google.appengine.api.datastore.Text;
+import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -40,7 +40,7 @@ public class StudentProfile extends BaseEntity {
     private String gender;
 
     @Unindex
-    private Text moreInfo;
+    private StringValue moreInfo;
 
     @Index
     @Translate(InstantTranslatorFactory.class)
@@ -147,11 +147,11 @@ public class StudentProfile extends BaseEntity {
     }
 
     public String getMoreInfo() {
-        return this.moreInfo == null ? null : this.moreInfo.getValue();
+        return this.moreInfo == null ? null : this.moreInfo.get();
     }
 
     public void setMoreInfo(String moreInfo) {
-        this.moreInfo = moreInfo == null ? null : new Text(moreInfo);
+        this.moreInfo = moreInfo == null ? null : new StringValue(moreInfo);
     }
 
     public Instant getModifiedDate() {

--- a/src/main/java/teammates/storage/entity/StudentProfile.java
+++ b/src/main/java/teammates/storage/entity/StudentProfile.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 
-import com.google.cloud.datastore.StringValue;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -40,7 +39,7 @@ public class StudentProfile extends BaseEntity {
     private String gender;
 
     @Unindex
-    private StringValue moreInfo;
+    private String moreInfo;
 
     @Index
     @Translate(InstantTranslatorFactory.class)
@@ -147,11 +146,11 @@ public class StudentProfile extends BaseEntity {
     }
 
     public String getMoreInfo() {
-        return this.moreInfo == null ? null : this.moreInfo.get();
+        return this.moreInfo == null ? null : this.moreInfo;
     }
 
     public void setMoreInfo(String moreInfo) {
-        this.moreInfo = moreInfo == null ? null : new StringValue(moreInfo);
+        this.moreInfo = moreInfo == null ? null : moreInfo;
     }
 
     public Instant getModifiedDate() {

--- a/src/test/java/teammates/architecture/ArchitectureTest.java
+++ b/src/test/java/teammates/architecture/ArchitectureTest.java
@@ -488,13 +488,6 @@ public class ArchitectureTest {
     }
 
     @Test
-    public void testArchitecture_externalApi_datastoreTypesCanOnlyBeAccessedByEntityClasses() {
-        noClasses().that().resideOutsideOfPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
-                .should().accessClassesThat().haveFullyQualifiedName("com.google.appengine.api.datastore.Text")
-                .check(ALL_CLASSES);
-    }
-
-    @Test
     public void testArchitecture_externalApi_servletApiCanOnlyBeAccessedBySomePackages() {
         noClasses().that().doNotHaveSimpleName("HttpRequestHelper")
                 .and().doNotHaveSimpleName("OfyHelper")


### PR DESCRIPTION
Part of #11001

This PR cleans up existing code which still contain traces using the old `com.google.appengine.api` used before the Objectify 6 migration. 

In Objectify 6, there's no way to explicitly store a `Text` type with the Google-provided SDK. The alternative,`StringValue` does not support `null`. 
- Replace `Text` type from the `com.google.appengine.api.datastore` package used in Objectify 5 with unindexed `String`.
