### PR TITLE
[#2917] Modify Solr to not use auto-created fields to prevent unnecessary tokenization

### DIFF
--- a/solr/solr.sh
+++ b/solr/solr.sh
@@ -2,8 +2,12 @@
 
 # Create core to run students collection
 bin/solr create -c students -s 2 -rf 2
-curl -X POST -H "Content-Type: application/json" --data-binary '{"add-copy-field": {"source": "*", "dest": "_text_"}}' localhost:8983/solr/students/schema
+bin/solr config -c students -p 8983 -action set-user-property -property update.autoCreateFields -value false
+curl -X POST -H 'Content-type: application/json' --data-binary '{"add-field": {"name": "courseId", "type": "string"}}' localhost:8983/solr/students/schema
+curl -X POST -H 'Content-type: application/json' --data-binary '{"add-field": {"name": "email", "type": "string"}}' localhost:8983/solr/students/schema
 
 # Create core to run instructors collection
 bin/solr create -c instructors -s 2 -rf 2
-curl -X POST -H "Content-Type: application/json" --data-binary '{"add-copy-field": {"source": "*", "dest": "_text_"}}' localhost:8983/solr/instructors/schema
+bin/solr config -c instructors -p 8983 -action set-user-property -property update.autoCreateFields -value false
+curl -X POST -H 'Content-type: application/json' --data-binary '{"add-field": {"name": "courseId", "type": "string"}}' localhost:8983/solr/instructors/schema
+curl -X POST -H 'Content-type: application/json' --data-binary '{"add-field": {"name": "email", "type": "string"}}' localhost:8983/solr/instructors/schema

--- a/src/main/java/teammates/storage/search/InstructorSearchDocument.java
+++ b/src/main/java/teammates/storage/search/InstructorSearchDocument.java
@@ -22,15 +22,16 @@ class InstructorSearchDocument extends SearchDocument<InstructorAttributes> {
     Map<String, Object> getSearchableFields() {
         Map<String, Object> fields = new HashMap<>();
         InstructorAttributes instructor = attribute;
+        String[] searchableTexts = {
+                instructor.getName(), instructor.getEmail(), instructor.getCourseId(),
+                course == null ? "" : course.getName(),
+                instructor.getGoogleId(), instructor.getRole(), instructor.getDisplayedName(),
+        };
 
         fields.put("id", instructor.getEmail() + "%" + instructor.getCourseId());
-        fields.put("name", instructor.getName());
-        fields.put("email", instructor.getEmail());
+        fields.put("_text_", String.join(" ", searchableTexts));
         fields.put("courseId", instructor.getCourseId());
-        fields.put("courseName", course == null ? "" : course.getName());
-        fields.put("googleId", instructor.getGoogleId());
-        fields.put("role", instructor.getRole());
-        fields.put("displayedName", instructor.getDisplayedName());
+        fields.put("email", instructor.getEmail());
 
         return fields;
     }

--- a/src/main/java/teammates/storage/search/StudentSearchDocument.java
+++ b/src/main/java/teammates/storage/search/StudentSearchDocument.java
@@ -22,14 +22,16 @@ class StudentSearchDocument extends SearchDocument<StudentAttributes> {
     Map<String, Object> getSearchableFields() {
         Map<String, Object> fields = new HashMap<>();
         StudentAttributes student = attribute;
+        String[] searchableTexts = {
+                student.getName(), student.getEmail(), student.getCourse(),
+                course == null ? "" : course.getName(),
+                student.getTeam(), student.getSection(),
+        };
 
         fields.put("id", student.getId());
-        fields.put("name", student.getName());
-        fields.put("email", student.getEmail());
+        fields.put("_text_", String.join(" ", searchableTexts));
         fields.put("courseId", student.getCourse());
-        fields.put("courseName", course == null ? "" : course.getName());
-        fields.put("team", student.getTeam());
-        fields.put("section", student.getSection());
+        fields.put("email", student.getEmail());
 
         return fields;
     }

--- a/src/main/java/teammates/storage/search/StudentSearchManager.java
+++ b/src/main/java/teammates/storage/search/StudentSearchManager.java
@@ -85,10 +85,9 @@ public class StudentSearchManager extends SearchManager<StudentAttributes> {
         QueryResponse response = performQuery(query);
         SolrDocumentList documents = response.getResults();
 
-        // Even though FQ has been applied, it may still match some unwanted results,
-        // e.g. if a course ID specified in FQ is the substring of another valid course.
-        // An additional filtering is done here such that only exact match will be returned.
-        // TODO a better way is to modify the field type in Solr instead of doing this
+        // Sanity check such that the course ID of the students match exactly.
+        // In ideal case, this check is not expected to do anything,
+        // i.e. the resulting list should be the same as the incoming list.
 
         List<SolrDocument> filteredDocuments = documents.stream()
                 .filter(document -> {


### PR DESCRIPTION
Fixes #2917 

This change will make additional filtering to be no longer necessary (kept there just for safety net), as the `courseId` field is now made into a `string` instead of `text` (auto-created fields default to `text`), and `string` fields only allow exact matches ([reference](https://answers.sap.com/questions/12771972/what-is-the-difference-between-string-and-text-typ.html)).

Auto-created fields are not considered good practice (in fact it's the first thing that Solr warns after starting up the server), and thus it is also removed here. The only remaining fields are `courseId` and `email` (they are the basic identifiers of the indexed student/instructor), on top of the default fields which include `id` (search document identifier) and `_text_` (this is where the searchable terms are added).