### PR TITLE
[#10481] Remove video tour on home page

### DIFF
--- a/src/web/app/pages-static/index-page/index-page.component.html
+++ b/src/web/app/pages-static/index-page/index-page.component.html
@@ -9,7 +9,7 @@
     <span class="color-orange">{{ submissionsNumber }}</span> feedback entries submitted so far ...
   </p>
   <div class="row">
-    <div class="margin-bottom-10px center col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3">
+    <div class="margin-bottom-10px button-center col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3">
       <a class="btn btn-success btn-block" tmRouterLink="/web/front/request">Request a Free Instructor Account</a>
     </div>
   </div>

--- a/src/web/app/pages-static/index-page/index-page.component.html
+++ b/src/web/app/pages-static/index-page/index-page.component.html
@@ -9,12 +9,7 @@
     <span class="color-orange">{{ submissionsNumber }}</span> feedback entries submitted so far ...
   </p>
   <div class="row">
-    <div class="margin-bottom-10px col-xs-10 col-sm-5 offset-xs-1 col-md-4 offset-md-2 col-lg-3 offset-lg-3">
-      <a class="btn btn-secondary btn-block" href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1" target="_blank" rel="noopener noreferrer">
-        <i class="fas fa-film"></i> Video Tour
-      </a>
-    </div>
-    <div class="margin-bottom-10px col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3">
+    <div class="margin-bottom-10px center col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3">
       <a class="btn btn-success btn-block" tmRouterLink="/web/front/request">Request a Free Instructor Account</a>
     </div>
   </div>

--- a/src/web/app/pages-static/index-page/index-page.component.scss
+++ b/src/web/app/pages-static/index-page/index-page.component.scss
@@ -5,3 +5,8 @@ img {
 .margin-bottom-10px {
   margin-bottom: 10px;
 }
+
+.center {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/web/app/pages-static/index-page/index-page.component.scss
+++ b/src/web/app/pages-static/index-page/index-page.component.scss
@@ -6,7 +6,7 @@ img {
   margin-bottom: 10px;
 }
 
-.center {
+.button-center {
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Fixes #10481

**Outline of Solution**
Remove `div` tag for video tour. Make the remaining button center.

Before:
![image](https://user-images.githubusercontent.com/53338059/119293903-f01c7080-bc85-11eb-8299-411d37d0682c.png)

After:
![image](https://user-images.githubusercontent.com/53338059/119293951-00cce680-bc86-11eb-82d6-019fd19b4ff9.png)
