### PR TITLE
[#11237] Feedback session table doesn't differentiate grace period and open status

### DIFF
--- a/src/web/app/components/session-edit-form/submission-status-name.pipe.ts
+++ b/src/web/app/components/session-edit-form/submission-status-name.pipe.ts
@@ -18,8 +18,9 @@ export class SubmissionStatusNamePipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
         return 'Awaiting';
       case FeedbackSessionSubmissionStatus.OPEN:
-      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
         return 'Open';
+      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
+        return 'Grace';
       case FeedbackSessionSubmissionStatus.CLOSED:
         return 'Closed';
       default:

--- a/src/web/app/components/session-edit-form/submission-status-name.pipe.ts
+++ b/src/web/app/components/session-edit-form/submission-status-name.pipe.ts
@@ -20,7 +20,7 @@ export class SubmissionStatusNamePipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.OPEN:
         return 'Open';
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        return 'Grace';
+        return 'Open (grace period)';
       case FeedbackSessionSubmissionStatus.CLOSED:
         return 'Closed';
       default:

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -43,7 +43,7 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
         msg += ', and is open for submissions';
         break;
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        msg += ', is open for submissions and is in the grace period';
+        msg += ', is open for submissions, and is in the grace period';
         break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', and has ended';

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -32,6 +32,9 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.OPEN:
         msg += ', and is open for submissions';
         break;
+      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
+        msg += ', and is in grace period';
+        break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', and has ended';
         break;

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -26,6 +26,8 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
     switch (status) {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
       case FeedbackSessionSubmissionStatus.OPEN:
+        msg += ', is visible';
+        break;
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
         msg += ' is visible to respondents';
         break;

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -19,6 +19,8 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
       case FeedbackSessionSubmissionStatus.OPEN:
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
+        msg += ', is visible to respondents'
+        break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', is visible';
         break;
@@ -33,7 +35,7 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
         msg += ', and is open for submissions';
         break;
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        msg += ', and is in grace period';
+        msg += ', is open for submissions. and is in the grace period';
         break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', and has ended';

--- a/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
+++ b/src/web/app/components/sessions-table/submission-status-tooltip.pipe.ts
@@ -13,13 +13,21 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
    * Transforms {@link FeedbackSessionSubmissionStatus} to a tooltip description.
    */
   transform(status: FeedbackSessionSubmissionStatus): string {
-    let msg: string = 'The feedback session has been created';
+    let msg: string = '';
+
+    switch (status) {
+      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
+        msg += 'The feedback session';
+        break;
+      default:
+        msg += 'The feedback session has been created';
+    }
 
     switch (status) {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
       case FeedbackSessionSubmissionStatus.OPEN:
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        msg += ', is visible to respondents'
+        msg += ' is visible to respondents';
         break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', is visible';
@@ -35,7 +43,7 @@ export class SubmissionStatusTooltipPipe implements PipeTransform {
         msg += ', and is open for submissions';
         break;
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        msg += ', is open for submissions. and is in the grace period';
+        msg += ', is open for submissions and is in the grace period';
         break;
       case FeedbackSessionSubmissionStatus.CLOSED:
         msg += ', and has ended';

--- a/src/web/app/components/teammates-common/submission-status-name.pipe.ts
+++ b/src/web/app/components/teammates-common/submission-status-name.pipe.ts
@@ -18,8 +18,9 @@ export class SubmissionStatusNamePipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN:
         return 'Awaiting';
       case FeedbackSessionSubmissionStatus.OPEN:
-      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
         return 'Open';
+      case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
+        return 'Grace';
       case FeedbackSessionSubmissionStatus.CLOSED:
         return 'Closed';
       default:

--- a/src/web/app/components/teammates-common/submission-status-name.pipe.ts
+++ b/src/web/app/components/teammates-common/submission-status-name.pipe.ts
@@ -20,7 +20,7 @@ export class SubmissionStatusNamePipe implements PipeTransform {
       case FeedbackSessionSubmissionStatus.OPEN:
         return 'Open';
       case FeedbackSessionSubmissionStatus.GRACE_PERIOD:
-        return 'Grace';
+        return 'Open (grace period)';
       case FeedbackSessionSubmissionStatus.CLOSED:
         return 'Closed';
       default:


### PR DESCRIPTION
Fixes #11237 

**Outline of Solution**

Added text descriptions for grace period and open status submission sessions at relevant switch case blocks.

Time of screenshot 6:03 pm.
<img width="1187" alt="Screenshot 2021-07-02 at 6 03 02 PM" src="https://user-images.githubusercontent.com/54242896/124258333-dcefa100-db5f-11eb-823f-c56a24f3bab6.png">


<img width="498" alt="Screenshot 2021-07-02 at 10 09 20 PM" src="https://user-images.githubusercontent.com/54242896/124287689-e50d0800-db82-11eb-93d7-5cb135888e53.png">

