### PR TITLE
[#11144] Update session link recovery search duration

### DIFF
--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -61,6 +61,8 @@ public class EmailGenerator {
 
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 
+    private static final Duration SESSION_LINK_RECOVERY_DURATION = Duration.ofDays(90);
+
     /**
      * Generates the feedback session opening emails for the given {@code session}.
      */
@@ -269,7 +271,7 @@ public class EmailGenerator {
         String subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         Instant endTime = Instant.now();
-        Instant startTime = endTime.minus(Duration.ofDays(180));
+        Instant startTime = endTime.minus(SESSION_LINK_RECOVERY_DURATION);
         Map<String, StringBuilder> linkFragmentsMap = new HashMap<>();
         String studentName = null;
 

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
@@ -4,7 +4,7 @@
   </h1>
 
   <p>
-    If you cannot find your feedback session links, enter your course registered email below. Links to all your feedback sessions over the past 6 months will be sent to the email address.
+    If you cannot find your feedback session links, enter your course registered email below. Links to all your feedback sessions over the past 90 days will be sent to the email address.
   </p>
 
   <div class="card bg-light top-padded col-sm-9 col-md-6">


### PR DESCRIPTION
Fixes #11144 

**Outline of Solution**

Move the magic number to named constant.
Change UI display of recovery duration.