### PR TITLE
[#11234] Fix request timeout value + failing L&P tests

### DIFF
--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master 
       - release
+  schedule:
+    - cron: "0 0 * * *" # end of every day
 jobs:
   LnP-testing:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   datastore:
     build:
       context: datastore-dev
+    volumes:
+      - ./src/main/appengine/index.yaml:/root/.config/gcloud/emulators/datastore/WEB-INF/index.yaml
     ports:
       - 8484:8484
   solr:

--- a/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
+++ b/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
@@ -54,10 +54,9 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
     protected static final String DELETE = HttpDelete.METHOD_NAME;
     protected static final Logger log = Logger.getLogger();
 
-    private static final BackDoor BACKDOOR = BackDoor.getInstance();
-
     private static final int RESULT_COUNT = 3;
 
+    protected final BackDoor backdoor = BackDoor.getInstance();
     protected String timeStamp;
     protected LNPSpecification specification;
 
@@ -236,7 +235,7 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
      */
     protected void persistTestData() throws IOException, HttpRequestFailedException {
         DataBundle dataBundle = loadDataBundle(getJsonDataPath());
-        String responseBody = BACKDOOR.removeAndRestoreDataBundle(dataBundle);
+        String responseBody = backdoor.removeAndRestoreDataBundle(dataBundle);
 
         String pathToResultFile = createFileAndDirectory(TestProperties.LNP_TEST_DATA_FOLDER, getJsonDataPath());
         String jsonValue = JsonUtils.parse(responseBody).getAsJsonObject().get("message").getAsString();
@@ -301,7 +300,7 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
      */
     protected void deleteTestData() {
         DataBundle dataBundle = loadDataBundle(getJsonDataPath());
-        BACKDOOR.removeDataBundle(dataBundle);
+        backdoor.removeDataBundle(dataBundle);
     }
 
     /**

--- a/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
@@ -56,8 +56,6 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String STUDENT_ID = "LnPStudent.tmms";
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
@@ -218,7 +216,6 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("fsname");
 
@@ -240,7 +237,6 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
                     csvRow.add(FEEDBACK_SESSION_NAME);
 

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
@@ -207,8 +207,10 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
                     csvRow.add(student.getGoogleId());
                     csvRow.add(student.getEmail());
 
-                    dataBundle.feedbackQuestions.forEach((feedbackQuestionKey, feedbackQuestion) -> {
-                        csvRow.add(feedbackQuestion.getId());
+                    dataBundle.feedbackQuestions.forEach((feedbackQuestionKey, fq) -> {
+                        FeedbackQuestionAttributes fqa = backdoor.getFeedbackQuestion(
+                                fq.getCourseId(), fq.getFeedbackSessionName(), fq.getQuestionNumber());
+                        csvRow.add(fqa.getId());
                     });
 
                     csvData.add(csvRow);

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
@@ -184,7 +184,6 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("googleId");
                 headers.add("studentEmail");
                 for (int i = 1; i <= NUMBER_OF_QUESTIONS; i++) {
@@ -203,7 +202,6 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(student.getGoogleId()); // "googleId" is used for logging in, not "email"
-                    csvRow.add("no");
                     csvRow.add(student.getGoogleId());
                     csvRow.add(student.getEmail());
 

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
@@ -176,7 +176,6 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("googleId");
                 headers.add("courseId");
                 headers.add("fsname");
@@ -193,7 +192,6 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(student.getGoogleId()); // "googleId" is used for logging in, not "email"
-                    csvRow.add("no");
                     csvRow.add(student.getGoogleId());
                     csvRow.add(COURSE_ID);
                     csvRow.add(FEEDBACK_SESSION_NAME);

--- a/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
@@ -50,8 +50,6 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String FEEDBACK_SESSION_NAME = "Test Feedback Session";
 
     private static final double ERROR_RATE_LIMIT = 0.01;
@@ -122,7 +120,6 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("updateData");
 
@@ -138,7 +135,6 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
 
                     CourseUpdateRequest courseUpdateRequest = new CourseUpdateRequest();

--- a/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
@@ -240,8 +240,10 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
                     }
 
                     // For loading feedback question IDs
-                    dataBundle.feedbackQuestions.forEach((feedbackQuestionKey, feedbackQuestion) -> {
-                        csvRow.add(feedbackQuestion.getId());
+                    dataBundle.feedbackQuestions.forEach((feedbackQuestionKey, fq) -> {
+                        FeedbackQuestionAttributes fqa = backdoor.getFeedbackQuestion(
+                                fq.getCourseId(), fq.getFeedbackSessionName(), fq.getQuestionNumber());
+                        csvRow.add(fqa.getId());
                     });
 
                     csvData.add(csvRow);

--- a/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
@@ -205,7 +205,6 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("fsname");
 
@@ -230,7 +229,6 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(instructor.getGoogleId()); // "googleId" is used for logging in, not "email"
-                    csvRow.add("no");
                     csvRow.add(COURSE_ID);
                     csvRow.add(FEEDBACK_SESSION_NAME);
 

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
@@ -183,7 +183,6 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("enrollData");
 
@@ -199,7 +198,6 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(instructor.getGoogleId());
-                    csvRow.add("yes");
                     csvRow.add(instructor.getCourseId());
 
                     // Create and add student enrollment data with a team number corresponding to each section number

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
@@ -94,7 +94,6 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("enrollData");
 
@@ -110,7 +109,6 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(instructor.getGoogleId());
-                    csvRow.add("no");
                     csvRow.add(instructor.getCourseId());
 
                     // Create and add student enrollment data with a team number corresponding to each section number

--- a/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
@@ -56,8 +56,6 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
 
     private static final String UPDATE_INSTRUCTOR_EMAIL = "update.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String STUDENT_ID = "LnPStudent.tmms";
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
@@ -245,7 +243,6 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("updateData");
 
@@ -261,7 +258,6 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
 
                     InstructorCreateRequest instructorCreateRequest =

--- a/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
@@ -53,8 +53,6 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String STUDENT_ID = "LnPStudent.tmms";
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
@@ -212,7 +210,6 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("studentId");
                 headers.add("studentEmail");
@@ -230,7 +227,6 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
                     csvRow.add(STUDENT_ID);
                     csvRow.add(STUDENT_EMAIL);

--- a/src/lnp/java/teammates/lnp/cases/StudentProfileLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentProfileLNPTest.java
@@ -134,7 +134,6 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("googleId");
 
                 return headers;
@@ -149,7 +148,6 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(student.getGoogleId()); // "googleId" is used for logging in, not "email"
-                    csvRow.add("no");
                     csvRow.add(student.getGoogleId());
 
                     csvData.add(csvRow);

--- a/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
@@ -53,8 +53,6 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String STUDENT_ID = "LnPStudent.tmms";
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
@@ -212,7 +210,6 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("studentId");
                 headers.add("studentEmail");
@@ -230,7 +227,6 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
                     csvRow.add(STUDENT_ID);
                     csvRow.add(STUDENT_EMAIL);

--- a/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
@@ -53,8 +53,6 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "tmms.test@gmail.tmt";
 
-    private static final String HAS_ADMIN_PRIVILEGE = "no";
-
     private static final String STUDENT_ID = "LnPStudent.tmms";
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "studentEmail@gmail.tmt";
@@ -212,7 +210,6 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
                 List<String> headers = new ArrayList<>();
 
                 headers.add("loginId");
-                headers.add("isAdmin");
                 headers.add("courseId");
                 headers.add("studentId");
                 headers.add("studentEmail");
@@ -230,7 +227,6 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
                     List<String> csvRow = new ArrayList<>();
 
                     csvRow.add(INSTRUCTOR_ID);
-                    csvRow.add(HAS_ADMIN_PRIVILEGE);
                     csvRow.add(COURSE_ID);
                     csvRow.add(STUDENT_ID);
                     csvRow.add(STUDENT_EMAIL);

--- a/src/lnp/java/teammates/lnp/util/JMeterElements.java
+++ b/src/lnp/java/teammates/lnp/util/JMeterElements.java
@@ -185,14 +185,14 @@ public final class JMeterElements {
     /**
      * Returns a HTTP Request element that is configured to login to a TEAMMATES instance.
      *
-     * <p>This element uses data from the "loginId" and "isAdmin" fields of the CSV config file.</p>
+     * <p>This element uses data from the "loginId" field of the CSV config file.</p>
      */
     public static HTTPSamplerProxy loginSampler() {
         HTTPSamplerProxy loginSampler = new HTTPSamplerProxy();
 
         loginSampler.setName("Login");
         loginSampler.setPath(
-                "devServerLogin?email=${loginId}&isAdmin=${isAdmin}&nextUrl="
+                "devServerLogin?email=${loginId}&nextUrl="
                         + TestProperties.TEAMMATES_URL + "/webapi/auth");
         loginSampler.setMethod("POST");
         loginSampler.setFollowRedirects(true);

--- a/src/main/java/teammates/ui/servlets/RequestTraceFilter.java
+++ b/src/main/java/teammates/ui/servlets/RequestTraceFilter.java
@@ -73,7 +73,7 @@ public class RequestTraceFilter implements Filter {
         // For user-invoked requests, we keep the time limit at 1 minute (as how it was
         // in the previous GAE runtime environment) in order to not let user wait for excessively long,
         // as well as a reminder for us to keep optimizing our API response time.
-        int timeoutInSeconds = isRequestFromAppEngineQueue ? 10 * 60 - 5 : 10;
+        int timeoutInSeconds = isRequestFromAppEngineQueue ? 10 * 60 - 5 : 60;
 
         RequestTracer.init(traceId, spanId, timeoutInSeconds);
 


### PR DESCRIPTION
Fixes #11234

There are two reasons for recent L&P test failures:
- Due to feedback question ID being made `transient` recently, the way to pass in question ID to the test plan needs to be modified
- The request timeout for user-invoked requests was misconfigured to be 10s instead of 60s (I don't think we're ready for that kind of latency... yet)

You may note that those changes are very recent. Previously, all errors are caused by misconfigured request timeout handling (or really, lack thereof) which has since been fixed but caused a new problem due to slight carelessness.

In addition:
- The Datastore emulator was not run with the indexes configuration `index.yaml` which adds up to some latency (this doesn't cause failure, but is something performance-related that needs to be fixed)
- `isAdmin` field in test plan is now redundant because the manual overriding of admin permission was removed