### PR TITLE
[#11148] ]Instructor home page: tweak session status tooltips

### DIFF
--- a/src/web/app/components/sessions-table/publish-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/publish-status-tooltip.pipe.ts
@@ -15,9 +15,9 @@ export class PublishStatusTooltipPipe implements PipeTransform {
   transform(status: FeedbackSessionPublishStatus): string {
     switch (status) {
       case FeedbackSessionPublishStatus.PUBLISHED:
-        return 'The responses for this session are visible.';
+        return 'Students can view responses received, as per the visibility settings of each question.';
       case FeedbackSessionPublishStatus.NOT_PUBLISHED:
-        return 'The responses for this session are not visible.';
+        return 'Students cannot view responses received.';
       default:
         return 'Unknown';
     }

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -13,14 +13,14 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
    * Transforms {@link FeedbackSessionSubmissionStatus} to a tooltip description.
    */
   transform(status: FeedbackSessionSubmissionStatus): string {
-    let msg: string = 'The feedback session has been created';
+    let msg: string = 'The feedback session ';
 
     switch (status) {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
       case FeedbackSessionSubmissionStatus.OPEN:
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
       case FeedbackSessionSubmissionStatus.CLOSED:
-        msg += ', is visible';
+        msg += ' is visible';
         break;
       default:
     }
@@ -33,7 +33,7 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
         msg += ', and is open for submissions';
         break;
       case FeedbackSessionSubmissionStatus.CLOSED:
-        msg += ', and has ended';
+        msg += ', and is closed for submissions';
         break;
       default:
     }


### PR DESCRIPTION
Fixes #11148 

Changed the tooltips for the submissions and responses columns of the sessions table. This was done by editing the return string in publish-status-tooltip.pipe.ts and submission-status-tooltip.pipe.ts files.  All static tests appeared to pass from what I can tell. Let me know if there's anything else I should do regarding this issue.

**Screenshots**

Before:

<img width="470" alt="before1" src="https://user-images.githubusercontent.com/44104701/120265451-bd660f80-c265-11eb-8a3d-60d6e1f736ec.png">



<img width="464" alt="before2" src="https://user-images.githubusercontent.com/44104701/120265532-e4bcdc80-c265-11eb-8a78-2f39d373b718.png">



After:

<img width="444" alt="after1" src="https://user-images.githubusercontent.com/44104701/120265535-e71f3680-c265-11eb-8c0f-03b6793bf9d1.png">



<img width="461" alt="after2" src="https://user-images.githubusercontent.com/44104701/120265539-e8506380-c265-11eb-8c3c-27fa5e081add.png">



<img width="458" alt="after3" src="https://user-images.githubusercontent.com/44104701/120265543-ea1a2700-c265-11eb-85e0-2f9f8618d7e2.png">