### PR TITLE
[#11096] Navigate to today date on click

### DIFF
--- a/src/web/app/components/datepicker/datepicker.component.html
+++ b/src/web/app/components/datepicker/datepicker.component.html
@@ -1,7 +1,7 @@
 <div class="input-group">
   <ng-template #footer>
     <button class="footer-button" type="button"
-            (click)="changeDate(calendar.getToday())">
+            (click)="selectTodayDate(timeDp)">
       Today
     </button>
   </ng-template>

--- a/src/web/app/components/datepicker/datepicker.component.ts
+++ b/src/web/app/components/datepicker/datepicker.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { NgbCalendar } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCalendar, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap';
 import { DateFormat } from '../session-edit-form/session-edit-form-model';
 
 /**
@@ -35,4 +35,10 @@ export class DatepickerComponent implements OnInit {
   changeDate(date: DateFormat): void {
     this.dateChangeCallback.emit(date);
   }
+
+  selectTodayDate(dp: NgbInputDatepicker): void {
+    this.dateChangeCallback.emit(this.calendar.getToday());
+    dp.navigateTo(this.calendar.getToday());
+  }
+
 }


### PR DESCRIPTION
Fixes #11096

Create a separate function to set today date which takes in a `NgInputDatepicker` and use the `navigateTo` method to navigate to today date