### PR TITLE
[#11161] Fix modal cancel loading bug

### DIFF
--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -197,7 +197,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
                 'The feedback session has been copied. Please modify settings/questions as necessary.',
                 { courseid: createdFeedbackSession.courseId, fsname: createdFeedbackSession.feedbackSessionName });
           }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
-    });
+    }).catch(() => this.isCopyOtherSessionLoading = false);
   }
 
   /**
@@ -620,7 +620,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
         }, (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
         });
-    });
+    }).catch(() => this.isPermanentDeleteLoading = false);
   }
 
   /**
@@ -650,7 +650,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
         }, (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
         });
-    });
+    }).catch(() => this.isPermanentDeleteLoading = false);
   }
 
   /**


### PR DESCRIPTION
Fixes #11161 

**Outline of Solution**
This bug is due to uncaught promise when a user click the `Cancel` ,  `Delete Permanently` or `Delete All` button, or when a user click outside the pop up window. Functions are added to catch these uncaught promises and set the `is*Loading` attribute to false.

Delete Permanently:
Before:
![120058313-8a145c80-c07c-11eb-94a5-aa2cc68ac7f3](https://user-images.githubusercontent.com/53338059/121879808-d4196580-cd3f-11eb-8f73-f0e75bb2ece1.gif)

After:
![copy20210614_183010](https://user-images.githubusercontent.com/53338059/121878687-9700a380-cd3e-11eb-83e6-e1e1d90124ff.gif)

Delete All:
Before:
![120058313-8a145c80-c07c-11eb-94a5-aa2cc68ac7f3](https://user-images.githubusercontent.com/53338059/121879605-a46a5d80-cd3f-11eb-8aa8-5fc8cbcc4b46.gif)

After:
![copy20210614_183424](https://user-images.githubusercontent.com/53338059/121879219-2e65f680-cd3f-11eb-96d7-051a5c6d329a.gif)

Copy from previous feedback sessions:
Before:
![120060253-4ecc5a80-c089-11eb-925d-fdabcea79076](https://user-images.githubusercontent.com/53338059/121879700-b8ae5a80-cd3f-11eb-8580-e25204597732.gif)

After:
![copy20210614_183609](https://user-images.githubusercontent.com/53338059/121879466-78e77300-cd3f-11eb-8919-c54e04db3b04.gif)


