### PR TITLE
[#11191] Instructor editing session: Save button is missing a space between icon and label

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -35,8 +35,8 @@
     <div class="row" *ngIf="formMode === SessionEditFormMode.EDIT">
       <div class="col-12 text-center text-md-right session-form-buttons">
         <button id="btn-fs-edit" type="button" class="btn btn-primary" (click)="triggerModelChange('isEditable', true)" *ngIf="formMode == SessionEditFormMode.EDIT && !model.isEditable && !model.isSaving"><i class="fas fa-pencil-alt"></i> Edit</button>
-        <button id="btn-fs-save" type="button" class="btn btn-primary" (click)="submitFormHandler()" [disabled]="model.isSaving" *ngIf="model.isEditable || model.isSaving"><tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading> <i class="fas fa-check"></i>Save </button>
-        <button type="button" class="btn btn-primary" ngbTooltip="Discard changes to the feedback session" (click)="cancelHandler()" *ngIf="model.isEditable" [disabled]="model.isSaving"><i class="fas fa-ban"></i> Cancel </button>
+        <button id="btn-fs-save" type="button" class="btn btn-primary" (click)="submitFormHandler()" [disabled]="model.isSaving" *ngIf="model.isEditable || model.isSaving"><tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading> <i class="fas fa-check"></i> Save</button>
+        <button type="button" class="btn btn-primary" ngbTooltip="Discard changes to the feedback session" (click)="cancelHandler()" *ngIf="model.isEditable" [disabled]="model.isSaving"><i class="fas fa-ban"></i> Cancel</button>
         <button id="btn-fs-delete" type="button" class="btn btn-primary" ngbTooltip="Delete the feedback session" (click)="deleteHandler()" [disabled]="model.isSaving"><tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete</button>
         <button id="btn-fs-copy" type="button" class="btn btn-primary" ngbTooltip="Copy this feedback session to other courses" (click)="copyHandler()" [disabled]="model.isSaving"><tm-ajax-loading *ngIf="model.isCopying"></tm-ajax-loading><i class="far fa-copy"></i> Copy</button>
       </div>


### PR DESCRIPTION
Fixes #11191 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Add a space between save button icon and label.

<img width="800" alt="Screenshot 2021-06-14 at 5 45 37 PM" src="https://user-images.githubusercontent.com/60355570/121873316-da581380-cd38-11eb-9a51-3b5c8a94f4fa.png">
