### PR TITLE
[#10950] Add backend tests for audit logs

### DIFF
--- a/src/main/java/teammates/ui/output/FeedbackSessionLogData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogData.java
@@ -35,7 +35,7 @@ public class FeedbackSessionLogData {
     /**
      * Returns all feedback session log entries.
      */
-    public List<FeedbackSessionLogEntryData> getfeedbackSessionLogEntries() {
+    public List<FeedbackSessionLogEntryData> getFeedbackSessionLogEntries() {
         return feedbackSessionLogEntries;
     }
 }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -22,9 +22,14 @@ class CreateFeedbackSessionLogAction extends Action {
 
     @Override
     JsonResult execute() {
+        String fslType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE);
+        if (!fslType.equals(Const.FeedbackSessionLogTypes.ACCESS)
+                && !fslType.equals(Const.FeedbackSessionLogTypes.SUBMISSION)) {
+            return new JsonResult("Invalid log type", HttpStatus.SC_BAD_REQUEST);
+        }
+
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String fsName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        String fslType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE);
         String studentEmail = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
 
         try {

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -31,6 +31,7 @@ class CreateFeedbackSessionLogAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String fsName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
         String studentEmail = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+        // Skip rigorous validations to avoid incurring extra db reads and to keep the endpoint light
 
         try {
             logsProcessor.createFeedbackSessionLog(courseId, studentEmail, fsName, fslType);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -16,6 +16,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.LogServiceException;
+import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.ui.output.FeedbackSessionLogsData;
@@ -31,8 +32,11 @@ public class GetFeedbackSessionLogsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        if (!userInfo.isInstructor) {
+            throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
+        }
 
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         CourseAttributes courseAttributes = logic.getCourse(courseId);
 
         if (courseAttributes == null) {

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -59,8 +59,14 @@ public class GetFeedbackSessionLogsAction extends Action {
         }
         String startTimeStr = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME);
         String endTimeStr = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME);
-        Instant startTime = Instant.ofEpochMilli(Long.parseLong(startTimeStr));
-        Instant endTime = Instant.ofEpochMilli(Long.parseLong(endTimeStr));
+        Instant startTime;
+        Instant endTime;
+        try {
+            startTime = Instant.ofEpochMilli(Long.parseLong(startTimeStr));
+            endTime = Instant.ofEpochMilli(Long.parseLong(endTimeStr));
+        } catch (NumberFormatException e) {
+            return new JsonResult("Invalid start or end time", HttpStatus.SC_BAD_REQUEST);
+        }
         // TODO: we might want to impose limits on the time range from startTime to endTime
 
         if (endTime.toEpochMilli() < startTime.toEpochMilli()) {

--- a/src/test/java/teammates/test/MockLogsProcessor.java
+++ b/src/test/java/teammates/test/MockLogsProcessor.java
@@ -1,9 +1,13 @@
 package teammates.test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
 import teammates.common.datatransfer.ErrorLogEntry;
+import teammates.common.datatransfer.FeedbackSessionLogEntry;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.logic.api.LogsProcessor;
 
 /**
@@ -12,17 +16,37 @@ import teammates.logic.api.LogsProcessor;
 public class MockLogsProcessor extends LogsProcessor {
 
     private List<ErrorLogEntry> errorLogs = new ArrayList<>();
+    private List<FeedbackSessionLogEntry> feedbackSessionLogs = new ArrayList<>();
 
     /**
      * Simulates insertion of error logs.
      */
-    public void insertErrorLogs(String message, String severity) {
+    public void insertErrorLog(String message, String severity) {
         errorLogs.add(new ErrorLogEntry(message, severity));
+    }
+
+    /**
+     * Simulates insertion of feedback session logs.
+     */
+    public void insertFeedbackSessionLog(StudentAttributes student, FeedbackSessionAttributes fs,
+            String fslType, long timestamp) {
+        feedbackSessionLogs.add(new FeedbackSessionLogEntry(student, fs, fslType, timestamp));
     }
 
     @Override
     public List<ErrorLogEntry> getRecentErrorLogs() {
         return errorLogs;
+    }
+
+    @Override
+    public void createFeedbackSessionLog(String courseId, String email, String fsName, String fslType) {
+        // No-op
+    }
+
+    @Override
+    public List<FeedbackSessionLogEntry> getFeedbackSessionLogs(String courseId, String email,
+            Instant startTime, Instant endTime) {
+        return feedbackSessionLogs;
     }
 
 }

--- a/src/test/java/teammates/ui/webapi/CompileLogsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CompileLogsActionTest.java
@@ -38,8 +38,8 @@ public class CompileLogsActionTest extends BaseActionTest<CompileLogsAction> {
         // The class does not check for the log severity as it is assumed that the logs service
         // will filter them correctly
 
-        mockLogsProcessor.insertErrorLogs("Test info message", "INFO");
-        mockLogsProcessor.insertErrorLogs("Test warning message", "WARNING");
+        mockLogsProcessor.insertErrorLog("Test info message", "INFO");
+        mockLogsProcessor.insertErrorLog("Test warning message", "WARNING");
 
         action = getAction();
         action.execute();

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionTest.java
@@ -3,6 +3,9 @@ package teammates.ui.webapi;
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 
 /**
@@ -24,46 +27,92 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
     protected void testExecute() throws Exception {
         JsonResult actionOutput;
 
+        CourseAttributes course1 = typicalBundle.courses.get("typicalCourse1");
+        String courseId1 = course1.getId();
+        FeedbackSessionAttributes fsa1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        FeedbackSessionAttributes fsa2 = typicalBundle.feedbackSessions.get("session2InCourse1");
+        StudentAttributes student1 = typicalBundle.students.get("student1InCourse1");
+        StudentAttributes student2 = typicalBundle.students.get("student2InCourse1");
+        StudentAttributes student3 = typicalBundle.students.get("student1InCourse3");
+
         ______TS("Failure case: not enough parameters");
-        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, "course-id");
+        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, courseId1);
         verifyHttpParameterFailure(
-                Const.ParamsNames.COURSE_ID, "course-id",
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name"
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName()
         );
         verifyHttpParameterFailure(
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
-                Const.ParamsNames.STUDENT_EMAIL, "student@email.com"
+                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail()
         );
 
         ______TS("Failure case: invalid log type");
         String[] paramsInvalid = {
-                Const.ParamsNames.COURSE_ID, "course-id",
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, "invalid log type",
-                Const.ParamsNames.STUDENT_EMAIL, "student@email.com",
+                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
         };
         actionOutput = getJsonResult(getAction(paramsInvalid));
         assertEquals(HttpStatus.SC_BAD_REQUEST, actionOutput.getStatusCode());
 
         ______TS("Success case: typical access");
         String[] paramsSuccessfulAccess = {
-                Const.ParamsNames.COURSE_ID, "course-id",
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.ACCESS,
-                Const.ParamsNames.STUDENT_EMAIL, "student@email.com",
+                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
         };
         actionOutput = getJsonResult(getAction(paramsSuccessfulAccess));
         assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
 
         ______TS("Success case: typical submission");
         String[] paramsSuccessfulSubmission = {
-                Const.ParamsNames.COURSE_ID, "course-id-2",
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name-2",
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa2.getFeedbackSessionName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
-                Const.ParamsNames.STUDENT_EMAIL, "student2@email.com",
+                Const.ParamsNames.STUDENT_EMAIL, student2.getEmail(),
         };
         actionOutput = getJsonResult(getAction(paramsSuccessfulSubmission));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        ______TS("Success case: should create even for invalid parameters");
+        String[] paramsNonExistentCourseId = {
+                Const.ParamsNames.COURSE_ID, "non-existent-course-id",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
+        };
+        actionOutput = getJsonResult(getAction(paramsNonExistentCourseId));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        String[] paramsNonExistentFsName = {
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "non-existent-feedback-session-name",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
+        };
+        actionOutput = getJsonResult(getAction(paramsNonExistentFsName));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        String[] paramsNonExistentStudentEmail = {
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, "non-existent-student@email.com",
+        };
+        actionOutput = getJsonResult(getAction(paramsNonExistentStudentEmail));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        ______TS("Success case: should create even when student cannot access feedback session in course");
+        String[] paramsWithoutAccess = {
+                Const.ParamsNames.COURSE_ID, courseId1,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsa1.getFeedbackSessionName(),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, student3.getEmail(),
+        };
+        actionOutput = getJsonResult(getAction(paramsWithoutAccess));
         assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
     }
 

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionTest.java
@@ -1,5 +1,6 @@
 package teammates.ui.webapi;
 
+import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
@@ -21,12 +22,54 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
     @Test
     @Override
     protected void testExecute() throws Exception {
-        // TODO: test execute
+        JsonResult actionOutput;
+
+        ______TS("Failure case: not enough parameters");
+        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, "course-id");
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, "course-id",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name"
+        );
+        verifyHttpParameterFailure(
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, "student@email.com"
+        );
+
+        ______TS("Failure case: invalid log type");
+        String[] paramsInvalid = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, "invalid log type",
+                Const.ParamsNames.STUDENT_EMAIL, "student@email.com",
+        };
+        actionOutput = getJsonResult(getAction(paramsInvalid));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, actionOutput.getStatusCode());
+
+        ______TS("Success case: typical access");
+        String[] paramsSuccessfulAccess = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.ACCESS,
+                Const.ParamsNames.STUDENT_EMAIL, "student@email.com",
+        };
+        actionOutput = getJsonResult(getAction(paramsSuccessfulAccess));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        ______TS("Success case: typical submission");
+        String[] paramsSuccessfulSubmission = {
+                Const.ParamsNames.COURSE_ID, "course-id-2",
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "feedback-session-name-2",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, Const.FeedbackSessionLogTypes.SUBMISSION,
+                Const.ParamsNames.STUDENT_EMAIL, "student2@email.com",
+        };
+        actionOutput = getJsonResult(getAction(paramsSuccessfulSubmission));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
     }
 
     @Test
     @Override
     protected void testAccessControl() throws Exception {
-        // TODO: test access control
+        verifyAnyUserCanAccess();
     }
 }

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
@@ -1,0 +1,156 @@
+package teammates.ui.webapi;
+
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.Const;
+import teammates.ui.constants.LogType;
+import teammates.ui.output.FeedbackSessionLogData;
+import teammates.ui.output.FeedbackSessionLogEntryData;
+import teammates.ui.output.FeedbackSessionLogsData;
+
+/**
+ * SUT: {@link GetFeedbackSessionLogsAction}.
+ */
+public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedbackSessionLogsAction> {
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SESSION_LOGS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+        JsonResult actionOutput;
+
+        CourseAttributes course = typicalBundle.courses.get("typicalCourse1");
+        String courseId = course.getId();
+        FeedbackSessionAttributes fsa1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        FeedbackSessionAttributes fsa2 = typicalBundle.feedbackSessions.get("session2InCourse1");
+        StudentAttributes student1 = typicalBundle.students.get("student1InCourse1");
+        StudentAttributes student2 = typicalBundle.students.get("student2InCourse1");
+        String student1Email = student1.getEmail();
+        String student2Email = student2.getEmail();
+        long startTime = 1600000000000L;
+        long endTime = 1600000000000L + 100000;
+
+        mockLogsProcessor.insertFeedbackSessionLog(student1, fsa1,
+                Const.FeedbackSessionLogTypes.ACCESS, startTime);
+        mockLogsProcessor.insertFeedbackSessionLog(student1, fsa2,
+                Const.FeedbackSessionLogTypes.ACCESS, startTime + 1000);
+        mockLogsProcessor.insertFeedbackSessionLog(student1, fsa2,
+                Const.FeedbackSessionLogTypes.SUBMISSION, startTime + 2000);
+        mockLogsProcessor.insertFeedbackSessionLog(student2, fsa1,
+                Const.FeedbackSessionLogTypes.ACCESS, startTime + 3000);
+        mockLogsProcessor.insertFeedbackSessionLog(student2, fsa1,
+                Const.FeedbackSessionLogTypes.SUBMISSION, startTime + 4000);
+
+        ______TS("Failure case: not enough parameters");
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, courseId
+        );
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime)
+        );
+        verifyHttpParameterFailure(
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime)
+        );
+
+        ______TS("Failure case: invalid parameters");
+        String[] paramsInvalid1 = {
+                Const.ParamsNames.COURSE_ID, "fake-course-id",
+                Const.ParamsNames.STUDENT_EMAIL, student1Email,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsInvalid1));
+        assertEquals(HttpStatus.SC_NOT_FOUND, actionOutput.getStatusCode());
+
+        String[] paramsInvalid2 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_EMAIL, "fake-student-email@gmail.com",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsInvalid2));
+        assertEquals(HttpStatus.SC_NOT_FOUND, actionOutput.getStatusCode());
+
+        ______TS("Success case: should group by feedback session");
+        String[] paramsSuccessful1 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsSuccessful1));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+
+        // The filtering by the logs processor cannot be tested directly, assume that it filters correctly
+        // Here, it simply returns all log entries
+        FeedbackSessionLogsData fslData = (FeedbackSessionLogsData) actionOutput.getOutput();
+        List<FeedbackSessionLogData> fsLogs = fslData.getFeedbackSessionLogs();
+
+        // Course has 6 feedback sessions, first 4 of which have no log entries
+        assertEquals(fsLogs.size(), 6);
+        assertEquals(fsLogs.get(0).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(1).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(2).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(3).getFeedbackSessionLogEntries().size(), 0);
+
+        List<FeedbackSessionLogEntryData> fsLogEntries1 = fsLogs.get(4).getFeedbackSessionLogEntries();
+        List<FeedbackSessionLogEntryData> fsLogEntries2 = fsLogs.get(5).getFeedbackSessionLogEntries();
+
+        assertEquals(fsLogEntries1.size(), 3);
+        assertEquals(fsLogEntries1.get(0).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries1.get(0).getFeedbackSessionLogType(), LogType.FEEDBACK_SESSION_ACCESS);
+        assertEquals(fsLogEntries1.get(1).getStudentData().getEmail(), student2Email);
+        assertEquals(fsLogEntries1.get(1).getFeedbackSessionLogType(), LogType.FEEDBACK_SESSION_ACCESS);
+        assertEquals(fsLogEntries1.get(2).getStudentData().getEmail(), student2Email);
+        assertEquals(fsLogEntries1.get(2).getFeedbackSessionLogType(), LogType.FEEDBACK_SESSION_SUBMISSION);
+
+        assertEquals(fsLogEntries2.size(), 2);
+        assertEquals(fsLogEntries2.get(0).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries2.get(0).getFeedbackSessionLogType(), LogType.FEEDBACK_SESSION_ACCESS);
+        assertEquals(fsLogEntries2.get(1).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries2.get(1).getFeedbackSessionLogType(), LogType.FEEDBACK_SESSION_SUBMISSION);
+
+        ______TS("Success case: should accept optional email");
+        String[] paramsSuccessful2 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_EMAIL, student1Email,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsSuccessful2));
+        assertEquals(HttpStatus.SC_OK, actionOutput.getStatusCode());
+        // No need to check output again here, it will be exactly the same as the previous case
+
+        // TODO: if we restrict the range from start to end time, it should be tested here as well
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        String courseId = instructor.getCourseId();
+
+        ______TS("Only instructors of the same course can access");
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, courseId,
+        };
+        verifyOnlyInstructorsOfTheSameCourseCanAccess(submissionParams);
+    }
+
+}

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
@@ -69,7 +69,7 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime)
         );
 
