### PR TITLE
[#11103] Audit logs: right-align timestamps

### DIFF
--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
     <tr *ngFor="let row of tableRows;">
-      <td *ngFor="let item of row">
+      <td *ngFor="let item of row" [style.text-align]="getAlignment(item)">
         <ndc-dynamic *ngIf="item.customComponent"
                      [ngComponentOutlet]="item.customComponent.component"
                      [ndcDynamicInputs]="item.customComponent.componentData"

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
     <tr *ngFor="let row of tableRows;">
-      <td *ngFor="let item of row" [style.text-align]="getAlignment(item)">
+      <td *ngFor="let item of row" [style.font-family]="getFont(item)">
         <ndc-dynamic *ngIf="item.customComponent"
                      [ngComponentOutlet]="item.customComponent.component"
                      [ndcDynamicInputs]="item.customComponent.componentData"

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -21,7 +21,7 @@ export interface ColumnData {
 export interface SortableTableCellData {
   value?: any; // Optional value used for sorting with sortBy provided in ColumnData
   displayValue?: string; // Raw string to be display in the cell
-  alignment?: string;
+  font?: String;
   customComponent?: {
     component: Type<any>;
     componentData: Record<string, any>; // @Input values for component
@@ -113,11 +113,11 @@ export class SortableTableComponent implements OnInit {
     this.sortRows();
   }
 
-  getAlignment(cellData: SortableTableCellData): String {
-    if (cellData.alignment === undefined) {
-      return 'left';
+  getFont(cellData: SortableTableCellData): String {
+    if (cellData.font === undefined) {
+      return '';
     }
 
-    return cellData.alignment;
+    return cellData.font;
   }
 }

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -21,6 +21,7 @@ export interface ColumnData {
 export interface SortableTableCellData {
   value?: any; // Optional value used for sorting with sortBy provided in ColumnData
   displayValue?: string; // Raw string to be display in the cell
+  alignment?: string;
   customComponent?: {
     component: Type<any>;
     componentData: Record<string, any>; // @Input values for component
@@ -110,5 +111,13 @@ export class SortableTableComponent implements OnInit {
 
     this.columnToSortBy = this.columns[indexOfColumnToSort].header;
     this.sortRows();
+  }
+
+  getAlignment(cellData: SortableTableCellData): String {
+    if (cellData.alignment === undefined) {
+      return 'left';
+    }
+
+    return 'right';
   }
 }

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -118,6 +118,6 @@ export class SortableTableComponent implements OnInit {
       return 'left';
     }
 
-    return 'right';
+    return cellData.alignment;
   }
 }

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -21,7 +21,7 @@ export interface ColumnData {
 export interface SortableTableCellData {
   value?: any; // Optional value used for sorting with sortBy provided in ColumnData
   displayValue?: string; // Raw string to be display in the cell
-  font?: String;
+  font?: string;
   customComponent?: {
     component: Type<any>;
     componentData: Record<string, any>; // @Input values for component
@@ -113,7 +113,7 @@ export class SortableTableComponent implements OnInit {
     this.sortRows();
   }
 
-  getFont(cellData: SortableTableCellData): String {
+  getFont(cellData: SortableTableCellData): string {
     if (cellData.font === undefined) {
       return '';
     }

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/__snapshots__/instructor-audit-logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/__snapshots__/instructor-audit-logs-page.component.spec.ts.snap
@@ -1171,42 +1171,54 @@ exports[`InstructorAuditLogsPageComponent should snap with results of a search 1
                   
                   <tr>
                     
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       
                       
                       15 January 2021
                     </td>
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       
                       
                       Doe John
                     </td>
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       
                       
                       Viewed the submission page
                     </td>
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       
                       
                       doejohn@email.com
                     </td>
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       
                       
                       section 1
                     </td>
-                    <td>
+                    <td
+                      style="text-align: left;"
+                    >
                       
                       
                       

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/__snapshots__/instructor-audit-logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/__snapshots__/instructor-audit-logs-page.component.spec.ts.snap
@@ -1171,54 +1171,42 @@ exports[`InstructorAuditLogsPageComponent should snap with results of a search 1
                   
                   <tr>
                     
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       
                       
                       15 January 2021
                     </td>
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       
                       
                       Doe John
                     </td>
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       
                       
                       Viewed the submission page
                     </td>
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       
                       
                       doejohn@email.com
                     </td>
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       
                       
                       section 1
                     </td>
-                    <td
-                      style="text-align: left;"
-                    >
+                    <td>
                       
                       
                       

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -178,7 +178,8 @@ export class InstructorAuditLogsPageComponent implements OnInit {
       ],
       logRowsData: log.feedbackSessionLogEntries.map((entry: FeedbackSessionLogEntry) => {
         return [
-          { value: this.timezoneService.formatToString(entry.timestamp, log.feedbackSessionData.timeZone, 'ddd, DD MMM, YYYY hh:mm:ss A') },
+          { value: this.timezoneService.formatToString(entry.timestamp, log.feedbackSessionData.timeZone, 'ddd, DD MMM, YYYY hh:mm:ss A'),
+            alignment: 'right' },
           { value: entry.studentData.name },
           { value: LogType[entry.feedbackSessionLogType.toString() as keyof typeof LogType]
             === LogType.FEEDBACK_SESSION_ACCESS ? 'Viewed the submission page' : 'Submitted responses' },

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -179,7 +179,7 @@ export class InstructorAuditLogsPageComponent implements OnInit {
       logRowsData: log.feedbackSessionLogEntries.map((entry: FeedbackSessionLogEntry) => {
         return [
           { value: this.timezoneService.formatToString(entry.timestamp, log.feedbackSessionData.timeZone, 'ddd, DD MMM, YYYY hh:mm:ss A'),
-            alignment: 'right' },
+            font: 'monospace' },
           { value: entry.studentData.name },
           { value: LogType[entry.feedbackSessionLogType.toString() as keyof typeof LogType]
             === LogType.FEEDBACK_SESSION_ACCESS ? 'Viewed the submission page' : 'Submitted responses' },


### PR DESCRIPTION
Fixes #11103

Before
<img width="509" alt="logs_cut" src="https://user-images.githubusercontent.com/58677983/118465162-3298f700-b734-11eb-8995-c611d7f2731d.png">

After
<img width="484" alt="updated logs" src="https://user-images.githubusercontent.com/58677983/118465219-42b0d680-b734-11eb-9467-f4f3e90fc6c3.png">

