### PR TITLE
[#11126] Expand empty search results for feedback session logs

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
@@ -59,7 +59,9 @@ public class InstructorAuditLogsPage extends AppPage {
                 .findElements(By.className("card"))
                 .forEach(card -> {
                     String sessionName = card.getText().trim();
-                    click(card.findElement(By.className("fa-chevron-down")));
+                    WebElement panelExpandButton = card.findElement(By.className("fa-chevron-down"));
+                    if (panelExpandButton == null) return;
+                    click(panelExpandButton);
                     isLogPresentForSession.put(sessionName, !card.findElements(By.className("card-body")).isEmpty());
                 });
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
@@ -58,11 +58,10 @@ public class InstructorAuditLogsPage extends AppPage {
         logsOutput
                 .findElements(By.className("card"))
                 .forEach(card -> {
-                    if (card.findElements(By.className("fa-chevron-down")).isEmpty()) {
-                        return;
+                    if (!card.findElements(By.className("fa-chevron-down")).isEmpty()) {
+                        click(card.findElement(By.className("fa-chevron-down")));
                     }
                     String sessionName = card.getText().trim();
-                    click(card.findElement(By.className("fa-chevron-down")));
                     isLogPresentForSession.put(sessionName, !card.findElements(By.className("card-body")).isEmpty());
                 });
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
@@ -58,10 +58,11 @@ public class InstructorAuditLogsPage extends AppPage {
         logsOutput
                 .findElements(By.className("card"))
                 .forEach(card -> {
+                    if (card.findElements(By.className("fa-chevron-down")).isEmpty()) {
+                        return;
+                    }
                     String sessionName = card.getText().trim();
-                    WebElement panelExpandButton = card.findElement(By.className("fa-chevron-down"));
-                    if (panelExpandButton == null) return;
-                    click(panelExpandButton);
+                    click(card.findElement(By.className("fa-chevron-down")));
                     isLogPresentForSession.put(sessionName, !card.findElements(By.className("card-body")).isEmpty());
                 });
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorAuditLogsPage.java
@@ -61,7 +61,7 @@ public class InstructorAuditLogsPage extends AppPage {
                     if (!card.findElements(By.className("fa-chevron-down")).isEmpty()) {
                         click(card.findElement(By.className("fa-chevron-down")));
                     }
-                    String sessionName = card.getText().trim();
+                    String sessionName = card.findElement(By.className("card-header")).getText().trim();
                     isLogPresentForSession.put(sessionName, !card.findElements(By.className("card-body")).isEmpty());
                 });
     }

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -166,7 +166,7 @@ export class InstructorAuditLogsPageComponent implements OnInit {
 
   private toFeedbackSessionLogModel(log: FeedbackSessionLog): FeedbackSessionLogModel {
     return {
-      isTabExpanded: false,
+      isTabExpanded: log.feedbackSessionLogEntries.length === 0,
       feedbackSessionName: log.feedbackSessionData.feedbackSessionName,
       logColumnsData: [
         { header: 'Time', sortBy: SortBy.LOG_DATE },


### PR DESCRIPTION
Fixes #11126 

**Outline of Solution**
* Modified that tap expand status depends on whether feedback session log entry is empty or not

before
![before](https://user-images.githubusercontent.com/17792043/119475117-cf3c4400-bd87-11eb-8b61-23197bfc5edb.gif)

after
![after](https://user-images.githubusercontent.com/17792043/119475079-c481af00-bd87-11eb-9410-aa40996afb9b.gif)
