### PR TITLE
[#11252] Use different method to impose request timeout limit

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
@@ -4,6 +4,7 @@ import org.testng.annotations.Test;
 
 import com.google.cloud.datastore.DatastoreException;
 
+import teammates.common.exception.DeadlineExceededException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
@@ -29,6 +30,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
     public void testAll() {
         testAssertionError();
         testNullPointerException();
+        testDeadlineExceededException();
         testDatastoreException();
         testUnauthorizedAccessException();
         testInvalidHttpParameterException();
@@ -60,6 +62,20 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
         BACKDOOR.executeGetRequest(url, null);
 
         print("NullPointerException triggered, verify that you have received error logs via email");
+
+    }
+
+    private void testDeadlineExceededException() {
+
+        ______TS("DeadlineExceededException testing");
+
+        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+                .withParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName())
+                .toString();
+
+        BACKDOOR.executeGetRequest(url, null);
+
+        print("DeadlineExceededException triggered, verify that you have received error logs via email");
 
     }
 

--- a/src/main/java/teammates/common/exception/DeadlineExceededException.java
+++ b/src/main/java/teammates/common/exception/DeadlineExceededException.java
@@ -1,0 +1,7 @@
+package teammates.common.exception;
+
+/**
+ * Exception thrown when an operation is determined to have exceeded the time it is allowed to run.
+ */
+public class DeadlineExceededException extends RuntimeException {
+}

--- a/src/main/java/teammates/common/util/RequestTracer.java
+++ b/src/main/java/teammates/common/util/RequestTracer.java
@@ -3,6 +3,8 @@ package teammates.common.util;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import teammates.common.exception.DeadlineExceededException;
+
 /**
  * Stores the information of the current HTTP request.
  */
