### PR TITLE
[#2673] Student: view responses: show response statistics of 'constant sum' questions

### DIFF
--- a/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
+++ b/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
@@ -65,6 +65,9 @@ export class SingleStatisticsComponent implements OnInit, OnChanges {
   }
 
   private isUsingResponsesToSelf(): boolean {
-    return this.isStudent && this.question.questionType === FeedbackQuestionType.NUMSCALE;
+    return this.isStudent 
+      && (this.question.questionType === FeedbackQuestionType.NUMSCALE
+      || this.question.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS
+      || this.question.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS);
   }
 }

--- a/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
+++ b/src/web/app/components/question-responses/single-statistics/single-statistics.component.ts
@@ -65,7 +65,7 @@ export class SingleStatisticsComponent implements OnInit, OnChanges {
   }
 
   private isUsingResponsesToSelf(): boolean {
-    return this.isStudent 
+    return this.isStudent
       && (this.question.questionType === FeedbackQuestionType.NUMSCALE
       || this.question.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS
       || this.question.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS);

--- a/src/web/app/components/question-types/question-statistics/constsum-options-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/constsum-options-question-statistics.component.html
@@ -1,9 +1,8 @@
-<div *ngIf="responses.length && !isStudent">
+<div *ngIf="responses.length">
   <div class="row">
     <div class="col-sm-4 text-color-gray mt-2">
-      <strong>
-        Response Summary
-      </strong>
+      <strong *ngIf="isStudent">Summary of responses received by you</strong>
+      <strong *ngIf="!isStudent">Response Summary</strong>
     </div>
   </div>
   <div class="row">

--- a/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/constsum-recipients-question-statistics.component.html
@@ -1,9 +1,8 @@
-<div *ngIf="responses.length && !isStudent">
+<div *ngIf="responses.length">
   <div class="row">
     <div class="col-sm-4 text-color-gray mt-2">
-      <strong>
-        Response Summary
-      </strong>
+      <strong *ngIf="isStudent">Summary of responses received by you</strong>
+      <strong *ngIf="!isStudent">Response Summary</strong>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
Fixes #2673

**Outline of Solution**
Display statistics to students for constant sum recipient questions and constant sum options questions.
The responses will be filtered in `SingleStatisticsComponent.ts` and will only show statistics of responses from others to self.
No statistics are displayed if responses are not visible to students

Constant sum options question before
![image](https://user-images.githubusercontent.com/58677983/119069591-fc4fc600-ba18-11eb-9665-f9e708cf3cd2.png)
Constant sum options question after
<img width="808" alt="constsum options" src="https://user-images.githubusercontent.com/58677983/118769465-c7296380-b8b2-11eb-8573-790d8c619673.png">

Constant sum recipients question before
![image](https://user-images.githubusercontent.com/58677983/119069636-11c4f000-ba19-11eb-8373-d7b2e00e8c30.png)
Constant sum recipients question after
<img width="806" alt="constsum recipients" src="https://user-images.githubusercontent.com/58677983/118769478-c8f32700-b8b2-11eb-9037-978bd73fe284.png">

