### PR TITLE
[#11310] Logs Interface: Support fetching more logs for both "before" and "after"

### DIFF
--- a/src/main/java/teammates/common/datatransfer/QueryLogsParams.java
+++ b/src/main/java/teammates/common/datatransfer/QueryLogsParams.java
@@ -18,6 +18,7 @@ public class QueryLogsParams {
     private String logEvent;
     private SourceLocation sourceLocation;
     private String exceptionClass;
+    private String order;
     private Integer pageSize;
     private String pageToken;
 
@@ -68,6 +69,10 @@ public class QueryLogsParams {
 
     public String getExceptionClass() {
         return exceptionClass;
+    }
+
+    public String getOrder() {
+        return order;
     }
 
     public Integer getPageSize() {
@@ -149,6 +154,11 @@ public class QueryLogsParams {
 
         public Builder withExceptionClass(String exceptionClass) {
             queryLogsParams.exceptionClass = exceptionClass;
+            return this;
+        }
+
+        public Builder withOrder(String order) {
+            queryLogsParams.order = order;
             return this;
         }
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -160,6 +160,7 @@ public final class Const {
         public static final String QUERY_LOGS_SOURCE_LOCATION_FILE = "sourcelocationfile";
         public static final String QUERY_LOGS_SOURCE_LOCATION_FUNCTION = "sourcelocationfunction";
         public static final String QUERY_LOGS_EXCEPTION_CLASS = "exceptionclass";
+        public static final String QUERY_LOGS_ORDER = "order";
         public static final String NEXT_PAGE_TOKEN = "nextpagetoken";
     }
 

--- a/src/main/java/teammates/logic/core/GoogleCloudLoggingService.java
+++ b/src/main/java/teammates/logic/core/GoogleCloudLoggingService.java
@@ -17,6 +17,8 @@ import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Logging.EntryListOption;
+import com.google.cloud.logging.Logging.SortingField;
+import com.google.cloud.logging.Logging.SortingOrder;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.logging.Payload;
 import com.google.cloud.logging.Payload.StringPayload;
@@ -294,6 +296,7 @@ public class GoogleCloudLoggingService implements LogService {
             List<EntryListOption> entryListOptions = new ArrayList<>();
 
             entryListOptions.add(EntryListOption.filter(logFilter));
+            entryListOptions.add(EntryListOption.sortOrder(SortingField.TIMESTAMP, SortingOrder.DESCENDING));
 
             if (p != null) {
                 if (p.pageSize != null) {

--- a/src/main/java/teammates/logic/core/GoogleCloudLoggingService.java
+++ b/src/main/java/teammates/logic/core/GoogleCloudLoggingService.java
@@ -59,6 +59,8 @@ public class GoogleCloudLoggingService implements LogService {
     private static final String STDOUT_LOG_NAME = "stdout";
     private static final String STDERR_LOG_NAME = "stderr";
 
+    private static final String ASCENDING_ORDER = "asc";
+
     private static final String TRACE_PREFIX = String.format("projects/%s/traces/", Config.APP_ID);
 
     private final StudentsLogic studentsLogic = StudentsLogic.inst();
@@ -303,7 +305,14 @@ public class GoogleCloudLoggingService implements LogService {
             List<EntryListOption> entryListOptions = new ArrayList<>();
 
             entryListOptions.add(EntryListOption.filter(logFilter));
-            entryListOptions.add(EntryListOption.sortOrder(SortingField.TIMESTAMP, SortingOrder.DESCENDING));
+
+            if (s.order != null) {
+                if (ASCENDING_ORDER.equals(s.order)) {
+                    entryListOptions.add(EntryListOption.sortOrder(SortingField.TIMESTAMP, SortingOrder.ASCENDING));
+                } else {
+                    entryListOptions.add(EntryListOption.sortOrder(SortingField.TIMESTAMP, SortingOrder.DESCENDING));
+                }
+            }
 
             if (p != null) {
                 if (p.pageSize != null) {
@@ -344,6 +353,7 @@ public class GoogleCloudLoggingService implements LogService {
         private String logEvent;
         private GeneralLogEntry.SourceLocation sourceLocation;
         private String exceptionClass;
+        private String order;
 
         public static LogSearchParams from(QueryLogsParams queryLogsParams) {
             LogSearchParams logSearchParams = new LogSearchParams()
@@ -353,7 +363,8 @@ public class GoogleCloudLoggingService implements LogService {
                     .setUserInfoParams(queryLogsParams.getUserInfoParams())
                     .setLogEvent(queryLogsParams.getLogEvent())
                     .setSourceLocation(queryLogsParams.getSourceLocation())
-                    .setExceptionClass(queryLogsParams.getExceptionClass());
+                    .setExceptionClass(queryLogsParams.getExceptionClass())
+                    .setOrder(queryLogsParams.getOrder());
             if (queryLogsParams.getSeverityLevel() != null) {
                 logSearchParams.setSeverity(queryLogsParams.getSeverityLevel());
             } else if (queryLogsParams.getMinSeverity() != null) {
@@ -438,6 +449,11 @@ public class GoogleCloudLoggingService implements LogService {
 
         public LogSearchParams setExceptionClass(String exceptionClass) {
             this.exceptionClass = exceptionClass;
+            return this;
+        }
+
+        public LogSearchParams setOrder(String order) {
+            this.order = order;
             return this;
         }
     }

--- a/src/main/java/teammates/ui/webapi/QueryLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/QueryLogsAction.java
@@ -59,6 +59,7 @@ public class QueryLogsAction extends AdminOnlyAction {
         String sourceLocationFile = getRequestParamValue(Const.ParamsNames.QUERY_LOGS_SOURCE_LOCATION_FILE);
         String sourceLocationFunction = getRequestParamValue(Const.ParamsNames.QUERY_LOGS_SOURCE_LOCATION_FUNCTION);
         String exceptionClass = getRequestParamValue(Const.ParamsNames.QUERY_LOGS_EXCEPTION_CLASS);
+        String order = getRequestParamValue(Const.ParamsNames.QUERY_LOGS_ORDER);
 
         QueryLogsParams queryLogsParams = QueryLogsParams.builder(startTime, endTime)
                 .withSeverityLevel(severity)
@@ -69,6 +70,7 @@ public class QueryLogsAction extends AdminOnlyAction {
                 .withLogEvent(logEvent)
                 .withSourceLocation(new SourceLocation(sourceLocationFile, null, sourceLocationFunction))
                 .withExceptionClass(exceptionClass)
+                .withOrder(order)
                 .withPageSize(DEFAULT_PAGE_SIZE)
                 .withPageToken(nextPageToken)
                 .build();

--- a/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
@@ -7,25 +7,27 @@ exports[`LogsPageComponent should snap when page is still loading 1`] = `
   EVENTS={[Function Array]}
   LOGS_RETENTION_PERIOD_IN_DAYS={[Function Number]}
   LOGS_RETENTION_PERIOD_IN_MILLISECONDS={[Function Number]}
-  MAXIMUM_PAGES_FOR_ERROR_LOGS={[Function Number]}
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
-  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
+  earliestLogTimestampRetrieved={[Function Number]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
+  hasNextPage="false"
+  hasPreviousPage={[Function Boolean]}
   hasResult="false"
   histogramResult={[Function Array]}
   isFiltersExpanded="false"
   isLoading={[Function Boolean]}
   isSearching="false"
   isTableView={[Function Boolean]}
+  latestLogTimestampRetrieved="0"
   logService={[Function LogService]}
-  nextPageToken=""
   queryParams={[Function Object]}
   searchEndTime="0"
   searchResults={[Function Array]}
+  searchStartTime="0"
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -54,9 +56,15 @@ exports[`LogsPageComponent should snap when page is still loading 1`] = `
   </tm-loading-spinner><div>
     
     
+    <div
+      class="center mb-4"
+    >
+      
+    </div>
+    
     
     <div
-      class="center"
+      class="center mb-4"
     >
       
     </div>
@@ -72,25 +80,27 @@ exports[`LogsPageComponent should snap when searching for details in search form
   EVENTS={[Function Array]}
   LOGS_RETENTION_PERIOD_IN_DAYS={[Function Number]}
   LOGS_RETENTION_PERIOD_IN_MILLISECONDS={[Function Number]}
-  MAXIMUM_PAGES_FOR_ERROR_LOGS={[Function Number]}
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
-  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
+  earliestLogTimestampRetrieved={[Function Number]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
+  hasNextPage="false"
+  hasPreviousPage={[Function Boolean]}
   hasResult="false"
   histogramResult={[Function Array]}
   isFiltersExpanded="false"
   isLoading="false"
   isSearching={[Function Boolean]}
   isTableView={[Function Boolean]}
+  latestLogTimestampRetrieved="0"
   logService={[Function LogService]}
-  nextPageToken=""
   queryParams={[Function Object]}
   searchEndTime="0"
   searchResults={[Function Array]}
+  searchStartTime="0"
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -446,6 +456,22 @@ exports[`LogsPageComponent should snap when searching for details in search form
   </div><div>
     
     
+    <tm-loading-spinner>
+      <div
+        class="loading-container"
+      >
+        <div
+          class="row spinner-border text-primary"
+          role="status"
+        />
+        <div
+          class="row text-secondary"
+        >
+          Loading...
+        </div>
+      </div>
+    </tm-loading-spinner>
+    
     
     <tm-loading-spinner>
       <div
@@ -474,25 +500,27 @@ exports[`LogsPageComponent should snap with default fields 1`] = `
   EVENTS={[Function Array]}
   LOGS_RETENTION_PERIOD_IN_DAYS={[Function Number]}
   LOGS_RETENTION_PERIOD_IN_MILLISECONDS={[Function Number]}
-  MAXIMUM_PAGES_FOR_ERROR_LOGS={[Function Number]}
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
-  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
+  earliestLogTimestampRetrieved={[Function Number]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
+  hasNextPage="false"
+  hasPreviousPage={[Function Boolean]}
   hasResult="false"
   histogramResult={[Function Array]}
   isFiltersExpanded="false"
   isLoading={[Function Boolean]}
   isSearching="false"
   isTableView={[Function Boolean]}
+  latestLogTimestampRetrieved="0"
   logService={[Function LogService]}
-  nextPageToken=""
   queryParams={[Function Object]}
   searchEndTime="0"
   searchResults={[Function Array]}
+  searchStartTime="0"
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -521,9 +549,15 @@ exports[`LogsPageComponent should snap with default fields 1`] = `
   </tm-loading-spinner><div>
     
     
+    <div
+      class="center mb-4"
+    >
+      
+    </div>
+    
     
     <div
-      class="center"
+      class="center mb-4"
     >
       
     </div>

--- a/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`LogsPageComponent should snap when page is still loading 1`] = `
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
+  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
@@ -23,6 +24,7 @@ exports[`LogsPageComponent should snap when page is still loading 1`] = `
   logService={[Function LogService]}
   nextPageToken=""
   queryParams={[Function Object]}
+  searchEndTime="0"
   searchResults={[Function Array]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
@@ -52,11 +54,13 @@ exports[`LogsPageComponent should snap when page is still loading 1`] = `
   </tm-loading-spinner><div>
     
     
+    
     <div
       class="center"
     >
       
     </div>
+    
   </div>
 </tm-logs-page>
 `;
@@ -72,6 +76,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
+  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
@@ -84,6 +89,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
   logService={[Function LogService]}
   nextPageToken=""
   queryParams={[Function Object]}
+  searchEndTime="0"
   searchResults={[Function Array]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
@@ -445,6 +451,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
   </div><div>
     
     
+    
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -460,6 +467,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
         </div>
       </div>
     </tm-loading-spinner>
+    
   </div>
 </tm-logs-page>
 `;
@@ -475,6 +483,7 @@ exports[`LogsPageComponent should snap with default fields 1`] = `
   MIN_SEVERITY={[Function String]}
   SEVERITIES={[Function Array]}
   SEVERITY={[Function String]}
+  TEN_MINUTES_IN_MILLISECONDS={[Function Number]}
   dateToday={[Function Object]}
   earliestSearchDate={[Function Object]}
   formModel={[Function Object]}
@@ -487,6 +496,7 @@ exports[`LogsPageComponent should snap with default fields 1`] = `
   logService={[Function LogService]}
   nextPageToken=""
   queryParams={[Function Object]}
+  searchEndTime="0"
   searchResults={[Function Array]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
@@ -516,11 +526,13 @@ exports[`LogsPageComponent should snap with default fields 1`] = `
   </tm-loading-spinner><div>
     
     
+    
     <div
       class="center"
     >
       
     </div>
+    
   </div>
 </tm-logs-page>
 `;

--- a/src/web/app/pages-logs/logs-page.component.html
+++ b/src/web/app/pages-logs/logs-page.component.html
@@ -135,16 +135,19 @@
 </div>
 
 <div *ngIf="isTableView">
-  <div class="center mb-4" *ngIf="hasResult">
-    <button class="btn btn-light" (click)="extendEndTime()">Extend end time by 10 minutes</button>
+  <div class="center mb-4" *ngIf="hasResult && !hasPreviousPage">
+    <button class="btn btn-light" (click)="extendStartTime()">Extend start time by 10 minutes</button>
+  </div>
+  <div *tmIsLoading="isSearching" class="center mb-4">
+    <button *ngIf="hasResult" id="load-previous-button" class="btn btn-primary" (click)="loadPreviousLogs()" [disabled]="!hasPreviousPage">Load more</button>
   </div>
   <tm-logs-table *ngIf="hasResult" [logs]="searchResults" (addTraceEvent)="addTraceToFilter($event)" (addActionClassEvent)="addActionClassToFilter($event)"
     (addSourceLocationEvent)="addSourceLocationToFilter($event)" (addUserInfoEvent)="addUserInfoToFilter($event)"></tm-logs-table>
-  <div *tmIsLoading="isSearching" class="center">
-    <button *ngIf="hasResult" id="load-button" class="btn btn-primary" (click)="getNextPageLogs()" [disabled]="nextPageToken === ''">Load more</button>
+  <div *tmIsLoading="isSearching" class="center mb-4">
+    <button *ngIf="hasResult" id="load-next-button" class="btn btn-primary" (click)="loadLaterLogs()" [disabled]="!hasNextPage">Load more</button>
   </div>
-  <div class="center mt-4" *ngIf="hasResult && nextPageToken === ''">
-    <button class="btn btn-light" (click)="extendStartTime()">Extend start time by 10 minutes</button>
+  <div class="center mt-4" *ngIf="hasResult && !hasNextPage">
+    <button class="btn btn-light" (click)="extendEndTime()">Extend end time by 10 minutes</button>
   </div>
 </div>
 

--- a/src/web/app/pages-logs/logs-page.component.html
+++ b/src/web/app/pages-logs/logs-page.component.html
@@ -135,10 +135,16 @@
 </div>
 
 <div *ngIf="isTableView">
+  <div class="center mb-4" *ngIf="hasResult">
+    <button class="btn btn-light" (click)="extendEndTime()">Extend end time by 10 minutes</button>
+  </div>
   <tm-logs-table *ngIf="hasResult" [logs]="searchResults" (addTraceEvent)="addTraceToFilter($event)"
     (addSourceLocationEvent)="addSourceLocationToFilter($event)" (addUserInfoEvent)="addUserInfoToFilter($event)"></tm-logs-table>
   <div *tmIsLoading="isSearching" class="center">
     <button *ngIf="hasResult" id="load-button" class="btn btn-primary" (click)="getNextPageLogs()" [disabled]="nextPageToken === ''">Load more</button>
+  </div>
+  <div class="center mt-4" *ngIf="hasResult && nextPageToken === ''">
+    <button class="btn btn-light" (click)="extendStartTime()">Extend start time by 10 minutes</button>
   </div>
 </div>
 

--- a/src/web/app/pages-logs/logs-page.component.html
+++ b/src/web/app/pages-logs/logs-page.component.html
@@ -139,12 +139,12 @@
     <button class="btn btn-light" (click)="extendStartTime()">Extend start time by 10 minutes</button>
   </div>
   <div *tmIsLoading="isSearching" class="center mb-4">
-    <button *ngIf="hasResult" id="load-previous-button" class="btn btn-primary" (click)="loadPreviousLogs()" [disabled]="!hasPreviousPage">Load more</button>
+    <button *ngIf="hasResult && hasPreviousPage" id="load-previous-button" class="btn btn-primary" (click)="loadPreviousLogs()">Load more</button>
   </div>
   <tm-logs-table *ngIf="hasResult" [logs]="searchResults" (addTraceEvent)="addTraceToFilter($event)" (addActionClassEvent)="addActionClassToFilter($event)"
     (addSourceLocationEvent)="addSourceLocationToFilter($event)" (addUserInfoEvent)="addUserInfoToFilter($event)"></tm-logs-table>
   <div *tmIsLoading="isSearching" class="center mb-4">
-    <button *ngIf="hasResult" id="load-next-button" class="btn btn-primary" (click)="loadLaterLogs()" [disabled]="!hasNextPage">Load more</button>
+    <button *ngIf="hasResult && hasNextPage" id="load-next-button" class="btn btn-primary" (click)="loadLaterLogs()">Load more</button>
   </div>
   <div class="center mt-4" *ngIf="hasResult && !hasNextPage">
     <button class="btn btn-light" (click)="extendEndTime()">Extend end time by 10 minutes</button>

--- a/src/web/app/pages-logs/logs-page.component.spec.ts
+++ b/src/web/app/pages-logs/logs-page.component.spec.ts
@@ -276,7 +276,7 @@ describe('LogsPageComponent', () => {
     fixture.detectChanges();
 
     const button: any = fixture.debugElement.nativeElement.querySelector('#load-previous-button');
-    expect(button.disabled).toBeTruthy();
+    expect(button).toBeNull();
   });
 
   it('should search for all error logs when search button is clicked', () => {

--- a/src/web/app/pages-logs/logs-page.component.spec.ts
+++ b/src/web/app/pages-logs/logs-page.component.spec.ts
@@ -94,6 +94,7 @@ describe('LogsPageComponent', () => {
     expect(logSpy).toHaveBeenCalledWith({
       searchFrom: '0',
       searchUntil: '0',
+      order: 'desc',
       severity: 'INFO',
       advancedFilters: {},
     });
@@ -126,6 +127,7 @@ describe('LogsPageComponent', () => {
     expect(logSpy).toHaveBeenCalledWith({
       searchFrom: '0',
       searchUntil: '0',
+      order: 'desc',
       minSeverity: 'INFO',
       advancedFilters: {},
     });
@@ -163,6 +165,7 @@ describe('LogsPageComponent', () => {
     expect(logSpy).toHaveBeenCalledWith({
       searchFrom: '0',
       searchUntil: '0',
+      order: 'desc',
       logEvent: 'REQUEST_LOG',
       advancedFilters: {
         traceId: 'testTrace',
@@ -254,11 +257,25 @@ describe('LogsPageComponent', () => {
   });
 
   it('should disable load button if there is no next page token', () => {
-    component.nextPageToken = '';
+    spyOn(logService, 'searchLogs').and.returnValue(of({ logEntries: [] }));
+    spyOn(timezoneService, 'resolveLocalDateTime').and.returnValue(0);
+    component.formModel = {
+      logsSeverity: 'INFO',
+      logsMinSeverity: '',
+      logsEvent: '',
+      logsFilter: 'severity',
+      logsDateFrom: { year: 2021, month: 6, day: 1 },
+      logsTimeFrom: { hour: 23, minute: 59 },
+      logsDateTo: { year: 2021, month: 6, day: 2 },
+      logsTimeTo: { hour: 23, minute: 59 },
+      advancedFilters: {},
+    };
     component.isSearching = false;
     component.hasResult = true;
+    component.searchForLogs();
     fixture.detectChanges();
-    const button: any = fixture.debugElement.nativeElement.querySelector('#load-button');
+
+    const button: any = fixture.debugElement.nativeElement.querySelector('#load-previous-button');
     expect(button.disabled).toBeTruthy();
   });
 

--- a/src/web/app/pages-logs/logs-page.component.ts
+++ b/src/web/app/pages-logs/logs-page.component.ts
@@ -75,7 +75,7 @@ export class LogsPageComponent implements OnInit {
   isFiltersExpanded: boolean = false;
   searchStartTime: number = 0;
   searchEndTime: number = 0;
-  earliestLogTimestampRetrieved: number = Number. MAX_SAFE_INTEGER;
+  earliestLogTimestampRetrieved: number = Number.MAX_SAFE_INTEGER;
   latestLogTimestampRetrieved: number = 0;
   hasPreviousPage: boolean = true;
   hasNextPage: boolean = false;
@@ -123,7 +123,7 @@ export class LogsPageComponent implements OnInit {
     this.histogramResult = [];
     this.searchResults = [];
     this.isFiltersExpanded = false;
-    this.earliestLogTimestampRetrieved = Number. MAX_SAFE_INTEGER;
+    this.earliestLogTimestampRetrieved = Number.MAX_SAFE_INTEGER;
     this.latestLogTimestampRetrieved = 0;
     this.hasPreviousPage = true;
     this.hasNextPage = false;

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -28,6 +28,7 @@ export interface LogsEndpointQueryParams {
   minSeverity?: string;
   logEvent?: string;
   nextPageToken?: string;
+  order?: string;
   advancedFilters: AdvancedFilters;
 }
 
@@ -91,6 +92,10 @@ export class LogService {
       starttime: queryParams.searchFrom,
       endtime: queryParams.searchUntil,
     };
+
+    if (queryParams.order) {
+      paramMap.order = queryParams.order;
+    }
 
     if (queryParams.severity) {
       paramMap.severity = queryParams.severity;


### PR DESCRIPTION
Fixes #11310

**Outline of Solution**
The logs are now displayed in descending order.
Users can extend the search period for "before" and "after".
The "Extend start time" button will only appear if there are no more logs to fetch in the selected time period.
![start](https://user-images.githubusercontent.com/58677983/126931523-38d6a0b0-cdc6-49b2-aecf-43aae3a984a6.gif)

Extend end time
![end](https://user-images.githubusercontent.com/58677983/126931622-def9a4ee-2833-45e8-b724-2811a14826dc.gif)