@@ -39,12 +41,23 @@ public final class RequestTracer {
     /**
      * Returns the remaining time (in millis) until the current request times out.
      */
-    public static long getRemainingTimeMillis() {
+    private static long getRemainingTimeMillis() {
         RequestTrace trace = THREAD_LOCAL.get();
         if (trace == null) {
-            return -1L;
+            return 1L;
         }
         return trace.timeoutTimestamp - Instant.now().toEpochMilli();
+    }
+
+    /**
+     * Throws {@link DeadlineExceededException} if the current thread has exceeded
+     * the limit for serving request.
+     */
+    public static void checkRemainingTime() {
+        long remainingTime = getRemainingTimeMillis();
+        if (remainingTime < 0) {
+            throw new DeadlineExceededException();
+        }
     }
 
     /**

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -21,6 +21,7 @@ import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
@@ -275,6 +276,7 @@ public class EmailGenerator {
         List<FeedbackSessionAttributes> sessions = fsLogic.getAllFeedbackSessionsWithinTimeRange(startTime, endTime);
 
         for (FeedbackSessionAttributes session : sessions) {
+            RequestTracer.checkRemainingTime();
             String courseId = session.getCourseId();
             CourseAttributes course = coursesLogic.getCourse(courseId);
             List<StudentAttributes> students = studentsForEmail.stream().filter(

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -30,6 +30,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 import teammates.common.util.TimeHelper;
 import teammates.storage.api.FeedbackSessionsDb;
 
@@ -532,6 +533,7 @@ public final class FeedbackSessionsLogic {
         for (FeedbackQuestionAttributes qn : allQuestions) {
             allQuestionsMap.put(qn.getId(), qn);
         }
+        RequestTracer.checkRemainingTime();
 
         // load response(s)
         StudentAttributes student = getStudent(courseId, userEmail, role);
@@ -556,6 +558,7 @@ public final class FeedbackSessionsLogic {
                 allResponses.addAll(viewableResponses);
             }
         }
+        RequestTracer.checkRemainingTime();
 
         // load comment(s)
         List<FeedbackResponseCommentAttributes> allComments;
@@ -564,6 +567,7 @@ public final class FeedbackSessionsLogic {
         } else {
             allComments = frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, section);
         }
+        RequestTracer.checkRemainingTime();
 
         // related questions, responses, and comment
         Map<String, FeedbackQuestionAttributes> relatedQuestionsMap = new HashMap<>();
@@ -610,6 +614,7 @@ public final class FeedbackSessionsLogic {
             responseRecipientVisibilityTable.put(response.getId(),
                     frLogic.isNameVisibleToUser(correspondingQuestion, response, userEmail, role, false, roster));
         }
+        RequestTracer.checkRemainingTime();
 
         // build comment
         for (FeedbackResponseCommentAttributes frc : allComments) {
@@ -630,6 +635,7 @@ public final class FeedbackSessionsLogic {
             // generate comment giver name visibility table
             commentVisibilityTable.put(frc.getId(), frcLogic.isNameVisibleToUser(frc, relatedResponse, userEmail, roster));
         }
+        RequestTracer.checkRemainingTime();
 
         List<FeedbackResponseAttributes> existingResponses = new ArrayList<>(relatedResponsesMap.values());
         List<FeedbackResponseAttributes> missingResponses = Collections.emptyList();
@@ -639,6 +645,7 @@ public final class FeedbackSessionsLogic {
                     instructor, responseGiverVisibilityTable, responseRecipientVisibilityTable, session,
                     relatedQuestionsMap, existingResponses, roster, section);
         }
+        RequestTracer.checkRemainingTime();
 
         return new SessionResultsBundle(session, relatedQuestionsMap, existingResponses, missingResponses,
                 responseGiverVisibilityTable, responseRecipientVisibilityTable, relatedCommentsMap,

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -14,6 +14,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.RegenerateStudentException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Const;
+import teammates.common.util.RequestTracer;
 import teammates.storage.api.StudentsDb;
 
 /**
@@ -333,6 +334,7 @@ public final class StudentsLogic {
     public void deleteStudentsInCourseCascade(String courseId) {
         List<StudentAttributes> studentsInCourse = getStudentsForCourse(courseId);
         for (StudentAttributes student : studentsInCourse) {
+            RequestTracer.checkRemainingTime();
             deleteStudentCascade(courseId, student.email);
         }
     }

--- a/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminExceptionTestAction.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.rpc.Code;
 
+import teammates.common.exception.DeadlineExceededException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
@@ -40,6 +41,9 @@ class AdminExceptionTestAction extends Action {
         }
         if (error.equals(NullPointerException.class.getSimpleName())) {
             throw new NullPointerException("NullPointerException testing");
+        }
+        if (error.equals(DeadlineExceededException.class.getSimpleName())) {
+            throw new DeadlineExceededException();
         }
         if (error.equals(DatastoreException.class.getSimpleName())) {
             throw new DatastoreException(Code.DEADLINE_EXCEEDED_VALUE, "DatastoreException testing",

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -14,6 +14,7 @@ import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
+import teammates.common.util.RequestTracer;
 import teammates.ui.output.EnrollStudentsData;
 import teammates.ui.output.StudentsData;
 import teammates.ui.request.StudentsEnrollRequest;
@@ -73,7 +74,8 @@ class EnrollStudentsAction extends Action {
                 existingStudents.stream().map(StudentAttributes::getEmail).collect(Collectors.toSet());
         List<StudentAttributes> enrolledStudents = new ArrayList<>();
         List<EnrollStudentsData.EnrollErrorResults> failToEnrollStudents = new ArrayList<>();
-        studentsToEnroll.forEach(student -> {
+        for (StudentAttributes student : studentsToEnroll) {
+            RequestTracer.checkRemainingTime();
             if (existingStudentsEmail.contains(student.email)) {
                 // The student has been enrolled in the course.
                 StudentAttributes.UpdateOptions updateOptions =
@@ -103,7 +105,7 @@ class EnrollStudentsAction extends Action {
                             exception.getMessage()));
                 }
             }
-        });
+        }
         return new JsonResult(new EnrollStudentsData(new StudentsData(enrolledStudents), failToEnrollStudents));
     }
 }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
@@ -6,6 +6,7 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 
 /**
  * Cron job: schedules feedback session closed emails to be sent.
@@ -19,6 +20,7 @@ class FeedbackSessionClosedRemindersAction extends AdminOnlyAction {
         List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsClosedWithinThePastHour();
 
         for (FeedbackSessionAttributes session : sessions) {
+            RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosedEmails(session);
             try {
                 taskQueuer.scheduleEmailsForSending(emailsToBeSent);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -6,6 +6,7 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 
 /**
  * Cron job: schedules feedback session closing emails to be sent.
@@ -19,6 +20,7 @@ class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
         List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsClosingWithinTimeLimit();
 
         for (FeedbackSessionAttributes session : sessions) {
+            RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosingEmails(session);
             try {
                 taskQueuer.scheduleEmailsForSending(emailsToBeSent);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningRemindersAction.java
@@ -6,6 +6,7 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
+import teammates.common.util.RequestTracer;
 
 /**
  * Cron job: schedules feedback session opening emails to be sent.
@@ -19,6 +20,7 @@ class FeedbackSessionOpeningRemindersAction extends AdminOnlyAction {
         List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsWhichNeedOpenEmailsToBeSent();
 
         for (FeedbackSessionAttributes session : sessions) {
+            RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionOpeningEmails(session);
             try {
                 taskQueuer.scheduleEmailsForSending(emailsToBeSent);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedRemindersAction.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import java.util.List;
 
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.util.RequestTracer;
 
 /**
  * Cron job: schedules feedback session published emails to be sent.
@@ -14,6 +15,7 @@ class FeedbackSessionPublishedRemindersAction extends AdminOnlyAction {
         List<FeedbackSessionAttributes> sessions =
                 logic.getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent();
         for (FeedbackSessionAttributes session : sessions) {
+            RequestTracer.checkRemainingTime();
             taskQueuer.scheduleFeedbackSessionPublishedEmail(session.getCourseId(), session.getFeedbackSessionName());
         }
         return new JsonResult("Successful");

--- a/src/main/java/teammates/ui/webapi/WebApiServlet.java
+++ b/src/main/java/teammates/ui/webapi/WebApiServlet.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpStatus;
 import com.google.cloud.datastore.DatastoreException;
 
 import teammates.common.exception.ActionMappingException;
+import teammates.common.exception.DeadlineExceededException;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.InvalidHttpRequestBodyException;
@@ -87,6 +88,11 @@ public class WebApiServlet extends HttpServlet {
             log.warning(enfe.getClass().getSimpleName() + " caught by WebApiServlet: "
                     + TeammatesException.toStringWithStackTrace(enfe));
             throwError(resp, statusCode, enfe.getMessage());
+        } catch (DeadlineExceededException dee) {
+            statusCode = HttpStatus.SC_GATEWAY_TIMEOUT;
+            log.severe("TimeoutException caught by WebApiServlet: "
+                    + TeammatesException.toStringWithStackTrace(dee));
+            throwError(resp, statusCode, "The request exceeded the server timeout limit. Please try again later.");
         } catch (DatastoreException e) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
             log.severe(e.getClass().getSimpleName() + " caught by WebApiServlet: "


### PR DESCRIPTION
Fixes #11252 

This brings back handling of `DeadlineExceededException` within the API layer itself together with other types of exceptions. (also, borrowing the name from the same class from the GAE first generation runtime)

While the idea of having codes liberally throwing `DeadlineExceededException` is inspired by GAE first generation runtime, the process is not automatic and the checks need to be manually added. While technically adding the check in every single action/function is harmless, it is waste of CPU time to do it as only very few operations are known to be possibly exceeding time limit.