### PR TITLE
[#11314] Minimize checkstyle javadoc suppressions

### DIFF
--- a/src/client/java/teammates/client/connector/DatastoreClient.java
+++ b/src/client/java/teammates/client/connector/DatastoreClient.java
@@ -18,10 +18,17 @@ import teammates.storage.api.OfyHelper;
  */
 public abstract class DatastoreClient {
 
+    /**
+     * Gets the Objectify instance.
+     */
     protected Objectify ofy() {
         return ObjectifyService.ofy();
     }
 
+    /**
+     * Performs the entire operation routine: setting up connection to the back-end,
+     * performing the operation itself, and tearing down the connection.
+     */
     protected void doOperationRemotely() throws IOException {
 
         String appUrl = ClientProperties.TARGET_URL.replaceAll("^https?://", "");
@@ -50,7 +57,7 @@ public abstract class DatastoreClient {
     }
 
     /**
-     * This operation is meant to be overridden by child classes.
+     * Performs the remote operation to the back-end.
      */
     protected abstract void doOperation();
 }

--- a/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
@@ -49,9 +49,9 @@ public abstract class DataMigrationEntitiesBaseScript<T extends BaseEntity> exte
         new File(BASE_LOG_URI).mkdir();
     }
 
-    protected AtomicLong numberOfScannedKey;
-    protected AtomicLong numberOfAffectedEntities;
-    protected AtomicLong numberOfUpdatedEntities;
+    AtomicLong numberOfScannedKey;
+    AtomicLong numberOfAffectedEntities;
+    AtomicLong numberOfUpdatedEntities;
 
     // buffer of entities to save
     private List<T> entitiesSavingBuffer;

--- a/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
@@ -44,9 +44,7 @@ public abstract class DataMigrationEntitiesBaseScript<T extends BaseEntity> exte
     // see https://stackoverflow.com/questions/41499505/objectify-queries-setting-limit-above-300-does-not-work
     private static final int BATCH_SIZE = 100;
 
-    /*
-     * Creates the folder that will contain the stored log.
-     */
+    // Creates the folder that will contain the stored log.
     static {
         new File(BASE_LOG_URI).mkdir();
     }

--- a/src/client/java/teammates/client/scripts/MockCourseWithLargeResponseScript.java
+++ b/src/client/java/teammates/client/scripts/MockCourseWithLargeResponseScript.java
@@ -71,7 +71,7 @@ public final class MockCourseWithLargeResponseScript extends DatastoreClient {
     @Override
     protected void doOperation() {
         try {
-            Logic logic = new Logic();
+            Logic logic = Logic.inst();
             DataBundle data = generateDataBundle();
             logic.removeDataBundle(data);
             logic.persistDataBundle(data);

--- a/src/client/java/teammates/client/scripts/PopulateCourseSearchDocuments.java
+++ b/src/client/java/teammates/client/scripts/PopulateCourseSearchDocuments.java
@@ -21,7 +21,7 @@ import teammates.storage.entity.Course;
 public class PopulateCourseSearchDocuments extends DataMigrationEntitiesBaseScript<Course> {
 
     private static final int STUDENT_SIZE_LIMIT = 300;
-    private final Logic logic = new Logic();
+    private final Logic logic = Logic.inst();
 
     public PopulateCourseSearchDocuments() {
         numberOfScannedKey.set(0L);

--- a/src/client/java/teammates/client/scripts/statistics/FileStore.java
+++ b/src/client/java/teammates/client/scripts/statistics/FileStore.java
@@ -41,9 +41,7 @@ public class FileStore {
 
     private static final String BASE_URI = "src/client/java/teammates/client/scripts/statistics/data/";
 
-    /*
-     * Creates the folder that will contain the stored data.
-     */
+    // Creates the folder that will contain the stored data.
     static {
         new File(BASE_URI).mkdir();
     }

--- a/src/e2e/java/teammates/e2e/cases/AutomatedSessionRemindersE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AutomatedSessionRemindersE2ETest.java
@@ -51,6 +51,11 @@ public class AutomatedSessionRemindersE2ETest extends BaseE2ETestCase {
         removeAndRestoreDataBundle(testData);
     }
 
+    @Override
+    protected void prepareBrowser() {
+        // this test does not require any browser
+    }
+
     @Test
     @Override
     public void testAll() {

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -53,12 +53,25 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         prepareBrowser();
     }
 
+    /**
+     * Prepares the browser used for the current test.
+     */
     protected void prepareBrowser() {
         browser = new Browser();
     }
 
-    protected abstract void prepareTestData() throws Exception;
+    /**
+     * Prepares the test data used for the current test.
+     */
+    protected abstract void prepareTestData();
 
+    /**
+     * Contains all the tests for the page.
+     *
+     * <p>This approach is chosen so that setup and teardown are only needed once per test page,
+     * thereby saving time. While it necessitates failed tests to be restarted from the beginning,
+     * test failures are rare and thus not causing significant overhead.
+     */
     protected abstract void testAll();
 
     @Override
@@ -66,22 +79,14 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return TestProperties.TEST_DATA_FOLDER;
     }
 
-    protected String getTestDownloadsFolder() {
-        return TestProperties.TEST_DOWNLOADS_FOLDER;
-    }
-
     @AfterClass
     public void baseClassTearDown(ITestContext context) {
-        boolean isSuccess = context.getFailedTests().getAllMethods()
-                .stream()
-                .noneMatch(method -> method.getConstructorOrMethod().getMethod().getDeclaringClass() == this.getClass());
-        releaseBrowser(isSuccess);
-    }
-
-    protected void releaseBrowser(boolean isSuccess) {
         if (browser == null) {
             return;
         }
+        boolean isSuccess = context.getFailedTests().getAllMethods()
+                .stream()
+                .noneMatch(method -> method.getConstructorOrMethod().getMethod().getDeclaringClass() == this.getClass());
         if (isSuccess || TestProperties.CLOSE_BROWSER_ON_FAILURE) {
             browser.close();
         }
@@ -141,7 +146,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
      * Deletes file with fileName from the downloads folder.
      */
     protected void deleteDownloadsFile(String fileName) {
-        String filePath = getTestDownloadsFolder() + fileName;
+        String filePath = TestProperties.TEST_DOWNLOADS_FOLDER + fileName;
         FileHelper.deleteFile(filePath);
     }
 
@@ -149,7 +154,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
      * Verifies downloaded file has correct fileName and contains expected content.
      */
     protected void verifyDownloadedFile(String expectedFileName, List<String> expectedContent) {
-        String filePath = getTestDownloadsFolder() + expectedFileName;
+        String filePath = TestProperties.TEST_DOWNLOADS_FOLDER + expectedFileName;
         int retryLimit = TestProperties.TEST_TIMEOUT;
         boolean actual = Files.exists(Paths.get(filePath));
         while (!actual && retryLimit > 0) {
@@ -169,6 +174,9 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         }
     }
 
+    /**
+     * Visits the URL and gets the page object representation of the visited web page in the browser.
+     */
     protected <T extends AppPage> T getNewPageInstance(AppUrl url, Class<T> typeOfPage) {
         browser.goToUrl(url.toAbsoluteString());
         return AppPage.getNewPageInstance(browser, typeOfPage);

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -44,7 +44,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
 
     static final BackDoor BACKDOOR = BackDoor.getInstance();
 
-    protected DataBundle testData;
+    DataBundle testData;
     private Browser browser;
 
     @BeforeClass
@@ -209,7 +209,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         }
     }
 
-    protected AccountAttributes getAccount(String googleId) {
+    AccountAttributes getAccount(String googleId) {
         return BACKDOOR.getAccount(googleId);
     }
 
@@ -224,7 +224,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return null; // BACKDOOR.getStudentProfile(studentProfileAttributes.googleId);
     }
 
-    protected CourseAttributes getCourse(String courseId) {
+    CourseAttributes getCourse(String courseId) {
         return BACKDOOR.getCourse(courseId);
     }
 
@@ -233,11 +233,11 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getCourse(course.getId());
     }
 
-    protected CourseAttributes getArchivedCourse(String instructorId, String courseId) {
+    CourseAttributes getArchivedCourse(String instructorId, String courseId) {
         return BACKDOOR.getArchivedCourse(instructorId, courseId);
     }
 
-    protected FeedbackQuestionAttributes getFeedbackQuestion(String courseId, String feedbackSessionName, int qnNumber) {
+    FeedbackQuestionAttributes getFeedbackQuestion(String courseId, String feedbackSessionName, int qnNumber) {
         return BACKDOOR.getFeedbackQuestion(courseId, feedbackSessionName, qnNumber);
     }
 
@@ -246,7 +246,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getFeedbackQuestion(fq.getCourseId(), fq.getFeedbackSessionName(), fq.getQuestionNumber());
     }
 
-    protected FeedbackResponseCommentAttributes getFeedbackResponseComment(String feedbackResponseId) {
+    FeedbackResponseCommentAttributes getFeedbackResponseComment(String feedbackResponseId) {
         return BACKDOOR.getFeedbackResponseComment(feedbackResponseId);
     }
 
@@ -255,7 +255,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getFeedbackResponseComment(frc.getFeedbackResponseId());
     }
 
-    protected FeedbackResponseAttributes getFeedbackResponse(String feedbackQuestionId, String giver, String recipient) {
+    FeedbackResponseAttributes getFeedbackResponse(String feedbackQuestionId, String giver, String recipient) {
         return BACKDOOR.getFeedbackResponse(feedbackQuestionId, giver, recipient);
     }
 
@@ -264,7 +264,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getFeedbackResponse(fr.getFeedbackQuestionId(), fr.getGiver(), fr.getRecipient());
     }
 
-    protected FeedbackSessionAttributes getFeedbackSession(String courseId, String feedbackSessionName) {
+    FeedbackSessionAttributes getFeedbackSession(String courseId, String feedbackSessionName) {
         return BACKDOOR.getFeedbackSession(courseId, feedbackSessionName);
     }
 
@@ -273,11 +273,11 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getFeedbackSession(fs.getCourseId(), fs.getFeedbackSessionName());
     }
 
-    protected FeedbackSessionAttributes getSoftDeletedSession(String feedbackSessionName, String instructorId) {
+    FeedbackSessionAttributes getSoftDeletedSession(String feedbackSessionName, String instructorId) {
         return BACKDOOR.getSoftDeletedSession(feedbackSessionName, instructorId);
     }
 
-    protected InstructorAttributes getInstructor(String courseId, String instructorEmail) {
+    InstructorAttributes getInstructor(String courseId, String instructorEmail) {
         return BACKDOOR.getInstructor(courseId, instructorEmail);
     }
 
@@ -286,7 +286,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return getInstructor(instructor.getCourseId(), instructor.getEmail());
     }
 
-    protected String getKeyForInstructor(String courseId, String instructorEmail) {
+    String getKeyForInstructor(String courseId, String instructorEmail) {
         return getInstructor(courseId, instructorEmail).getKey();
     }
 
@@ -295,7 +295,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         return BACKDOOR.getStudent(student.getCourse(), student.getEmail());
     }
 
-    protected String getKeyForStudent(StudentAttributes student) {
+    String getKeyForStudent(StudentAttributes student) {
         return getStudent(student).getKey();
     }
 

--- a/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
@@ -23,16 +23,16 @@ import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
  * will save some testing time.
  */
 public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
-    protected InstructorAttributes instructor;
-    protected CourseAttributes course;
-    protected FeedbackSessionAttributes feedbackSession;
-    protected StudentAttributes student;
+    InstructorAttributes instructor;
+    CourseAttributes course;
+    FeedbackSessionAttributes feedbackSession;
+    StudentAttributes student;
 
-    protected abstract void testEditPage();
+    abstract void testEditPage();
 
-    protected abstract void testSubmitPage();
+    abstract void testSubmitPage();
 
-    protected InstructorFeedbackEditPage loginToFeedbackEditPage() {
+    InstructorFeedbackEditPage loginToFeedbackEditPage() {
         AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
@@ -40,7 +40,7 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
         return loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
     }
 
-    protected FeedbackSubmitPage loginToFeedbackSubmitPage() {
+    FeedbackSubmitPage loginToFeedbackSubmitPage() {
         AppUrl url = createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(student.getCourse())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
@@ -48,7 +48,7 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
         return loginToPage(url, FeedbackSubmitPage.class, student.getGoogleId());
     }
 
-    protected FeedbackSubmitPage getFeedbackSubmitPage() {
+    FeedbackSubmitPage getFeedbackSubmitPage() {
         AppUrl url = createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(student.getCourse())
                 .withSessionName(feedbackSession.getFeedbackSessionName());

--- a/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
+++ b/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
@@ -20,6 +20,7 @@ import teammates.e2e.pageobjects.IanaTimezonePage;
  */
 public class TimezoneSyncerTest extends BaseE2ETestCase {
 
+    private static final String IANA_TIMEZONE_DATABASE_URL = "https://www.iana.org/time-zones";
     private static final int DAYS_TO_UPDATE_TZ = 120;
 
     @Override
@@ -51,7 +52,7 @@ public class TimezoneSyncerTest extends BaseE2ETestCase {
         ______TS("ensure the timezone databases are up-to-date");
         String currentTzVersion = timezonePage.getMomentTimezoneVersion();
         IanaTimezonePage ianaPage = getNewPageInstance(
-                new AppUrl(IanaTimezonePage.IANA_TIMEZONE_DATABASE_URL), IanaTimezonePage.class);
+                new AppUrl(IANA_TIMEZONE_DATABASE_URL), IanaTimezonePage.class);
         String latestTzVersion = ianaPage.getVersion();
 
         if (!currentTzVersion.equals(latestTzVersion)) {

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -109,7 +109,9 @@ public abstract class AppPage {
     }
 
     /**
-     * Fails if the new page content does not match content expected in a page of
+     * Gets a new page object representation of the currently open web page in the browser.
+     *
+     * <p>Fails if the new page content does not match content expected in a page of
      * the type indicated by the parameter {@code typeOfPage}.
      */
     public static <T extends AppPage> T getNewPageInstance(Browser currentBrowser, Class<T> typeOfPage) {

--- a/src/e2e/java/teammates/e2e/pageobjects/IanaTimezonePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/IanaTimezonePage.java
@@ -8,8 +8,6 @@ import org.openqa.selenium.support.FindBy;
  */
 public class IanaTimezonePage extends AppPage {
 
-    public static final String IANA_TIMEZONE_DATABASE_URL = "https://www.iana.org/time-zones";
-
     @FindBy(id = "version")
     private WebElement timezoneVersion;
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -22,29 +22,29 @@ import teammates.common.util.ThreadHelper;
  * Represents the instructor course edit page of the website.
  */
 public class InstructorCourseEditPage extends AppPage {
-    public static final int INSTRUCTOR_TYPE_COOWNER = 0;
-    public static final int INSTRUCTOR_TYPE_MANAGER = 1;
-    public static final int INSTRUCTOR_TYPE_OBSERVER = 2;
-    public static final int INSTRUCTOR_TYPE_TUTOR = 3;
-    public static final int INSTRUCTOR_TYPE_CUSTOM = 4;
+    private static final int INSTRUCTOR_TYPE_COOWNER = 0;
+    private static final int INSTRUCTOR_TYPE_MANAGER = 1;
+    private static final int INSTRUCTOR_TYPE_OBSERVER = 2;
+    private static final int INSTRUCTOR_TYPE_TUTOR = 3;
+    private static final int INSTRUCTOR_TYPE_CUSTOM = 4;
 
-    public static final int COURSE_MODIFY_COURSE = 0;
-    public static final int COURSE_MODIFY_INSTRUCTORS = 1;
-    public static final int COURSE_MODIFY_SESSIONS = 2;
-    public static final int COURSE_MODIFY_STUDENTS = 3;
-    public static final int COURSE_VIEW_STUDENTS = 4;
-    public static final int COURSE_GIVE_RESPONSES_IN_SESSION = 5;
-    public static final int COURSE_VIEW_RESPONSES_IN_SESSION = 6;
-    public static final int COURSE_MODIFY_RESPONSES_IN_SESSION = 7;
+    private static final int COURSE_MODIFY_COURSE = 0;
+    private static final int COURSE_MODIFY_INSTRUCTORS = 1;
+    private static final int COURSE_MODIFY_SESSIONS = 2;
+    private static final int COURSE_MODIFY_STUDENTS = 3;
+    private static final int COURSE_VIEW_STUDENTS = 4;
+    private static final int COURSE_GIVE_RESPONSES_IN_SESSION = 5;
+    private static final int COURSE_VIEW_RESPONSES_IN_SESSION = 6;
+    private static final int COURSE_MODIFY_RESPONSES_IN_SESSION = 7;
 
-    public static final int SECTION_VIEW_STUDENTS = 0;
-    public static final int SECTION_GIVE_RESPONSES_IN_SESSION = 1;
-    public static final int SECTION_VIEW_RESPONSES_IN_SESSION = 2;
-    public static final int SECTION_MODIFY_RESPONSES_IN_SESSION = 3;
+    private static final int SECTION_VIEW_STUDENTS = 0;
+    private static final int SECTION_GIVE_RESPONSES_IN_SESSION = 1;
+    private static final int SECTION_VIEW_RESPONSES_IN_SESSION = 2;
+    private static final int SECTION_MODIFY_RESPONSES_IN_SESSION = 3;
 
-    public static final int SESSION_GIVE_RESPONSES = 0;
-    public static final int SESSION_VIEW_RESPONSES = 1;
-    public static final int SESSION_MODIFY_RESPONSES = 2;
+    private static final int SESSION_GIVE_RESPONSES = 0;
+    private static final int SESSION_VIEW_RESPONSES = 1;
+    private static final int SESSION_MODIFY_RESPONSES = 2;
 
     @FindBy(id = "course-id")
     private WebElement courseIdTextBox;

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -279,7 +279,7 @@ public class InstructorCourseEditPage extends AppPage {
         return browser.driver.findElements(By.cssSelector(".card-header")).size() - 1;
     }
 
-    /* Methods for clicking buttons and links */
+    // Methods for clicking buttons and links
 
     private void clickEditCourseButton() {
         click(editCourseButton);
@@ -320,7 +320,7 @@ public class InstructorCourseEditPage extends AppPage {
         click(getAddSessionLevelPrivilegesLink(instrNum, panelNum));
     }
 
-    /* Methods that return WebElements of the page */
+    // Methods that return WebElements of the page
 
     public String getCourseId() {
         return courseIdTextBox.getAttribute("value");
@@ -485,7 +485,7 @@ public class InstructorCourseEditPage extends AppPage {
         return sessionLevelTableRow.findElements(By.cssSelector("input[type='checkbox']")).get(checkBoxIndex);
     }
 
-    /* Methods for indexing */
+    // Methods for indexing
 
     private int getRoleIndex(String role) {
         switch(role) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -557,7 +557,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             return;
         }
         verifyOptions(questionNum, questionDetails.getMcqChoices());
-        verifyOptionWeights(questionNum, questionDetails.hasAssignedWeights(), questionDetails.getMcqWeights());
+        verifyOptionWeights(questionNum, questionDetails.isHasAssignedWeights(), questionDetails.getMcqWeights());
         verifyOtherOption(questionNum, questionDetails.isOtherEnabled(), questionDetails.getMcqOtherWeight());
     }
 
@@ -583,7 +583,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             return;
         }
         verifyOptions(questionNum, questionDetails.getMsqChoices());
-        verifyOptionWeights(questionNum, questionDetails.hasAssignedWeights(), questionDetails.getMsqWeights());
+        verifyOptionWeights(questionNum, questionDetails.isHasAssignedWeights(), questionDetails.getMsqWeights());
         verifyOtherOption(questionNum, questionDetails.isOtherEnabled(), questionDetails.getMsqOtherWeight());
     }
 
@@ -717,7 +717,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             }
         }
 
-        if (questionDetails.hasAssignedWeights()) {
+        if (questionDetails.isHasAssignedWeights()) {
             assertTrue(getWeightCheckbox(questionNum).isSelected());
             List<List<Double>> weights = questionDetails.getRubricWeights();
             for (int i = 0; i < numSubQn; i++) {
@@ -753,7 +753,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             FeedbackRankOptionsQuestionDetails optionDetails = (FeedbackRankOptionsQuestionDetails) questionDetails;
             verifyOptions(questionNum, optionDetails.getOptions());
         }
-        assertEquals(getAllowDuplicateRankCheckbox(questionNum).isSelected(), questionDetails.areDuplicatesAllowed());
+        assertEquals(getAllowDuplicateRankCheckbox(questionNum).isSelected(), questionDetails.isAreDuplicatesAllowed());
         verifyMaxOptions(questionNum, questionDetails.getMaxOptionsToBeRanked());
         verifyMinOptions(questionNum, questionDetails.getMinOptionsToBeRanked());
     }
@@ -1265,7 +1265,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
 
         inputOptions(questionNum, questionDetails.getMcqChoices());
-        inputOptionWeights(questionNum, questionDetails.hasAssignedWeights(), questionDetails.getMcqWeights());
+        inputOptionWeights(questionNum, questionDetails.isHasAssignedWeights(), questionDetails.getMcqWeights());
         inputOtherChoice(questionNum, questionDetails.isOtherEnabled(), questionDetails.getMcqOtherWeight());
     }
 
@@ -1367,7 +1367,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
 
         inputOptions(questionNum, questionDetails.getMsqChoices());
-        inputOptionWeights(questionNum, questionDetails.hasAssignedWeights(), questionDetails.getMsqWeights());
+        inputOptionWeights(questionNum, questionDetails.isHasAssignedWeights(), questionDetails.getMsqWeights());
         inputOtherChoice(questionNum, questionDetails.isOtherEnabled(), questionDetails.getMsqOtherWeight());
         inputMaxOptions(questionNum, questionDetails.getMaxSelectableChoices());
         inputMinOptions(questionNum, questionDetails.getMinSelectableChoices());
@@ -1530,7 +1530,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             }
         }
 
-        if (questionDetails.hasAssignedWeights()) {
+        if (questionDetails.isHasAssignedWeights()) {
             markOptionAsSelected(getWeightCheckbox(questionNum));
             List<List<Double>> weights = questionDetails.getRubricWeights();
             for (int i = 0; i < numSubQn; i++) {
@@ -1577,7 +1577,7 @@ public class InstructorFeedbackEditPage extends AppPage {
             FeedbackRankOptionsQuestionDetails optionDetails = (FeedbackRankOptionsQuestionDetails) questionDetails;
             inputOptions(questionNum, optionDetails.getOptions());
         }
-        if (questionDetails.areDuplicatesAllowed()) {
+        if (questionDetails.isAreDuplicatesAllowed()) {
             markOptionAsSelected(getAllowDuplicateRankCheckbox(questionNum));
         } else {
             markOptionAsUnselected(getAllowDuplicateRankCheckbox(questionNum));

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -667,7 +667,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         List<Double> weights = questionDetails.getMcqWeights();
         Double otherWeight = questionDetails.getMcqOtherWeight();
         boolean isOtherEnabled = questionDetails.isOtherEnabled();
-        boolean hasAssignedWeights = questionDetails.hasAssignedWeights();
+        boolean hasAssignedWeights = questionDetails.isHasAssignedWeights();
 
         int numRows = isOtherEnabled ? choices.size() + 1 : choices.size();
         String[][] expectedStatistics = new String[numRows][2];

--- a/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
+++ b/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
@@ -32,7 +32,6 @@ import com.google.gson.stream.JsonReader;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.exception.HttpRequestFailedException;
-import teammates.common.exception.TeammatesException;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.Logger;
 import teammates.lnp.util.BackDoor;
@@ -52,7 +51,8 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
     protected static final String POST = HttpPost.METHOD_NAME;
     protected static final String PUT = HttpPut.METHOD_NAME;
     protected static final String DELETE = HttpDelete.METHOD_NAME;
-    protected static final Logger log = Logger.getLogger();
+
+    private static final Logger log = Logger.getLogger();
 
     private static final int RESULT_COUNT = 3;
 
@@ -222,15 +222,11 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
     /**
      * Creates the JSON test data and CSV config data files for the performance test from {@code testData}.
      */
-    protected void createTestData() {
+    protected void createTestData() throws IOException, HttpRequestFailedException {
         LNPTestData testData = getTestData();
-        try {
-            createJsonDataFile(testData);
-            persistTestData();
-            createCsvConfigDataFile(testData);
-        } catch (IOException | HttpRequestFailedException ex) {
-            log.severe(TeammatesException.toStringWithStackTrace(ex));
-        }
+        createJsonDataFile(testData);
+        persistTestData();
+        createCsvConfigDataFile(testData);
     }
 
     /**

--- a/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
+++ b/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
@@ -60,6 +60,9 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
     protected String timeStamp;
     protected LNPSpecification specification;
 
+    /**
+     * Returns the test data used for the current test.
+     */
     protected abstract LNPTestData getTestData();
 
     /**

--- a/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
+++ b/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
@@ -47,18 +47,18 @@ import teammates.test.FileHelper;
  */
 public abstract class BaseLNPTestCase extends BaseTestCase {
 
-    protected static final String GET = HttpGet.METHOD_NAME;
-    protected static final String POST = HttpPost.METHOD_NAME;
-    protected static final String PUT = HttpPut.METHOD_NAME;
-    protected static final String DELETE = HttpDelete.METHOD_NAME;
+    static final String GET = HttpGet.METHOD_NAME;
+    static final String POST = HttpPost.METHOD_NAME;
+    static final String PUT = HttpPut.METHOD_NAME;
+    static final String DELETE = HttpDelete.METHOD_NAME;
 
     private static final Logger log = Logger.getLogger();
 
     private static final int RESULT_COUNT = 3;
 
-    protected final BackDoor backdoor = BackDoor.getInstance();
-    protected String timeStamp;
-    protected LNPSpecification specification;
+    final BackDoor backdoor = BackDoor.getInstance();
+    String timeStamp;
+    LNPSpecification specification;
 
     /**
      * Returns the test data used for the current test.
@@ -117,7 +117,7 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
                         this.getClass().getSimpleName(), this.timeStamp);
     }
 
-    protected String createFileAndDirectory(String directory, String fileName) throws IOException {
+    String createFileAndDirectory(String directory, String fileName) throws IOException {
         File dir = new File(directory);
         if (!dir.exists()) {
             dir.mkdir();

--- a/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
@@ -30,6 +30,7 @@ import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -325,7 +326,7 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -81,11 +80,6 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
@@ -28,6 +28,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -270,7 +271,7 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
@@ -25,6 +25,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.lnp.util.JMeterElements;
 import teammates.lnp.util.LNPSpecification;
@@ -239,7 +240,7 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -59,11 +58,6 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
@@ -23,6 +23,7 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -196,7 +197,7 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
@@ -72,11 +71,6 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
             return testData;
         }
         testData = new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
@@ -27,7 +27,6 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.exception.HttpRequestFailedException;
-import teammates.common.exception.TeammatesException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -242,14 +241,10 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @Override
-    protected void createTestData() {
+    protected void createTestData() throws IOException, HttpRequestFailedException {
         LNPTestData testData = getTestData();
-        try {
-            createJsonDataFile(testData);
-            persistTestData();
-        } catch (IOException | HttpRequestFailedException ex) {
-            log.severe(TeammatesException.toStringWithStackTrace(ex));
-        }
+        createJsonDataFile(testData);
+        persistTestData();
     }
 
     @Override
@@ -318,7 +313,7 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
@@ -19,6 +19,7 @@ import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -180,7 +181,7 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
@@ -16,7 +16,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.HttpRequestFailedException;
@@ -48,11 +47,6 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
@@ -30,6 +30,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -323,7 +324,7 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -80,11 +79,6 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
@@ -29,6 +29,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -296,7 +297,7 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -78,11 +77,6 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/StudentProfileLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentProfileLNPTest.java
@@ -20,6 +20,7 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.lnp.util.JMeterElements;
 import teammates.lnp.util.LNPSpecification;
@@ -189,7 +190,7 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -78,11 +77,6 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
@@ -29,6 +29,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -296,7 +297,7 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -78,11 +77,6 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
     @Override
     protected LNPTestData getTestData() {
         return new LNPTestData() {
-            @Override
-            protected Map<String, AccountAttributes> generateAccounts() {
-                return new HashMap<>();
-            }
-
             @Override
             protected Map<String, CourseAttributes> generateCourses() {
                 Map<String, CourseAttributes> courses = new HashMap<>();

--- a/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
@@ -29,6 +29,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.lnp.util.JMeterElements;
@@ -296,7 +297,7 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
     }
 
     @BeforeClass
-    public void classSetup() {
+    public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
         setupSpecification();

--- a/src/lnp/java/teammates/lnp/util/LNPSpecification.java
+++ b/src/lnp/java/teammates/lnp/util/LNPSpecification.java
@@ -77,7 +77,6 @@ public class LNPSpecification {
             specification = new LNPSpecification();
         }
 
-        //CHECKSTYLE.OFF:MissingJavadocMethod
         public Builder withErrorRateLimit(double errorRateLimit) {
             specification.errorRateLimit = errorRateLimit;
             return this;
@@ -91,6 +90,5 @@ public class LNPSpecification {
         public LNPSpecification build() {
             return specification;
         }
-        //CHECKSTYLE.ON:MissingJavadocMethod
     }
 }

--- a/src/lnp/java/teammates/lnp/util/LNPTestData.java
+++ b/src/lnp/java/teammates/lnp/util/LNPTestData.java
@@ -21,6 +21,8 @@ import teammates.common.datatransfer.attributes.StudentProfileAttributes;
  */
 public abstract class LNPTestData {
 
+    // CHECKSTYLE.OFF:MissingJavadocMethod generator for different entities are self-explained by the method name
+
     protected Map<String, AccountAttributes> generateAccounts() {
         return new HashMap<>();
     }
@@ -56,6 +58,8 @@ public abstract class LNPTestData {
     protected Map<String, StudentProfileAttributes> generateProfiles() {
         return new HashMap<>();
     }
+
+    // CHECKSTYLE.ON:MissingJavadocMethod
 
     /**
      * Returns a JSON data bundle containing the data relevant for the performance test.

--- a/src/main/java/teammates/common/datatransfer/CourseRoster.java
+++ b/src/main/java/teammates/common/datatransfer/CourseRoster.java
@@ -39,6 +39,9 @@ public class CourseRoster {
         return teamToMembersTable;
     }
 
+    /**
+     * Checks whether a student is in course.
+     */
     public boolean isStudentInCourse(String studentEmail) {
         return studentListByEmail.containsKey(studentEmail);
     }
@@ -50,11 +53,17 @@ public class CourseRoster {
         return teamToMembersTable.containsKey(teamName);
     }
 
+    /**
+     * Checks whether a student is in team.
+     */
     public boolean isStudentInTeam(String studentEmail, String targetTeamName) {
         StudentAttributes student = studentListByEmail.get(studentEmail);
         return student != null && student.getTeam().equals(targetTeamName);
     }
 
+    /**
+     * Checks whether two students are in the same team.
+     */
     public boolean isStudentsInSameTeam(String studentEmail1, String studentEmail2) {
         StudentAttributes student1 = studentListByEmail.get(studentEmail1);
         StudentAttributes student2 = studentListByEmail.get(studentEmail2);
@@ -62,10 +71,16 @@ public class CourseRoster {
                 && student1.getTeam() != null && student1.getTeam().equals(student2.getTeam());
     }
 
+    /**
+     * Returns the student object for the given email.
+     */
     public StudentAttributes getStudentForEmail(String email) {
         return studentListByEmail.get(email);
     }
 
+    /**
+     * Returns the instructor object for the given email.
+     */
     public InstructorAttributes getInstructorForEmail(String email) {
         return instructorListByEmail.get(email);
     }

--- a/src/main/java/teammates/common/datatransfer/DataBundle.java
+++ b/src/main/java/teammates/common/datatransfer/DataBundle.java
@@ -15,8 +15,10 @@ import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 
 /**
  * Holds a bundle of *Attributes data transfer objects.
- * This class is mainly used for serializing JSON strings.
+ *
+ * <p>This class is mainly used for serializing JSON strings.
  */
+// CHECKSTYLE.OFF:JavadocVariable each field represents different entity types
 public class DataBundle {
     public Map<String, AccountAttributes> accounts = new LinkedHashMap<>();
     public Map<String, CourseAttributes> courses = new LinkedHashMap<>();

--- a/src/main/java/teammates/common/datatransfer/ErrorLogEntry.java
+++ b/src/main/java/teammates/common/datatransfer/ErrorLogEntry.java
@@ -4,11 +4,19 @@ package teammates.common.datatransfer;
  * Represents an error level entry from the logs.
  */
 public class ErrorLogEntry {
-    public String message;
-    public String severity;
+    private final String message;
+    private final String severity;
 
     public ErrorLogEntry(String message, String severity) {
         this.message = message;
         this.severity = severity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getSeverity() {
+        return severity;
     }
 }

--- a/src/main/java/teammates/common/datatransfer/ErrorLogEntry.java
+++ b/src/main/java/teammates/common/datatransfer/ErrorLogEntry.java
@@ -1,5 +1,8 @@
 package teammates.common.datatransfer;
 
+/**
+ * Represents an error level entry from the logs.
+ */
 public class ErrorLogEntry {
     public String message;
     public String severity;

--- a/src/main/java/teammates/common/datatransfer/FeedbackParticipantType.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackParticipantType.java
@@ -4,22 +4,79 @@ package teammates.common.datatransfer;
  * Represents the type of an entity that is involved in a feedback question or response.
  */
 public enum FeedbackParticipantType {
-    // booleans represent: isValidGiver?, isValidRecipient? isValidViewer?
+    // booleans represent: isValidGiver?, isValidRecipient?, isValidViewer?
+
+    /**
+     * Represents "own self".
+     *
+     * <p>As a recipient, it represents the same person as the response giver.
+     *
+     * <p>As a giver, it represents the feedback session creator.
+     */
     SELF(true, true, false),
+
+    /**
+     * Students of the course.
+     */
     STUDENTS(true, true, true),
-    //used to generate options for MCQ & MSQ:
+
+    /**
+     * Students of the course, excluding the response giver.
+     *
+     * <p>Used to generate options for MCQ & MSQ.
+     */
     STUDENTS_EXCLUDING_SELF(false, false, false),
 
+    /**
+     * Instructors of the course.
+     */
     INSTRUCTORS(true, true, true),
+
+    /**
+     * Teams of the course.
+     */
     TEAMS(true, true, false),
+
+    /**
+     * Teams of the course, excluding the response giver.
+     */
     TEAMS_EXCLUDING_SELF(false, false, false),
+
+    /**
+     * Team of the response giver.
+     */
     OWN_TEAM(false, true, false),
+
+    /**
+     * Team members of the response giver, excluding the response giver.
+     */
     OWN_TEAM_MEMBERS(false, true, true),
+
+    /**
+     * Team members of the response giver, including the response giver.
+     */
     OWN_TEAM_MEMBERS_INCLUDING_SELF(false, true, true),
+
+    /**
+     * Receiver of the response.
+     */
     RECEIVER(false, false, true),
+
+    /**
+     * Team members of the receiver of the response.
+     */
     RECEIVER_TEAM_MEMBERS(false, false, true),
+
+    /**
+     * Represents "no specific recipient".
+     */
     NONE(false, true, false),
-    // Used by feedbackResponseComment:
+
+    /**
+     * Giver of the response.
+     *
+     * <p>Used by feedbackResponseComment.
+     */
     GIVER(false, false, true);
 
     private final boolean validGiver;

--- a/src/main/java/teammates/common/datatransfer/FeedbackParticipantType.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackParticipantType.java
@@ -1,5 +1,8 @@
 package teammates.common.datatransfer;
 
+/**
+ * Represents the type of an entity that is involved in a feedback question or response.
+ */
 public enum FeedbackParticipantType {
     // booleans represent: isValidGiver?, isValidRecipient? isValidViewer?
     SELF(true, true, false),

--- a/src/main/java/teammates/common/datatransfer/GeneralLogEntry.java
+++ b/src/main/java/teammates/common/datatransfer/GeneralLogEntry.java
@@ -77,6 +77,9 @@ public class GeneralLogEntry {
         return details;
     }
 
+    /**
+     * Represents a location of source code that produces a log line.
+     */
     public static class SourceLocation {
         private final String file;
         private final Long line;

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -264,18 +264,30 @@ public final class InstructorPrivileges {
         return isAllowedInSessionLevelAnySection(sessionName, privilegeName);
     }
 
+    /**
+     * Returns true if co-owner privilege exists.
+     */
     public boolean hasCoownerPrivileges() {
         return hasSamePrivileges(PRIVILEGES_COOWNER);
     }
 
+    /**
+     * Returns true if manager privilege exists.
+     */
     public boolean hasManagerPrivileges() {
         return hasSamePrivileges(PRIVILEGES_MANAGER);
     }
 
+    /**
+     * Returns true if observer privilege exists.
+     */
     public boolean hasObserverPrivileges() {
         return hasSamePrivileges(PRIVILEGES_OBSERVER);
     }
 
+    /**
+     * Returns true if tutor privilege exists.
+     */
     public boolean hasTutorPrivileges() {
         return hasSamePrivileges(PRIVILEGES_TUTOR);
     }
@@ -366,12 +378,18 @@ public final class InstructorPrivileges {
         return new LinkedHashMap<>(courseLevel);
     }
 
+    /**
+     * Returns the section level privileges of the instructor.
+     */
     public Map<String, Map<String, Boolean>> getSectionLevelPrivileges() {
         Map<String, Map<String, Boolean>> copy = new LinkedHashMap<>();
         sectionLevel.forEach((key, value) -> copy.put(key, new LinkedHashMap<>(value)));
         return copy;
     }
 
+    /**
+     * Returns the session level privileges of the instructor.
+     */
     public Map<String, Map<String, Map<String, Boolean>>> getSessionLevelPrivileges() {
         Map<String, Map<String, Map<String, Boolean>>> copy = new LinkedHashMap<>();
         sessionLevel.forEach((sessionLevelKey, sessionLevelValue) -> {

--- a/src/main/java/teammates/common/datatransfer/QueryLogsParams.java
+++ b/src/main/java/teammates/common/datatransfer/QueryLogsParams.java
@@ -26,6 +26,9 @@ public class QueryLogsParams {
         this.endTime = endTime;
     }
 
+    /**
+     * Returns a builder for {@link QueryLogsParams}.
+     */
     public static Builder builder(Instant startTime, Instant endTime) {
         return new Builder(startTime, endTime);
     }
@@ -105,6 +108,9 @@ public class QueryLogsParams {
         }
     }
 
+    /**
+     * Builder for {@link QueryLogsParams}.
+     */
     public static class Builder {
         private QueryLogsParams queryLogsParams;
 

--- a/src/main/java/teammates/common/datatransfer/UserInfo.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfo.java
@@ -7,11 +7,29 @@ package teammates.common.datatransfer;
  */
 public class UserInfo {
 
+    /**
+     * The user's Google ID.
+     */
     public String id;
 
+    /**
+     * Indicates whether the user has admin privilege.
+     */
     public boolean isAdmin;
+
+    /**
+     * Indicates whether the user has instructor privilege.
+     */
     public boolean isInstructor;
+
+    /**
+     * Indicates whether the user has student privilege.
+     */
     public boolean isStudent;
+
+    /**
+     * Indicates whether the user has maintainer privilege.
+     */
     public boolean isMaintainer;
 
     public UserInfo(String googleId) {

--- a/src/main/java/teammates/common/datatransfer/UserRole.java
+++ b/src/main/java/teammates/common/datatransfer/UserRole.java
@@ -4,6 +4,8 @@ package teammates.common.datatransfer;
  * Represents the role played by the user. e.g. when loading
  * instructorHomePage, the user is playing the role INSTRUCTOR
  */
+// CHECKSTYLE.OFF:JavadocVariable
+@Deprecated
 public enum UserRole {
     ADMIN, INSTRUCTOR, STUDENT
 }

--- a/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
@@ -11,7 +11,7 @@ import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.Account;
 
 /**
- * A data transfer object for Account entities.
+ * The data transfer object for {@link Account} entities.
  */
 public class AccountAttributes extends EntityAttributes<Account> {
 

--- a/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
@@ -26,6 +26,9 @@ public class AccountAttributes extends EntityAttributes<Account> {
         this.googleId = googleId;
     }
 
+    /**
+     * Gets the {@link AccountAttributes} instance of the given {@link Account}.
+     */
     public static AccountAttributes valueOf(Account a) {
         AccountAttributes accountAttributes = new AccountAttributes(a.getGoogleId());
 

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -14,7 +14,7 @@ import teammates.common.util.Logger;
 import teammates.storage.entity.Course;
 
 /**
- * The data transfer object for Course entities.
+ * The data transfer object for {@link Course} entities.
  */
 public class CourseAttributes extends EntityAttributes<Course> implements Comparable<CourseAttributes> {
 

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -33,6 +33,9 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         this.deletedAt = null;
     }
 
+    /**
+     * Gets the {@link CourseAttributes} instance of the given {@link Course}.
+     */
     public static CourseAttributes valueOf(Course course) {
         CourseAttributes courseAttributes = new CourseAttributes(course.getUniqueId());
 
@@ -161,6 +164,9 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         return o.createdAt.compareTo(createdAt);
     }
 
+    /**
+     * Sorts the list of courses by the course ID.
+     */
     public static void sortById(List<CourseAttributes> courses) {
         courses.sort(Comparator.comparing(CourseAttributes::getId));
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -15,6 +15,9 @@ import teammates.common.util.JsonUtils;
 import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.FeedbackQuestion;
 
+/**
+ * The data transfer object for {@link FeedbackQuestion} entities.
+ */
 public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestion>
         implements Comparable<FeedbackQuestionAttributes> {
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -49,6 +49,9 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         return new Builder();
     }
 
+    /**
+     * Gets the {@link FeedbackQuestionAttributes} instance of the given {@link FeedbackQuestion}.
+     */
     public static FeedbackQuestionAttributes valueOf(FeedbackQuestion fq) {
         FeedbackQuestionAttributes faq = new FeedbackQuestionAttributes();
 
@@ -103,6 +106,9 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
                                     showResponsesTo, showGiverNameTo, showRecipientNameTo);
     }
 
+    /**
+     * Gets a deep copy of this object.
+     */
     public FeedbackQuestionAttributes getCopy() {
         FeedbackQuestionAttributes faq = new FeedbackQuestionAttributes();
 
@@ -161,6 +167,9 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         return getInvalidityInfo().isEmpty();
     }
 
+    /**
+     * Returns true if the response is visible to the given participant type.
+     */
     public boolean isResponseVisibleTo(FeedbackParticipantType userType) {
         return showResponsesTo.contains(userType);
     }
@@ -317,6 +326,9 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         return true;
     }
 
+    /**
+     * Removes irrelevant/extraneous response visibility option settings from the question.
+     */
     public void removeIrrelevantVisibilityOptions() {
         List<FeedbackParticipantType> optionsToRemove = new ArrayList<>();
 
@@ -348,10 +360,6 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
             }
         }
 
-        removeVisibilities(optionsToRemove);
-    }
-
-    private void removeVisibilities(List<FeedbackParticipantType> optionsToRemove) {
         if (showRecipientNameTo != null) {
             showResponsesTo.removeAll(optionsToRemove);
         }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
@@ -62,6 +62,9 @@ public class FeedbackResponseAttributes extends EntityAttributes<FeedbackRespons
         this.responseDetails = copy.getResponseDetailsCopy();
     }
 
+    /**
+     * Gets the {@link FeedbackResponseAttributes} instance of the given {@link FeedbackResponse}.
+     */
     public static FeedbackResponseAttributes valueOf(FeedbackResponse fr) {
         FeedbackResponseAttributes fra =
                 new FeedbackResponseAttributes(

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseAttributes.java
@@ -13,6 +13,9 @@ import teammates.common.util.FieldValidator;
 import teammates.common.util.JsonUtils;
 import teammates.storage.entity.FeedbackResponse;
 
+/**
+ * The data transfer object for {@link FeedbackResponse} entities.
+ */
 public class FeedbackResponseAttributes extends EntityAttributes<FeedbackResponse> {
 
     private String feedbackQuestionId;

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseCommentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseCommentAttributes.java
@@ -12,7 +12,7 @@ import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.FeedbackResponseComment;
 
 /**
- * Represents a data transfer object for {@link FeedbackResponseComment} entities.
+ * The data transfer object for {@link FeedbackResponseComment} entities.
  */
 public class FeedbackResponseCommentAttributes extends EntityAttributes<FeedbackResponseComment> {
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseCommentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseCommentAttributes.java
@@ -51,6 +51,9 @@ public class FeedbackResponseCommentAttributes extends EntityAttributes<Feedback
         isCommentFromFeedbackParticipant = false;
     }
 
+    /**
+     * Gets the {@link FeedbackResponseCommentAttributes} instance of the given {@link FeedbackResponseComment}.
+     */
     public static FeedbackResponseCommentAttributes valueOf(FeedbackResponseComment comment) {
         FeedbackResponseCommentAttributes frca = new FeedbackResponseCommentAttributes();
         frca.courseId = comment.getCourseId();
@@ -99,6 +102,9 @@ public class FeedbackResponseCommentAttributes extends EntityAttributes<Feedback
         return new Builder();
     }
 
+    /**
+     * Returns true if the response comment is visible to the given participant type.
+     */
     public boolean isVisibleTo(FeedbackParticipantType viewerType) {
         return showCommentTo.contains(viewerType);
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -54,6 +54,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     }
 
+    /**
+     * Gets the {@link FeedbackSessionAttributes} instance of the given {@link FeedbackSession}.
+     */
     public static FeedbackSessionAttributes valueOf(FeedbackSession fs) {
         FeedbackSessionAttributes feedbackSessionAttributes =
                 new FeedbackSessionAttributes(fs.getFeedbackSessionName(), fs.getCourseId());
@@ -88,6 +91,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         return new Builder(feedbackSessionName, courseId);
     }
 
+    /**
+     * Gets a deep copy of this object.
+     */
     public FeedbackSessionAttributes getCopy() {
         return valueOf(toEntity());
     }
@@ -100,6 +106,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         return feedbackSessionName;
     }
 
+    /**
+     * Gets the instructions of the feedback session.
+     */
     public String getInstructionsString() {
         if (instructions == null) {
             return null;
@@ -182,10 +191,16 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         return errors;
     }
 
+    /**
+     * Returns true if the feedback session is closed after the number of specified hours.
+     */
     public boolean isClosedAfter(long hours) {
         return Instant.now().plus(Duration.ofHours(hours)).isAfter(endTime);
     }
 
+    /**
+     * Returns true if the feedback session is closing (almost closed) after the number of specified hours.
+     */
     public boolean isClosingWithinTimeLimit(long hours) {
         Instant now = Instant.now();
         Duration difference = Duration.between(now, endTime);
@@ -276,6 +291,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         return now.isAfter(publishTime) || now.equals(publishTime);
     }
 
+    /**
+     * Returns true if the given email is the same as the creator email of the feedback session.
+     */
     public boolean isCreator(String instructorEmail) {
         return creatorEmail.equals(instructorEmail);
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -12,6 +12,9 @@ import teammates.common.util.FieldValidator;
 import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.FeedbackSession;
 
+/**
+ * The data transfer object for {@link FeedbackSession} entities.
+ */
 public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession> {
 
     private String feedbackSessionName;

--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -46,6 +46,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         return new Builder(courseId, email);
     }
 
+    /**
+     * Gets the {@link InstructorAttributes} instance of the given {@link Instructor}.
+     */
     public static InstructorAttributes valueOf(Instructor instructor) {
         InstructorAttributes instructorAttributes =
                 new InstructorAttributes(instructor.getCourseId(), instructor.getEmail());
@@ -73,6 +76,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         return instructorAttributes;
     }
 
+    /**
+     * Gets a deep copy of this object.
+     */
     public InstructorAttributes getCopy() {
         InstructorAttributes instructorAttributes = new InstructorAttributes(courseId, email);
         instructorAttributes.name = name;
@@ -241,6 +247,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         }
     }
 
+    /**
+     * Returns true if the instructor has the given privilege in the course.
+     */
     public boolean isAllowedForPrivilege(String privilegeName) {
         if (privileges == null) {
             privileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
@@ -248,6 +257,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         return privileges.isAllowedForPrivilege(privilegeName);
     }
 
+    /**
+     * Returns true if the instructor has the given privilege in the given section.
+     */
     public boolean isAllowedForPrivilege(String sectionName, String privilegeName) {
         if (privileges == null) {
             privileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
@@ -255,6 +267,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         return privileges.isAllowedForPrivilege(sectionName, privilegeName);
     }
 
+    /**
+     * Returns true if the instructor has the given privilege in the given section for the given feedback session.
+     */
     public boolean isAllowedForPrivilege(String sectionName, String sessionName, String privilegeName) {
         if (privileges == null) {
             privileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
@@ -272,6 +287,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         return privileges.isAllowedForPrivilegeAnySection(sessionName, privilegeName);
     }
 
+    /**
+     * Returns true if the instructor has co-owner privilege.
+     */
     public boolean hasCoownerPrivileges() {
         return privileges.hasCoownerPrivileges();
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
@@ -40,6 +40,9 @@ public class StudentAttributes extends EntityAttributes<CourseStudent> {
         this.updatedAt = Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP;
     }
 
+    /**
+     * Gets the {@link StudentAttributes} instance of the given {@link CourseStudent}.
+     */
     public static StudentAttributes valueOf(CourseStudent student) {
         StudentAttributes studentAttributes = new StudentAttributes(student.getCourseId(), student.getEmail());
         studentAttributes.name = student.getName();
@@ -70,6 +73,9 @@ public class StudentAttributes extends EntityAttributes<CourseStudent> {
         return new Builder(courseId, email);
     }
 
+    /**
+     * Gets a deep copy of this object.
+     */
     public StudentAttributes getCopy() {
         StudentAttributes studentAttributes = new StudentAttributes(course, email);
 
@@ -225,12 +231,18 @@ public class StudentAttributes extends EntityAttributes<CourseStudent> {
         return errors;
     }
 
+    /**
+     * Sorts the list of students by the section name, then team name, then name.
+     */
     public static void sortBySectionName(List<StudentAttributes> students) {
         students.sort(Comparator.comparing((StudentAttributes student) -> student.section)
                 .thenComparing(student -> student.team)
                 .thenComparing(student -> student.name));
     }
 
+    /**
+     * Sorts the list of students by the team name, then name.
+     */
     public static void sortByTeamName(List<StudentAttributes> students) {
         students.sort(Comparator.comparing((StudentAttributes student) -> student.team)
                 .thenComparing(student -> student.name));

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
@@ -13,6 +13,9 @@ import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 import teammates.storage.entity.CourseStudent;
 
+/**
+ * The data transfer object for {@link CourseStudent} entities.
+ */
 public class StudentAttributes extends EntityAttributes<CourseStudent> {
 
     private String email;

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
@@ -12,7 +12,7 @@ import teammates.common.util.StringHelper;
 import teammates.storage.entity.StudentProfile;
 
 /**
- * The data transfer object for StudentProfile entities.
+ * The data transfer object for {@link StudentProfile} entities.
  */
 public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
 

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
@@ -36,6 +36,9 @@ public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
         this.modifiedDate = Instant.now();
     }
 
+    /**
+     * Gets the {@link StudentProfileAttributes} instance of the given {@link StudentProfile}.
+     */
     public static StudentProfileAttributes valueOf(StudentProfile sp) {
         StudentProfileAttributes studentProfileAttributes = new StudentProfileAttributes(sp.getGoogleId());
 
@@ -69,6 +72,9 @@ public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
         return new Builder(googleId);
     }
 
+    /**
+     * Gets a deep copy of this object.
+     */
     public StudentProfileAttributes getCopy() {
         StudentProfileAttributes studentProfileAttributes = new StudentProfileAttributes(googleId);
 

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
@@ -261,9 +261,11 @@ public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
      * Represents the gender of a student.
      */
     public enum Gender {
+        // CHECKSTYLE.OFF:JavadocVariable enum names are self-documenting
         MALE,
         FEMALE,
         OTHER;
+        // CHECKSTYLE.ON:JavadocVariable
 
         /**
          * Returns the Gender enum value corresponding to {@code gender}, or OTHER by default.

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumDistributePointsType.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumDistributePointsType.java
@@ -6,8 +6,17 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Enum that defines different distribute points options for constant sum questions.
  */
 public enum FeedbackConstantSumDistributePointsType {
+    /**
+     * All options need to have different points.
+     */
     DISTRIBUTE_ALL_UNEVENLY("All options"),
+    /**
+     * At least some options need to have different points.
+     */
     DISTRIBUTE_SOME_UNEVENLY("At least some options"),
+    /**
+     * No restrictions.
+     */
     NONE("None");
 
     private String displayedOption;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.FieldValidator;
 
+/**
+ * Contains specific structure and processing logic for constant sum feedback questions.
+ */
 public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME_OPTION = "Distribute points (among options) question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
@@ -3,8 +3,10 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FeedbackConstantSumResponseDetails extends
-        FeedbackResponseDetails {
+/**
+ * Contains specific structure and processing logic for constant sum feedback responses.
+ */
+public class FeedbackConstantSumResponseDetails extends FeedbackResponseDetails {
     private List<Integer> answers;
 
     public FeedbackConstantSumResponseDetails() {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -346,7 +346,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
      * Represents a list of participants to their question statistics for one contribution question.
      */
     public static class ContributionStatistics {
-        public final Map<String, ContributionStatisticsEntry> results = new HashMap<>();
+        private final Map<String, ContributionStatisticsEntry> results = new HashMap<>();
 
         public Map<String, ContributionStatisticsEntry> getResults() {
             return results;
@@ -361,10 +361,10 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
      * @see TeamEvalResult
      */
     public static class ContributionStatisticsEntry {
-        public final int claimed;
-        public final int perceived;
-        public final Map<String, Integer> claimedOthers;
-        public final int[] perceivedOthers;
+        private final int claimed;
+        private final int perceived;
+        private final Map<String, Integer> claimedOthers;
+        private final int[] perceivedOthers;
 
         public ContributionStatisticsEntry(int claimed, int perceived, Map<String, Integer> claimedOthers,
                                            int[] perceivedOthers) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -21,6 +21,9 @@ import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.Logger;
 
+/**
+ * Contains specific structure and processing logic for contribution feedback questions.
+ */
 public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Team contribution question";
@@ -339,6 +342,9 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         isNotSureAllowed = notSureAllowed;
     }
 
+    /**
+     * Represents a list of participants to their question statistics for one contribution question.
+     */
     public static class ContributionStatistics {
         public final Map<String, ContributionStatisticsEntry> results = new HashMap<>();
 
@@ -347,6 +353,13 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         }
     }
 
+    /**
+     * Represents the statistics of one feedback participant in one contribution question.
+     *
+     * <p>This class is a container for some representative values from {@link TeamEvalResult}.
+     *
+     * @see TeamEvalResult
+     */
     public static class ContributionStatisticsEntry {
         public final int claimed;
         public final int perceived;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -2,6 +2,9 @@ package teammates.common.datatransfer.questions;
 
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for contribution feedback responses.
+ */
 public class FeedbackContributionResponseDetails extends FeedbackResponseDetails {
 
     /**

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -156,7 +156,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
         return "";
     }
 
-    public boolean hasAssignedWeights() {
+    public boolean isHasAssignedWeights() {
         return hasAssignedWeights;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -6,6 +6,9 @@ import java.util.List;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 
+/**
+ * Contains specific structure and processing logic for MCQ feedback questions.
+ */
 public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Multiple-choice (single answer) question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
@@ -1,5 +1,8 @@
 package teammates.common.datatransfer.questions;
 
+/**
+ * Contains specific structure and processing logic for MCQ feedback responses.
+ */
 public class FeedbackMcqResponseDetails extends FeedbackResponseDetails {
     private String answer;
     private boolean isOther;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -7,6 +7,9 @@ import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for MSQ feedback questions.
+ */
 public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Multiple-choice (multiple answers) question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -295,7 +295,7 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
         this.otherEnabled = otherEnabled;
     }
 
-    public boolean hasAssignedWeights() {
+    public boolean isHasAssignedWeights() {
         return hasAssignedWeights;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import teammates.common.util.StringHelper;
 
+/**
+ * Contains specific structure and processing logic for MCQ feedback responses.
+ */
 public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
     private List<String> answers; // answers contain the "other" answer, if any
     private boolean isOther;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 
+/**
+ * Contains specific structure and processing logic for numerical scale feedback questions.
+ */
 public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Numerical-scale question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
@@ -3,6 +3,9 @@ package teammates.common.datatransfer.questions;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 
+/**
+ * Contains specific structure and processing logic for numerical scale feedback responses.
+ */
 public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetails {
 
     private double answer;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -119,11 +119,17 @@ public abstract class FeedbackQuestionDetails {
         return this.getJsonString().hashCode();
     }
 
+    /**
+     * Returns a JSON string representation of the question details.
+     */
     public String getJsonString() {
         assert questionType != null;
         return JsonUtils.toJson(this, questionType.getQuestionDetailsClass());
     }
 
+    /**
+     * Returns a deep copy of the question details.
+     */
     public FeedbackQuestionDetails getDeepCopy() {
         assert questionType != null;
         String serializedDetails = getJsonString();

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionType.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionType.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 /**
  * Feedback Question Type Definitions.
  */
+// CHECKSTYLE.OFF:JavadocVariable enum names are self-documenting
 public enum FeedbackQuestionType {
     TEXT(FeedbackTextQuestionDetails.class, FeedbackTextResponseDetails.class),
     MCQ(FeedbackMcqQuestionDetails.class, FeedbackMcqResponseDetails.class),

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for rank options feedback questions.
+ */
 public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Rank (options) question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for rank options feedback responses.
+ */
 public class FeedbackRankOptionsResponseDetails extends FeedbackResponseDetails {
     private List<Integer> answers;
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -33,7 +33,7 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
         this.maxOptionsToBeRanked = maxOptionsToBeRanked;
     }
 
-    public boolean areDuplicatesAllowed() {
+    public boolean isAreDuplicatesAllowed() {
         return areDuplicatesAllowed;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -7,9 +7,9 @@ import teammates.common.util.Const;
  */
 public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetails {
 
-    protected int minOptionsToBeRanked;
-    protected int maxOptionsToBeRanked;
-    protected boolean areDuplicatesAllowed;
+    int minOptionsToBeRanked;
+    int maxOptionsToBeRanked;
+    boolean areDuplicatesAllowed;
 
     FeedbackRankQuestionDetails(FeedbackQuestionType questionType, String questionText) {
         super(questionType, questionText);

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -2,6 +2,9 @@ package teammates.common.datatransfer.questions;
 
 import teammates.common.util.Const;
 
+/**
+ * Contains common abstractions between rank options and rank recipients questions.
+ */
 public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetails {
 
     protected int minOptionsToBeRanked;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for rank recipients feedback questions.
+ */
 public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionDetails {
 
     public FeedbackRankRecipientsQuestionDetails() {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
@@ -2,6 +2,9 @@ package teammates.common.datatransfer.questions;
 
 import teammates.common.util.Const;
 
+/**
+ * Contains specific structure and processing logic for rank recipients feedback responses.
+ */
 public class FeedbackRankRecipientsResponseDetails extends FeedbackResponseDetails {
     private int answer;
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
@@ -17,8 +17,14 @@ public abstract class FeedbackResponseDetails {
         this.questionType = questionType;
     }
 
+    /**
+     * Returns a string representation of the response.
+     */
     public abstract String getAnswerString();
 
+    /**
+     * Returns a JSON string representation of the response details.
+     */
     public String getJsonString() {
         assert questionType != null;
         if (questionType == FeedbackQuestionType.TEXT) {
@@ -29,6 +35,9 @@ public abstract class FeedbackResponseDetails {
         return JsonUtils.toJson(this, questionType.getResponseDetailsClass());
     }
 
+    /**
+     * Returns a deep copy of the response details.
+     */
     public FeedbackResponseDetails getDeepCopy() {
         assert questionType != null;
         if (questionType == FeedbackQuestionType.TEXT) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 
+/**
+ * Contains specific structure and processing logic for rubric feedback questions.
+ */
 public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
     static final String QUESTION_TYPE_NAME = "Rubric question";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -196,7 +196,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         return new ArrayList<>();
     }
 
-    public boolean hasAssignedWeights() {
+    public boolean isHasAssignedWeights() {
         return hasAssignedWeights;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -3,6 +3,9 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Contains specific structure and processing logic for rubric feedback responses.
+ */
 public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
 
     /**

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -7,6 +7,9 @@ import javax.annotation.Nullable;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 
+/**
+ * Contains specific structure and processing logic for text feedback questions.
+ */
 public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
 
     static final String TEXT_ERROR_INVALID_RECOMMENDED_LENGTH = "Recommended length must be 1 or greater";

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
@@ -2,6 +2,9 @@ package teammates.common.datatransfer.questions;
 
 import teammates.common.util.SanitizationHelper;
 
+/**
+ * Contains specific structure and processing logic for text feedback responses.
+ */
 public class FeedbackTextResponseDetails extends FeedbackResponseDetails {
 
     //For essay questions the response is saved as plain-text due to legacy format before there were multiple question types

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -73,6 +73,9 @@ public final class Const {
         // Utility class containing constants
     }
 
+    /**
+     * Represents role names for instructors based on their permission settings.
+     */
     public static class InstructorPermissionRoleNames {
         public static final String INSTRUCTOR_PERMISSION_ROLE_COOWNER = "Co-owner";
         public static final String INSTRUCTOR_PERMISSION_ROLE_MANAGER = "Manager";
@@ -81,6 +84,9 @@ public final class Const {
         public static final String INSTRUCTOR_PERMISSION_ROLE_CUSTOM = "Custom";
     }
 
+    /**
+     * Represents atomic permission for instructors.
+     */
     public static class InstructorPermissions {
         public static final String CAN_MODIFY_COURSE = "canmodifycourse";
         public static final String CAN_MODIFY_INSTRUCTOR = "canmodifyinstructor";
@@ -92,6 +98,9 @@ public final class Const {
         public static final String CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS = "canmodifysessioncommentinsection";
     }
 
+    /**
+     * Represents keys for HTTP requests to the API layer.
+     */
     public static class ParamsNames {
 
         public static final String IS_IN_RECYCLE_BIN = "isinrecyclebin";
@@ -173,6 +182,9 @@ public final class Const {
         public static final String SOFT_DELETED = "softDeleted";
     }
 
+    /**
+     * Represents user types.
+     */
     public static class EntityType {
 
         public static final String STUDENT = "student";
@@ -182,6 +194,9 @@ public final class Const {
 
     }
 
+    /**
+     * Represents security-related configuration.
+     */
     public static class SecurityConfig {
 
         public static final String CSRF_HEADER_NAME = "X-CSRF-TOKEN";
@@ -190,12 +205,18 @@ public final class Const {
 
     }
 
+    /**
+     * Represents types of feedback session-related events to be audited.
+     */
     public static class FeedbackSessionLogTypes {
         public static final String ACCESS = "access";
         public static final String SUBMISSION = "submission";
         public static final String VIEW_RESULT = "view result";
     }
 
+    /**
+     * Represents URIs of accessible pages in the front-end in past versions (V6 and before).
+     */
     @Deprecated
     public static class LegacyURIs {
 
@@ -211,6 +232,9 @@ public final class Const {
 
     }
 
+    /**
+     * Represents URIs of accessible pages in the front-end.
+     */
     public static class WebPageURIs {
         public static final String LOGIN = "/login";
         public static final String LOGOUT = "/logout";
@@ -259,6 +283,9 @@ public final class Const {
         public static final String SESSIONS_LINK_RECOVERY_PAGE = FRONT_PAGE + "/help/session-links-recovery";
     }
 
+    /**
+     * Represents URIs of resource endpoints.
+     */
     public static class ResourceURIs {
         private static final String URI_PREFIX = "/webapi";
 
@@ -315,6 +342,9 @@ public final class Const {
         public static final String STUDENT_COURSE_LINKS_REGENERATION = URI_PREFIX + "/student/courselinks/regeneration";
     }
 
+    /**
+     * Represents URIs of endpoints used by cron jobs.
+     */
     public static class CronJobURIs {
         private static final String URI_PREFIX = "/auto";
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -11,10 +11,7 @@ import java.time.ZoneId;
  */
 public final class Const {
 
-    /*
-     * This section holds constants that are defined as constants primarily
-     * because they are repeated in many places.
-     */
+    // This section holds constants that are defined as constants primarily because they are repeated in many places.
 
     public static final String USER_NOBODY_TEXT = "-";
 
@@ -34,10 +31,8 @@ public final class Const {
     public static final Duration FEEDBACK_SESSIONS_SEARCH_WINDOW = Duration.ofDays(30);
     public static final Duration LOGS_RETENTION_PERIOD = Duration.ofDays(30);
 
-    /*
-     * These constants are used as variable values to mean that the variable
-     * is in a 'special' state.
-     */
+    // These constants are used as variable values to mean that the variable is in a 'special' state.
+
     public static final int INT_UNINITIALIZED = -9999;
 
     public static final int MAX_POSSIBLE_RECIPIENTS = -100;
@@ -65,9 +60,7 @@ public final class Const {
 
     public static final String TEST_EMAIL_DOMAIN = "@gmail.tmt";
 
-    /*
-     * Other Constants
-     */
+    // Other Constants
 
     private Const() {
         // Utility class containing constants

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -591,6 +591,13 @@ public final class FieldValidator {
         return "";
     }
 
+    /**
+     * Checks if both the giver type and recipient type for the feedback question is valid.
+     *
+     * @param giverType feedback question giver type to be checked.
+     * @param recipientType feedback question recipient type to be checked.
+     * @return Error string if either type is invalid, otherwise empty string.
+     */
     public static List<String> getValidityInfoForFeedbackParticipantType(
             FeedbackParticipantType giverType, FeedbackParticipantType recipientType) {
 
@@ -649,6 +656,15 @@ public final class FieldValidator {
         return "";
     }
 
+    /**
+     * Checks if all the given participant types are valid for the purpose of
+     * showing different fields of a feedback response.
+     *
+     * @param showResponsesTo the list of participant types to whom responses can be shown
+     * @param showGiverNameTo the list of participant types to whom giver name can be shown
+     * @param showRecipientNameTo the list of participant types to whom recipient name can be shown
+     * @return Error string if any type in any list is invalid, otherwise empty string.
+     */
     public static List<String> getValidityInfoForFeedbackResponseVisibility(
             List<FeedbackParticipantType> showResponsesTo,
             List<FeedbackParticipantType> showGiverNameTo,
@@ -697,12 +713,18 @@ public final class FieldValidator {
         return errors;
     }
 
+    /**
+     * Checks if the given {@code value} has no HTML code.
+     */
     static String getValidityInfoForNonHtmlField(String fieldName, String value) {
         String sanitizedValue = SanitizationHelper.sanitizeForHtml(value);
         //Fails if sanitized value is not same as value
         return value.equals(sanitizedValue) ? "" : NON_HTML_FIELD_ERROR_MESSAGE.replace("${fieldName}", fieldName);
     }
 
+    /**
+     * Checks if the given {@code value} is not null.
+     */
     public static String getValidityInfoForNonNullField(String fieldName, Object value) {
         return value == null ? NON_NULL_FIELD_ERROR_MESSAGE.replace("${fieldName}", fieldName) : "";
     }
@@ -743,7 +765,7 @@ public final class FieldValidator {
                               .replace("${reason}", errorReason);
     }
 
-    public static String getPopulatedEmptyStringErrorMessage(String messageTemplate,
+    private static String getPopulatedEmptyStringErrorMessage(String messageTemplate,
             String fieldName, int maxLength) {
         return messageTemplate.replace("${fieldName}", fieldName)
                               .replace("${maxLength}", String.valueOf(maxLength));

--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -1,5 +1,8 @@
 package teammates.common.util;
 
+/**
+ * Contains utility methods for creating strings from given templates.
+ */
 public final class Templates {
 
     public static final String INSTRUCTOR_SAMPLE_DATA = FileHelper.readResourceFile("InstructorSampleData.json");

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -807,7 +807,7 @@ public class EmailGenerator {
     public EmailWrapper generateCompiledLogsEmail(List<ErrorLogEntry> logs) {
         StringBuilder emailBody = new StringBuilder();
         for (int i = 0; i < logs.size(); i++) {
-            emailBody.append(generateSevereErrorLogLine(i, logs.get(i).message, logs.get(i).severity));
+            emailBody.append(generateSevereErrorLogLine(i, logs.get(i).getMessage(), logs.get(i).getSeverity()));
         }
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -39,7 +39,7 @@ import teammates.logic.core.StudentsLogic;
  * @see EmailType
  * @see EmailWrapper
  */
-public class EmailGenerator {
+public final class EmailGenerator {
     // status-related strings
     private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
@@ -60,10 +60,20 @@ public class EmailGenerator {
 
     private static final Duration SESSION_LINK_RECOVERY_DURATION = Duration.ofDays(90);
 
+    private static final EmailGenerator instance = new EmailGenerator();
+
     private final CoursesLogic coursesLogic = CoursesLogic.inst();
     private final FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
     private final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
     private final StudentsLogic studentsLogic = StudentsLogic.inst();
+
+    private EmailGenerator() {
+        // prevent initialization
+    }
+
+    public static EmailGenerator inst() {
+        return instance;
+    }
 
     /**
      * Generates the feedback session opening emails for the given {@code session}.

--- a/src/main/java/teammates/logic/api/EmailSender.java
+++ b/src/main/java/teammates/logic/api/EmailSender.java
@@ -25,9 +25,10 @@ public class EmailSender {
 
     private static final Logger log = Logger.getLogger();
 
+    private static final EmailSender instance = new EmailSender();
     private final EmailSenderService service;
 
-    public EmailSender() {
+    EmailSender() {
         if (Config.isDevServer()) {
             service = new EmptyEmailService();
         } else {
@@ -41,6 +42,10 @@ public class EmailSender {
                 service = new EmptyEmailService();
             }
         }
+    }
+
+    public static EmailSender inst() {
+        return instance;
     }
 
     /**

--- a/src/main/java/teammates/logic/api/FileStorage.java
+++ b/src/main/java/teammates/logic/api/FileStorage.java
@@ -10,14 +10,19 @@ import teammates.logic.core.LocalFileStorageService;
  */
 public class FileStorage {
 
+    private static final FileStorage instance = new FileStorage();
     private final FileStorageService service;
 
-    public FileStorage() {
+    FileStorage() {
         if (Config.isDevServer()) {
             service = new LocalFileStorageService();
         } else {
             service = new GoogleCloudStorageService();
         }
+    }
+
+    public static FileStorage inst() {
+        return instance;
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -44,6 +44,8 @@ import teammates.logic.core.StudentsLogic;
  */
 public class Logic {
 
+    private static final Logic instance = new Logic();
+
     final AccountsLogic accountsLogic = AccountsLogic.inst();
     final StudentsLogic studentsLogic = StudentsLogic.inst();
     final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
@@ -54,6 +56,14 @@ public class Logic {
     final FeedbackResponseCommentsLogic feedbackResponseCommentsLogic = FeedbackResponseCommentsLogic.inst();
     final ProfilesLogic profilesLogic = ProfilesLogic.inst();
     final DataBundleLogic dataBundleLogic = DataBundleLogic.inst();
+
+    Logic() {
+        // prevent initialization
+    }
+
+    public static Logic inst() {
+        return instance;
+    }
 
     /**
      * Preconditions: <br>

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -44,17 +44,16 @@ import teammates.logic.core.StudentsLogic;
  */
 public class Logic {
 
-    protected final AccountsLogic accountsLogic = AccountsLogic.inst();
-    protected final StudentsLogic studentsLogic = StudentsLogic.inst();
-    protected final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
-    protected final CoursesLogic coursesLogic = CoursesLogic.inst();
-    protected final FeedbackSessionsLogic feedbackSessionsLogic = FeedbackSessionsLogic.inst();
-    protected final FeedbackQuestionsLogic feedbackQuestionsLogic = FeedbackQuestionsLogic.inst();
-    protected final FeedbackResponsesLogic feedbackResponsesLogic = FeedbackResponsesLogic.inst();
-    protected final FeedbackResponseCommentsLogic feedbackResponseCommentsLogic =
-            FeedbackResponseCommentsLogic.inst();
-    protected final ProfilesLogic profilesLogic = ProfilesLogic.inst();
-    protected final DataBundleLogic dataBundleLogic = DataBundleLogic.inst();
+    final AccountsLogic accountsLogic = AccountsLogic.inst();
+    final StudentsLogic studentsLogic = StudentsLogic.inst();
+    final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
+    final CoursesLogic coursesLogic = CoursesLogic.inst();
+    final FeedbackSessionsLogic feedbackSessionsLogic = FeedbackSessionsLogic.inst();
+    final FeedbackQuestionsLogic feedbackQuestionsLogic = FeedbackQuestionsLogic.inst();
+    final FeedbackResponsesLogic feedbackResponsesLogic = FeedbackResponsesLogic.inst();
+    final FeedbackResponseCommentsLogic feedbackResponseCommentsLogic = FeedbackResponseCommentsLogic.inst();
+    final ProfilesLogic profilesLogic = ProfilesLogic.inst();
+    final DataBundleLogic dataBundleLogic = DataBundleLogic.inst();
 
     /**
      * Preconditions: <br>

--- a/src/main/java/teammates/logic/api/LogsProcessor.java
+++ b/src/main/java/teammates/logic/api/LogsProcessor.java
@@ -21,14 +21,19 @@ import teammates.logic.core.LogService;
  */
 public class LogsProcessor {
 
+    private static final LogsProcessor instance = new LogsProcessor();
     private final LogService service;
 
-    public LogsProcessor() {
+    LogsProcessor() {
         if (Config.isDevServer()) {
             service = new LocalLoggingService();
         } else {
             service = new GoogleCloudLoggingService();
         }
+    }
+
+    public static LogsProcessor inst() {
+        return instance;
     }
 
     /**

--- a/src/main/java/teammates/logic/api/RecaptchaVerifier.java
+++ b/src/main/java/teammates/logic/api/RecaptchaVerifier.java
@@ -1,0 +1,35 @@
+package teammates.logic.api;
+
+import teammates.common.util.Config;
+import teammates.logic.core.EmptyRecaptchaService;
+import teammates.logic.core.GoogleRecaptchaService;
+import teammates.logic.core.RecaptchaService;
+
+/**
+ * Used to handle the verification of the user's reCAPTCHA response.
+ */
+public class RecaptchaVerifier {
+
+    private static final RecaptchaVerifier instance = new RecaptchaVerifier();
+    private final RecaptchaService service;
+
+    RecaptchaVerifier() {
+        if (Config.isDevServer()) {
+            service = new EmptyRecaptchaService();
+        } else {
+            service = new GoogleRecaptchaService(Config.CAPTCHA_SECRET_KEY);
+        }
+    }
+
+    public static RecaptchaVerifier inst() {
+        return instance;
+    }
+
+    /**
+     * Returns true if the {@code captchaResponse} token is verified successfully.
+     */
+    public boolean isVerificationSuccessful(String captchaResponse) {
+        return service.isVerificationSuccessful(captchaResponse);
+    }
+
+}

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -37,12 +37,12 @@ public class TaskQueuer {
     // Using this method, the actual logic can still be black-boxed
     // while at the same time allowing this API to be mocked during test.
 
-    protected void addTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody) {
+    private void addTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody) {
         addDeferredTask(queueName, workerUrl, paramMap, requestBody, 0);
     }
 
-    protected void addDeferredTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody,
-                                   long countdownTime) {
+    void addDeferredTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody,
+                         long countdownTime) {
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, paramMap, requestBody);
         service.addDeferredTask(task, countdownTime);
     }

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -23,14 +23,19 @@ public class TaskQueuer {
 
     private static final Logger log = Logger.getLogger();
 
+    private static final TaskQueuer instance = new TaskQueuer();
     private final TaskQueueService service;
 
-    public TaskQueuer() {
+    TaskQueuer() {
         if (Config.isDevServer()) {
             service = new LocalTaskQueueService();
         } else {
             service = new GoogleCloudTasksService();
         }
+    }
+
+    public static TaskQueuer inst() {
+        return instance;
     }
 
     // The following methods are facades to the actual logic for adding tasks to the queue.

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -11,8 +11,18 @@ import teammates.logic.core.StudentsLogic;
  */
 public class UserProvision {
 
+    private static final UserProvision instance = new UserProvision();
+
     private final AccountsLogic accountsLogic = AccountsLogic.inst();
     private final StudentsLogic studentsLogic = StudentsLogic.inst();
+
+    UserProvision() {
+        // prevent initialization
+    }
+
+    public static UserProvision inst() {
+        return instance;
+    }
 
     /**
      * Gets the information of the current logged in user.

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -32,7 +32,7 @@ public class UserProvision {
         return user;
     }
 
-    protected UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
+    UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
         if (uic == null || !uic.isValid()) {
             return null;
         }

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -57,15 +57,26 @@ public final class AccountsLogic {
         return accountsDb.createEntity(accountData);
     }
 
+    /**
+     * Gets an account.
+     */
     public AccountAttributes getAccount(String googleId) {
         return accountsDb.getAccount(googleId);
     }
 
+    /**
+     * Returns true if the given account exists and is an instructor.
+     */
     public boolean isAccountAnInstructor(String googleId) {
         AccountAttributes a = accountsDb.getAccount(googleId);
         return a != null && a.isInstructor();
     }
 
+    /**
+     * Gets the institute associated with the course.
+     *
+     * <p>The institute of a course is determined by the account of an instructor associated to it.
+     */
     public String getCourseInstitute(String courseId) {
         CourseAttributes cd = coursesLogic.getCourse(courseId);
         assert cd != null : "Trying to getCourseInstitute for inexistent course with id " + courseId;

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -97,7 +97,7 @@ public final class CoursesLogic {
 
         CourseAttributes createdCourse = createCourse(courseToCreate);
 
-        /* Create the initial instructor for the course */
+        // Create the initial instructor for the course
         InstructorPrivileges privileges = new InstructorPrivileges(
                 Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
         InstructorAttributes instructor = InstructorAttributes

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -347,6 +347,9 @@ public final class DataBundleLogic {
         return sessionKey + "%" + questionNumber;
     }
 
+    /**
+     * Removes the items in the data bundle from the database.
+     */
     public void removeDataBundle(DataBundle dataBundle) {
 
         // Questions and responses will be deleted automatically.

--- a/src/main/java/teammates/logic/core/EmptyRecaptchaService.java
+++ b/src/main/java/teammates/logic/core/EmptyRecaptchaService.java
@@ -1,0 +1,13 @@
+package teammates.logic.core;
+
+/**
+ * Service that bypasses reCAPTCHA verification, i.e. always returning successful verification.
+ */
+public class EmptyRecaptchaService implements RecaptchaService {
+
+    @Override
+    public boolean isVerificationSuccessful(String captchaResponse) {
+        return true;
+    }
+
+}

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -206,6 +206,9 @@ public final class FeedbackQuestionsLogic {
         return getFeedbackQuestionsForCreatorInstructor(fsa);
     }
 
+    /**
+     * Gets the list of feedback questions whose giver is the creator of the feedback session.
+     */
     public List<FeedbackQuestionAttributes> getFeedbackQuestionsForCreatorInstructor(
                                     FeedbackSessionAttributes fsa) {
 
@@ -272,6 +275,9 @@ public final class FeedbackQuestionsLogic {
                 || fqDb.hasFeedbackQuestionsForGiverType(feedbackSessionName, courseId, FeedbackParticipantType.TEAMS);
     }
 
+    /**
+     * Gets the email-name mapping of recipients for the given question for the given giver.
+     */
     Map<String, String> getRecipientsForQuestion(FeedbackQuestionAttributes question, String giver)
             throws EntityDoesNotExistException {
 
@@ -697,6 +703,9 @@ public final class FeedbackQuestionsLogic {
         return giverTeam;
     }
 
+    /**
+     * Returns true if the feedback question has been fully answered by the given user.
+     */
     public boolean isQuestionFullyAnsweredByUser(FeedbackQuestionAttributes question, String email)
             throws EntityDoesNotExistException {
 

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -71,15 +71,26 @@ public final class FeedbackResponseCommentsLogic {
         return frcDb.createEntity(frComment);
     }
 
+    /**
+     * Gets a feedback response comment.
+     */
     public FeedbackResponseCommentAttributes getFeedbackResponseComment(Long feedbackResponseCommentId) {
         return frcDb.getFeedbackResponseComment(feedbackResponseCommentId);
     }
 
+    /**
+     * Gets a feedback response comment by "fake" unique constraint response-giver-createdAt.
+     *
+     * <p>The method is only used in testing</p>
+     */
     public FeedbackResponseCommentAttributes getFeedbackResponseComment(
             String responseId, String giverEmail, Instant creationDate) {
         return frcDb.getFeedbackResponseComment(responseId, giverEmail, creationDate);
     }
 
+    /**
+     * Gets all response comments for a response.
+     */
     public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentForResponse(String feedbackResponseId) {
         return frcDb.getFeedbackResponseCommentsForResponse(feedbackResponseId);
     }
@@ -127,15 +138,19 @@ public final class FeedbackResponseCommentsLogic {
         return frcDb.getFeedbackResponseCommentsForQuestionInSection(questionId, section);
     }
 
-    /*
-     * Updates all email fields of feedback response comments with the new email
+    /**
+     * Updates all email fields of feedback response comments with the new email.
      */
     public void updateFeedbackResponseCommentsEmails(String courseId, String oldEmail, String updatedEmail) {
         frcDb.updateGiverEmailOfFeedbackResponseComments(courseId, oldEmail, updatedEmail);
         frcDb.updateLastEditorEmailOfFeedbackResponseComments(courseId, oldEmail, updatedEmail);
     }
 
-    // right now this method only updates comment's giverSection and receiverSection for a given response
+    /**
+     * Updates all common fields of feedback response comments with the same field from its parent response.
+     *
+     * <p>Currently, this method only updates comment's giverSection and receiverSection for a given response.</p>
+     */
     public void updateFeedbackResponseCommentsForResponse(String feedbackResponseId)
             throws InvalidParametersException, EntityDoesNotExistException {
         List<FeedbackResponseCommentAttributes> comments = getFeedbackResponseCommentForResponse(feedbackResponseId);
@@ -164,8 +179,11 @@ public final class FeedbackResponseCommentsLogic {
         return frcDb.updateFeedbackResponseComment(updateOptions);
     }
 
-    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentsForGiver(String courseId,
-                                                                                       String giverEmail) {
+    /**
+     * Gets all comments given by a user in a course.
+     */
+    public List<FeedbackResponseCommentAttributes> getFeedbackResponseCommentsForGiver(
+            String courseId, String giverEmail) {
         return frcDb.getFeedbackResponseCommentForGiver(courseId, giverEmail);
     }
 

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -198,6 +198,10 @@ public final class FeedbackSessionsLogic {
         return sessionsToSendEmailsFor;
     }
 
+    /**
+     * Gets a list of undeleted feedback sessions which start within the last 2 hours
+     * and need an open email to be sent.
+     */
     public List<FeedbackSessionAttributes> getFeedbackSessionsWhichNeedOpenEmailsToBeSent() {
         List<FeedbackSessionAttributes> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpenEmail();
         List<FeedbackSessionAttributes> sessionsToSendEmailsFor = new ArrayList<>();
@@ -214,6 +218,9 @@ public final class FeedbackSessionsLogic {
         return sessionsToSendEmailsFor;
     }
 
+    /**
+     * Returns true if the given email is the creator of the given session.
+     */
     public boolean isCreatorOfSession(String feedbackSessionName, String courseId, String userEmail) {
         FeedbackSessionAttributes fs = getFeedbackSession(feedbackSessionName, courseId);
         return fs.getCreatorEmail().equals(userEmail);
@@ -223,6 +230,9 @@ public final class FeedbackSessionsLogic {
         return fsDb.getFeedbackSession(courseId, feedbackSessionName) != null;
     }
 
+    /**
+     * Returns true if the feedback session has question for students.
+     */
     public boolean isFeedbackSessionHasQuestionForStudents(
             String feedbackSessionName,
             String courseId) throws EntityDoesNotExistException {
@@ -396,6 +406,9 @@ public final class FeedbackSessionsLogic {
                         .build());
     }
 
+    /**
+     * Returns returns a list of sessions that are going to close within the next 24 hours.
+     */
     public List<FeedbackSessionAttributes> getFeedbackSessionsClosingWithinTimeLimit() {
         List<FeedbackSessionAttributes> requiredSessions = new ArrayList<>();
 
@@ -772,7 +785,7 @@ public final class FeedbackSessionsLogic {
         return null;
     }
 
-    /*
+    /**
      * Gets emails of student's teammates if student is not null, else returns an empty set.
      */
     private Set<String> getTeammateEmails(StudentAttributes student, CourseRoster roster) {
@@ -868,6 +881,9 @@ public final class FeedbackSessionsLogic {
         return fsDb.getSoftDeletedFeedbackSessionsForCourse(courseId);
     }
 
+    /**
+     * Returns true if the feedback session has been fully answered by the given student.
+     */
     public boolean isFeedbackSessionFullyCompletedByStudent(
             String feedbackSessionName,
             String courseId, String userEmail)
@@ -891,6 +907,9 @@ public final class FeedbackSessionsLogic {
         return true;
     }
 
+    /**
+     * Returns true if the feedback session has been attempted (i.e. any question is answered) by the given student.
+     */
     public boolean isFeedbackSessionAttemptedByStudent(
             String feedbackSessionName,
             String courseId, String userEmail)
@@ -913,6 +932,9 @@ public final class FeedbackSessionsLogic {
         return false;
     }
 
+    /**
+     * Returns true if the feedback session is viewable by the given student.
+     */
     public boolean isFeedbackSessionViewableToStudents(
             FeedbackSessionAttributes session) {
         // Allow students to view the feedback session if there are questions for them

--- a/src/main/java/teammates/logic/core/FileStorageService.java
+++ b/src/main/java/teammates/logic/core/FileStorageService.java
@@ -5,12 +5,24 @@ package teammates.logic.core;
  */
 public interface FileStorageService {
 
+    /**
+     * Returns true if a file with the specified {@code fileKey} exists in the storage.
+     */
     boolean doesFileExist(String fileKey);
 
+    /**
+     * Gets the content of the file with the specified {@code fileKey} as bytes.
+     */
     byte[] getContent(String fileKey);
 
+    /**
+     * Deletes the file with the specified {@code fileKey}.
+     */
     void delete(String fileKey);
 
+    /**
+     * Creates a file with the specified {@code contentBytes} as content and with type {@code contentType}.
+     */
     void create(String fileKey, byte[] contentBytes, String contentType);
 
 }

--- a/src/main/java/teammates/logic/core/GoogleRecaptchaService.java
+++ b/src/main/java/teammates/logic/core/GoogleRecaptchaService.java
@@ -1,4 +1,4 @@
-package teammates.common.util;
+package teammates.logic.core;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -9,13 +9,16 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import teammates.common.exception.TeammatesException;
+import teammates.common.util.HttpRequest;
+import teammates.common.util.JsonUtils;
+import teammates.common.util.Logger;
 
 /**
- * Used to handle the verification of the user's reCAPTCHA response.
+ * Google-based reCAPTCHA verifier service.
  *
  * @see <a href="https://developers.google.com/recaptcha/docs/verify">reCAPTCHA user response verification API</a>
  */
-public class RecaptchaVerifier {
+public class GoogleRecaptchaService implements RecaptchaService {
 
     /** The Google reCAPTCHA API URL to verify the response token. */
     private static final String VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
@@ -24,19 +27,14 @@ public class RecaptchaVerifier {
 
     private final String secretKey;
 
-    public RecaptchaVerifier(String secretKey) {
+    public GoogleRecaptchaService(String secretKey) {
         this.secretKey = secretKey;
     }
 
-    /**
-     * Returns true if the {@code captchaResponse} token is verified successfully or {@code secretKey} is null.
-     * @param captchaResponse The user's captcha response from the client side
-     * @return true if the {@code captchaResponse} is verified successfully or {@code secretKey} is null, and false if a
-     *         exception occurs or if the API request fails
-     */
+    @Override
     public boolean isVerificationSuccessful(String captchaResponse) {
         if (secretKey == null || secretKey.isEmpty()) {
-            return true;
+            return false;
         }
 
         if (captchaResponse == null || captchaResponse.isEmpty()) {

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -48,11 +48,6 @@ public final class InstructorsLogic {
         frcLogic = FeedbackResponseCommentsLogic.inst();
     }
 
-    /* ====================================
-     * methods related to google search API
-     * ====================================
-     */
-
     /**
      * Batch creates or updates documents for the given Instructors.
      * @param instructors a list of instructors to be put into documents
@@ -71,10 +66,6 @@ public final class InstructorsLogic {
             throws SearchServiceException {
         return instructorsDb.searchInstructorsInWholeSystem(queryString);
     }
-
-    /* ====================================
-     * ====================================
-     */
 
     /**
      * Creates an instructor.

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -101,26 +101,37 @@ public final class InstructorsLogic {
         );
     }
 
+    /**
+     * Gets an instructor by unique constraint courseId-email.
+     */
     public InstructorAttributes getInstructorForEmail(String courseId, String email) {
-
         return instructorsDb.getInstructorForEmail(courseId, email);
     }
 
+    /**
+     * Gets an instructor by unique ID.
+     */
     public InstructorAttributes getInstructorById(String courseId, String email) {
-
         return instructorsDb.getInstructorById(courseId, email);
     }
 
+    /**
+     * Gets an instructor by unique constraint courseId-googleId.
+     */
     public InstructorAttributes getInstructorForGoogleId(String courseId, String googleId) {
-
         return instructorsDb.getInstructorForGoogleId(courseId, googleId);
     }
 
+    /**
+     * Gets an instructor by unique constraint encryptedKey.
+     */
     public InstructorAttributes getInstructorForRegistrationKey(String encryptedKey) {
-
         return instructorsDb.getInstructorForRegistrationKey(encryptedKey);
     }
 
+    /**
+     * Gets all instructors of a course.
+     */
     public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
         List<InstructorAttributes> instructorReturnList = instructorsDb.getInstructorsForCourse(courseId);
         InstructorAttributes.sortByName(instructorReturnList);
@@ -128,16 +139,27 @@ public final class InstructorsLogic {
         return instructorReturnList;
     }
 
+    /**
+     * Gets all non-archived instructors associated with a googleId.
+     */
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId) {
-
         return getInstructorsForGoogleId(googleId, false);
     }
 
+    /**
+     * Gets all instructors associated with a googleId.
+     *
+     * @param omitArchived whether archived instructors should be omitted or not
+     */
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId, boolean omitArchived) {
-
         return instructorsDb.getInstructorsForGoogleId(googleId, omitArchived);
     }
 
+    /**
+     * Verifies that at least one instructor is displayed to student.
+     *
+     * @throws InvalidParametersException if there is no instructor displayed to student.
+     */
     void verifyAtLeastOneInstructorIsDisplayed(String courseId, boolean isOriginalInstructorDisplayed,
                                                boolean isEditedInstructorDisplayed)
             throws InvalidParametersException {
@@ -287,6 +309,9 @@ public final class InstructorsLogic {
         }
     }
 
+    /**
+     * Gets the list of instructors with co-owner privileges in a course.
+     */
     public List<InstructorAttributes> getCoOwnersForCourse(String courseId) {
         List<InstructorAttributes> instructors = getInstructorsForCourse(courseId);
         List<InstructorAttributes> instructorsWithCoOwnerPrivileges = new ArrayList<>();

--- a/src/main/java/teammates/logic/core/LogService.java
+++ b/src/main/java/teammates/logic/core/LogService.java
@@ -14,12 +14,25 @@ import teammates.common.exception.LogServiceException;
  */
 public interface LogService {
 
+    /**
+     * Gets the list of recent error- or higher level logs.
+     */
     List<ErrorLogEntry> getRecentErrorLogs();
 
+    /**
+     * Gets the list of logs satisfying the given criteria.
+     */
     QueryLogsResults queryLogs(QueryLogsParams queryLogsParams) throws LogServiceException;
 
+    /**
+     * Creates a feedback session log.
+     */
+    @Deprecated
     void createFeedbackSessionLog(String courseId, String email, String fsName, String fslType) throws LogServiceException;
 
+    /**
+     * Gets the feedback session logs as filtered by the given parameters.
+     */
     List<FeedbackSessionLogEntry> getFeedbackSessionLogs(String courseId, String email,
             Instant startTime, Instant endTime, String fsName)
             throws LogServiceException;

--- a/src/main/java/teammates/logic/core/RecaptchaService.java
+++ b/src/main/java/teammates/logic/core/RecaptchaService.java
@@ -1,0 +1,13 @@
+package teammates.logic.core;
+
+/**
+ * An interface to verify the user's reCAPTCHA response.
+ */
+public interface RecaptchaService {
+
+    /**
+     * Returns true if the {@code captchaResponse} token is verified successfully.
+     */
+    boolean isVerificationSuccessful(String captchaResponse);
+
+}

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -64,26 +64,44 @@ public final class StudentsLogic {
         return studentsDb.createEntity(studentData);
     }
 
+    /**
+     * Gets a student by unique constraint courseId-email.
+     */
     public StudentAttributes getStudentForEmail(String courseId, String email) {
         return studentsDb.getStudentForEmail(courseId, email);
     }
 
+    /**
+     * Gets list of students by email.
+     */
     public List<StudentAttributes> getAllStudentsForEmail(String email) {
         return studentsDb.getAllStudentsForEmail(email);
     }
 
+    /**
+     * Gets a student by unique constraint courseId-googleId.
+     */
     public StudentAttributes getStudentForCourseIdAndGoogleId(String courseId, String googleId) {
         return studentsDb.getStudentForGoogleId(courseId, googleId);
     }
 
+    /**
+     * Gets a student by unique constraint encryptedKey.
+     */
     public StudentAttributes getStudentForRegistrationKey(String registrationKey) {
         return studentsDb.getStudentForRegistrationKey(registrationKey);
     }
 
+    /**
+     * Gets all students associated with a googleId.
+     */
     public List<StudentAttributes> getStudentsForGoogleId(String googleId) {
         return studentsDb.getStudentsForGoogleId(googleId);
     }
 
+    /**
+     * Gets all students of a course.
+     */
     public List<StudentAttributes> getStudentsForCourse(String courseId) {
         return studentsDb.getStudentsForCourse(courseId);
     }
@@ -95,10 +113,18 @@ public final class StudentsLogic {
         return studentsDb.getStudentsForTeam(teamName, courseId);
     }
 
+    /**
+     * Gets all unregistered students of a course.
+     */
     public List<StudentAttributes> getUnregisteredStudentsForCourse(String courseId) {
         return studentsDb.getUnregisteredStudentsForCourse(courseId);
     }
 
+    /**
+     * Searches for students.
+     *
+     * @param instructors the constraint that restricts the search result
+     */
     public List<StudentAttributes> searchStudents(String queryString, List<InstructorAttributes> instructors)
             throws SearchServiceException {
         return studentsDb.search(queryString, instructors);
@@ -115,10 +141,16 @@ public final class StudentsLogic {
         return studentsDb.searchStudentsInWholeSystem(queryString);
     }
 
+    /**
+     * Returns true if the user associated with the googleId is a student in any course in the system.
+     */
     public boolean isStudentInAnyCourse(String googleId) {
-        return studentsDb.getStudentsForGoogleId(googleId).size() != 0;
+        return !getStudentsForGoogleId(googleId).isEmpty();
     }
 
+    /**
+     * Returns true if the given student is in the given team of course.
+     */
     boolean isStudentInTeam(String courseId, String teamName, String studentEmail) {
 
         StudentAttributes student = getStudentForEmail(courseId, studentEmail);
@@ -135,6 +167,9 @@ public final class StudentsLogic {
         return false;
     }
 
+    /**
+     * Returns true if the two given emails belong to the same team in the given course.
+     */
     public boolean isStudentsInSameTeam(String courseId, String student1Email, String student2Email) {
         StudentAttributes student1 = getStudentForEmail(courseId, student1Email);
         if (student1 == null) {
@@ -256,6 +291,9 @@ public final class StudentsLogic {
         return mergedList;
     }
 
+    /**
+     * Returns the section name for the given team name for the given course.
+     */
     public String getSectionForTeam(String courseId, String teamName) {
 
         List<StudentAttributes> students = getStudentsForTeam(teamName, courseId);
@@ -366,7 +404,7 @@ public final class StudentsLogic {
      * Deletes all students associated a googleId and cascade its associated feedback responses and comments.
      */
     public void deleteStudentsForGoogleIdCascade(String googleId) {
-        List<StudentAttributes> students = studentsDb.getStudentsForGoogleId(googleId);
+        List<StudentAttributes> students = getStudentsForGoogleId(googleId);
 
         // Cascade delete students
         for (StudentAttributes student : students) {

--- a/src/main/java/teammates/storage/entity/StudentProfile.java
+++ b/src/main/java/teammates/storage/entity/StudentProfile.java
@@ -35,7 +35,7 @@ public class StudentProfile extends BaseEntity {
 
     private String nationality;
 
-    /* only accepts "male", "female" or "other" */
+    // only accepts "male", "female" or "other"
     private String gender;
 
     @Unindex

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -579,7 +579,6 @@ public class SessionResultsData extends ApiOutput {
                 responseOutput = new ResponseOutput();
             }
 
-            //CHECKSTYLE.OFF:MissingJavadocMethod
             private Builder withIsMissingResponse(boolean isMissingResponse) {
                 responseOutput.isMissingResponse = isMissingResponse;
                 return this;
@@ -663,7 +662,6 @@ public class SessionResultsData extends ApiOutput {
             ResponseOutput build() {
                 return responseOutput;
             }
-            //CHECKSTYLE.ON:MissingJavadocMethod
         }
     }
 
@@ -709,7 +707,6 @@ public class SessionResultsData extends ApiOutput {
                 commentOutput = new CommentOutput(frc);
             }
 
-            //CHECKSTYLE.OFF:MissingJavadocMethod
             Builder withCommentGiver(@Nullable String commentGiver) {
                 commentOutput.commentGiver = commentGiver;
                 return this;
@@ -733,7 +730,6 @@ public class SessionResultsData extends ApiOutput {
             CommentOutput build() {
                 return commentOutput;
             }
-            //CHECKSTYLE.ON:MissingJavadocMethod
         }
     }
 

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -65,7 +65,7 @@ public class WebApiServlet extends HttpServlet {
         int statusCode = 0;
         Action action = null;
         try {
-            action = new ActionFactory().getAction(req, req.getMethod());
+            action = ActionFactory.getAction(req, req.getMethod());
             action.init(req);
             action.checkAccessControl();
 

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -40,15 +40,15 @@ import teammates.ui.request.BasicRequest;
  */
 public abstract class Action {
 
-    Logic logic = new Logic();
-    UserProvision userProvision = new UserProvision();
-    GateKeeper gateKeeper = new GateKeeper();
-    EmailGenerator emailGenerator = new EmailGenerator();
-    TaskQueuer taskQueuer = new TaskQueuer();
-    EmailSender emailSender = new EmailSender();
-    FileStorage fileStorage = new FileStorage();
+    Logic logic = Logic.inst();
+    UserProvision userProvision = UserProvision.inst();
+    GateKeeper gateKeeper = GateKeeper.inst();
+    EmailGenerator emailGenerator = EmailGenerator.inst();
+    TaskQueuer taskQueuer = TaskQueuer.inst();
+    EmailSender emailSender = EmailSender.inst();
+    FileStorage fileStorage = FileStorage.inst();
     RecaptchaVerifier recaptchaVerifier = new RecaptchaVerifier(Config.CAPTCHA_SECRET_KEY);
-    LogsProcessor logsProcessor = new LogsProcessor();
+    LogsProcessor logsProcessor = LogsProcessor.inst();
 
     HttpServletRequest req;
     UserInfo userInfo;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -21,13 +21,13 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.JsonUtils;
-import teammates.common.util.RecaptchaVerifier;
 import teammates.common.util.StringHelper;
 import teammates.logic.api.EmailGenerator;
 import teammates.logic.api.EmailSender;
 import teammates.logic.api.FileStorage;
 import teammates.logic.api.Logic;
 import teammates.logic.api.LogsProcessor;
+import teammates.logic.api.RecaptchaVerifier;
 import teammates.logic.api.TaskQueuer;
 import teammates.logic.api.UserProvision;
 import teammates.ui.output.InstructorPrivilegeData;
@@ -47,7 +47,7 @@ public abstract class Action {
     TaskQueuer taskQueuer = TaskQueuer.inst();
     EmailSender emailSender = EmailSender.inst();
     FileStorage fileStorage = FileStorage.inst();
-    RecaptchaVerifier recaptchaVerifier = new RecaptchaVerifier(Config.CAPTCHA_SECRET_KEY);
+    RecaptchaVerifier recaptchaVerifier = RecaptchaVerifier.inst();
     LogsProcessor logsProcessor = LogsProcessor.inst();
 
     HttpServletRequest req;

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -20,7 +20,7 @@ import teammates.common.util.Const.TaskQueue;
 /**
  * Generates the matching {@link Action} for a given URI and request method.
  */
-public class ActionFactory {
+public final class ActionFactory {
 
     protected static final Map<String, Map<String, Class<? extends Action>>> ACTION_MAPPINGS = new HashMap<>();
 
@@ -151,6 +151,10 @@ public class ActionFactory {
 
     }
 
+    private ActionFactory() {
+        // prevent initialization
+    }
+
     private static void map(String uri, String method, Class<? extends Action> actionClass) {
         ACTION_MAPPINGS.computeIfAbsent(uri, k -> new HashMap<>()).put(method, actionClass);
     }
@@ -158,7 +162,7 @@ public class ActionFactory {
     /**
      * Returns the matching {@link Action} object for the URI and method in {@code req}.
      */
-    public Action getAction(HttpServletRequest req, String method) throws ActionMappingException {
+    public static Action getAction(HttpServletRequest req, String method) throws ActionMappingException {
         String uri = req.getRequestURI();
         if (uri.contains(";")) {
             uri = uri.split(";")[0];
@@ -166,7 +170,7 @@ public class ActionFactory {
         return getAction(uri, method);
     }
 
-    private Action getAction(String uri, String method) throws ActionMappingException {
+    private static Action getAction(String uri, String method) throws ActionMappingException {
         if (!ACTION_MAPPINGS.containsKey(uri)) {
             throw new ActionMappingException("Resource with URI " + uri + " is not found.", HttpStatus.SC_NOT_FOUND);
         }

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -22,7 +22,7 @@ import teammates.common.util.Const.TaskQueue;
  */
 public final class ActionFactory {
 
-    protected static final Map<String, Map<String, Class<? extends Action>>> ACTION_MAPPINGS = new HashMap<>();
+    static final Map<String, Map<String, Class<? extends Action>>> ACTION_MAPPINGS = new HashMap<>();
 
     private static final String GET = HttpGet.METHOD_NAME;
     private static final String POST = HttpPost.METHOD_NAME;

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -47,7 +47,7 @@ class CreateInstructorAction extends Action {
                 instructorRequest.getName(), instructorRequest.getEmail(), instructorRequest.getRoleName(),
                 instructorRequest.getIsDisplayedToStudent(), instructorRequest.getDisplayName());
 
-        /* Process adding the instructor and setup status to be shown to user and admin */
+        // Process adding the instructor and setup status to be shown to user and admin
         try {
             InstructorAttributes createdInstructor = logic.createInstructor(instructorToAdd);
             taskQueuer.scheduleCourseRegistrationInviteToInstructor(

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -15,9 +15,18 @@ import teammates.logic.api.Logic;
 /**
  * Provides access control mechanisms.
  */
-class GateKeeper {
+final class GateKeeper {
 
-    private Logic logic = new Logic();
+    private static final GateKeeper instance = new GateKeeper();
+    private final Logic logic = Logic.inst();
+
+    private GateKeeper() {
+        // prevent initialization
+    }
+
+    public static GateKeeper inst() {
+        return instance;
+    }
 
     /**
      * Verifies the user is logged in.

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
@@ -359,7 +359,7 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
     }
 
     @Test
-    public void testValidate() {
+    public void testValidate() throws Exception {
 
         List<FeedbackParticipantType> showGiverNameToList = new ArrayList<>();
         showGiverNameToList.add(FeedbackParticipantType.SELF);

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetailsTest.java
@@ -18,7 +18,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
 
         assertEquals(FeedbackQuestionType.MCQ, mcqDetails.getQuestionType());
-        assertFalse(mcqDetails.hasAssignedWeights());
+        assertFalse(mcqDetails.isHasAssignedWeights());
         assertTrue(mcqDetails.getMcqWeights().isEmpty());
         assertEquals(0.0, mcqDetails.getMcqOtherWeight());
     }

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
@@ -22,7 +22,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
 
         assertEquals(FeedbackQuestionType.MSQ, msqDetails.getQuestionType());
-        assertFalse(msqDetails.hasAssignedWeights());
+        assertFalse(msqDetails.isHasAssignedWeights());
         assertTrue(msqDetails.getMsqWeights().isEmpty());
         assertEquals(0.0, msqDetails.getMsqOtherWeight());
     }

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
@@ -21,7 +21,7 @@ public class FeedbackRankOptionsQuestionDetailsTest extends BaseTestCase {
         assertEquals(FeedbackQuestionType.RANK_OPTIONS, rankDetails.getQuestionType());
         assertEquals(rankDetails.getMinOptionsToBeRanked(), Const.POINTS_NO_VALUE);
         assertEquals(rankDetails.getMaxOptionsToBeRanked(), Const.POINTS_NO_VALUE);
-        assertFalse(rankDetails.areDuplicatesAllowed());
+        assertFalse(rankDetails.isAreDuplicatesAllowed());
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetailsTest.java
@@ -19,7 +19,7 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
         FeedbackRubricQuestionDetails rubricDetails = new FeedbackRubricQuestionDetails();
 
         assertEquals(FeedbackQuestionType.RUBRIC, rubricDetails.getQuestionType());
-        assertFalse(rubricDetails.hasAssignedWeights());
+        assertFalse(rubricDetails.isHasAssignedWeights());
         assertTrue(rubricDetails.getRubricWeights().isEmpty());
     }
 

--- a/src/test/java/teammates/logic/api/BaseLogicTest.java
+++ b/src/test/java/teammates/logic/api/BaseLogicTest.java
@@ -10,14 +10,14 @@ import teammates.test.BaseTestCaseWithLocalDatabaseAccess;
  */
 public abstract class BaseLogicTest extends BaseTestCaseWithLocalDatabaseAccess {
 
-    protected DataBundle dataBundle;
+    DataBundle dataBundle;
 
     @BeforeClass
     public void baseClassSetup() {
         prepareTestData();
     }
 
-    protected void prepareTestData() {
+    void prepareTestData() {
         dataBundle = getTypicalDataBundle();
         removeAndRestoreTypicalDataBundle();
     }

--- a/src/test/java/teammates/logic/api/EmailGeneratorTest.java
+++ b/src/test/java/teammates/logic/api/EmailGeneratorTest.java
@@ -37,6 +37,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
     private final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
     private final StudentsLogic studentsLogic = StudentsLogic.inst();
 
+    private final EmailGenerator emailGenerator = EmailGenerator.inst();
+
     @Override
     public void prepareTestData() {
         dataBundle = loadDataBundle("/EmailGeneratorTest.json");
@@ -74,7 +76,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("invalid email address");
 
-        EmailWrapper email = new EmailGenerator().generateSessionLinksRecoveryEmailForStudent(
+        EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
                 "non-existing-student");
         String subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
@@ -85,7 +87,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         StudentAttributes student1InCourse1 = dataBundle.students.get("student1InCourse1");
 
-        email = new EmailGenerator().generateSessionLinksRecoveryEmailForStudent(
+        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
                 student1InCourse1.getEmail());
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
@@ -96,7 +98,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         StudentAttributes student1InCourse3 = dataBundle.students.get("student1InCourse3");
 
-        email = new EmailGenerator().generateSessionLinksRecoveryEmailForStudent(
+        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
                 student1InCourse3.getEmail());
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
@@ -108,7 +110,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         StudentAttributes student1InCourse4 = dataBundle.students.get("student1InCourse4");
 
-        email = new EmailGenerator().generateSessionLinksRecoveryEmailForStudent(
+        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
                 student1InCourse4.getEmail());
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
@@ -137,7 +139,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session opening emails");
 
-        List<EmailWrapper> emails = new EmailGenerator().generateFeedbackSessionOpeningEmails(session);
+        List<EmailWrapper> emails = emailGenerator.generateFeedbackSessionOpeningEmails(session);
         assertEquals(11, emails.size());
 
         String subject = String.format(EmailType.FEEDBACK_OPENING.getSubject(),
@@ -148,7 +150,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session reminders");
 
-        emails = new EmailGenerator().generateFeedbackSessionReminderEmails(session, students, instructors,
+        emails = emailGenerator.generateFeedbackSessionReminderEmails(session, students, instructors,
                 instructorToNotify);
         // (5 instructors, 6 students reminded) and (1 instructor to be notified)
         assertEquals(12, emails.size());
@@ -170,7 +172,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session closing alerts");
 
-        emails = new EmailGenerator().generateFeedbackSessionClosingEmails(session);
+        emails = emailGenerator.generateFeedbackSessionClosingEmails(session);
         assertEquals(8, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_CLOSING.getSubject(),
@@ -190,7 +192,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session closed alerts");
 
-        emails = new EmailGenerator().generateFeedbackSessionClosedEmails(session);
+        emails = emailGenerator.generateFeedbackSessionClosedEmails(session);
         assertEquals(8, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_CLOSED.getSubject(),
@@ -200,7 +202,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session published alerts");
 
-        emails = new EmailGenerator().generateFeedbackSessionPublishedEmails(session);
+        emails = emailGenerator.generateFeedbackSessionPublishedEmails(session);
         assertEquals(11, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_PUBLISHED.getSubject(),
@@ -211,7 +213,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session unpublished alerts");
 
-        emails = new EmailGenerator().generateFeedbackSessionUnpublishedEmails(session);
+        emails = emailGenerator.generateFeedbackSessionUnpublishedEmails(session);
         assertEquals(11, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_UNPUBLISHED.getSubject(),
@@ -223,7 +225,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all feedback sessions of course email to new student. "
                 + "Edited student has joined the course");
 
-        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(
+        EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
                 session.getCourseId(), student1.getEmail(), Templates.EmailTemplates.USER_FEEDBACK_SESSION_RESEND_ALL_LINKS);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
 
@@ -232,7 +234,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all feedback sessions of course email to new student. "
                 + "Edited student has not joined the course");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(
+        email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
                 session.getCourseId(), unregisteredStudent.getEmail(),
                 Templates.EmailTemplates.USER_FEEDBACK_SESSION_RESEND_ALL_LINKS);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
@@ -243,7 +245,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all regenerated feedback session links of course email to student. "
                 + "Student has joined the course");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1.getEmail(),
+        email = emailGenerator.generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1.getEmail(),
                                             Templates.EmailTemplates.USER_REGKEY_REGENERATION_RESEND_ALL_COURSE_LINKS);
         subject = String.format(EmailType.STUDENT_COURSE_LINKS_REGENERATED.getSubject(), course.getName(), course.getId());
 
@@ -253,7 +255,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all regenerated feedback session links of course email to student. "
                 + "Student has not joined the course");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(),
+        email = emailGenerator.generateFeedbackSessionSummaryOfCourse(session.getCourseId(),
                 unregisteredStudent.getEmail(), Templates.EmailTemplates.USER_REGKEY_REGENERATION_RESEND_ALL_COURSE_LINKS);
         subject = String.format(EmailType.STUDENT_COURSE_LINKS_REGENERATED.getSubject(), course.getName(), course.getId());
 
@@ -265,19 +267,19 @@ public class EmailGeneratorTest extends BaseLogicTest {
         FeedbackSessionAttributes notAnswerableSession =
                 fsLogic.getFeedbackSession("Not answerable feedback session", "idOfTypicalCourse2");
 
-        emails = new EmailGenerator().generateFeedbackSessionOpeningEmails(notAnswerableSession);
+        emails = emailGenerator.generateFeedbackSessionOpeningEmails(notAnswerableSession);
         assertTrue(emails.isEmpty());
 
-        emails = new EmailGenerator().generateFeedbackSessionClosingEmails(notAnswerableSession);
+        emails = emailGenerator.generateFeedbackSessionClosingEmails(notAnswerableSession);
         assertTrue(emails.isEmpty());
 
-        emails = new EmailGenerator().generateFeedbackSessionClosedEmails(notAnswerableSession);
+        emails = emailGenerator.generateFeedbackSessionClosedEmails(notAnswerableSession);
         assertTrue(emails.isEmpty());
 
-        emails = new EmailGenerator().generateFeedbackSessionPublishedEmails(notAnswerableSession);
+        emails = emailGenerator.generateFeedbackSessionPublishedEmails(notAnswerableSession);
         assertTrue(emails.isEmpty());
 
-        emails = new EmailGenerator().generateFeedbackSessionUnpublishedEmails(notAnswerableSession);
+        emails = emailGenerator.generateFeedbackSessionUnpublishedEmails(notAnswerableSession);
         assertTrue(emails.isEmpty());
 
     }
@@ -294,7 +296,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session opening emails: sanitization required");
 
-        List<EmailWrapper> emails = new EmailGenerator().generateFeedbackSessionOpeningEmails(session);
+        List<EmailWrapper> emails = emailGenerator.generateFeedbackSessionOpeningEmails(session);
 
         assertEquals(2, emails.size());
 
@@ -308,7 +310,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback session closed alerts: sanitization required");
 
-        emails = new EmailGenerator().generateFeedbackSessionClosedEmails(session);
+        emails = emailGenerator.generateFeedbackSessionClosedEmails(session);
         assertEquals(2, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_CLOSED.getSubject(),
@@ -321,7 +323,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback sessions summary of course email: sanitization required");
 
-        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(
+        EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
                 session.getCourseId(), student1.getEmail(), Templates.EmailTemplates.USER_FEEDBACK_SESSION_RESEND_ALL_LINKS);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
         verifyEmail(email, student1.getEmail(), subject,
@@ -356,7 +358,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
                 .withEntityType(Const.EntityType.INSTRUCTOR)
                 .toAbsoluteString();
 
-        EmailWrapper email = new EmailGenerator()
+        EmailWrapper email = emailGenerator
                 .generateNewInstructorAccountJoinEmail(instructorEmail, instructorName, joinLink);
         String subject = String.format(EmailType.NEW_INSTRUCTOR_ACCOUNT.getSubject(), instructorName);
 
@@ -371,7 +373,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
                 .withTimezone(ZoneId.of("UTC"))
                 .build();
 
-        email = new EmailGenerator().generateInstructorCourseJoinEmail(inviter, instructor, course);
+        email = emailGenerator.generateInstructorCourseJoinEmail(inviter, instructor, course);
         subject = String.format(EmailType.INSTRUCTOR_COURSE_JOIN.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, instructor.getEmail(), subject, "/instructorCourseJoinEmail.html");
@@ -390,7 +392,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all feedback sessions of course email to new student. "
                 + "No feedback session opening or published emails have been sent");
 
-        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(
+        EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
                                                             session.getCourseId(), noLinksStudent.getEmail(),
                                                             Templates.EmailTemplates.USER_FEEDBACK_SESSION_RESEND_ALL_LINKS);
         String subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
@@ -401,7 +403,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all regenerated feedback session links of course email to student. "
                 + "No feedback session opening or published emails have been sent");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), noLinksStudent.getEmail(),
+        email = emailGenerator.generateFeedbackSessionSummaryOfCourse(session.getCourseId(), noLinksStudent.getEmail(),
                 Templates.EmailTemplates.USER_REGKEY_REGENERATION_RESEND_ALL_COURSE_LINKS);
         subject = String.format(EmailType.STUDENT_COURSE_LINKS_REGENERATED.getSubject(), course.getName(), course.getId());
 
@@ -421,7 +423,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
                 .withEntityType(Const.EntityType.INSTRUCTOR)
                 .toAbsoluteString();
 
-        EmailWrapper email = new EmailGenerator()
+        EmailWrapper email = emailGenerator
                 .generateNewInstructorAccountJoinEmail(instructor1.getEmail(), instructor1.getName(), joinLink);
         // InstructorAttributes sanitizes name before saving
         String subject = String.format(EmailType.NEW_INSTRUCTOR_ACCOUNT.getSubject(),
@@ -434,14 +436,14 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         AccountAttributes inviter = dataBundle.accounts.get("instructor1OfTestingSanitizationCourse");
         CourseAttributes course = coursesLogic.getCourse("idOfTestingSanitizationCourse");
-        email = new EmailGenerator().generateInstructorCourseJoinEmail(inviter, instructor1, course);
+        email = emailGenerator.generateInstructorCourseJoinEmail(inviter, instructor1, course);
         subject = String.format(EmailType.INSTRUCTOR_COURSE_JOIN.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, instructor1.getEmail(), subject, "/instructorCourseJoinEmailTestingSanitization.html");
 
         ______TS("instructor course join email after Google ID reset");
 
-        email = new EmailGenerator().generateInstructorCourseRejoinEmailAfterGoogleIdReset(instructor1, course, null);
+        email = emailGenerator.generateInstructorCourseRejoinEmailAfterGoogleIdReset(instructor1, course, null);
         subject = String.format(EmailType.INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET.getSubject(),
                 course.getName(), course.getId());
 
@@ -450,7 +452,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("instructor course join email after Google ID reset (with institute name set)");
 
-        email = new EmailGenerator()
+        email = emailGenerator
                 .generateInstructorCourseRejoinEmailAfterGoogleIdReset(instructor1, course, "Test Institute");
         subject = String.format(EmailType.INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET.getSubject(),
                 course.getName(), course.getId());
@@ -476,14 +478,14 @@ public class EmailGeneratorTest extends BaseLogicTest {
                         .build();
         student.setKey("skxxxxxxxxxks");
 
-        EmailWrapper email = new EmailGenerator().generateStudentCourseJoinEmail(course, student);
+        EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
         String subject = String.format(EmailType.STUDENT_COURSE_JOIN.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, student.getEmail(), subject, "/studentCourseWithCoOwnersJoinEmail.html");
 
         ______TS("student course with co-owners join email after Google ID reset");
 
-        email = new EmailGenerator().generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student);
+        email = emailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student);
         subject = String.format(EmailType.STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET.getSubject(),
                                 course.getName(), course.getId());
 
@@ -496,14 +498,14 @@ public class EmailGeneratorTest extends BaseLogicTest {
                 .withTimezone(ZoneId.of("UTC"))
                 .build();
 
-        email = new EmailGenerator().generateStudentCourseJoinEmail(course, student);
+        email = emailGenerator.generateStudentCourseJoinEmail(course, student);
         subject = String.format(EmailType.STUDENT_COURSE_JOIN.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, student.getEmail(), subject, "/studentCourseWithoutCoOwnersJoinEmail.html");
 
         ______TS("student course (without-co-owners) join email after Google ID reset");
 
-        email = new EmailGenerator().generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student);
+        email = emailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student);
         subject = String.format(EmailType.STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET.getSubject(),
                                 course.getName(), course.getId());
 
@@ -518,14 +520,14 @@ public class EmailGeneratorTest extends BaseLogicTest {
         CourseAttributes course = coursesLogic.getCourse("idOfTestingSanitizationCourse");
         StudentAttributes student1 = studentsLogic.getStudentForEmail(course.getId(), "normal@sanitization.tmt");
 
-        EmailWrapper email = new EmailGenerator().generateStudentCourseJoinEmail(course, student1);
+        EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student1);
         String subject = String.format(EmailType.STUDENT_COURSE_JOIN.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, student1.getEmail(), subject, "/studentCourseJoinEmailTestingSanitization.html");
 
         ______TS("student course join email after Google ID reset: sanitization required");
 
-        email = new EmailGenerator().generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student1);
+        email = emailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(course, student1);
         subject = String.format(EmailType.STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET.getSubject(),
                 course.getName(), course.getId());
 
@@ -548,7 +550,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         String googleId = "user.googleid";
 
         EmailWrapper email =
-                new EmailGenerator().generateUserCourseRegisteredEmail(name, emailAddress, googleId, false, course);
+                emailGenerator.generateUserCourseRegisteredEmail(name, emailAddress, googleId, false, course);
         String subject = String.format(EmailType.USER_COURSE_REGISTER.getSubject(),
                 course.getName(), course.getId());
 
@@ -556,7 +558,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("instructor course register email");
 
-        email = new EmailGenerator().generateUserCourseRegisteredEmail(name, emailAddress, googleId, true, course);
+        email = emailGenerator.generateUserCourseRegisteredEmail(name, emailAddress, googleId, true, course);
         subject = String.format(EmailType.USER_COURSE_REGISTER.getSubject(),
                 course.getName(), course.getId());
 
@@ -571,7 +573,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
                 new ErrorLogEntry("Log line <br> with line break <br> and also HTML br tag", "ERROR")
         );
 
-        EmailWrapper email = new EmailGenerator().generateCompiledLogsEmail(errorLogs);
+        EmailWrapper email = emailGenerator.generateCompiledLogsEmail(errorLogs);
 
         String subject = String.format(EmailType.SEVERE_LOGS_COMPILATION.getSubject(), Config.APP_VERSION);
 

--- a/src/test/java/teammates/logic/api/MockEmailSender.java
+++ b/src/test/java/teammates/logic/api/MockEmailSender.java
@@ -1,4 +1,4 @@
-package teammates.test;
+package teammates.logic.api;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -7,7 +7,6 @@ import org.apache.http.HttpStatus;
 
 import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailWrapper;
-import teammates.logic.api.EmailSender;
 
 /**
  * Allows mocking of the {@link EmailSender} API used in production.

--- a/src/test/java/teammates/logic/api/MockFileStorage.java
+++ b/src/test/java/teammates/logic/api/MockFileStorage.java
@@ -1,9 +1,7 @@
-package teammates.test;
+package teammates.logic.api;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import teammates.logic.api.FileStorage;
 
 /**
  * Allows mocking of {@link FileStorage}.

--- a/src/test/java/teammates/logic/api/MockLogsProcessor.java
+++ b/src/test/java/teammates/logic/api/MockLogsProcessor.java
@@ -1,4 +1,4 @@
-package teammates.test;
+package teammates.logic.api;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -15,7 +15,6 @@ import teammates.common.datatransfer.QueryLogsParams;
 import teammates.common.datatransfer.QueryLogsResults;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.logic.api.LogsProcessor;
 
 /**
  * Allows mocking of {@link LogsProcessor}.

--- a/src/test/java/teammates/logic/api/MockRecaptchaVerifier.java
+++ b/src/test/java/teammates/logic/api/MockRecaptchaVerifier.java
@@ -1,0 +1,13 @@
+package teammates.logic.api;
+
+/**
+ * Allows mocking of the {@link RecaptchaVerifier} used in production.
+ */
+public class MockRecaptchaVerifier extends RecaptchaVerifier {
+
+    @Override
+    public boolean isVerificationSuccessful(String captchaResponse) {
+        return true;
+    }
+
+}

--- a/src/test/java/teammates/logic/api/MockTaskQueuer.java
+++ b/src/test/java/teammates/logic/api/MockTaskQueuer.java
@@ -1,4 +1,4 @@
-package teammates.test;
+package teammates.logic.api;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import teammates.common.util.TaskWrapper;
-import teammates.logic.api.TaskQueuer;
 
 /**
  * Allows mocking of the {@link TaskQueuer} API used in production.
@@ -19,8 +18,8 @@ public class MockTaskQueuer extends TaskQueuer {
     private List<TaskWrapper> tasksAdded = new ArrayList<>();
 
     @Override
-    protected void addDeferredTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody,
-                                   long countdownTime) {
+    void addDeferredTask(String queueName, String workerUrl, Map<String, String> paramMap, Object requestBody,
+                         long countdownTime) {
         // countdown time not tested
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, paramMap, requestBody);
         tasksAdded.add(task);

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -1,8 +1,7 @@
-package teammates.test;
+package teammates.logic.api;
 
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.datatransfer.UserInfoCookie;
-import teammates.logic.api.UserProvision;
 
 /**
  * Allows mocking of the {@link UserProvision} API used in production.
@@ -48,7 +47,7 @@ public class MockUserProvision extends UserProvision {
     }
 
     @Override
-    protected UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
+    UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
         return isLoggedIn ? mockUser : null;
     }
 

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -13,7 +13,7 @@ import teammates.common.util.Config;
  */
 public class UserProvisionTest extends BaseLogicTest {
 
-    private static UserProvision userProvision = new UserProvision();
+    private static UserProvision userProvision = UserProvision.inst();
 
     @Test
     public void testGetCurrentUser() {

--- a/src/test/java/teammates/logic/core/BaseLogicTest.java
+++ b/src/test/java/teammates/logic/core/BaseLogicTest.java
@@ -10,14 +10,14 @@ import teammates.test.BaseTestCaseWithLocalDatabaseAccess;
  */
 public abstract class BaseLogicTest extends BaseTestCaseWithLocalDatabaseAccess {
 
-    protected DataBundle dataBundle;
+    DataBundle dataBundle;
 
     @BeforeClass
     public void baseClassSetup() {
         prepareTestData();
     }
 
-    protected void prepareTestData() {
+    void prepareTestData() {
         dataBundle = getTypicalDataBundle();
         removeAndRestoreTypicalDataBundle();
     }

--- a/src/test/java/teammates/logic/core/GoogleRecaptchaServiceTest.java
+++ b/src/test/java/teammates/logic/core/GoogleRecaptchaServiceTest.java
@@ -1,4 +1,4 @@
-package teammates.common.util;
+package teammates.logic.core;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -11,55 +11,55 @@ import org.testng.annotations.Test;
 import teammates.test.BaseTestCase;
 
 /**
- * SUT: {@link RecaptchaVerifier}.
+ * SUT: {@link GoogleRecaptchaService}.
  */
-public class RecaptchaVerifierTest extends BaseTestCase {
+public class GoogleRecaptchaServiceTest extends BaseTestCase {
 
     /**
-     * Tests the overloaded {@link RecaptchaVerifier#isVerificationSuccessful(String)} method.
+     * Tests the overloaded {@link GoogleRecaptchaService#isVerificationSuccessful(String)} method.
      */
     @Test
     public void testIsVerificationSuccessful() {
         ______TS("null or empty CAPTCHA response");
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful(null));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful(""));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful(null));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful(""));
 
         ______TS("empty CAPTCHA secret key");
-        assertTrue(new RecaptchaVerifierStub(null).isVerificationSuccessful("empty secret key"));
-        assertTrue(new RecaptchaVerifierStub("").isVerificationSuccessful("empty secret key"));
+        assertFalse(new GoogleRecaptchaServiceStub(null).isVerificationSuccessful("empty secret key"));
+        assertFalse(new GoogleRecaptchaServiceStub("").isVerificationSuccessful("empty secret key"));
 
         ______TS("Successful verification");
         // Use RecaptchaVerifierStub to mimic success response
-        assertTrue(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("success"));
+        assertTrue(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("success"));
 
         ______TS("reCAPTCHA error codes that can occur during the API request execution");
         // Use RecaptchaVerifierStub to mimic error codes
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("missing recaptcha params"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("invalid recaptcha secret key"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("invalid recaptcha response"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("invalid recaptcha request"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("missing recaptcha params"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("invalid recaptcha secret key"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("invalid recaptcha response"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("invalid recaptcha request"));
 
         ______TS("Exceptions that can occur during the API request execution");
         // Use RecaptchaVerifierStub to mimic runtime exceptions
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("null response"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("invalid uri"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("http protocol error"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("i/o exception"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("timeout exception"));
-        assertFalse(new RecaptchaVerifierStub("testKey").isVerificationSuccessful("non 2xx http response"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("null response"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("invalid uri"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("http protocol error"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("i/o exception"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("timeout exception"));
+        assertFalse(new GoogleRecaptchaServiceStub("testKey").isVerificationSuccessful("non 2xx http response"));
     }
 
     /**
      * A subclass to mock responses and exceptions that could result in
-     * {@link RecaptchaVerifier#getApiResponse(String, String)}.
+     * {@link GoogleRecaptchaService#getApiResponse(String, String)}.
      * Success response is also mocked to decouple from the Google server for testing purposes. This way, tests are not
      * affected by potential issues in the Google server (e.g. server down).
      *
      * @see <a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">reCAPTCHA API error codes</a>
      */
-    private static class RecaptchaVerifierStub extends RecaptchaVerifier {
+    private static class GoogleRecaptchaServiceStub extends GoogleRecaptchaService {
 
-        private RecaptchaVerifierStub(String secretKey) {
+        private GoogleRecaptchaServiceStub(String secretKey) {
             super(secretKey);
         }
 

--- a/src/test/java/teammates/storage/search/BaseSearchTest.java
+++ b/src/test/java/teammates/storage/search/BaseSearchTest.java
@@ -10,14 +10,14 @@ import teammates.test.BaseTestCaseWithLocalDatabaseAccess;
  */
 public abstract class BaseSearchTest extends BaseTestCaseWithLocalDatabaseAccess {
 
-    protected DataBundle dataBundle;
+    DataBundle dataBundle;
 
     @BeforeMethod
     public void baseClassSetup() {
         prepareTestData();
     }
 
-    protected void prepareTestData() {
+    void prepareTestData() {
         dataBundle = getTypicalDataBundle();
         removeAndRestoreTypicalDataBundle();
         putDocuments(dataBundle);

--- a/src/test/java/teammates/storage/search/InstructorSearchTest.java
+++ b/src/test/java/teammates/storage/search/InstructorSearchTest.java
@@ -208,7 +208,7 @@ public class InstructorSearchTest extends BaseSearchTest {
                 () -> instructorsDb.searchInstructorsInWholeSystem("anything"));
     }
 
-    /*
+    /**
      * Verifies that search results match with expected output.
      * Parameters are modified to standardize {@link InstructorAttributes} for comparison.
      *
@@ -224,8 +224,8 @@ public class InstructorSearchTest extends BaseSearchTest {
         AssertHelper.assertSameContentIgnoreOrder(Arrays.asList(expected), actual);
     }
 
-    /*
-     * Standardizes instructors for comparison by setting key fields to null
+    /**
+     * Standardizes instructors for comparison by setting key fields to null.
      *
      * @param instructors the instructors to standardize.
      */

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -69,10 +69,19 @@ import teammates.ui.request.Intent;
  */
 public abstract class AbstractBackDoor {
 
+    /**
+     * Gets the URL of the back-end.
+     */
     protected abstract String getAppUrl();
 
+    /**
+     * Gets the backdoor key used to authenticate with the back-end.
+     */
     protected abstract String getBackdoorKey();
 
+    /**
+     * Gets the CSRF key used to authenticate with the back-end.
+     */
     protected abstract String getCsrfKey();
 
     /**

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -126,8 +126,11 @@ public class BaseTestCase {
                                      null, new Object[] { messageTemplate, userInput, fieldName, errorReason, maxLength });
     }
 
-    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String fieldName, int maxLength) {
-        return FieldValidator.getPopulatedEmptyStringErrorMessage(messageTemplate, fieldName, maxLength);
+    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String fieldName, int maxLength)
+            throws ReflectiveOperationException {
+        return (String) invokeMethod(FieldValidator.class, "getPopulatedEmptyStringErrorMessage",
+                new Class<?>[] { String.class, String.class, int.class },
+                null, new Object[] { messageTemplate, fieldName, maxLength });
     }
 
     /*

--- a/src/test/java/teammates/ui/webapi/ActionFactoryTest.java
+++ b/src/test/java/teammates/ui/webapi/ActionFactoryTest.java
@@ -17,14 +17,12 @@ public class ActionFactoryTest extends BaseTestCase {
 
     @Test
     public void testGetAction() throws Exception {
-        ActionFactory actionFactory = new ActionFactory();
-
         ______TS("Action exists and is retrieved");
 
         MockHttpServletRequest existingActionServletRequest = new MockHttpServletRequest(
                 HttpGet.METHOD_NAME, Const.ResourceURIs.AUTH);
         existingActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
-        Action existingAction = actionFactory.getAction(existingActionServletRequest, HttpGet.METHOD_NAME);
+        Action existingAction = ActionFactory.getAction(existingActionServletRequest, HttpGet.METHOD_NAME);
         assertTrue(existingAction instanceof GetAuthInfoAction);
 
         ______TS("Action does not exist and ActionMappingException is thrown");
@@ -33,7 +31,7 @@ public class ActionFactoryTest extends BaseTestCase {
                 HttpGet.METHOD_NAME, "/blahblahblah");
         nonExistentActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
         ActionMappingException nonExistentActionException = assertThrows(ActionMappingException.class,
-                () -> actionFactory.getAction(nonExistentActionServletRequest, HttpGet.METHOD_NAME));
+                () -> ActionFactory.getAction(nonExistentActionServletRequest, HttpGet.METHOD_NAME));
         assertTrue(nonExistentActionException.getMessage()
                 .equals("Resource with URI /blahblahblah is not found."));
 
@@ -43,7 +41,7 @@ public class ActionFactoryTest extends BaseTestCase {
                 HttpGet.METHOD_NAME, Const.ResourceURIs.AUTH);
         nonExistentMethodOnActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
         ActionMappingException nonExistentMethodOnActionException = assertThrows(ActionMappingException.class,
-                () -> actionFactory.getAction(nonExistentMethodOnActionServletRequest, HttpPost.METHOD_NAME));
+                () -> ActionFactory.getAction(nonExistentMethodOnActionServletRequest, HttpPost.METHOD_NAME));
         assertTrue(nonExistentMethodOnActionException.getMessage()
                 .equals("Method [" + HttpPost.METHOD_NAME + "] is not allowed for URI "
                 + Const.ResourceURIs.AUTH + "."));

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -33,11 +33,11 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.JsonUtils;
-import teammates.common.util.RecaptchaVerifier;
 import teammates.logic.api.LogicExtension;
 import teammates.logic.api.MockEmailSender;
 import teammates.logic.api.MockFileStorage;
 import teammates.logic.api.MockLogsProcessor;
+import teammates.logic.api.MockRecaptchaVerifier;
 import teammates.logic.api.MockTaskQueuer;
 import teammates.logic.api.MockUserProvision;
 import teammates.test.BaseTestCaseWithLocalDatabaseAccess;
@@ -67,6 +67,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
     protected MockFileStorage mockFileStorage = new MockFileStorage();
     protected MockLogsProcessor mockLogsProcessor = new MockLogsProcessor();
     protected MockUserProvision mockUserProvision = new MockUserProvision();
+    protected MockRecaptchaVerifier mockRecaptchaVerifier = new MockRecaptchaVerifier();
 
     protected abstract String getActionUri();
 
@@ -121,7 +122,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
             action.setFileStorage(mockFileStorage);
             action.setLogsProcessor(mockLogsProcessor);
             action.setUserProvision(mockUserProvision);
-            action.setRecaptchaVerifier(new RecaptchaVerifier(null));
+            action.setRecaptchaVerifier(mockRecaptchaVerifier);
             action.init(req);
             return (T) action;
         } catch (ActionMappingException e) {

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -55,23 +55,23 @@ import teammates.ui.request.BasicRequest;
  */
 public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithLocalDatabaseAccess {
 
-    protected static final String GET = HttpGet.METHOD_NAME;
-    protected static final String POST = HttpPost.METHOD_NAME;
-    protected static final String PUT = HttpPut.METHOD_NAME;
-    protected static final String DELETE = HttpDelete.METHOD_NAME;
+    static final String GET = HttpGet.METHOD_NAME;
+    static final String POST = HttpPost.METHOD_NAME;
+    static final String PUT = HttpPut.METHOD_NAME;
+    static final String DELETE = HttpDelete.METHOD_NAME;
 
-    protected DataBundle typicalBundle = getTypicalDataBundle();
-    protected LogicExtension logic = new LogicExtension();
-    protected MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();
-    protected MockEmailSender mockEmailSender = new MockEmailSender();
-    protected MockFileStorage mockFileStorage = new MockFileStorage();
-    protected MockLogsProcessor mockLogsProcessor = new MockLogsProcessor();
-    protected MockUserProvision mockUserProvision = new MockUserProvision();
-    protected MockRecaptchaVerifier mockRecaptchaVerifier = new MockRecaptchaVerifier();
+    DataBundle typicalBundle = getTypicalDataBundle();
+    LogicExtension logic = new LogicExtension();
+    MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();
+    MockEmailSender mockEmailSender = new MockEmailSender();
+    MockFileStorage mockFileStorage = new MockFileStorage();
+    MockLogsProcessor mockLogsProcessor = new MockLogsProcessor();
+    MockUserProvision mockUserProvision = new MockUserProvision();
+    MockRecaptchaVerifier mockRecaptchaVerifier = new MockRecaptchaVerifier();
 
-    protected abstract String getActionUri();
+    abstract String getActionUri();
 
-    protected abstract String getRequestMethod();
+    abstract String getRequestMethod();
 
     /**
      * Gets an action with empty request body and empty multipart config.
@@ -256,7 +256,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         mockUserProvision.logoutUser();
     }
 
-    protected void grantInstructorWithSectionPrivilege(
+    void grantInstructorWithSectionPrivilege(
             InstructorAttributes instructor, String privilege, String[] sections)
             throws InvalidParametersException, EntityDoesNotExistException {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
@@ -275,19 +275,19 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     // 'High-level' access-control tests: here it tests access control of an action for the full range of user types.
 
-    protected void verifyAnyUserCanAccess(String... params) {
+    void verifyAnyUserCanAccess(String... params) {
         verifyAccessibleWithoutLogin(params);
         verifyAccessibleForUnregisteredUsers(params);
         verifyAccessibleForAdmin(params);
     }
 
-    protected void verifyAnyLoggedInUserCanAccess(String... params) {
+    void verifyAnyLoggedInUserCanAccess(String... params) {
         verifyInaccessibleWithoutLogin(params);
         verifyAccessibleForUnregisteredUsers(params);
         verifyAccessibleForAdmin(params);
     }
 
-    protected void verifyOnlyAdminCanAccess(String... params) {
+    void verifyOnlyAdminCanAccess(String... params) {
         verifyInaccessibleWithoutLogin(params);
         verifyInaccessibleForUnregisteredUsers(params);
         verifyInaccessibleForStudents(params);
@@ -295,7 +295,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyAccessibleForAdmin(params);
     }
 
-    protected void verifyOnlyInstructorsCanAccess(String... params) {
+    void verifyOnlyInstructorsCanAccess(String... params) {
         verifyInaccessibleWithoutLogin(params);
         verifyInaccessibleForUnregisteredUsers(params);
         verifyInaccessibleForStudents(params);
@@ -304,7 +304,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyAccessibleForAdminToMasqueradeAsInstructor(params);
     }
 
-    protected void verifyOnlyInstructorsOfTheSameCourseCanAccess(String[] submissionParams) {
+    void verifyOnlyInstructorsOfTheSameCourseCanAccess(String[] submissionParams) {
         verifyInaccessibleWithoutLogin(submissionParams);
         verifyInaccessibleForUnregisteredUsers(submissionParams);
         verifyInaccessibleForStudents(submissionParams);
@@ -313,7 +313,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyAccessibleForAdminToMasqueradeAsInstructor(submissionParams);
     }
 
-    protected void verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
+    void verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
             String privilege, String[] submissionParams)
             throws InvalidParametersException, EntityDoesNotExistException {
         verifyInaccessibleWithoutLogin(submissionParams);
@@ -325,7 +325,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     // 'Mid-level' access control tests: here it tests access control of an action for one user type.
 
-    protected void verifyAccessibleWithoutLogin(String... params) {
+    void verifyAccessibleWithoutLogin(String... params) {
 
         ______TS("Non-logged-in users can access");
 
@@ -334,7 +334,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyInaccessibleWithoutLogin(String... params) {
+    void verifyInaccessibleWithoutLogin(String... params) {
 
         ______TS("Non-logged-in users cannot access");
 
@@ -343,7 +343,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyAccessibleForUnregisteredUsers(String... params) {
+    void verifyAccessibleForUnregisteredUsers(String... params) {
 
         ______TS("Non-registered users can access");
 
@@ -353,7 +353,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyInaccessibleForUnregisteredUsers(String... params) {
+    void verifyInaccessibleForUnregisteredUsers(String... params) {
 
         ______TS("Non-registered users cannot access");
 
@@ -363,7 +363,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyAccessibleForAdmin(String... params) {
+    void verifyAccessibleForAdmin(String... params) {
 
         ______TS("Admin can access");
 
@@ -372,7 +372,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyInaccessibleForAdmin(String... params) {
+    void verifyInaccessibleForAdmin(String... params) {
 
         ______TS("Admin cannot access");
 
@@ -381,7 +381,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyInaccessibleForStudents(String... params) {
+    void verifyInaccessibleForStudents(String... params) {
 
         ______TS("Students cannot access");
 
@@ -392,7 +392,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyInaccessibleForInstructors(String... params) {
+    void verifyInaccessibleForInstructors(String... params) {
 
         ______TS("Instructors cannot access");
 
@@ -403,7 +403,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyAccessibleForAdminToMasqueradeAsInstructor(
+    void verifyAccessibleForAdminToMasqueradeAsInstructor(
             InstructorAttributes instructor, String[] submissionParams) {
 
         ______TS("admin can access");
@@ -413,7 +413,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCanMasquerade(instructor.getGoogleId(), submissionParams);
     }
 
-    protected void verifyAccessibleForAdminToMasqueradeAsInstructor(String[] submissionParams) {
+    void verifyAccessibleForAdminToMasqueradeAsInstructor(String[] submissionParams) {
 
         ______TS("admin can access");
 
@@ -424,7 +424,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCanMasquerade(instructor1OfCourse1.getGoogleId(), submissionParams);
     }
 
-    protected void verifyInaccessibleWithoutModifySessionPrivilege(String[] submissionParams) {
+    void verifyInaccessibleWithoutModifySessionPrivilege(String[] submissionParams) {
 
         ______TS("without Modify-Session privilege cannot access");
 
@@ -434,7 +434,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCannotAccess(submissionParams);
     }
 
-    protected void verifyInaccessibleWithoutSubmitSessionInSectionsPrivilege(String[] submissionParams) {
+    void verifyInaccessibleWithoutSubmitSessionInSectionsPrivilege(String[] submissionParams) {
 
         ______TS("without Submit-Session-In-Sections privilege cannot access");
 
@@ -444,7 +444,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCannotAccess(submissionParams);
     }
 
-    protected void verifyInaccessibleWithoutCorrectCoursePrivilege(
+    void verifyInaccessibleWithoutCorrectCoursePrivilege(
             String privilege, String[] submissionParams)
             throws InvalidParametersException, EntityDoesNotExistException {
         CourseAttributes course = typicalBundle.courses.get("typicalCourse1");
@@ -473,7 +473,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
                 .build());
     }
 
-    protected void verifyAccessibleForInstructorsOfTheSameCourse(String[] submissionParams) {
+    void verifyAccessibleForInstructorsOfTheSameCourse(String[] submissionParams) {
 
         ______TS("course instructor can access");
 
@@ -489,7 +489,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
 
     }
 
-    protected void verifyAccessibleForInstructorsOfOtherCourse(String[] submissionParams) {
+    void verifyAccessibleForInstructorsOfOtherCourse(String[] submissionParams) {
 
         ______TS("other course's instructor can access");
 
@@ -504,7 +504,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCannotMasquerade(otherInstructor.getGoogleId(), submissionParams);
     }
 
-    protected void verifyAccessibleForStudentsOfTheSameCourse(String[] submissionParams) {
+    void verifyAccessibleForStudentsOfTheSameCourse(String[] submissionParams) {
 
         ______TS("course students can access");
 
@@ -513,7 +513,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCanAccess(submissionParams);
     }
 
-    protected void verifyInaccessibleForStudentsOfOtherCourse(String[] submissionParams) {
+    void verifyInaccessibleForStudentsOfOtherCourse(String[] submissionParams) {
 
         ______TS("other course student cannot access");
 
@@ -523,7 +523,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCannotAccess(submissionParams);
     }
 
-    protected void verifyInaccessibleForInstructorsOfOtherCourses(String[] submissionParams) {
+    void verifyInaccessibleForInstructorsOfOtherCourses(String[] submissionParams) {
 
         ______TS("other course instructor cannot access");
 
@@ -533,7 +533,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         verifyCannotAccess(submissionParams);
     }
 
-    protected void verifyAccessibleForMaintainers(String... params) {
+    void verifyAccessibleForMaintainers(String... params) {
 
         ______TS("Maintainer can access");
 

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -151,12 +151,27 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         prepareTestData();
     }
 
+    /**
+     * Prepares the test data used for the current test.
+     */
     protected void prepareTestData() {
         removeAndRestoreTypicalDataBundle();
     }
 
+    /**
+     * Tests the {@link Action#execute()} method.
+     *
+     * <p>Some actions, particularly those with large number of different outcomes,
+     * can alternatively separate each test case to different test blocks.
+     */
     protected abstract void testExecute() throws Exception;
 
+    /**
+     * Tests the {@link Action#checkAccessControl()} method.
+     *
+     * <p>Some actions, particularly those with large number of different access control settings,
+     * can alternatively separate each test case to different test blocks.
+     */
     protected abstract void testAccessControl() throws Exception;
 
     /**
@@ -225,6 +240,9 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         assertFalse(user.isAdmin);
     }
 
+    /**
+     * Logs in the user to the test environment as a maintainer.
+     */
     protected void loginAsMaintainer() {
         UserInfo user = mockUserProvision.loginUser(Config.APP_MAINTAINERS.get(0));
         assertTrue(user.isMaintainer);
@@ -593,43 +611,70 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
         assertThrows(InvalidHttpParameterException.class, c::execute);
     }
 
+    /**
+     * Verifies that the executed action does not result in any background task being added.
+     */
     protected void verifyNoTasksAdded() {
         Map<String, Integer> tasksAdded = mockTaskQueuer.getNumberOfTasksAdded();
         assertEquals(0, tasksAdded.keySet().size());
     }
 
+    /**
+     * Verifies that the executed action results in the specified background tasks being added.
+     */
     protected void verifySpecifiedTasksAdded(String taskName, int taskCount) {
         Map<String, Integer> tasksAdded = mockTaskQueuer.getNumberOfTasksAdded();
         assertEquals(taskCount, tasksAdded.get(taskName).intValue());
     }
 
+    /**
+     * Verifies that the executed action does not result in any email being sent.
+     */
     protected void verifyNoEmailsSent() {
         assertTrue(getEmailsSent().isEmpty());
     }
 
+    /**
+     * Returns the list of emails sent as part of the executed action.
+     */
     protected List<EmailWrapper> getEmailsSent() {
         return mockEmailSender.getEmailsSent();
     }
 
+    /**
+     * Verifies that the executed action results in the specified number of emails being sent.
+     */
     protected void verifyNumberOfEmailsSent(int emailCount) {
         assertEquals(emailCount, mockEmailSender.getEmailsSent().size());
     }
 
+    /**
+     * Verifies that the executed action results in {@link EntityNotFoundException} being thrown.
+     */
     protected void verifyEntityNotFound(String... params) {
         Action c = getAction(params);
         assertThrows(EntityNotFoundException.class, c::checkAccessControl);
     }
 
+    /**
+     * Writes a file into the mock file storage.
+     */
     protected void writeFileToStorage(String targetFileName, String sourceFilePath) throws IOException {
         byte[] bytes = FileHelper.readFileAsBytes(sourceFilePath);
         String contentType = URLConnection.guessContentTypeFromName(sourceFilePath);
         mockFileStorage.create(targetFileName, bytes, contentType);
     }
 
+    /**
+     * Deletes a file from the mock file storage.
+     */
     protected void deleteFile(String fileName) {
         mockFileStorage.delete(fileName);
     }
 
+    /**
+     * Returns true if the specified file exists in the mock file storage.
+     */
     protected boolean doesFileExist(String fileName) {
         return mockFileStorage.doesFileExist(fileName);
     }

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -115,7 +115,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCaseWithL
             }
         }
         try {
-            Action action = new ActionFactory().getAction(req, getRequestMethod());
+            Action action = ActionFactory.getAction(req, getRequestMethod());
             action.setTaskQueuer(mockTaskQueuer);
             action.setEmailSender(mockEmailSender);
             action.setFileStorage(mockFileStorage);

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -35,15 +35,15 @@ import teammates.common.util.EmailWrapper;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.RecaptchaVerifier;
 import teammates.logic.api.LogicExtension;
+import teammates.logic.api.MockEmailSender;
+import teammates.logic.api.MockFileStorage;
+import teammates.logic.api.MockLogsProcessor;
+import teammates.logic.api.MockTaskQueuer;
+import teammates.logic.api.MockUserProvision;
 import teammates.test.BaseTestCaseWithLocalDatabaseAccess;
 import teammates.test.FileHelper;
-import teammates.test.MockEmailSender;
-import teammates.test.MockFileStorage;
 import teammates.test.MockHttpServletRequest;
-import teammates.test.MockLogsProcessor;
 import teammates.test.MockPart;
-import teammates.test.MockTaskQueuer;
-import teammates.test.MockUserProvision;
 import teammates.ui.request.BasicRequest;
 
 /**

--- a/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
@@ -107,7 +107,7 @@ public class SendJoinReminderEmailActionTest extends BaseActionTest<SendJoinRemi
         logic.createStudent(unregisteredStudent1);
         logic.createStudent(unregisteredStudent2);
 
-        /* Reassign the attributes to retrieve their keys */
+        // Reassign the attributes to retrieve their keys
         unregisteredStudent1 = logic.getStudentForEmail(courseId, unregisteredStudent1.getEmail());
         unregisteredStudent2 = logic.getStudentForEmail(courseId, unregisteredStudent2.getEmail());
 

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -10,7 +10,6 @@
     <suppress checks="UncommentedMain" files="client[/\\]scripts[/\\].*\.java"/>
 
     <!-- To be implemented slowly -->
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -16,7 +16,6 @@
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]AppUrl\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]Url\.java"/>
-    <suppress checks="MissingJavadocType" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -11,7 +11,6 @@
 
     <!-- To be implemented slowly -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -6,9 +6,6 @@
     <!-- Ignore auto-generated code -->
     <suppress checks="." files="com[/\\]google[/\\]appengine[/\\]logging[/\\]v1[/\\].*\.java"/>
 
-    <!-- Most variables in scripts are constants -->
-    <suppress checks="ConstantName" files="client[/\\]scripts[/\\].*\.java"/>
-
     <!-- Scripts inherently need main method to run -->
     <suppress checks="UncommentedMain" files="client[/\\]scripts[/\\].*\.java"/>
 

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -15,5 +15,6 @@
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]api[/\\]Logic\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]api[/\\]LogicExtension\.java"/>
+    <suppress checks="MissingJavadocMethod" files="teammates[/\\]test[/\\]Base.*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
 </suppressions>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -17,7 +17,6 @@
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]Url\.java"/>
     <suppress checks="MissingJavadocType" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
-    <suppress checks="MissingJavadocType" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -11,7 +11,6 @@
 
     <!-- To be implemented slowly -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
-    <suppress checks="MissingJavadocType" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]AppUrl\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -21,5 +21,4 @@
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]api[/\\]LogicExtension\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]core[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
-    <suppress checks="JavadocVariable" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
 </suppressions>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -11,7 +11,6 @@
 
     <!-- To be implemented slowly -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
-    <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]AppUrl\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]Url\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -16,6 +16,5 @@
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]api[/\\]Logic\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]api[/\\]LogicExtension\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]logic[/\\]core[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
 </suppressions>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -11,9 +11,7 @@
 
     <!-- To be implemented slowly -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]datatransfer[/\\].*\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]AppUrl\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]common[/\\]util[/\\]Url\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Const\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]FieldValidator\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]common[/\\]util[/\\]Templates\.java"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -140,7 +140,7 @@
         </module>
         <module name="SingleLineJavadoc"/>
         <module name="JavadocVariable">
-            <property name="scope" value="public"/>
+            <property name="scope" value="protected"/>
         </module>
         <module name="CommentsIndentation"/>
         <module name="ImportOrder">
@@ -180,7 +180,7 @@
         </module>
         <module name="MissingJavadocMethod">
             <property name="allowedAnnotations" value="Test, Override, BeforeSuite, BeforeClass, BeforeTest, BeforeMethod, AfterSuite, AfterClass, AfterTest, AfterMethod"/>
-            <property name="scope" value="public"/>
+            <property name="scope" value="protected"/>
             <property name="allowMissingPropertyJavadoc" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>
             <property name="ignoreMethodNamesRegex" value="main|inst|build|(with.+)"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -183,7 +183,7 @@
             <property name="scope" value="public"/>
             <property name="allowMissingPropertyJavadoc" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>
-            <property name="ignoreMethodNamesRegex" value="main|inst"/>
+            <property name="ignoreMethodNamesRegex" value="main|inst|build|(with.+)"/>
         </module>
         <module name="JavadocContentLocationCheck"/>
         <module name="JavadocMissingWhitespaceAfterAsteriskCheck"/>


### PR DESCRIPTION
Fixes #11314 

- Most of the suppressions are fixed, and in addition the rule is extended to `protected` methods and fields
  - Most of the time suppressions are fixed by just adding the missing documentation
  - Some are fixed by reducing the method visibility to package level (sort of the lazy way out, yes, but the fact that those methods can be package level means they don't warrant documentation that much?)
- Some minor refactoring done in order to make the above possible
- Unnecessary block comments are converted to single-line comments
  - Interestingly, some are proper javadoc comment with wrong block comment format; this type of mistake was fixed by simply adding one `*` at the beginning