### PR TITLE
[#11002] Separate emulator ports and include its setup into CI for tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
         run: npm run build -- --progress=false --serviceWorker=false
       - name: Set up gcloud Cloud SDK environment
         uses: google-github-actions/setup-gcloud@v0.2.0
+      - name: Install beta command group
+        run: gcloud components install beta
       - name: Set up local datastore emulator
         run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,16 +39,16 @@ jobs:
         run: mv $GITHUB_WORKSPACE/src/e2e/resources/test.ci-$E2E_BROWSER.properties src/e2e/resources/test.properties
         env:
           E2E_BROWSER: ${{ matrix.browser }}
-      - name: Create Config Files 
+      - name: Install cloud datastore emulator
+        run: sudo apt-get install google-cloud-sdk-datastore-emulator
+      - name: Set up local datastore emulator
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0 &
+      - name: Create Config Files
         run: ./gradlew createConfigs testClasses generateTypes 
       - name: Install Frontend Dependencies
         run: npm ci 
       - name: Build Frontend Bundle 
         run: npm run build -- --progress=false --serviceWorker=false
-      - name: Install cloud datastore emulator
-        run: sudo apt-get install google-cloud-sdk-datastore-emulator
-      - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0 &
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install beta command group
         run: yes | gcloud components install beta cloud-datastore-emulator
       - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
         run: npm ci 
       - name: Build Frontend Bundle 
         run: npm run build -- --progress=false --serviceWorker=false
+      - name: Install cloud datastore emulator
+        run: sudo apt-get install google-cloud-sdk-datastore-emulator
       - name: Set up local datastore emulator
         run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install cloud datastore emulator
         run: sudo apt-get install google-cloud-sdk-datastore-emulator
       - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0 &
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install cloud datastore emulator
         run: sudo apt-get install google-cloud-sdk-datastore-emulator
       - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Frontend Dependencies
         run: npm ci 
       - name: Build Frontend Bundle 
-        run: npm run build -- --progress=false --serviceWorker=false
+        run: npm run build -- --progress=false --serviceWorker=false 
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up gcloud Cloud SDK environment
         uses: google-github-actions/setup-gcloud@v0.2.0
       - name: Install beta command group
-        run: gcloud components install beta
+        run: yes | gcloud components install beta cloud-datastore-emulator
       - name: Set up local datastore emulator
         run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Install Frontend Dependencies
         run: npm ci 
       - name: Build Frontend Bundle 
-        run: npm run build -- --progress=false --serviceWorker=false 
+        run: npm run build -- --progress=false --serviceWorker=false
+      - name: Set up gcloud Cloud SDK environment
+        uses: google-github-actions/setup-gcloud@v0.2.0
+      - name: Set up local datastore emulator
+        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,12 +45,8 @@ jobs:
         run: npm ci 
       - name: Build Frontend Bundle 
         run: npm run build -- --progress=false --serviceWorker=false
-      - name: Set up gcloud Cloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.2.0
-      - name: Install beta command group
-        run: yes | gcloud components install beta cloud-datastore-emulator
       - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
+        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine 
         run: ./gradlew appengineStart 
       - name: Start Tests 

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up gcloud Cloud SDK environment
         uses: google-github-actions/setup-gcloud@v0.2.0
       - name: Install beta command group
-        run: gcloud components install beta
+        run: yes | gcloud components install beta cloud-datastore-emulator
       - name: Set up local datastore emulator
         run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -26,6 +26,10 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Create Config Files
         run: ./gradlew createConfigs
+      - name: Set up gcloud Cloud SDK environment
+        uses: google-github-actions/setup-gcloud@v0.2.0
+      - name: Set up local datastore emulator
+        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine
         run: ./gradlew appengineStart
       - name: Start Tests

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -28,6 +28,8 @@ jobs:
         run: ./gradlew createConfigs
       - name: Set up gcloud Cloud SDK environment
         uses: google-github-actions/setup-gcloud@v0.2.0
+      - name: Install beta command group
+        run: gcloud components install beta
       - name: Set up local datastore emulator
         run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -24,14 +24,12 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Install cloud datastore emulator
+        run: sudo apt-get install google-cloud-sdk-datastore-emulator
+      - name: Set up local datastore emulator
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0 &
       - name: Create Config Files
         run: ./gradlew createConfigs
-      - name: Set up gcloud Cloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.2.0
-      - name: Install beta command group
-        run: yes | gcloud components install beta cloud-datastore-emulator
-      - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine
         run: ./gradlew appengineStart
       - name: Start Tests

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install beta command group
         run: yes | gcloud components install beta cloud-datastore-emulator
       - name: Set up local datastore emulator
-        run: gcloud beta emulators datastore start --host-port=localhost:8484 --consistency=1.0
+        run: gcloud beta emulators datastore start --project=tm-obj-v6-test --host-port=localhost:8484 --consistency=1.0
       - name: Start App Engine
         run: ./gradlew appengineStart
       - name: Start Tests

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -232,8 +232,20 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatastoreAccess {
 
     @Override
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    public void setupLocalDatastoreHelper() {
+        // Should be prepared separately
+    }
+
+    @Override
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     public void resetLocalDatastoreHelper() {
         // Local datastore state should persist across e2e test suites
+    }
+
+    @Override
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    public void tearDownLocalDatastoreHelper() {
+        // Should be prepared separately
     }
 
     @Override

--- a/src/test/java/teammates/test/BaseTestCaseWithObjectifyAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithObjectifyAccess.java
@@ -14,7 +14,6 @@ import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.ObjectifyService;
 import com.googlecode.objectify.util.Closeable;
 
-import teammates.common.util.Config;
 import teammates.storage.api.OfyHelper;
 
 /**
@@ -23,7 +22,7 @@ import teammates.storage.api.OfyHelper;
  */
 public abstract class BaseTestCaseWithObjectifyAccess extends BaseTestCaseWithMinimalGaeEnvironment {
     private static final double DB_CONSISTENCY = 1.0;
-    private static final int EMULATOR_PORT = Integer.parseInt(Config.APP_LOCALDATASTORE_PORT);
+    private static final int EMULATOR_PORT = TestProperties.TEST_LOCALDATASTORE_PORT;
     private static LocalDatastoreHelper localDatastoreHelper;
     private Closeable closeable;
 

--- a/src/test/java/teammates/test/TestProperties.java
+++ b/src/test/java/teammates/test/TestProperties.java
@@ -17,6 +17,9 @@ public final class TestProperties {
     /** The directory where JSON files used to create data bundles are stored. */
     public static final String TEST_DATA_FOLDER = "src/test/resources/data";
 
+    /** The value of "test.localdatastore.port" in test.properties file. */
+    public static final int TEST_LOCALDATASTORE_PORT;
+
     /** The value of "test.persistence.timeout" in test.properties file. */
     public static final int PERSISTENCE_RETRY_PERIOD_IN_S;
 
@@ -37,6 +40,8 @@ public final class TestProperties {
             IS_SNAPSHOT_UPDATE = Boolean.parseBoolean(prop.getProperty("test.snapshot.update", "false"));
 
             PERSISTENCE_RETRY_PERIOD_IN_S = Integer.parseInt(prop.getProperty("test.persistence.timeout"));
+
+            TEST_LOCALDATASTORE_PORT = Integer.parseInt(prop.getProperty("test.localdatastore.port"));
 
         } catch (IOException | NumberFormatException e) {
             throw new RuntimeException(e);

--- a/src/test/resources/test.template.properties
+++ b/src/test/resources/test.template.properties
@@ -10,3 +10,6 @@ test.persistence.timeout=4
 # Please read the snapshot testing documentation if you are not yet familiar with it, and use with care.
 # Remember to set back to false when done and rerun the test(s).
 test.snapshot.update=false
+
+# This is the port to connect with local datastore emulator.
+test.localdatastore.port=8482

--- a/src/test/resources/test.template.properties
+++ b/src/test/resources/test.template.properties
@@ -11,5 +11,6 @@ test.persistence.timeout=4
 # Remember to set back to false when done and rerun the test(s).
 test.snapshot.update=false
 
-# This is the port to connect with local datastore emulator.
+# This is the port where local datastore emulator will be instantiated.
+# CAUTION: it must be set to a free port.
 test.localdatastore.port=8482


### PR DESCRIPTION
Fixes #11002 

**Outline of Solution**
* removed emulator setup for e2e tests
* add emulator setup in CI for e2e and LNP
* separate datastore port of component tests from development

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
