### PR TITLE
[#11039] [#10677] [#9083] Remove fake google ID in sample students + add migration scripts

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForConstSumForceUnevenDistribution.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForConstSumForceUnevenDistribution.java
@@ -1,0 +1,58 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.questions.FeedbackConstantSumDistributePointsType;
+import teammates.common.datatransfer.questions.FeedbackConstantSumQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.storage.entity.FeedbackQuestion;
+
+/**
+ * Script to set distributePointsFor to DISTRIBUTE_ALL_UNEVENLY if forceUnevenDistribution is true.
+ *
+ * <p>See issue #8577.
+ */
+public class DataMigrationForConstSumForceUnevenDistribution extends
+        DataMigrationEntitiesBaseScript<FeedbackQuestion> {
+
+    public static void main(String[] args) throws IOException {
+        new DataMigrationForConstSumForceUnevenDistribution().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<FeedbackQuestion> getFilterQuery() {
+        return ofy().load().type(FeedbackQuestion.class)
+                .filter("questionType =", FeedbackQuestionType.CONSTSUM.name());
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(FeedbackQuestion question) {
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.valueOf(question);
+        FeedbackConstantSumQuestionDetails fcsqd = (FeedbackConstantSumQuestionDetails) fqa.getQuestionDetails();
+
+        return fcsqd.isForceUnevenDistribution()
+                && FeedbackConstantSumDistributePointsType.NONE.getDisplayedOption().equals(fcsqd.getDistributePointsFor());
+    }
+
+    @Override
+    protected void migrateEntity(FeedbackQuestion question) {
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.valueOf(question);
+        FeedbackConstantSumQuestionDetails fcsqd = (FeedbackConstantSumQuestionDetails) fqa.getQuestionDetails();
+
+        fcsqd.setDistributePointsFor(
+                FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY.getDisplayedOption());
+
+        fqa.setQuestionDetails(fcsqd);
+
+        saveEntityDeferred(question);
+    }
+
+}

--- a/src/client/java/teammates/client/scripts/DataMigrationForNullCommentGiverType.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForNullCommentGiverType.java
@@ -1,0 +1,46 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.storage.entity.FeedbackResponseComment;
+
+/**
+ * Script to set commentGiverType as INSTRUCTOR in all comments by instructor.
+ *
+ * <p>See issue #9083</p>
+ */
+public class DataMigrationForNullCommentGiverType extends
+        DataMigrationEntitiesBaseScript<FeedbackResponseComment> {
+
+    public static void main(String[] args) throws IOException {
+        new DataMigrationForNullCommentGiverType().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<FeedbackResponseComment> getFilterQuery() {
+        return ofy().load().type(FeedbackResponseComment.class)
+                .filter("commentGiverType =", null);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(FeedbackResponseComment comment) {
+        return comment.getCommentGiverType() == null;
+    }
+
+    @Override
+    protected void migrateEntity(FeedbackResponseComment comment) {
+        comment.setCommentGiverType(FeedbackParticipantType.INSTRUCTORS);
+        comment.setIsCommentFromFeedbackParticipant(false);
+
+        saveEntityDeferred(comment);
+    }
+
+}

--- a/src/client/java/teammates/client/scripts/DataMigrationForSampleGoogleIdInStudentAttributes.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSampleGoogleIdInStudentAttributes.java
@@ -1,0 +1,53 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.storage.entity.CourseStudent;
+
+/**
+ * Script to remove google ID of {@link CourseStudent} if it is fake google ID.
+ */
+public class DataMigrationForSampleGoogleIdInStudentAttributes
+        extends DataMigrationEntitiesBaseScript<CourseStudent> {
+
+    public static void main(String[] args) throws IOException {
+        DataMigrationForSampleGoogleIdInStudentAttributes migrator =
+                new DataMigrationForSampleGoogleIdInStudentAttributes();
+        migrator.doOperationRemotely();
+    }
+
+    @Override
+    protected Query<CourseStudent> getFilterQuery() {
+        String sampleGoogleId = "alice.b.tmms.sampleData";
+        // Uncomment the google ID to be removed as necessary
+        // sampleGoogleId = "benny.c.tmms.sampleData";
+        // sampleGoogleId = "charlie.d.tmms.sampleData";
+        // sampleGoogleId = "danny.e.tmms.sampleData";
+        // sampleGoogleId = "emma.f.tmms.sampleData";
+        // sampleGoogleId = "francis.g.tmms.sampleData";
+        // sampleGoogleId = "gene.h.tmms.sampleData";
+        // sampleGoogleId = "teammates.demo.instructor";
+
+        return ofy().load().type(CourseStudent.class)
+                .filter("googleId =", sampleGoogleId);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(CourseStudent student) throws Exception {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(CourseStudent student) throws Exception {
+        student.setGoogleId("");
+
+        saveEntityDeferred(student);
+    }
+}

--- a/src/client/java/teammates/client/scripts/DataMigrationForTextQuestionRecommendedLength.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForTextQuestionRecommendedLength.java
@@ -1,0 +1,53 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
+import teammates.storage.entity.FeedbackQuestion;
+
+/**
+ * Script to set recommendedLength as null in all text questions whose recommendedLength is 0.
+ *
+ * <p>See issue #10677</p>
+ */
+public class DataMigrationForTextQuestionRecommendedLength extends
+        DataMigrationEntitiesBaseScript<FeedbackQuestion> {
+
+    public static void main(String[] args) throws IOException {
+        new DataMigrationForTextQuestionRecommendedLength().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<FeedbackQuestion> getFilterQuery() {
+        return ofy().load().type(FeedbackQuestion.class)
+                .filter("questionType =", FeedbackQuestionType.TEXT.name());
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(FeedbackQuestion question) {
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.valueOf(question);
+        FeedbackTextQuestionDetails ftqd = (FeedbackTextQuestionDetails) fqa.getQuestionDetails();
+        return ftqd.getRecommendedLength() != null && ftqd.getRecommendedLength() == 0;
+    }
+
+    @Override
+    protected void migrateEntity(FeedbackQuestion question) {
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.valueOf(question);
+        FeedbackTextQuestionDetails ftqd = (FeedbackTextQuestionDetails) fqa.getQuestionDetails();
+        ftqd.setRecommendedLength(null);
+
+        fqa.setQuestionDetails(ftqd);
+
+        saveEntityDeferred(fqa.toEntity());
+    }
+
+}

--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -1,5 +1,6 @@
 package teammates.common.datatransfer.attributes;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -38,6 +39,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
     public boolean isDisplayedToStudents;
     public InstructorPrivileges privileges;
 
+    private transient Instant createdAt;
+    private transient Instant updatedAt;
+
     private InstructorAttributes(String courseId, String email) {
         this.courseId = courseId;
         this.email = email;
@@ -47,6 +51,9 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         this.isArchived = false;
         this.isDisplayedToStudents = true;
         this.privileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+
+        this.createdAt = Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP;
+        this.updatedAt = Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP;
     }
 
     /**
@@ -79,6 +86,12 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
             instructorAttributes.privileges =
                     JsonUtils.fromJson(instructor.getInstructorPrivilegesAsText(), InstructorPrivileges.class);
         }
+        if (instructor.getCreatedAt() != null) {
+            instructorAttributes.createdAt = instructor.getCreatedAt();
+        }
+        if (instructor.getUpdatedAt() != null) {
+            instructorAttributes.updatedAt = instructor.getUpdatedAt();
+        }
 
         return instructorAttributes;
     }
@@ -93,6 +106,8 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
         instructorAttributes.isArchived = isArchived;
         instructorAttributes.isDisplayedToStudents = isDisplayedToStudents;
         instructorAttributes.privileges = privileges;
+        instructorAttributes.createdAt = createdAt;
+        instructorAttributes.updatedAt = updatedAt;
 
         return instructorAttributes;
     }
@@ -261,6 +276,22 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
 
     public String getRole() {
         return role;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionType.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionType.java
@@ -11,7 +11,8 @@ public enum FeedbackQuestionType {
 
     CONSTSUM(FeedbackConstantSumQuestionDetails.class, FeedbackConstantSumResponseDetails.class),
 
-    // TODO: dummy enum, need to migrate CONSTSUM to either CONSTSUM_OPTIONS or CONSTSUM_RECIPIENTS
+    // In the back-end, only CONSTSUM and not its branched versions is recognized as a valid question type.
+    // The branching here is done to make it simpler for the front-end to render the right items.
     CONSTSUM_OPTIONS(FeedbackConstantSumQuestionDetails.class, FeedbackConstantSumResponseDetails.class),
     CONSTSUM_RECIPIENTS(FeedbackConstantSumQuestionDetails.class, FeedbackConstantSumResponseDetails.class),
 

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -1,11 +1,14 @@
 package teammates.storage.entity;
 
 import java.security.SecureRandom;
+import java.time.Instant;
 
 import com.google.appengine.api.datastore.Text;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
 
 /**
@@ -54,6 +57,12 @@ public class Instructor extends BaseEntity {
 
     private Text instructorPrivilegesAsText;
 
+    @Translate(InstantTranslatorFactory.class)
+    private Instant createdAt;
+
+    @Translate(InstantTranslatorFactory.class)
+    private Instant updatedAt;
+
     @SuppressWarnings("unused")
     private Instructor() {
         // required by Objectify
@@ -74,6 +83,7 @@ public class Instructor extends BaseEntity {
         // setId should be called after setting email and courseId
         this.setUniqueId(generateId(this.getEmail(), this.getCourseId()));
         this.setRegistrationKey(generateRegistrationKey());
+        this.setCreatedAt(Instant.now());
     }
 
     /**
@@ -211,4 +221,33 @@ public class Instructor extends BaseEntity {
     public void setInstructorPrivilegeAsText(String instructorPrivilegesAsText) {
         this.instructorPrivilegesAsText = new Text(instructorPrivilegesAsText);
     }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the createdAt timestamp.
+     */
+    public void setCreatedAt(Instant created) {
+        this.createdAt = created;
+        setLastUpdate(created);
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setLastUpdate(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Updates the updatedAt timestamp when saving.
+     */
+    @OnSave
+    public void updateLastUpdateTimestamp() {
+        this.setLastUpdate(Instant.now());
+    }
+
 }

--- a/src/main/java/teammates/ui/output/FeedbackQuestionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackQuestionData.java
@@ -81,9 +81,6 @@ public class FeedbackQuestionData extends ApiOutput {
         }
 
         if (this.questionType == FeedbackQuestionType.CONSTSUM) {
-            // TODO: remove the abstraction after migration
-            // need to migrate CONSTSUM to either CONSTSUM_OPTIONS or CONSTSUM_RECIPIENTS
-            // correct to either CONSTSUM_OPTIONS or CONSTSUM_RECIPIENTS
             FeedbackConstantSumQuestionDetails constantSumQuestionDetails =
                     (FeedbackConstantSumQuestionDetails) this.questionDetails;
             this.questionType = constantSumQuestionDetails.isDistributeToRecipients()

--- a/src/main/java/teammates/ui/request/FeedbackQuestionBasicRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackQuestionBasicRequest.java
@@ -72,7 +72,6 @@ public class FeedbackQuestionBasicRequest extends BasicRequest {
         FeedbackQuestionDetails details =
                 JsonUtils.fromJson(JsonUtils.toCompactJson(questionDetails), questionType.getQuestionDetailsClass());
         details.setQuestionText(questionBrief);
-        // TODO remove this after migrate CONSTSUM to either CONSTSUM_OPTIONS or CONSTSUM_RECIPIENTS
         if (questionType == FeedbackQuestionType.CONSTSUM_OPTIONS
                 || questionType == FeedbackQuestionType.CONSTSUM_RECIPIENTS) {
             details.setQuestionType(FeedbackQuestionType.CONSTSUM);

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -1,62 +1,5 @@
 {
-  "accounts": {
-    "alice.b.tmms": {
-      "googleId": "alice.b.tmms.sampleData",
-      "name": "Alice Betsy",
-      "isInstructor": false,
-      "email": "alice.b.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 2"
-    },
-    "benny.c.tmms": {
-      "googleId": "benny.c.tmms.sampleData",
-      "name": "Benny Charles",
-      "isInstructor": false,
-      "email": "benny.c.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 3"
-    },
-    "danny.e.tmms": {
-      "googleId": "danny.e.tmms.sampleData",
-      "name": "Danny Engrid",
-      "isInstructor": false,
-      "email": "danny.e.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 4"
-    },
-    "emma.f.tmms": {
-      "googleId": "emma.f.tmms.sampleData",
-      "name": "Emma Farrell",
-      "isInstructor": false,
-      "email": "emma.f.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 5"
-    },
-    "charlie.d.tmms": {
-      "googleId": "charlie.d.tmms.sampleData",
-      "name": "Charlie Davis",
-      "isInstructor": false,
-      "email": "charlie.d.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 5"
-    },
-    "teammates.demo.instructor@demo.course": {
-      "googleId": "teammates.demo.instructor",
-      "name": "Demo_Instructor",
-      "isInstructor": false,
-      "email": "teammates.demo.instructor@demo.course",
-      "institute": "TEAMMATES Test Institute 1"
-    },
-    "francis.g.tmms@demo.course": {
-      "googleId": "francis.g.tmms.sampleData",
-      "name": "Francis Gabriel",
-      "isInstructor": false,
-      "email": "francis.g.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 1"
-    },
-    "gene.h.tmms@demo.course": {
-      "googleId": "gene.h.tmms.sampleData",
-      "name": "Gene Hudson",
-      "isInstructor": false,
-      "email": "gene.h.tmms@gmail.tmt",
-      "institute": "TEAMMATES Test Institute 6"
-    }
-  },
+  "accounts": {},
   "courses": {
     "Demo Course": {
       "id": "demo.course",
@@ -90,7 +33,7 @@
   },
   "students": {
     "alice.b.tmms@demo.course": {
-      "googleId": "alice.b.tmms.sampleData",
+      "googleId": "",
       "email": "alice.b.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Alice Betsy",
@@ -99,7 +42,7 @@
       "section": "Tutorial Group 1"
     },
     "benny.c.tmms@demo.course": {
-      "googleId": "benny.c.tmms.sampleData",
+      "googleId": "",
       "email": "benny.c.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Benny Charles",
@@ -108,7 +51,7 @@
       "section": "Tutorial Group 1"
     },
     "danny.e.tmms@demo.course": {
-      "googleId": "danny.e.tmms.sampleData",
+      "googleId": "",
       "email": "danny.e.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Danny Engrid",
@@ -117,7 +60,7 @@
       "section": "Tutorial Group 1"
     },
     "emma.f.tmms@demo.course": {
-      "googleId": "emma.f.tmms.sampleData",
+      "googleId": "",
       "email": "emma.f.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Emma Farrell",
@@ -126,7 +69,7 @@
       "section": "Tutorial Group 1"
     },
     "charlie.d.tmms@demo.course": {
-      "googleId": "charlie.d.tmms.sampleData",
+      "googleId": "",
       "email": "charlie.d.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Charlie Davis",
@@ -135,7 +78,7 @@
       "section": "Tutorial Group 2"
     },
     "teammates.demo.instructor@demo.course": {
-      "googleId": "teammates.demo.instructor",
+      "googleId": "",
       "email": "teammates.demo.instructor@demo.course",
       "course": "demo.course",
       "name": "Demo_Instructor",
@@ -144,7 +87,7 @@
       "section": "Tutorial Group 2"
     },
     "francis.g.tmms@demo.course": {
-      "googleId": "francis.g.tmms.sampleData",
+      "googleId": "",
       "email": "francis.g.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Francis Gabriel",
@@ -153,7 +96,7 @@
       "section": "Tutorial Group 2"
     },
     "gene.h.tmms@demo.course": {
-      "googleId": "gene.h.tmms.sampleData",
+      "googleId": "",
       "email": "gene.h.tmms@gmail.tmt",
       "course": "demo.course",
       "name": "Gene Hudson",
@@ -3019,51 +2962,5 @@
       "commentText": "<p>Design could have been more interactive.</p>"
     }
   },
-  "profiles": {
-    "alice.b.tmms": {
-      "googleId": "alice.b.tmms.sampleData",
-      "shortName": "Alice",
-      "email": "alice@b.tmt",
-      "institute": "TEAMMATES Test Institute 5",
-      "nationality": "Chinese",
-      "gender": "FEMALE",
-      "moreInfo": "I am Alice from TEAMMATES Test Institute 1 and am here at Cambridge for exchange. My Major in TEAMMATES Test Institute 5 is Art History with Minor in Business Administration. I really look forward to a great and fruitful semester ahead!"
-    },
-    "danny.e.tmms": {
-      "googleId": "danny.e.tmms.sampleData",
-      "shortName": "Danny",
-      "email": "danny@e.tmt",
-      "institute": "TEAMMATES Test Institute 7",
-      "nationality": "Singaporean",
-      "gender": "MALE",
-      "moreInfo": ""
-    },
-    "emma.f.tmms": {
-      "googleId": "emma.f.tmms.sampleData",
-      "shortName": "Emm",
-      "email": "emma@f.tmt",
-      "institute": "TEAMMATES Test Institute 8",
-      "nationality": "Indian",
-      "gender": "FEMALE",
-      "moreInfo": "I am Emma from TEAMMATES Test Institute 8 India and am here at TEAMMATES Test Institute 5 for exchange. "
-    },
-    "charlie.d.tmms": {
-      "googleId": "charlie.d.tmms.sampleData",
-      "shortName": "Char",
-      "email": "charlie@d.tmt",
-      "institute": "TEAMMATES Test Institute 8",
-      "nationality": "American",
-      "gender": "MALE",
-      "moreInfo": "I am Charlie - an exchange student"
-    },
-    "gene.h.tmms@demo.course": {
-      "googleId": "gene.h.tmms.sampleData",
-      "shortName": "Gene",
-      "email": "gene@h.tmt",
-      "institute": "TEAMMATES Test Institute 5",
-      "nationality": "Nigerian",
-      "gender": "FEMALE",
-      "moreInfo": ""
-    }
-  }
+  "profiles": {}
 }

--- a/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
@@ -134,6 +134,8 @@ public class InstructorAttributesTest extends BaseAttributesTest {
         assertEquals(instructor.getDisplayedName(), instructorAttributes.getDisplayedName());
         assertEquals(instructor.getInstructorPrivilegesAsText(),
                 JsonUtils.toJson(instructorAttributes.getPrivileges(), InstructorPrivileges.class));
+        assertEquals(instructor.getCreatedAt(), instructorAttributes.getCreatedAt());
+        assertEquals(instructor.getUpdatedAt(), instructorAttributes.getUpdatedAt());
     }
 
     @Test


### PR DESCRIPTION
- Fixes #11039. Added script to remove the fake google IDs from the sample students.
- Part of #10677 
- Part of #9083 
- Part of #8577 (the follow-up action is not documented here)
- Added `updatedAt` and `createdAt` fields for `Instructor`, in the somewhat likely event we're going to need it
- Removed the misleading comments about the need to migrate CONSTSUM question type; that is never a candidate for migration in the first place