### PR TITLE
[#10569] Missing loading icons for Question Edit Form

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -87,6 +87,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             id="btn-delete-question"
             type="button"
           >
+            
             <i
               class="fas fa-trash"
             />

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -100,6 +100,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             ngbtooltip="Make a copy of the existing question and add to the current feedback session."
             type="button"
           >
+            
             <i
               class="far fa-copy"
             />

--- a/src/web/app/components/question-edit-form/question-edit-form-model.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form-model.ts
@@ -50,9 +50,10 @@ export interface QuestionEditFormModel {
   commonVisibilitySettingName?: string;
   isUsingOtherVisibilitySetting?: boolean;
 
+  isDuplicating: boolean;
+  isDeleting: boolean;
   isEditable: boolean;
   isSaving: boolean;
-  isDeleting: boolean;
   isCollapsed: boolean;
   isVisibilityChanged: boolean;
   isFeedbackPathChanged: boolean;

--- a/src/web/app/components/question-edit-form/question-edit-form-model.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form-model.ts
@@ -52,6 +52,7 @@ export interface QuestionEditFormModel {
 
   isEditable: boolean;
   isSaving: boolean;
+  isDeleting: boolean;
   isCollapsed: boolean;
   isVisibilityChanged: boolean;
   isFeedbackPathChanged: boolean;

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -31,7 +31,7 @@
         </button>
         <button id="btn-delete-question" type="button" class="btn btn-primary btn-sm"
                 (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();" [disabled]="model.isSaving">
-          <i class="fas fa-trash"></i> Delete
+          <tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
         </button>
         <button id="btn-duplicate-question" type="button" class="btn btn-primary btn-sm" container="body"
                 (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();" [disabled]="model.isSaving"

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -18,31 +18,36 @@
       <div *ngIf="formMode === QuestionEditFormMode.EDIT">
         <button id="btn-edit-question" type="button" class="btn btn-primary btn-sm" *ngIf="!model.isEditable"
                 (click)="triggerModelChangeBatch({'isEditable': true, 'isCollapsed': false}); $event.stopPropagation();"
-                [disabled]="model.isSaving">
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
           <i class="fas fa-pencil-alt"></i> Edit
         </button>
         <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
-                (click)="saveQuestionHandler(); $event.stopPropagation();" [disabled]="model.isSaving">
+                (click)="saveQuestionHandler(); $event.stopPropagation();"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
           <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
         </button>
         <button type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
-                (click)="discardChangesHandler(false); $event.stopPropagation();" [disabled]="model.isSaving">
+                (click)="discardChangesHandler(false); $event.stopPropagation();"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
           <i class="fas fa-ban"></i> Cancel
         </button>
         <button id="btn-delete-question" type="button" class="btn btn-primary btn-sm"
-                (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();" [disabled]="model.isSaving">
+                (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
           <tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
         </button>
         <button id="btn-duplicate-question" type="button" class="btn btn-primary btn-sm" container="body"
-                (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();" [disabled]="model.isSaving"
+                (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
                 ngbTooltip="Make a copy of the existing question and add to the current feedback session."
                 container="body">
-          <i class="far fa-copy"></i> Duplicate
+          <tm-ajax-loading *ngIf="model.isDuplicating"></tm-ajax-loading><i class="far fa-copy"></i> Duplicate
         </button>
       </div>
       <div *ngIf="formMode === QuestionEditFormMode.ADD">
         <button type="button" class="btn btn-primary btn-sm"
-                (click)="discardChangesHandler(true); $event.stopPropagation();" [disabled]="model.isSaving">
+                (click)="discardChangesHandler(true); $event.stopPropagation();"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
           <i class="fas fa-ban"></i>
           Cancel
         </button>
@@ -237,10 +242,13 @@
       <div class="row margin-top-15px" *ngIf="!isDisplayOnly">
         <div class="col-12 text-right">
           <button type="button" class="btn btn-light btn-margin-right" *ngIf="model.isEditable"
-                  (click)="discardChangesHandler(false)" [disabled]="model.isSaving">
+                  (click)="discardChangesHandler(false)"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
             <i class="fas fa-ban"></i> Cancel
           </button>
-          <button class="btn btn-success" [disabled]="!model.isEditable || model.isSaving" (click)="saveQuestionHandler()">
+          <button class="btn btn-success"
+              [disabled]="!model.isEditable || model.isSaving || model.isDeleting || model.isDuplicating"
+              (click)="saveQuestionHandler()">
             <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>
             <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>
             <span id="btn-save-new" *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Question</span>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -148,6 +148,7 @@ export class QuestionEditFormComponent implements OnInit {
 
     isUsingOtherFeedbackPath: false,
     isUsingOtherVisibilitySetting: false,
+    isDeleting: false,
     isEditable: false,
     isSaving: false,
     isCollapsed: false,

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -149,6 +149,7 @@ export class QuestionEditFormComponent implements OnInit {
     isUsingOtherFeedbackPath: false,
     isUsingOtherVisibilitySetting: false,
     isDeleting: false,
+    isDuplicating: false,
     isEditable: false,
     isSaving: false,
     isCollapsed: false,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -55,6 +55,7 @@ export const EXAMPLE_ESSAY_QUESTION_MODEL: QuestionEditFormModel = {
   questionDetails: DEFAULT_TEXT_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -86,6 +87,7 @@ export const EXAMPLE_NUMERICAL_SCALE_QUESTION_MODEL: QuestionEditFormModel = {
   questionDetails: DEFAULT_NUMSCALE_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -557,6 +559,7 @@ export const EXAMPLE_DISTRIBUTED_POINT_OPTION_MODEL: QuestionEditFormModel = {
   questionDetails: EXAMPLE_DISTRIBUTE_POINT_OPTION_QUESTION_DETAIL,
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -745,6 +748,7 @@ export const EXAMPLE_DISTRIBUTED_POINT_RECIPIENT_MODEL: QuestionEditFormModel = 
   questionDetails: DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -776,6 +780,7 @@ export const EXAMPLE_TEAM_CONTRIBUTION_QUESTION_MODEL: QuestionEditFormModel = {
   questionDetails: DEFAULT_CONTRIBUTION_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1024,6 +1029,7 @@ export const EXAMPLE_RUBRIC_QUESTION_MODEL: QuestionEditFormModel = {
   } as FeedbackRubricQuestionDetails,
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1212,6 +1218,7 @@ export const EXAMPLE_RANK_RECIPIENT_QUESTION_MODEL: QuestionEditFormModel = {
   questionDetails: DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1400,6 +1407,7 @@ export const EXAMPLE_RANK_OPTION_QUESTION_MODEL: QuestionEditFormModel = {
   questionDetails: DEFAULT_RANK_OPTIONS_QUESTION_DETAILS(),
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1438,6 +1446,7 @@ export const EXAMPLE_MCQ_QUESTION_WITHOUT_WEIGHTS_MODEL: QuestionEditFormModel =
   } as FeedbackMcqQuestionDetails,
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1476,6 +1485,7 @@ export const EXAMPLE_MCQ_QUESTION_WITH_WEIGHTS_MODEL: QuestionEditFormModel = {
   } as FeedbackMcqQuestionDetails,
 
   isDeleting: false,
+  isDuplicating: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -54,6 +54,7 @@ export const EXAMPLE_ESSAY_QUESTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.TEXT,
   questionDetails: DEFAULT_TEXT_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -84,6 +85,7 @@ export const EXAMPLE_NUMERICAL_SCALE_QUESTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.NUMSCALE,
   questionDetails: DEFAULT_NUMSCALE_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -554,6 +556,7 @@ export const EXAMPLE_DISTRIBUTED_POINT_OPTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.CONSTSUM_OPTIONS,
   questionDetails: EXAMPLE_DISTRIBUTE_POINT_OPTION_QUESTION_DETAIL,
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -741,6 +744,7 @@ export const EXAMPLE_DISTRIBUTED_POINT_RECIPIENT_MODEL: QuestionEditFormModel = 
   questionType: FeedbackQuestionType.CONSTSUM_RECIPIENTS,
   questionDetails: DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -771,6 +775,7 @@ export const EXAMPLE_TEAM_CONTRIBUTION_QUESTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.CONTRIB,
   questionDetails: DEFAULT_CONTRIBUTION_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1018,6 +1023,7 @@ export const EXAMPLE_RUBRIC_QUESTION_MODEL: QuestionEditFormModel = {
         'Tasks are always completed before the deadline.']],
   } as FeedbackRubricQuestionDetails,
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1205,6 +1211,7 @@ export const EXAMPLE_RANK_RECIPIENT_QUESTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.RANK_RECIPIENTS,
   questionDetails: DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1392,6 +1399,7 @@ export const EXAMPLE_RANK_OPTION_QUESTION_MODEL: QuestionEditFormModel = {
   questionType: FeedbackQuestionType.RANK_OPTIONS,
   questionDetails: DEFAULT_RANK_OPTIONS_QUESTION_DETAILS(),
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1429,6 +1437,7 @@ export const EXAMPLE_MCQ_QUESTION_WITHOUT_WEIGHTS_MODEL: QuestionEditFormModel =
     mcqWeights: [],
   } as FeedbackMcqQuestionDetails,
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,
@@ -1466,6 +1475,7 @@ export const EXAMPLE_MCQ_QUESTION_WITH_WEIGHTS_MODEL: QuestionEditFormModel = {
     mcqWeights: [1, 3, 5],
   } as FeedbackMcqQuestionDetails,
 
+  isDeleting: false,
   isEditable: false,
   isSaving: false,
   isCollapsed: false,

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -155,6 +155,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     showRecipientNameTo: [],
 
     isDeleting: false,
+    isDuplicating: false,
     isEditable: true,
     isSaving: false,
     isCollapsed: false,
@@ -526,6 +527,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       showRecipientNameTo: feedbackQuestion.showRecipientNameTo,
 
       isDeleting: false,
+      isDuplicating: false,
       isEditable: false,
       isSaving: false,
       isCollapsed: false,
@@ -642,7 +644,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   duplicateCurrentQuestionHandler(index: number): void {
     const questionEditFormModel: QuestionEditFormModel = this.questionEditFormModels[index];
 
-    questionEditFormModel.isSaving = true;
+    questionEditFormModel.isDuplicating = true;
     this.feedbackQuestionsService.createFeedbackQuestion(this.courseId, this.feedbackSessionName, {
       questionNumber: this.questionEditFormModels.length + 1, // add the duplicated question at the end
       questionBrief: questionEditFormModel.questionBrief,
@@ -663,7 +665,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     })
         .pipe(
             finalize(() => {
-              questionEditFormModel.isSaving = false;
+              questionEditFormModel.isDuplicating = false;
             }),
         )
         .subscribe((newQuestion: FeedbackQuestion) => {
@@ -771,6 +773,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       showRecipientNameTo: newQuestionModel.showRecipientNameTo,
 
       isDeleting: false,
+      isDuplicating: false,
       isEditable: true,
       isSaving: false,
       isCollapsed: false,

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -154,6 +154,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     showGiverNameTo: [],
     showRecipientNameTo: [],
 
+    isDeleting: false,
     isEditable: true,
     isSaving: false,
     isCollapsed: false,
@@ -524,6 +525,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       showGiverNameTo: feedbackQuestion.showGiverNameTo,
       showRecipientNameTo: feedbackQuestion.showRecipientNameTo,
 
+      isDeleting: false,
       isEditable: false,
       isSaving: false,
       isCollapsed: false,
@@ -680,15 +682,18 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             'Warning: Deleted question cannot be recovered. <b>All existing responses for this question to be deleted.</b>');
     modalRef.result.then(() => {
       const questionEditFormModel: QuestionEditFormModel = this.questionEditFormModels[index];
-      this.feedbackQuestionsService.deleteFeedbackQuestion(questionEditFormModel.feedbackQuestionId).subscribe(
-          () => {
-            // remove form model
-            this.feedbackQuestionModels.delete(questionEditFormModel.feedbackQuestionId);
-            this.questionEditFormModels.splice(index, 1);
-            this.normalizeQuestionNumberInQuestionForms();
+      questionEditFormModel.isDeleting = true;
+      this.feedbackQuestionsService.deleteFeedbackQuestion(questionEditFormModel.feedbackQuestionId)
+          .pipe(finalize(() => questionEditFormModel.isDeleting = false))
+          .subscribe(
+            () => {
+              // remove form model
+              this.feedbackQuestionModels.delete(questionEditFormModel.feedbackQuestionId);
+              this.questionEditFormModels.splice(index, 1);
+              this.normalizeQuestionNumberInQuestionForms();
 
-            this.statusMessageService.showSuccessToast('The question has been deleted.');
-          }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
+              this.statusMessageService.showSuccessToast('The question has been deleted.');
+            }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorToast(resp.error.message); });
     }, () => {});
   }
 
@@ -765,6 +770,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       showGiverNameTo: newQuestionModel.showGiverNameTo,
       showRecipientNameTo: newQuestionModel.showRecipientNameTo,
 
+      isDeleting: false,
       isEditable: true,
       isSaving: false,
       isCollapsed: false,

--- a/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.ts
@@ -54,6 +54,7 @@ export class TemplateQuestionModalComponent implements OnInit {
             showRecipientNameTo: template.question.showRecipientNameTo,
 
             isDeleting: false,
+            isDuplicating: false,
             isEditable: false,
             isSaving: false,
             isCollapsed: false,

--- a/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/template-question-modal/template-question-modal.component.ts
@@ -53,6 +53,7 @@ export class TemplateQuestionModalComponent implements OnInit {
             showGiverNameTo: template.question.showGiverNameTo,
             showRecipientNameTo: template.question.showRecipientNameTo,
 
+            isDeleting: false,
             isEditable: false,
             isSaving: false,
             isCollapsed: false,


### PR DESCRIPTION
Part of #10569 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Delete Button:

https://user-images.githubusercontent.com/60355570/122361017-737d6900-cf89-11eb-948e-ff28a268c99e.mov

Duplicate Button:

https://user-images.githubusercontent.com/60355570/122361136-8db74700-cf89-11eb-930b-b1188addd559.mov


For both buttons, similar to current implementation for the save button, I added boolean values that control whether the spinner is displayed. 
