### PR TITLE
[#11196] Fix incorrect display of average value for rubric question stats

### DIFF
--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
@@ -17,6 +17,7 @@ export interface PerRecipientStats {
   percentages: number[][];
   subQuestionTotalChosenWeight: number[];
   subQuestionWeightAverage: number[];
+  weightAverage: number;
 }
 
 /**
@@ -86,15 +87,14 @@ export class RubricQuestionStatisticsCalculation
 
     this.percentages = this.calculatePercentages(this.answers);
     this.percentagesExcludeSelf = this.calculatePercentages(this.answersExcludeSelf);
-    // apply weights average if applicable
-    if (this.hasWeights) {
-      this.subQuestionWeightAverage = this.calculateSubQuestionWeightAverage(this.answers);
-      this.subQuestionWeightAverageExcludeSelf = this.calculateSubQuestionWeightAverage(this.answersExcludeSelf);
-    }
 
+    // only apply weights average if applicable
     if (!this.hasWeights) {
       return;
     }
+
+    this.subQuestionWeightAverage = this.calculateSubQuestionWeightAverage(this.answers);
+    this.subQuestionWeightAverageExcludeSelf = this.calculateSubQuestionWeightAverage(this.answersExcludeSelf);
 
     // calculate per recipient stats
     for (const response of this.responses) {
@@ -124,6 +124,11 @@ export class RubricQuestionStatisticsCalculation
       perRecipientStats.percentages = this.calculatePercentages(perRecipientStats.answers);
       perRecipientStats.subQuestionWeightAverage =
           this.calculateSubQuestionWeightAverage(perRecipientStats.answers);
+
+      const weightAgg: number =
+        perRecipientStats.subQuestionWeightAverage.reduce((sum: number, curr: number) => sum + curr, 0);
+      const totalQuestions: number = perRecipientStats.subQuestionWeightAverage.length;
+      perRecipientStats.weightAverage = +((weightAgg / totalQuestions).toFixed(2));
     }
   }
 

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -123,14 +123,26 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
 
     this.perRecipientOverallRowsData = [];
     Object.values(this.perRecipientStatsMap).forEach((perRecipientStats: PerRecipientStats) => {
+      let questionWeightSum: number = 0;
+      let numAnsweredQuestions: number = 0;
+      let overallWeightAverage: number = 0;
+      this.subQuestions.forEach((_: string, questionIndex: number) => {
+        const weight: number = perRecipientStats.subQuestionWeightAverage[questionIndex];
+        if (weight) {
+          // TODO: handle zero weight
+          //  currently we cannot distinguish between unanswered question and 0 weight answer
+          questionWeightSum += weight;
+          numAnsweredQuestions += 1;
+        }
+      });
+      if (numAnsweredQuestions > 0) {
+        overallWeightAverage = questionWeightSum / numAnsweredQuestions;
+      }
+
       this.perRecipientOverallRowsData.push([
         { value: perRecipientStats.recipientTeam },
         { value: perRecipientStats.recipientName },
-        { value: (this.subQuestions.map((_: string, questionIndex: number) => {
-          return perRecipientStats.subQuestionWeightAverage[questionIndex];
-        }).reduce((accValue: number, currValue: number) => accValue + currValue) / this.subQuestions.length
-        ).toFixed(2),
-        },
+        { value: overallWeightAverage.toFixed(2) },
         { value: this.subQuestions.map((_: string, questionIndex: number) => {
           const currValue: number = perRecipientStats.subQuestionWeightAverage[questionIndex];
           return currValue ? currValue.toString() : 'N/A';

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -126,9 +126,10 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
       this.perRecipientOverallRowsData.push([
         { value: perRecipientStats.recipientTeam },
         { value: perRecipientStats.recipientName },
-        { value: this.subQuestions.map((_: string, questionIndex: number) => {
+        { value: (this.subQuestions.map((_: string, questionIndex: number) => {
           return perRecipientStats.subQuestionWeightAverage[questionIndex];
-        }).reduce((accValue: number, currValue: number) => accValue + currValue) / this.subQuestions.length,
+        }).reduce((accValue: number, currValue: number) => accValue + currValue) / this.subQuestions.length
+        ).toFixed(2),
         },
         { value: this.subQuestions.map((_: string, questionIndex: number) => {
           const currValue: number = perRecipientStats.subQuestionWeightAverage[questionIndex];

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -123,30 +123,11 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
 
     this.perRecipientOverallRowsData = [];
     Object.values(this.perRecipientStatsMap).forEach((perRecipientStats: PerRecipientStats) => {
-      let questionWeightSum: number = 0;
-      let numAnsweredQuestions: number = 0;
-      let overallWeightAverage: number = 0;
-      this.subQuestions.forEach((_: string, questionIndex: number) => {
-        const weight: number = perRecipientStats.subQuestionWeightAverage[questionIndex];
-        if (weight) {
-          // TODO: handle zero weight
-          //  currently we cannot distinguish between unanswered question and 0 weight answer
-          questionWeightSum += weight;
-          numAnsweredQuestions += 1;
-        }
-      });
-      if (numAnsweredQuestions > 0) {
-        overallWeightAverage = questionWeightSum / numAnsweredQuestions;
-      }
-
       this.perRecipientOverallRowsData.push([
         { value: perRecipientStats.recipientTeam },
         { value: perRecipientStats.recipientName },
-        { value: overallWeightAverage.toFixed(2) },
-        { value: this.subQuestions.map((_: string, questionIndex: number) => {
-          const currValue: number = perRecipientStats.subQuestionWeightAverage[questionIndex];
-          return currValue ? currValue.toString() : 'N/A';
-        }).reduce((accValue: string, currValue: string) => `${accValue}, ${currValue}`),
+        { value: perRecipientStats.weightAverage },
+        { value: perRecipientStats.subQuestionWeightAverage.toString(),
         },
       ]);
     });

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -428,10 +428,10 @@ Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient's Email,Average,Breakdown
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,-0.44999999999999996,\\"1.25, -1.7\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,-0.44999999999999996,\\"-1.7, 1.25\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,2.5,\\"1.25, 1.25\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"NA, 1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,-0.22,\\"1.25, -1.7\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,-0.22,\\"-1.7, 1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.25,\\"1.25, 1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"NA, 1.25\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number
@@ -476,9 +476,9 @@ Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient's Email,Average,Breakdown
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1,\\"1, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,0.63,\\"1.25, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,0.50,\\"1, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"1.25, NA\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -431,7 +431,7 @@ Team,Recipient Name,Recipient's Email,Average,Breakdown
 \\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,-0.22,\\"1.25, -1.7\\"
 \\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,-0.22,\\"-1.7, 1.25\\"
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.25,\\"1.25, 1.25\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"NA, 1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"NA, 1.25\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number
@@ -476,9 +476,9 @@ Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient's Email,Average,Breakdown
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,0.63,\\"1.25, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,0.50,\\"1, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"1.25, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.00,\\"1, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -428,10 +428,10 @@ Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient's Email,Average,Breakdown
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,-0.22,\\"1.25, -1.7\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,-0.22,\\"-1.7, 1.25\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.25,\\"1.25, 1.25\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"NA, 1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,-0.22,\\"1.25,-1.7\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,-0.22,\\"-1.7,1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.25,\\"1.25,1.25\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"0,1.25\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number
@@ -476,9 +476,9 @@ Team,Recipient Name,Recipient's Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient's Email,Average,Breakdown
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,1.00,\\"1, NA\\"
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,1.25,\\"1.25, NA\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,0.63,\\"1.25,0\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,0.5,\\"1,0\\"
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,0.63,\\"1.25,0\\"
 
 
 Team,Giver's Full Name,Giver's Last Name,Giver's Email,Recipient's Team,Recipient's Full Name,Recipient's Last Name,Recipient's Email,Sub Question,Choice Value,Choice Number

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -128,15 +128,26 @@ ${ statsCalculation.hasWeights ? `[${ statsCalculation.weights[questionIndex][ch
       .sort((a: PerRecipientStats, b: PerRecipientStats) =>
         a.recipientTeam.localeCompare(b.recipientTeam) || a.recipientName.localeCompare(b.recipientName))
       .forEach((perRecipientStats: PerRecipientStats) => {
+        let questionWeightSum: number = 0;
+        let numAnsweredQuestions: number = 0;
+        let overallWeightAverage: number = 0;
+        perRecipientStats.subQuestionWeightAverage
+          .filter((weight: number) => weight !== 0)
+          .forEach((weight: number) => {
+            // TODO: handle zero weight
+            //  currently we cannot distinguish between unanswered question and 0 weight answer
+            questionWeightSum += weight;
+            numAnsweredQuestions += 1;
+          });
+        if (numAnsweredQuestions > 0) {
+          overallWeightAverage = questionWeightSum / numAnsweredQuestions;
+        }
+
         statsRows.push([
           perRecipientStats.recipientTeam,
           perRecipientStats.recipientName,
           perRecipientStats.recipientEmail ? perRecipientStats.recipientEmail : '',
-          (perRecipientStats.subQuestionWeightAverage
-            .reduce(((prevValue: number, currValue: number) => prevValue + currValue))
-            / perRecipientStats.subQuestionWeightAverage.length)
-            .toFixed(2)
-            .toString(),
+          overallWeightAverage.toFixed(2),
           perRecipientStats.subQuestionWeightAverage
             .map((value: number) => value !== 0 ? value.toString() : 'NA')
             .reduce(((prevValue: string, currValue: string) => `${prevValue}, ${currValue}`)),

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -132,8 +132,10 @@ ${ statsCalculation.hasWeights ? `[${ statsCalculation.weights[questionIndex][ch
           perRecipientStats.recipientTeam,
           perRecipientStats.recipientName,
           perRecipientStats.recipientEmail ? perRecipientStats.recipientEmail : '',
-          perRecipientStats.subQuestionWeightAverage
+          (perRecipientStats.subQuestionWeightAverage
             .reduce(((prevValue: number, currValue: number) => prevValue + currValue))
+            / perRecipientStats.subQuestionWeightAverage.length)
+            .toFixed(2)
             .toString(),
           perRecipientStats.subQuestionWeightAverage
             .map((value: number) => value !== 0 ? value.toString() : 'NA')

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -128,29 +128,12 @@ ${ statsCalculation.hasWeights ? `[${ statsCalculation.weights[questionIndex][ch
       .sort((a: PerRecipientStats, b: PerRecipientStats) =>
         a.recipientTeam.localeCompare(b.recipientTeam) || a.recipientName.localeCompare(b.recipientName))
       .forEach((perRecipientStats: PerRecipientStats) => {
-        let questionWeightSum: number = 0;
-        let numAnsweredQuestions: number = 0;
-        let overallWeightAverage: number = 0;
-        perRecipientStats.subQuestionWeightAverage
-          .filter((weight: number) => weight !== 0)
-          .forEach((weight: number) => {
-            // TODO: handle zero weight
-            //  currently we cannot distinguish between unanswered question and 0 weight answer
-            questionWeightSum += weight;
-            numAnsweredQuestions += 1;
-          });
-        if (numAnsweredQuestions > 0) {
-          overallWeightAverage = questionWeightSum / numAnsweredQuestions;
-        }
-
         statsRows.push([
           perRecipientStats.recipientTeam,
           perRecipientStats.recipientName,
           perRecipientStats.recipientEmail ? perRecipientStats.recipientEmail : '',
-          overallWeightAverage.toFixed(2),
-          perRecipientStats.subQuestionWeightAverage
-            .map((value: number) => value !== 0 ? value.toString() : 'NA')
-            .reduce(((prevValue: string, currValue: string) => `${prevValue}, ${currValue}`)),
+          String(perRecipientStats.weightAverage),
+          perRecipientStats.subQuestionWeightAverage.toString(),
         ]);
       });
 


### PR DESCRIPTION
Fixes #11196 

Patches a bug from #10621

Added missing division by length.

Also decorate the numbers with `.toFixed(2)`.