-        ______TS("Failure case: invalid parameters");
+        ______TS("Failure case: invalid course id");
         String[] paramsInvalid1 = {
                 Const.ParamsNames.COURSE_ID, "fake-course-id",
                 Const.ParamsNames.STUDENT_EMAIL, student1Email,
@@ -79,6 +79,7 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
         actionOutput = getJsonResult(getAction(paramsInvalid1));
         assertEquals(HttpStatus.SC_NOT_FOUND, actionOutput.getStatusCode());
 
+        ______TS("Failure case: invalid student email");
         String[] paramsInvalid2 = {
                 Const.ParamsNames.COURSE_ID, courseId,
                 Const.ParamsNames.STUDENT_EMAIL, "fake-student-email@gmail.com",
@@ -87,6 +88,23 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
         };
         actionOutput = getJsonResult(getAction(paramsInvalid2));
         assertEquals(HttpStatus.SC_NOT_FOUND, actionOutput.getStatusCode());
+
+        ______TS("Failure case: invalid start or end times");
+        String[] paramsInvalid3 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, "abc",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsInvalid3));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, actionOutput.getStatusCode());
+
+        String[] paramsInvalid4 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, " ",
+        };
+        actionOutput = getJsonResult(getAction(paramsInvalid4));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, actionOutput.getStatusCode());
 
         ______TS("Success case: should group by feedback session");
         String[] paramsSuccessful1 = {


### PR DESCRIPTION
Part of #10950 

- Added unit tests for `CreateFeedbackSessionLogAction` and `GetFeedbackSessionLogsAction`
- Added an extra check for creating a feedback session log, such that log type is either an access or a submission: this should be OK, because it doesn't involve db reads
- Added an extra check for getting feedback session logs, requiring instructor privilege to access it