### PR TITLE
[#11120] [#11121] Implement HTTP request interceptor and structured logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ task copyDistToExplodedWar {
 task serverRun(type: JavaExec) {
     classpath "${explodeWar.destinationDir}/WEB-INF/lib/*", "${explodeWar.destinationDir}/WEB-INF/classes/."
     main = "teammates.main.Application"
-    jvmArgs "-ea"
+    jvmArgs "-ea", "-Djava.util.logging.config.file=${explodeWar.destinationDir}/WEB-INF/logging-dev.properties"
     dependsOn explodeWar, copyDistToExplodedWar
 }
 

--- a/src/main/appengine/app.template.yaml
+++ b/src/main/appengine/app.template.yaml
@@ -4,7 +4,7 @@
 runtime: java11
 
 # Command to run the application as how it would be done in command line.
-entrypoint: 'java -ea -cp "WEB-INF/lib/*:WEB-INF/classes/." teammates.main.Application'
+entrypoint: 'java -ea -Djava.util.logging.config.file=WEB-INF/logging.properties -cp "WEB-INF/lib/*:WEB-INF/classes/." teammates.main.Application'
 
 # GAE instance class that determines compute resources available to the application.
 instance_class: F1

--- a/src/main/java/teammates/common/util/Logger.java
+++ b/src/main/java/teammates/common/util/Logger.java
@@ -1,15 +1,25 @@
 package teammates.common.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Allows any component of the application to log messages at appropriate levels.
  */
+@SuppressWarnings("PMD.MoreThanOneLogger") // class is designed as a facade for two different loggers
 public final class Logger {
 
-    private java.util.logging.Logger log;
+    private final java.util.logging.Logger standardLog;
+    private final java.util.logging.Logger errorLog;
 
     private Logger() {
-        StackTraceElement logRequester = Thread.currentThread().getStackTrace()[2];
-        this.log = java.util.logging.Logger.getLogger(logRequester.getClassName());
+        StackTraceElement logRequester = getLoggerSource();
+        String loggerName = logRequester == null ? "null" : logRequester.getClassName();
+        this.standardLog = java.util.logging.Logger.getLogger(loggerName + "-out");
+        this.standardLog.setUseParentHandlers(false);
+        this.standardLog.addHandler(new StdOutConsoleHandler());
+
+        this.errorLog = java.util.logging.Logger.getLogger(loggerName + "-err");
     }
 
     public static Logger getLogger() {
@@ -18,38 +28,98 @@ public final class Logger {
 
     /**
      * Logs a message at FINE level.
-     *
-     * @see java.util.logging.Logger#fine(String)
      */
-    public void fine(String msg) {
-        log.fine(msg);
+    public void fine(String message) {
+        standardLog.fine(formatLogMessage(message, "DEBUG"));
     }
 
     /**
      * Logs a message at INFO level.
-     *
-     * @see java.util.logging.Logger#info(String)
      */
-    public void info(String msg) {
-        log.info(msg);
+    public void info(String message) {
+        standardLog.info(formatLogMessage(message, "INFO"));
     }
 
     /**
      * Logs a message at WARNING level.
-     *
-     * @see java.util.logging.Logger#warning(String)
      */
-    public void warning(String msg) {
-        log.warning(msg);
+    public void warning(String message) {
+        standardLog.warning(formatLogMessage(message, "WARNING"));
     }
 
     /**
      * Logs a message at SEVERE level.
-     *
-     * @see java.util.logging.Logger#severe(String)
      */
-    public void severe(String msg) {
-        log.severe(msg);
+    public void severe(String message) {
+        errorLog.severe(formatLogMessage(message, "ERROR"));
+    }
+
+    private String formatLogMessage(String message, String severity) {
+        if (Config.isDevServer()) {
+            return formatLogMessageForHumanDisplay(message);
+        }
+        return formatLogMessageForCloudLogging(message, severity);
+    }
+
+    private String formatLogMessageForHumanDisplay(String message) {
+        StringBuilder prefix = new StringBuilder();
+
+        StackTraceElement source = getLoggerSource();
+        if (source != null) {
+            prefix.append(source.getClassName()).append(':')
+                    .append(source.getMethodName()).append(':')
+                    .append(source.getLineNumber()).append(':');
+        }
+        prefix.append(' ');
+
+        if (RequestTracer.getRequestId() == null) {
+            return prefix.toString() + message;
+        }
+        return prefix.toString() + "[" + RequestTracer.getRequestId() + "] " + message;
+    }
+
+    private String formatLogMessageForCloudLogging(String message, String severity) {
+        return JsonUtils.toCompactJson(getBaseCloudLoggingPayload(message, severity));
+    }
+
+    private Map<String, Object> getBaseCloudLoggingPayload(String message, String severity) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("message", message);
+        payload.put("severity", severity);
+
+        StackTraceElement source = getLoggerSource();
+        if (source != null) {
+            Map<String, Object> sourceLocation = new HashMap<>();
+            sourceLocation.put("file", source.getClassName());
+            sourceLocation.put("line", source.getLineNumber());
+            sourceLocation.put("function", source.getMethodName());
+
+            payload.put("logging.googleapis.com/sourceLocation", sourceLocation);
+        }
+
+        if (RequestTracer.getRequestId() != null) {
+            String[] traceAndSpan = RequestTracer.getRequestId().split("/", 2);
+            payload.put("logging.googleapis.com/trace", "projects/" + Config.APP_ID + "/traces/" + traceAndSpan[0]);
+            if (traceAndSpan.length == 2) {
+                payload.put("logging.googleapis.com/spanId", traceAndSpan[1].split(";")[0]);
+            }
+        }
+
+        return payload;
+    }
+
+    private StackTraceElement getLoggerSource() {
+        StackTraceElement[] stes = Thread.currentThread().getStackTrace();
+        for (int i = 0; i < stes.length; i++) {
+            StackTraceElement ste = stes[i];
+            if (ste.getClassName().equals(Logger.class.getName()) && i + 1 < stes.length) {
+                StackTraceElement nextSte = stes[i + 1];
+                if (!nextSte.getClassName().equals(Logger.class.getName())) {
+                    return nextSte;
+                }
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/teammates/common/util/RequestTracer.java
+++ b/src/main/java/teammates/common/util/RequestTracer.java
@@ -1,5 +1,8 @@
 package teammates.common.util;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import org.apache.commons.lang3.RandomStringUtils;
 
 /**
@@ -25,21 +28,47 @@ public final class RequestTracer {
     }
 
     /**
-     * Initializes the request with an ID.
+     * Returns the remaining time (in millis) until the current request times out.
      */
-    public static void init(String requestIdParam) {
+    public static long getRemainingTimeMillis() {
+        RequestTrace trace = THREAD_LOCAL.get();
+        if (trace == null) {
+            return -1L;
+        }
+        return trace.timeoutTimestamp - Instant.now().toEpochMilli();
+    }
+
+    /**
+     * Returns the remaining time (in millis) until the current request times out.
+     */
+    public static long getTimeElapsedMillis() {
+        RequestTrace trace = THREAD_LOCAL.get();
+        if (trace == null) {
+            return -1L;
+        }
+        return Instant.now().toEpochMilli() - trace.initTimestamp;
+    }
+
+    /**
+     * Initializes the request with an ID and the timeout value (in seconds).
+     */
+    public static void init(String requestIdParam, int timeoutInSeconds) {
         String requestId = requestIdParam;
         if (requestId == null) {
             requestId = RandomStringUtils.randomAlphanumeric(32);
         }
-        THREAD_LOCAL.set(new RequestTrace(requestId));
+        THREAD_LOCAL.set(new RequestTrace(requestId, timeoutInSeconds));
     }
 
     private static class RequestTrace {
         private final String requestId;
+        private final long initTimestamp;
+        private final long timeoutTimestamp;
 
-        private RequestTrace(String requestId) {
+        private RequestTrace(String requestId, int timeoutInSeconds) {
             this.requestId = requestId;
+            this.initTimestamp = Instant.now().toEpochMilli();
+            this.timeoutTimestamp = Instant.now().plus(timeoutInSeconds, ChronoUnit.SECONDS).toEpochMilli();
         }
     }
 

--- a/src/main/java/teammates/common/util/RequestTracer.java
+++ b/src/main/java/teammates/common/util/RequestTracer.java
@@ -1,0 +1,46 @@
+package teammates.common.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+/**
+ * Stores the information of the current HTTP request.
+ */
+public final class RequestTracer {
+
+    private static final ThreadLocal<RequestTrace> THREAD_LOCAL = new ThreadLocal<>();
+
+    private RequestTracer() {
+        // utility class
+    }
+
+    /**
+     * Returns the ID of the current request.
+     */
+    public static String getRequestId() {
+        RequestTrace trace = THREAD_LOCAL.get();
+        if (trace == null) {
+            return null;
+        }
+        return trace.requestId;
+    }
+
+    /**
+     * Initializes the request with an ID.
+     */
+    public static void init(String requestIdParam) {
+        String requestId = requestIdParam;
+        if (requestId == null) {
+            requestId = RandomStringUtils.randomAlphanumeric(32);
+        }
+        THREAD_LOCAL.set(new RequestTrace(requestId));
+    }
+
+    private static class RequestTrace {
+        private final String requestId;
+
+        private RequestTrace(String requestId) {
+            this.requestId = requestId;
+        }
+    }
+
+}

--- a/src/main/java/teammates/common/util/StdOutConsoleHandler.java
+++ b/src/main/java/teammates/common/util/StdOutConsoleHandler.java
@@ -1,0 +1,16 @@
+package teammates.common.util;
+
+import java.io.OutputStream;
+import java.util.logging.ConsoleHandler;
+
+/**
+ * {@link ConsoleHandler} implementation that uses {@link System#out} instead of {@link System#err}.
+ */
+public class StdOutConsoleHandler extends ConsoleHandler {
+
+    @Override
+    protected void setOutputStream(OutputStream out) {
+        super.setOutputStream(System.out);
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/ActionResult.java
+++ b/src/main/java/teammates/ui/webapi/ActionResult.java
@@ -9,7 +9,6 @@ import javax.servlet.http.HttpServletResponse;
  */
 abstract class ActionResult {
 
-    String requestId;
     private final int statusCode;
 
     ActionResult(int statusCode) {
@@ -23,10 +22,6 @@ abstract class ActionResult {
 
     int getStatusCode() {
         return statusCode;
-    }
-
-    void setRequestId(String requestId) {
-        this.requestId = requestId;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/JsonResult.java
+++ b/src/main/java/teammates/ui/webapi/JsonResult.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpStatus;
 
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.RequestTracer;
 import teammates.ui.output.ApiOutput;
 import teammates.ui.output.MessageOutput;
 
@@ -52,7 +53,7 @@ class JsonResult extends ActionResult {
 
     @Override
     void send(HttpServletResponse resp) throws IOException {
-        output.setRequestId(requestId);
+        output.setRequestId(RequestTracer.getRequestId());
         for (Cookie cookie : cookies) {
             cookie.setSecure(!Config.isDevServer());
             resp.addCookie(cookie);

--- a/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
+++ b/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
@@ -24,6 +24,7 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Url;
 
@@ -168,7 +169,7 @@ public class OriginCheckFilter implements Filter {
         log.info("Request failed origin check: [" + request.getMethod() + "] " + request.getRequestURL().toString()
                 + ", Params: " + HttpRequestHelper.getRequestParametersAsString(request)
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(request)
-                + ", Request ID: " + request.getHeader("X-Cloud-Trace-Context"));
+                + ", Request ID: " + RequestTracer.getRequestId());
 
         JsonResult result = new JsonResult(message, HttpStatus.SC_FORBIDDEN);
         result.send(response);

--- a/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
+++ b/src/main/java/teammates/ui/webapi/OriginCheckFilter.java
@@ -72,6 +72,16 @@ public class OriginCheckFilter implements Filter {
             return;
         }
 
+        // The header X-AppEngine-QueueName cannot be spoofed as GAE will strip any user-sent X-AppEngine-QueueName headers.
+        // Reference: https://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-handlers#reading_request_headers
+        boolean isRequestFromAppEngineQueue = request.getHeader("X-AppEngine-QueueName") != null;
+
+        if (isRequestFromAppEngineQueue) {
+            // Requests from App Engine are allowed to bypass CSRF check
+            chain.doFilter(req, res);
+            return;
+        }
+
         String referrer = request.getHeader("referer");
         if (referrer == null) {
             // Requests with missing referrer information are given the benefit of the doubt

--- a/src/main/java/teammates/ui/webapi/RequestTraceFilter.java
+++ b/src/main/java/teammates/ui/webapi/RequestTraceFilter.java
@@ -1,15 +1,25 @@
 package teammates.ui.webapi;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
+
+import teammates.common.exception.TeammatesException;
+import teammates.common.util.Logger;
 import teammates.common.util.RequestTracer;
 
 /**
@@ -17,23 +27,62 @@ import teammates.common.util.RequestTracer;
  */
 public class RequestTraceFilter implements Filter {
 
+    private static final Logger log = Logger.getLogger();
+
     @Override
     public void init(FilterConfig filterConfig) {
         // nothing to do
     }
 
     @Override
-    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException {
         HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
 
-        RequestTracer.init(request.getHeader("X-Cloud-Trace-Context"));
+        // The header X-AppEngine-QueueName cannot be spoofed as GAE will strip any user-sent X-AppEngine-QueueName headers.
+        // Reference: https://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-handlers#reading_request_headers
+        boolean isRequestFromAppEngineQueue = request.getHeader("X-AppEngine-QueueName") != null;
 
-        chain.doFilter(req, resp);
+        // GAE will terminate an instance if any request exceeds 10 minutes.
+        // For GAE-invoked requests, we set the limit here minus a small grace period of 5 seconds
+        // to ensure that the 10 minutes limit will not be exceeded.
+        // For user-invoked requests, we keep the time limit at 1 minute (as how it was
+        // in the previous GAE runtime environment) in order to not let user wait for excessively long,
+        // as well as a reminder for us to keep optimizing our API response time.
+        int timeoutInSeconds = isRequestFromAppEngineQueue ? 10 * 60 - 5 : 60;
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        Future<Void> f = es.submit(() -> {
+            RequestTracer.init(request.getHeader("X-Cloud-Trace-Context"), timeoutInSeconds);
+            chain.doFilter(req, resp);
+            return null;
+        });
+
+        try {
+            f.get(timeoutInSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException e) {
+            log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: "
+                    + TeammatesException.toStringWithStackTrace(e));
+            throwError(response, HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (TimeoutException e) {
+            log.severe("TimeoutException caught by WebApiServlet: "
+                    + TeammatesException.toStringWithStackTrace(e));
+            throwError(response, HttpStatus.SC_GATEWAY_TIMEOUT,
+                    "The request exceeded the server timeout limit. Please try again later.");
+        } finally {
+            f.cancel(true);
+            es.shutdown();
+        }
     }
 
     @Override
     public void destroy() {
         // nothing to do
+    }
+
+    private void throwError(HttpServletResponse resp, int statusCode, String message) throws IOException {
+        JsonResult result = new JsonResult(message, statusCode);
+        result.send(resp);
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/RequestTraceFilter.java
+++ b/src/main/java/teammates/ui/webapi/RequestTraceFilter.java
@@ -1,0 +1,39 @@
+package teammates.ui.webapi;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import teammates.common.util.RequestTracer;
+
+/**
+ * Extracts trace ID of HTTP requests.
+ */
+public class RequestTraceFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // nothing to do
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+
+        RequestTracer.init(request.getHeader("X-Cloud-Trace-Context"));
+
+        chain.doFilter(req, resp);
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to do
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -20,6 +20,7 @@ import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Config;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 import teammates.common.util.TimeHelper;
 
 /**
@@ -77,7 +78,7 @@ public class WebApiServlet extends HttpServlet {
         log.info("Request received: [" + req.getMethod() + "] " + req.getRequestURL().toString()
                 + ", Params: " + requestParametersAsString
                 + ", Headers: " + HttpRequestHelper.getRequestHeadersAsString(req)
-                + ", Request ID: " + req.getHeader("X-Cloud-Trace-Context"));
+                + ", Request ID: " + RequestTracer.getRequestId());
 
         if (Config.MAINTENANCE) {
             throwError(resp, HttpStatus.SC_SERVICE_UNAVAILABLE,
@@ -92,7 +93,6 @@ public class WebApiServlet extends HttpServlet {
             action.checkAccessControl();
 
             ActionResult result = action.execute();
-            result.setRequestId(req.getHeader("X-Cloud-Trace-Context"));
             result.send(resp);
         } catch (ActionMappingException e) {
             throwErrorBasedOnRequester(req, resp, e, e.getStatusCode());

--- a/src/main/webapp/WEB-INF/logging-dev.properties
+++ b/src/main/webapp/WEB-INF/logging-dev.properties
@@ -2,4 +2,4 @@ handlers=java.util.logging.ConsoleHandler
 .level=INFO
 java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=%5$s%n
+java.util.logging.SimpleFormatter.format=%1$tF %1$tT.%1$tL:%4$s:%5$s%n

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -21,6 +21,8 @@
     <filter-mapping>
         <filter-name>OriginCheckFilter</filter-name>
         <url-pattern>/webapi/*</url-pattern>
+        <url-pattern>/auto/*</url-pattern>
+        <url-pattern>/worker/*</url-pattern>
     </filter-mapping>
     <filter>
         <filter-name>ObjectifyFilter</filter-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,6 +5,17 @@
         version="3.1" metadata-complete="true">
 
     <filter>
+        <filter-name>RequestTraceFilter</filter-name>
+        <filter-class>teammates.ui.webapi.RequestTraceFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>RequestTraceFilter</filter-name>
+        <url-pattern>/webapi/*</url-pattern>
+        <url-pattern>/auto/*</url-pattern>
+        <url-pattern>/worker/*</url-pattern>
+    </filter-mapping>
+
+    <filter>
         <filter-name>ObjectifyFilter</filter-name>
         <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
     </filter>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,22 +14,6 @@
         <url-pattern>/auto/*</url-pattern>
         <url-pattern>/worker/*</url-pattern>
     </filter-mapping>
-
-    <filter>
-        <filter-name>ObjectifyFilter</filter-name>
-        <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>ObjectifyFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-    <listener>
-        <listener-class>teammates.storage.api.OfyHelper</listener-class>
-    </listener>
-    <listener>
-        <listener-class>teammates.storage.search.SearchManagerStarter</listener-class>
-    </listener>
-
     <filter>
         <filter-name>OriginCheckFilter</filter-name>
         <filter-class>teammates.ui.webapi.OriginCheckFilter</filter-class>
@@ -38,6 +22,22 @@
         <filter-name>OriginCheckFilter</filter-name>
         <url-pattern>/webapi/*</url-pattern>
     </filter-mapping>
+    <filter>
+        <filter-name>ObjectifyFilter</filter-name>
+        <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>ObjectifyFilter</filter-name>
+        <url-pattern>/webapi/*</url-pattern>
+        <url-pattern>/auto/*</url-pattern>
+        <url-pattern>/worker/*</url-pattern>
+    </filter-mapping>
+    <listener>
+        <listener-class>teammates.storage.api.OfyHelper</listener-class>
+    </listener>
+    <listener>
+        <listener-class>teammates.storage.search.SearchManagerStarter</listener-class>
+    </listener>
 
     <servlet>
         <description>REST API Servlet</description>

--- a/src/test/java/teammates/architecture/ArchitectureTest.java
+++ b/src/test/java/teammates/architecture/ArchitectureTest.java
@@ -447,6 +447,7 @@ public class ArchitectureTest {
     @Test
     public void testArchitecture_externalApi_loggingApiCanOnlyBeAccessedByLogger() {
         noClasses().that().doNotHaveSimpleName("Logger")
+                .and().doNotHaveSimpleName("StdOutConsoleHandler")
                 .should().accessClassesThat().resideInAPackage("java.util.logging..")
                 .check(ALL_CLASSES);
     }


### PR DESCRIPTION
Fixes #11120 
Fixes #11121 

Fixing two issues together because both involves creating a filter to intercept incoming HTTP requests.

The last commit enables [structured logging](https://cloud.google.com/logging/docs/structured-logging).