### PR TITLE
[#11001] Handle datastore exceptions using the new Google-provided SDK

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
@@ -2,8 +2,8 @@ package teammates.e2e.cases;
 
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.datastore.DatastoreTimeoutException;
 import com.google.apphosting.api.DeadlineExceededException;
+import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
@@ -31,7 +31,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
         testAssertionError();
         testNullPointerException();
         testDeadlineExceededException();
-        testDatastoreTimeoutException();
+        testDatastoreException();
         testUnauthorizedAccessException();
         testInvalidHttpParameterException();
         testEntityNotFoundException();
@@ -79,17 +79,17 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
     }
 
-    private void testDatastoreTimeoutException() {
+    private void testDatastoreException() {
 
-        ______TS("DatastoreTimeoutException testing");
+        ______TS("DatastoreException testing");
 
         String url = createUrl(Const.ResourceURIs.EXCEPTION)
-                .withParam(Const.ParamsNames.ERROR, DatastoreTimeoutException.class.getSimpleName())
+                .withParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName())
                 .toString();
 
         BACKDOOR.executeGetRequest(url, null);
 
-        print("DatastoreTimeoutException triggered, verify that you have received error logs via email");
+        print("DatastoreException triggered, verify that you have received error logs via email");
 
     }
 

--- a/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import com.google.apphosting.api.DeadlineExceededException;
 import com.google.cloud.datastore.DatastoreException;
+import com.google.rpc.Code;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
@@ -41,7 +42,8 @@ class AdminExceptionTestAction extends Action {
             throw new DeadlineExceededException("DeadlineExceededException testing");
         }
         if (error.equals(DatastoreException.class.getSimpleName())) {
-            throw new DatastoreException(4, "DatastoreException testing", "DEADLINE_EXCEEDED");
+            throw new DatastoreException(Code.DEADLINE_EXCEEDED_VALUE, "DatastoreException testing",
+                    Code.DEADLINE_EXCEEDED.name());
         }
         if (error.equals(InvalidHttpParameterException.class.getSimpleName())) {
             throw new InvalidHttpParameterException("InvalidHttpParameterException testing");

--- a/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
@@ -1,7 +1,7 @@
 package teammates.ui.webapi;
 
-import com.google.appengine.api.datastore.DatastoreTimeoutException;
 import com.google.apphosting.api.DeadlineExceededException;
+import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
@@ -40,8 +40,8 @@ class AdminExceptionTestAction extends Action {
         if (error.equals(DeadlineExceededException.class.getSimpleName())) {
             throw new DeadlineExceededException("DeadlineExceededException testing");
         }
-        if (error.equals(DatastoreTimeoutException.class.getSimpleName())) {
-            throw new DatastoreTimeoutException("DatastoreTimeoutException testing");
+        if (error.equals(DatastoreException.class.getSimpleName())) {
+            throw new DatastoreException(4, "DatastoreException testing", "DEADLINE_EXCEEDED");
         }
         if (error.equals(InvalidHttpParameterException.class.getSimpleName())) {
             throw new InvalidHttpParameterException("InvalidHttpParameterException testing");

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -105,7 +105,7 @@ public class WebApiServlet extends HttpServlet {
             log.warning(enfe.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(enfe));
             throwError(resp, HttpStatus.SC_NOT_FOUND, enfe.getMessage());
-        } catch (DeadlineExceededException | DatastoreException e) {
+        } catch (DeadlineExceededException e) {
 
             // This exception may not be caught because GAE kills the request soon after throwing it
             // In that case, the error message in the log will be emailed to the admin by a separate cron job
@@ -114,7 +114,10 @@ public class WebApiServlet extends HttpServlet {
                     + TeammatesException.toStringWithStackTrace(e));
             throwError(resp, HttpStatus.SC_GATEWAY_TIMEOUT,
                     "The request exceeded the server timeout limit. Please try again later.");
-
+        } catch (DatastoreException e) {
+            log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: "
+                    + TeammatesException.toStringWithStackTrace(e));
+            throwError(resp, HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         } catch (Throwable t) {
             log.severe(t.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(t));

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -9,8 +9,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 
-import com.google.appengine.api.datastore.DatastoreTimeoutException;
 import com.google.apphosting.api.DeadlineExceededException;
+import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.ActionMappingException;
 import teammates.common.exception.EntityNotFoundException;
@@ -105,7 +105,7 @@ public class WebApiServlet extends HttpServlet {
             log.warning(enfe.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(enfe));
             throwError(resp, HttpStatus.SC_NOT_FOUND, enfe.getMessage());
-        } catch (DeadlineExceededException | DatastoreTimeoutException e) {
+        } catch (DeadlineExceededException | DatastoreException e) {
 
             // This exception may not be caught because GAE kills the request soon after throwing it
             // In that case, the error message in the log will be emailed to the admin by a separate cron job

--- a/src/test/java/teammates/ui/webapi/WebApiServletTest.java
+++ b/src/test/java/teammates/ui/webapi/WebApiServletTest.java
@@ -10,8 +10,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.datastore.DatastoreTimeoutException;
 import com.google.apphosting.api.DeadlineExceededException;
+import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
@@ -89,10 +89,10 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
         SERVLET.doGet(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
 
-        ______TS("Failure case: DatastoreTimeoutException");
+        ______TS("Failure case: DatastoreException");
 
         setupMocks(HttpGet.METHOD_NAME, Const.ResourceURIs.EXCEPTION);
-        mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreTimeoutException.class.getSimpleName());
+        mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName());
 
         SERVLET.doGet(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
@@ -180,7 +180,7 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
         ______TS("Failure case: DatastoreTimeoutException");
 
         setupMocksFromGaeQueue(HttpGet.METHOD_NAME, Const.ResourceURIs.EXCEPTION);
-        mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreTimeoutException.class.getSimpleName());
+        mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName());
 
         SERVLET.doGet(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());

--- a/src/test/java/teammates/ui/webapi/WebApiServletTest.java
+++ b/src/test/java/teammates/ui/webapi/WebApiServletTest.java
@@ -95,7 +95,7 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
         mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName());
 
         SERVLET.doGet(mockRequest, mockResponse);
-        assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, mockResponse.getStatus());
 
         ______TS("Failure case: UnauthorizedAccessException");
 
@@ -183,7 +183,7 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
         mockRequest.addParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName());
 
         SERVLET.doGet(mockRequest, mockResponse);
-        assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, mockResponse.getStatus());
 
         ______TS("Failure case: UnauthorizedAccessException");
 


### PR DESCRIPTION
Part of #11001 

In the new Google-provided SDK used by Objectify 6 to access the datastore, exceptions are handled using `DatastoreException` which classifies errors based on canonical error codes (e.g. `NOT_FOUND`, `DEADLINE_EXCEEDED` etc). 

Considerations made:
* Previously, `DatastoreTimeoutException` (provided by the old appengine api) is thrown if a timeout is encountered when trying to access the the datastore. Now the Google-provided SDK used by Objectify 6 does not have such a specific class to handle timeouts, canonical error codes are used instead to specify error type. 

Solution:
- Handle `DatastoreException` separately from `DeadlineExceededException` to throw more specific datastore error messages.