### PR TITLE
[#11079] Migrate remaining usages of internal App Engine APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     annotationProcessor(objectify)
 
     implementation("com.google.appengine:appengine-api-1.0-sdk:${appengineVersion}")
+    implementation("com.google.auth:google-auth-library-oauth2-http:0.24.1")
     implementation("com.google.cloud:google-cloud-tasks:1.30.11")
     implementation("com.google.cloud:google-cloud-logging:2.1.2")
     implementation("com.google.cloud:google-cloud-storage:1.113.9")

--- a/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
@@ -2,7 +2,6 @@ package teammates.e2e.cases;
 
 import org.testng.annotations.Test;
 
-import com.google.apphosting.api.DeadlineExceededException;
 import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.EntityNotFoundException;
@@ -30,7 +29,6 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
     public void testAll() {
         testAssertionError();
         testNullPointerException();
-        testDeadlineExceededException();
         testDatastoreException();
         testUnauthorizedAccessException();
         testInvalidHttpParameterException();
@@ -62,20 +60,6 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
         BACKDOOR.executeGetRequest(url, null);
 
         print("NullPointerException triggered, verify that you have received error logs via email");
-
-    }
-
-    private void testDeadlineExceededException() {
-
-        ______TS("DeadlineExceededException testing");
-
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
-                .withParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName())
-                .toString();
-
-        BACKDOOR.executeGetRequest(url, null);
-
-        print("DeadlineExceededException triggered, verify that you have received error logs via email");
 
     }
 

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -125,16 +125,7 @@ public final class Config {
     }
 
     static String getBaseAppUrl() {
-        ApiProxy.Environment serverEnvironment = ApiProxy.getCurrentEnvironment();
-        if (serverEnvironment == null) {
-            return null;
-        }
-        String hostname = (String) serverEnvironment.getAttributes()
-                .get("com.google.appengine.runtime.default_version_hostname");
-        if (hostname == null) {
-            return null;
-        }
-        return (isDevServer() ? "http://" : "https://") + hostname;
+        return isDevServer() ? "http://localhost:8080" : "https://" + APP_ID + ".appspot.com";
     }
 
     /**

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import com.google.appengine.api.utils.SystemProperty;
 import com.google.apphosting.api.ApiProxy;
 
 import teammates.common.exception.TeammatesException;
@@ -132,7 +131,22 @@ public final class Config {
      * Returns true if the server is configured to be the dev server.
      */
     public static boolean isDevServer() {
-        return SystemProperty.environment.value() != SystemProperty.Environment.Value.Production;
+        // In production server, GAE sets some non-overrideable environment variables.
+        // We will make use of some of them to determine whether the server is dev server or not.
+        // This means that any developer can replicate this condition in dev server,
+        // but it is their own choice and risk should they choose to do so.
+
+        String appName = System.getenv("GAE_APPLICATION");
+        String version = System.getenv("GAE_VERSION");
+        String env = System.getenv("GAE_ENV");
+
+        if (appName == null || version == null || env == null) {
+            return true;
+        }
+
+        return !appName.endsWith(APP_ID)
+                || !APP_VERSION.equals(version.replace("-", "."))
+                || !"standard".equals(env);
     }
 
     /**

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import com.google.apphosting.api.ApiProxy;
-
 import teammates.common.exception.TeammatesException;
 
 /**
@@ -147,21 +145,6 @@ public final class Config {
         return !appName.endsWith(APP_ID)
                 || !APP_VERSION.equals(version.replace("-", "."))
                 || !"standard".equals(env);
-    }
-
-    /**
-     * Returns the GAE's internal request ID of a request. This is not related to HttpServletRequest.
-     *
-     * @see <a href="https://cloud.google.com/appengine/docs/standard/java/how-requests-are-handled">https://cloud.google.com/appengine/docs/standard/java/how-requests-are-handled</a>
-     */
-    public static String getRequestId() {
-        ApiProxy.Environment serverEnvironment = ApiProxy.getCurrentEnvironment();
-        if (serverEnvironment == null) {
-            // This will be the case in dev server
-            return "dummyrequestid";
-        }
-        return String.valueOf(ApiProxy.getCurrentEnvironment().getAttributes()
-                .get("com.google.appengine.runtime.request_log_id"));
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/ActionResult.java
+++ b/src/main/java/teammates/ui/webapi/ActionResult.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 abstract class ActionResult {
 
+    String requestId;
     private final int statusCode;
 
     ActionResult(int statusCode) {
@@ -22,6 +23,10 @@ abstract class ActionResult {
 
     int getStatusCode() {
         return statusCode;
+    }
+
+    void setRequestId(String requestId) {
+        this.requestId = requestId;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
@@ -1,6 +1,5 @@
 package teammates.ui.webapi;
 
-import com.google.apphosting.api.DeadlineExceededException;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.rpc.Code;
 
@@ -37,9 +36,6 @@ class AdminExceptionTestAction extends Action {
         }
         if (error.equals(NullPointerException.class.getSimpleName())) {
             throw new NullPointerException("NullPointerException testing");
-        }
-        if (error.equals(DeadlineExceededException.class.getSimpleName())) {
-            throw new DeadlineExceededException("DeadlineExceededException testing");
         }
         if (error.equals(DatastoreException.class.getSimpleName())) {
             throw new DatastoreException(Code.DEADLINE_EXCEEDED_VALUE, "DatastoreException testing",

--- a/src/main/java/teammates/ui/webapi/JsonResult.java
+++ b/src/main/java/teammates/ui/webapi/JsonResult.java
@@ -52,7 +52,7 @@ class JsonResult extends ActionResult {
 
     @Override
     void send(HttpServletResponse resp) throws IOException {
-        output.setRequestId(Config.getRequestId());
+        output.setRequestId(requestId);
         for (Cookie cookie : cookies) {
             cookie.setSecure(!Config.isDevServer());
             resp.addCookie(cookie);

--- a/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
+++ b/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
@@ -168,7 +168,7 @@ public class OriginCheckFilter implements Filter {
         log.info("Request failed origin check: [" + request.getMethod() + "] " + request.getRequestURL().toString()
                 + ", Params: " + HttpRequestHelper.getRequestParametersAsString(request)
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(request)
-                + ", Request ID: " + Config.getRequestId());
+                + ", Request ID: " + request.getHeader("X-Cloud-Trace-Context"));
 
         JsonResult result = new JsonResult(message, HttpStatus.SC_FORBIDDEN);
         result.send(response);

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -9,7 +9,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 
-import com.google.apphosting.api.DeadlineExceededException;
 import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.ActionMappingException;
@@ -86,6 +85,7 @@ public class WebApiServlet extends HttpServlet {
             return;
         }
 
+        // TODO need to handle the server timeout error
         try {
             Action action = new ActionFactory().getAction(req, req.getMethod());
             action.init(req);
@@ -107,15 +107,6 @@ public class WebApiServlet extends HttpServlet {
             log.warning(enfe.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(enfe));
             throwError(resp, HttpStatus.SC_NOT_FOUND, enfe.getMessage());
-        } catch (DeadlineExceededException e) {
-
-            // This exception may not be caught because GAE kills the request soon after throwing it
-            // In that case, the error message in the log will be emailed to the admin by a separate cron job
-
-            log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: "
-                    + TeammatesException.toStringWithStackTrace(e));
-            throwError(resp, HttpStatus.SC_GATEWAY_TIMEOUT,
-                    "The request exceeded the server timeout limit. Please try again later.");
         } catch (DatastoreException e) {
             log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(e));

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -78,7 +78,7 @@ public class WebApiServlet extends HttpServlet {
         log.info("Request received: [" + req.getMethod() + "] " + req.getRequestURL().toString()
                 + ", Params: " + requestParametersAsString
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(req)
-                + ", Request ID: " + Config.getRequestId());
+                + ", Request ID: " + req.getHeader("X-Cloud-Trace-Context"));
 
         if (Config.MAINTENANCE) {
             throwError(resp, HttpStatus.SC_SERVICE_UNAVAILABLE,
@@ -92,6 +92,7 @@ public class WebApiServlet extends HttpServlet {
             action.checkAccessControl();
 
             ActionResult result = action.execute();
+            result.setRequestId(req.getHeader("X-Cloud-Trace-Context"));
             result.send(resp);
         } catch (ActionMappingException e) {
             throwErrorBasedOnRequester(req, resp, e, e.getStatusCode());

--- a/src/test/java/teammates/ui/webapi/WebApiServletTest.java
+++ b/src/test/java/teammates/ui/webapi/WebApiServletTest.java
@@ -10,7 +10,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.testng.annotations.Test;
 
-import com.google.apphosting.api.DeadlineExceededException;
 import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.EntityNotFoundException;
@@ -80,14 +79,6 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
 
         SERVLET.doGet(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-
-        ______TS("Failure case: DeadlineExceededException");
-
-        setupMocks(HttpGet.METHOD_NAME, Const.ResourceURIs.EXCEPTION);
-        mockRequest.addParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName());
-
-        SERVLET.doGet(mockRequest, mockResponse);
-        assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
 
         ______TS("Failure case: DatastoreException");
 
@@ -168,14 +159,6 @@ public class WebApiServletTest extends BaseTestCaseWithObjectifyAccess {
 
         SERVLET.doGet(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_ACCEPTED, mockResponse.getStatus());
-
-        ______TS("Failure case: DeadlineExceededException");
-
-        setupMocksFromGaeQueue(HttpGet.METHOD_NAME, Const.ResourceURIs.EXCEPTION);
-        mockRequest.addParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName());
-
-        SERVLET.doGet(mockRequest, mockResponse);
-        assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, mockResponse.getStatus());
 
         ______TS("Failure case: DatastoreTimeoutException");
 


### PR DESCRIPTION
Fixes #11079 

After this PR it can be confirmed that there are no more references to `com.google.appengine.api.*` and `com.google.apphosting.api.*`, other than `com.google.appengine.api.users.*` (will be resolved in #11073) and `com.google.appengine.api.search.*` (will be resolved in #11064).