### PR TITLE
[#11182] Proof-of-submission file: Add a warning if no answers were saved

### DIFF
--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -25,19 +25,23 @@
       </li>
     </ul>
   </div>
+  <p *ngIf="hasFailToSaveQuestions">
+    Please try to submit your responses again.
+  </p>
   <p *ngIf="!hasFailToSaveQuestions">
     All your responses have been successfully recorded!
   </p>
   <p>
     Note that you can change your responses and submit them again any time before the session closes.
   </p>
-  <p>
+  <p *ngIf="!hasFailToSaveQuestions">
     You are encouraged to download the proof of submission, which will also contain your latest responses.
   </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-info"
-          (click)="downloadProofOfSubmission()">Download proof of submission</button>
+          (click)="downloadProofOfSubmission()"
+          [disabled]="hasFailToSaveQuestions">Download proof of submission</button>
   <button type="button" class="btn modal-btn-ok"
           [ngClass]="
                 {'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions}"

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -5,7 +5,7 @@
           <i class="fas fa-check-circle"></i> All responses submitted successfully!
         </span>
     <span *ngIf="hasFailToSaveQuestions">
-          <i class="fas fa-exclamation-circle"></i> Some questions were not saved!
+          <i class="fas fa-exclamation-circle"></i> Some response submissions failed!
         </span>
   </h5>
   <button type="button" class="close" (click)="activeModal.dismiss()">
@@ -18,7 +18,7 @@
     They are: {{ notYetAnsweredQuestions.join(', ') }}.
   </p>
   <div *ngIf="hasFailToSaveQuestions" class="text-danger" style="margin-bottom: 10px;">
-    <i class="fas fa-exclamation"></i> Some answers to questions are not saved due to errors.
+    <i class="fas fa-exclamation"></i> ERROR! The response submissions to the following questions failed.
     <ul>
       <li *ngFor="let question of failToSaveQuestions | keyvalue">
         Question {{ question.key }}:  {{ question.value }}

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -41,7 +41,7 @@
 <div class="modal-footer">
   <button type="button" class="btn btn-info"
           (click)="downloadProofOfSubmission()"
-          [disabled]="hasFailToSaveQuestions">Download proof of submission</button>
+          [disabled]="isAllQuestionSavingFailed">Download proof of submission</button>
   <button type="button" class="btn modal-btn-ok"
           [ngClass]="
                 {'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions}"

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
@@ -26,9 +26,6 @@ export class SavingCompleteModalComponent implements OnInit {
   feedbackSessionTimezone: string = '';
 
   @Input()
-  numberOfQuestions: number = 0;
-
-  @Input()
   personEmail: string = '';
 
   @Input()
@@ -54,7 +51,7 @@ export class SavingCompleteModalComponent implements OnInit {
   }
 
   get isAllQuestionSavingFailed(): boolean {
-    return Object.keys(this.failToSaveQuestions).length === this.numberOfQuestions;
+    return Object.keys(this.failToSaveQuestions).length === this.questions.length;
   }
 
   constructor(public activeModal: NgbActiveModal,

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
@@ -26,6 +26,9 @@ export class SavingCompleteModalComponent implements OnInit {
   feedbackSessionTimezone: string = '';
 
   @Input()
+  numberOfQuestions: number = 0;
+
+  @Input()
   personEmail: string = '';
 
   @Input()
@@ -48,6 +51,10 @@ export class SavingCompleteModalComponent implements OnInit {
 
   get hasFailToSaveQuestions(): boolean {
     return Object.keys(this.failToSaveQuestions).length !== 0;
+  }
+
+  get isAllQuestionSavingFailed(): boolean {
+    return Object.keys(this.failToSaveQuestions).length === this.numberOfQuestions;
   }
 
   constructor(public activeModal: NgbActiveModal,
@@ -74,10 +81,11 @@ export class SavingCompleteModalComponent implements OnInit {
     ];
 
     for (const question of this.questions) {
+      fileContent.push(`${question.questionNumber}: ${question.questionBrief}`);
+      fileContent.push(question.feedbackQuestionId);
+
       if (this.requestIds[question.feedbackQuestionId]) {
         // Question is either answered or skipped
-        fileContent.push(`${question.questionNumber}: ${question.questionBrief}`);
-        fileContent.push(question.feedbackQuestionId);
         fileContent.push(this.requestIds[question.feedbackQuestionId]);
 
         if (this.answers[question.feedbackQuestionId]) {
@@ -89,10 +97,12 @@ export class SavingCompleteModalComponent implements OnInit {
                 .join(','));
           }
         }
-
-        fileContent.push('');
-        fileContent.push('');
+      } else {
+        fileContent.push('WARNING: The response for this question is not saved');
       }
+
+      fileContent.push('');
+      fileContent.push('');
     }
 
     const blob: Blob = new Blob([fileContent.join('\r\n')], { type: 'text/plain' });

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
@@ -98,7 +98,7 @@ export class SavingCompleteModalComponent implements OnInit {
           }
         }
       } else {
-        fileContent.push('WARNING: The response for this question is not saved');
+        fileContent.push('ERROR! The response submission to this question failed.');
       }
 
       fileContent.push('');

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -90,6 +90,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   formattedSessionClosingTime: string = '';
   feedbackSessionInstructions: string = '';
   feedbackSessionTimezone: string = '';
+  feedbackSessionNumberOfQuestions: number = 0;
   feedbackSessionSubmissionStatus: FeedbackSessionSubmissionStatus = FeedbackSessionSubmissionStatus.OPEN;
 
   intent: Intent = Intent.STUDENT_SUBMISSION;
@@ -362,6 +363,7 @@ this session.`;
     }).pipe(finalize(() => this.isFeedbackSessionQuestionsLoading = false))
         .subscribe((response: FeedbackQuestionsResponse) => {
           this.isFeedbackSessionQuestionResponsesLoading = response.questions.length !== 0;
+          this.feedbackSessionNumberOfQuestions = response.questions.length;
           response.questions.forEach((feedbackQuestion: FeedbackQuestion) => {
             const model: QuestionSubmissionFormModel = {
               feedbackQuestionId: feedbackQuestion.feedbackQuestionId,
@@ -660,6 +662,7 @@ this session.`;
           modalRef.componentInstance.courseId = this.courseId;
           modalRef.componentInstance.feedbackSessionName = this.feedbackSessionName;
           modalRef.componentInstance.feedbackSessionTimezone = this.feedbackSessionTimezone;
+          modalRef.componentInstance.numberOfQuestions = this.feedbackSessionNumberOfQuestions;
           modalRef.componentInstance.personEmail = this.personEmail;
           modalRef.componentInstance.personName = this.personName;
           modalRef.componentInstance.questions = this.questionSubmissionForms;

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -90,7 +90,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   formattedSessionClosingTime: string = '';
   feedbackSessionInstructions: string = '';
   feedbackSessionTimezone: string = '';
-  feedbackSessionNumberOfQuestions: number = 0;
   feedbackSessionSubmissionStatus: FeedbackSessionSubmissionStatus = FeedbackSessionSubmissionStatus.OPEN;
 
   intent: Intent = Intent.STUDENT_SUBMISSION;
@@ -363,7 +362,6 @@ this session.`;
     }).pipe(finalize(() => this.isFeedbackSessionQuestionsLoading = false))
         .subscribe((response: FeedbackQuestionsResponse) => {
           this.isFeedbackSessionQuestionResponsesLoading = response.questions.length !== 0;
-          this.feedbackSessionNumberOfQuestions = response.questions.length;
           response.questions.forEach((feedbackQuestion: FeedbackQuestion) => {
             const model: QuestionSubmissionFormModel = {
               feedbackQuestionId: feedbackQuestion.feedbackQuestionId,
@@ -662,7 +660,6 @@ this session.`;
           modalRef.componentInstance.courseId = this.courseId;
           modalRef.componentInstance.feedbackSessionName = this.feedbackSessionName;
           modalRef.componentInstance.feedbackSessionTimezone = this.feedbackSessionTimezone;
-          modalRef.componentInstance.numberOfQuestions = this.feedbackSessionNumberOfQuestions;
           modalRef.componentInstance.personEmail = this.personEmail;
           modalRef.componentInstance.personName = this.personName;
           modalRef.componentInstance.questions = this.questionSubmissionForms;


### PR DESCRIPTION
Fixes #11182

**Outline of Solution**
It seems like the reason for empty proof is because all the responses were not saved. 

Updated:
Students will be unable to download the proof of submission if all questions are not saved.
![image](https://user-images.githubusercontent.com/58677983/121335794-7f47aa80-c94d-11eb-9464-f1aaa1ca8cc6.png)

If partial saving is done (ie some questions are saved), students can download the proof of submission and an error message will be displayed for questions unsaved.
![image](https://user-images.githubusercontent.com/58677983/121335095-e022b300-c94c-11eb-98af-d0c36770b0a1.png)
![image](https://user-images.githubusercontent.com/58677983/121335423-28da6c00-c94d-11eb-8f65-bf04c815de8e.png)


@damithc do you want to allow the students to download the proof if there is a question saved properly? (ie some questions are saved and some are not, so the proof will not be entirely empty)
I think an alternative is to display in the proof of submission which questions are not saved.