### PR TITLE
[#11329] Release V8.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,7 +6,7 @@ about: Report a bug or defect in the application
 
 <!-- Issue title: [brief description of bug] -->
 
-- **Environment**: <!-- The environment in which you encountered the bug, e.g. live server at `V7.0.0`, `master` branch at commit 1234567. -->
+- **Environment**: <!-- The environment in which you encountered the bug, e.g. live server at `V8.0.0`, `master` branch at commit 1234567. -->
 
 **Steps to reproduce**
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,7 +6,7 @@ about: Request a new or a change to existing user-facing feature
 
 <!-- Issue title: [brief description of feature/enhancement] -->
 
-- **Environment**: <!-- The environment in which the said feature/enhancement is absent, e.g. live server at `V7.0.0`, `master` branch at commit 1234567. -->
+- **Environment**: <!-- The environment in which the said feature/enhancement is absent, e.g. live server at `V8.0.0`, `master` branch at commit 1234567. -->
 
 **Description of feature/enhancement**
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,10 @@ dependencies {
     // For using Gmail API
     testImplementation("com.google.apis:google-api-services-gmail:v1-rev20200601-1.30.9")
     // For using JMeter APIs
-    testImplementation("org.apache.jmeter:ApacheJMeter_core:5.3") {
+    testImplementation("org.apache.jmeter:ApacheJMeter_core:5.4.1") {
         exclude group: "org.apache.jmeter", module: "bom"
     }
-    testImplementation("org.apache.jmeter:ApacheJMeter_http:5.3") {
+    testImplementation("org.apache.jmeter:ApacheJMeter_http:5.4.1") {
         exclude group: "org.apache.jmeter", module: "bom"
     }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -92,8 +92,8 @@ This type of request will be processed as follows:
 1. Request forwarded to the `WebApiServlet` and subsequent actions are the same as user-invoked AJAX requests.
 
 GAE server sends such automated requests through two different configurations:
-- Cron jobs: These are jobs that are automatically scheduled for a specified period of time, e.g. scheduling feedback session opening reminders. It is configured in `cron.xml`.
-- Task queue workers: These are hybrids of user-invoked and GAE-invoked in that they are queued by users (i.e. users request for the tasks to be added to queue), but executed by GAE (i.e. GAE determines when and which tasks in the queue are executed at any point of time). This is typically used for tasks that may take a long time to finish and can exceed the 1 minute standard request processing limit imposed by GAE. It is configured in `queue.xml` as well as the `TaskQueue` nested class of the [Const](../src/main/java/teammates/common/util/Const.java) class.
+- Cron jobs: These are jobs that are automatically scheduled for a specified period of time, e.g. scheduling feedback session opening reminders. It is configured in `cron.yaml`.
+- Task queue workers: These are hybrids of user-invoked and GAE-invoked in that they are queued by users (i.e. users request for the tasks to be added to queue), but executed by GAE (i.e. GAE determines when and which tasks in the queue are executed at any point of time). This is typically used for tasks that may take a long time to finish and might be blocking user's interaction. It is configured in `queue.yaml` as well as the `TaskQueue` nested class of the [Const](../src/main/java/teammates/common/util/Const.java) class.
 
 ### Template Method pattern
 
@@ -119,7 +119,7 @@ On designing API endpoints (for AJAX requests):
   - Some fields are required be hidden in the API response, mostly for data privacy purposes. Whenever required, there should be methods in the request output objects catered for this.
 - API endpoints should not be concerned with how data is presented.
   - Case study 1: some endpoint will pass timezone information via two information: timezone ID and UNIX epoch milliseconds. It is up to the front-end on how to make use of those two pieces of information.
-  - Case study 2: CSV file for session result or student list is just a different way of presenting the same information in the web page. Due to this, when downloding CSV, the web page will request the same information as that used when displaying in web page and do the necessary conversion to CSV.
+  - Case study 2: CSV file for session result or student list is just a different way of presenting the same information in the web page. Due to this, when downloading CSV, the web page will request the same information as that used when displaying in web page and do the necessary conversion to CSV.
 
 On data exchange between front-end and back-end:
 
@@ -284,11 +284,9 @@ The E2E component has no knowledge of the internal workings of the application a
 
 Package overview:
 
-- **`e2e.util`**: Contains helpers needed for running E2E tests.
+- **`e2e.util`**: Contains helpers needed for running E2E tests. Also contains the test cases for the said infrastructure/helpers.
 - **`e2e.pageobjects`**: Contains abstractions of the pages as they appear on a Browser (i.e. SUTs).
-- **`e2e.cases`**: Contains test cases.
-  - **`.util`**: Component test cases for testing the test helpers.
-  - **`.e2e`**: System test cases for testing the application as a whole.
+- **`e2e.cases`**: Contains system test cases for testing the application as a whole.
 
 ## Client Component
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -143,17 +143,17 @@ The steps for adding a student is almost identical to the steps for adding instr
 - Where appropriate, change the reference to "instructor" to "student".
 - `Students` → `Enroll` to add students for the course.
 
-**Alternative**: Run the test cases, they create several student and instructor accounts in the datastore. Use one of them to log in.
+**Alternative**: Run the E2E test cases, they create several student and instructor accounts in the database. Use one of them to log in.
 
 ### Logging in without UI
 
 In dev server, it is also possible to "log in" without UI (e.g. when only testing API endpoints). In order to do that, you need to submit the following API call:
 
 ```sh
-POST http://localhost:8080/devServerLogin?email=test@example.com&isAdmin=on
+POST http://localhost:8080/devServerLogin?email=test@example.com
 ```
 
-where `email=test@example.com` and `isAdmin=on` can be replaced as appropriate.
+where `email=test@example.com` can be replaced as appropriate.
 
 The back-end server will return cookies which will subsequently be used to authenticate your requests.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -72,22 +72,15 @@ If you are testing against a production server (staging server or live server), 
 1. Edit `src/e2e/resources/test.properties` as instructed is in its comments.
    * In particular, you will need a legitimate Gmail account to be used for testing.
 
-1. You need to setup a `Gmail API`<sup>1</sup> as follows:
+1. If you are testing email sending, you need to setup a `Gmail API` as follows:
    * [Obtain a Gmail API credentials](https://github.com/TEAMMATES/teammates-ops/blob/master/platform-guide.md#setting-up-gmail-api-credentials) and download it.
    * Copy the file to `src/e2e/resources/gmail-api` (create the `gmail-api` folder) of your project and rename it to `client_secret.json`.
    * It is also possible to use the Gmail API credentials from any other Google Cloud Platform project for this purpose.
    * Run `EmailAccountTest` to confirm that the setup works. For the first run, it is expected that you will need to grant access from the test Gmail account to the above API.
 
-1. Login manually to TEAMMATES on the browser used for testing to add cookie with login details to the browser profile.
-   * This profile will be added to the web driver so that E2E tests will start with user already logged in. 
-   * This is required as Google does not allow login by automated software.
-
 1. Run the full test suite or any subset of it as how you would have done it in dev server. 
    * Do note that the GAE daily quota is usually not enough to run the full test suite, in particular for accounts with no billing enabled.
    
-<sup>1</sup> This setup is necessary because our test suite uses the Gmail API to access the Gmail account used for testing (the account is specified in `test.properties`) to confirm that the account receives the expected emails from TEAMMATES.
-This is needed only when testing against a production server because no actual emails are sent by the dev server and therefore delivery of emails is not tested when testing against the dev server.
-
 ## Creating E2E tests
   
 As E2E tests should be written from the end user perspective, each test case should reflect some user workflow.   

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -19,7 +19,7 @@ To see a sample implementation of a test case, you can refer to `StudentProfileL
 
 If you want to use your own copy of [JMeter](https://jmeter.apache.org/download_jmeter.cgi), update the `test.jmeter.*` properties in `src/lnp/resources/test.properties` accordingly.  
 
-First, open the terminal and navigate to the root of project folder. Start the backend server, i.e. `./gradlew appengineRun`, before running the performance tests.
+First, open the terminal and navigate to the root of project folder. Start the backend server, i.e. `./gradlew serverRun`, before running the performance tests.
 
 For more details about how to set up and run your local server, please refer to [Developer Guide](https://github.com/TEAMMATES/teammates/blob/master/docs/development.md).
 

--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -41,7 +41,6 @@ More information can be found at [this documentation](https://help.github.com/ar
 These tools are necessary regardless of whether you are developing front-end or back-end:
 
 1. Install Java JDK 11.
-1. Install Python 3 (recommended) or Python 2.7.
 
 If you want to develop front-end, you need to install the following:
 

--- a/src/client/resources/client.template.properties
+++ b/src/client/resources/client.template.properties
@@ -7,7 +7,7 @@
 # This is the URL of the database the script will run against.
 # For staging server, the URL should be the URL of the application.
 # e.g. client.target.url=http\://localhost\:8484
-# e.g. client.target.url=https\://7-0-0-dot-teammates-john.appspot.com
+# e.g. client.target.url=https\://8-0-0-dot-teammates-john.appspot.com
 client.target.url=http\://localhost\:8484
 
 # This is the URL of the API back-end that the script will be run against.
@@ -15,7 +15,7 @@ client.target.url=http\://localhost\:8484
 # This URL will be used for other back-end operations that need connection to other services such as search service.
 # The backdoor key and CSRF key will be the keys that are used in the specified API back-end.
 # e.g. client.api.url=https\://localhost\:8080
-# e.g. client.api.url=https\://7-0-0-dot-teammates-john.appspot.com
+# e.g. client.api.url=https\://8-0-0-dot-teammates-john.appspot.com
 client.api.url=
 client.backdoor.key=
 client.csrf.key=

--- a/src/e2e/resources/test.template.properties
+++ b/src/e2e/resources/test.template.properties
@@ -6,7 +6,7 @@
 
 # This is the url of the app we are testing against.
 # e.g. test.app.url=http\://localhost\:8080
-# e.g. test.app.url=https\://7-0-0-dot-teammates-john.appspot.com
+# e.g. test.app.url=https\://8-0-0-dot-teammates-john.appspot.com
 # Note: the '.' in the url has been replaced by -dot- to support https connection for the staging server.
 test.app.url=http\://localhost\:8080
 

--- a/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
@@ -136,7 +136,7 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
@@ -134,7 +134,7 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                                                             .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                                                             .withCreatorEmail(INSTRUCTOR_EMAIL)
-                                                            .withStartTime(Instant.now())
+                                                            .withStartTime(Instant.now().plusMillis(100))
                                                             .withEndTime(Instant.now().plusSeconds(500))
                                                             .withSessionVisibleFromTime(Instant.now())
                                                             .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionViewLNPTest.java
@@ -129,7 +129,7 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                                                             .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                                                             .withCreatorEmail(INSTRUCTOR_EMAIL)
-                                                            .withStartTime(Instant.now())
+                                                            .withStartTime(Instant.now().plusMillis(100))
                                                             .withEndTime(Instant.now().plusSeconds(500))
                                                             .withSessionVisibleFromTime(Instant.now())
                                                             .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorSessionResultLNPTest.java
@@ -130,7 +130,7 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
@@ -135,7 +135,7 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
@@ -133,7 +133,7 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
@@ -133,7 +133,7 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
@@ -133,7 +133,7 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
                 FeedbackSessionAttributes session = FeedbackSessionAttributes
                         .builder(FEEDBACK_SESSION_NAME, COURSE_ID)
                         .withCreatorEmail(INSTRUCTOR_EMAIL)
-                        .withStartTime(Instant.now())
+                        .withStartTime(Instant.now().plusMillis(100))
                         .withEndTime(Instant.now().plusSeconds(500))
                         .withSessionVisibleFromTime(Instant.now())
                         .withResultsVisibleFromTime(Instant.now())

--- a/src/lnp/resources/test.template.properties
+++ b/src/lnp/resources/test.template.properties
@@ -6,13 +6,13 @@
 
 # This is the url of the app we are testing against.
 # e.g. test.app.url=http\://localhost\:8080
-# e.g. test.app.url=https\://7-0-0-dot-teammates-john.appspot.com
+# e.g. test.app.url=https\://8-0-0-dot-teammates-john.appspot.com
 # Note: the '.' in the url has been replaced by -dot- to support https connection for the staging server.
 test.app.url=http\://localhost\:8080
 
 # This is the domain of the app we are testing against.
 # e.g. test.app.domain=localhost
-# e.g. test.app.domain=7-0-0-dot-teammates-john.appspot.com
+# e.g. test.app.domain=8-0-0-dot-teammates-john.appspot.com
 test.app.domain=localhost
 
 # This is the port of the app we are testing against.

--- a/src/main/java/teammates/storage/search/SearchManager.java
+++ b/src/main/java/teammates/storage/search/SearchManager.java
@@ -54,7 +54,10 @@ abstract class SearchManager<T extends EntityAttributes<?>> {
         if (StringHelper.isEmpty(searchServiceHost)) {
             this.client = null;
         } else {
-            this.client = new HttpSolrClient.Builder(searchServiceHost).build();
+            this.client = new HttpSolrClient.Builder(searchServiceHost)
+                    .withConnectionTimeout(2000) // timeout for connecting to Solr server
+                    .withSocketTimeout(5000) // timeout for reading data
+                    .build();
         }
     }
 

--- a/src/main/java/teammates/ui/servlets/WebSecurityHeaderFilter.java
+++ b/src/main/java/teammates/ui/servlets/WebSecurityHeaderFilter.java
@@ -11,17 +11,23 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import teammates.common.util.Config;
+
 /**
  * Filter to add web security headers.
  */
 public class WebSecurityHeaderFilter implements Filter {
+
+    private static final String IMG_SRC_CSP = Config.isDevServer()
+            ? "'self' data: http: https:"
+            : "'self' data: https:";
 
     private static final String CSP_POLICY = String.join("; ", Arrays.asList(
             "default-src 'none'",
             "script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://cdn.jsdelivr.net/",
             "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/",
             "frame-src 'self' docs.google.com https://www.google.com/recaptcha/",
-            "img-src 'self' data: http: https:",
+            "img-src " + IMG_SRC_CSP,
             "font-src 'self' https://cdn.jsdelivr.net/",
             "connect-src 'self'",
             "manifest-src 'self'",

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -16,8 +16,8 @@ app.region=us-central1
 
 # This is the version number of the app.
 # Use dashes instead of dots because GAE does not allow dots in version number.
-# e.g. app.version = 7-0-0
-app.version = 7-0-0
+# e.g. app.version = 8-0-0
+app.version = 8-0-0
 
 # This is the URL for the front-end dev server.
 # This should be used only during development mode where the dev server needs to be whitelisted for CORS.

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`InstructorSearchPageComponent should snap with a search key 1`] = `
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function SearchService]}
+  searchWarningDisplayed="false"
   statusMessageService={[Function StatusMessageService]}
   studentsListRowTables={[Function Array]}
 >
@@ -77,6 +78,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function SearchService]}
+  searchWarningDisplayed="false"
   statusMessageService={[Function StatusMessageService]}
   studentsListRowTables={[Function Array]}
 >
@@ -606,6 +608,7 @@ exports[`InstructorSearchPageComponent should snap with default fields 1`] = `
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function SearchService]}
+  searchWarningDisplayed="false"
   statusMessageService={[Function StatusMessageService]}
   studentsListRowTables={[Function Array]}
 >

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.html
@@ -1,3 +1,9 @@
+<div class="text-muted" style="margin: 10px 0;" *ngIf="searchWarningDisplayed">
+  NOTE: We are currently upgrading the search infrastructure of the system.
+  During this period, you may find your search results not up-to-date, particularly for older data.
+  <br>
+  The upgrade is expected to finish by Aug 16, 2021. We apologize for any inconvenience caused.
+</div>
 <tm-instructor-search-bar (searched)="search()" [(searchParams)]="searchParams"></tm-instructor-search-bar>
 
 <div *tmIsLoading="isSearching">

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { forkJoin, Observable, of } from 'rxjs';
 import { finalize, map, mergeMap } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
 import { CourseService } from '../../../services/course.service';
 import { InstructorSearchResult, SearchService } from '../../../services/search.service';
 import { StatusMessageService } from '../../../services/status-message.service';
@@ -28,6 +29,7 @@ export class InstructorSearchPageComponent implements OnInit {
   };
   studentsListRowTables: SearchStudentsListRowTable[] = [];
   isSearching: boolean = false;
+  searchWarningDisplayed: boolean = !!environment.searchWarningDisplayed;
 
   constructor(
     private statusMessageService: StatusMessageService,

--- a/src/web/data/developers.json
+++ b/src/web/data/developers.json
@@ -322,6 +322,10 @@
     },
     {
       "multiple": true,
+      "username": "BoazWu"
+    },
+    {
+      "multiple": true,
       "name": "Brian Coveney",
       "username": "BrianCoveney"
     },
@@ -337,6 +341,10 @@
       "multiple": true,
       "name": "Chan Junwei",
       "username": "chanjunweimy"
+    },
+    {
+      "name": "Chanwoo Jung",
+      "username": "ChanwooJung1"
     },
     {
       "name": "Chao Song",
@@ -585,6 +593,9 @@
     {
       "name": "Georgios Theodorou",
       "username": "gthd"
+    },
+    {
+      "username": "Gily-H"
     },
     {
       "name": "Gonçalo Garcia",
@@ -908,6 +919,10 @@
       "username": "rclakmal"
     },
     {
+      "name": "Lan Yu Xuan",
+      "username": "Jellybeano"
+    },
+    {
       "name": "Le Minh Duc",
       "username": "darrenlmd"
     },
@@ -975,6 +990,7 @@
       "username": "lmk1988"
     },
     {
+      "multiple": true,
       "name": "Lye Yi Xian",
       "username": "lyeyixian"
     },
@@ -1277,6 +1293,11 @@
       "username": "praveshjain"
     },
     {
+      "multiple": true,
+      "name": "Priscilla Paulson",
+      "username": "pPris"
+    },
+    {
       "name": "Prithviraj Billa"
     },
     {
@@ -1389,6 +1410,11 @@
       "multiple": true,
       "name": "Samat Davletshin",
       "username": "samatdav"
+    },
+    {
+      "multiple": true,
+      "name": "Samuel Fang",
+      "username": "samuelfangjw"
     },
     {
       "name": "Sandeep Choudhary",
@@ -1623,6 +1649,11 @@
     },
     {
       "multiple": true,
+      "name": "Tan Jin",
+      "username": "tjtanjin"
+    },
+    {
+      "multiple": true,
       "name": "Tan Jun Kiat",
       "username": "junkiattan"
     },
@@ -1692,6 +1723,9 @@
     {
       "name": "Tom Elliott",
       "username": "tomelliott1988"
+    },
+    {
+      "username": "TomKemperNL"
     },
     {
       "username": "tong72"
@@ -1868,6 +1902,11 @@
       "multiple": true,
       "name": "Zhang Haoqiang",
       "username": "haoqiang"
+    },
+    {
+      "multiple": true,
+      "name": "Zhang Xinyi",
+      "username": "xyzhang00"
     },
     {
       "multiple": true,

--- a/src/web/data/developers.json
+++ b/src/web/data/developers.json
@@ -439,11 +439,6 @@
     },
     {
       "multiple": true,
-      "name": "Dao Ngoc Hieu",
-      "username": "daongochieu2810"
-    },
-    {
-      "multiple": true,
       "name": "Daryl Lim"
     },
     {
@@ -937,11 +932,6 @@
     },
     {
       "multiple": true,
-      "name": "Li Jianhan",
-      "username": "jianhandev"
-    },
-    {
-      "multiple": true,
       "name": "Lian Wenhui Florine"
     },
     {
@@ -951,11 +941,6 @@
     {
       "name": "Lim Jia Yee",
       "username": "jia1"
-    },
-    {
-      "multiple": true,
-      "name": "Lim Zi Wei",
-      "username": "halfwhole"
     },
     {
       "name": "Liu Jia Hao",
@@ -1080,11 +1065,6 @@
     },
     {
       "username": "misaunde"
-    },
-    {
-      "multiple": true,
-      "name": "Mo Zongran",
-      "username": "moziliar"
     },
     {
       "name": "Moaz Baghdadi",
@@ -1805,11 +1785,6 @@
       "name": "Wu Lifu"
     },
     {
-      "multiple": true,
-      "name": "Wu Qirui",
-      "username": "hhdqirui"
-    },
-    {
       "name": "Wu Xiao Xiao",
       "username": "a0129998"
     },
@@ -1851,11 +1826,6 @@
     {
       "name": "Yatri Patel",
       "username": "yatri1609"
-    },
-    {
-      "multiple": true,
-      "name": "Yen Pinhsuan",
-      "username": "ypinhsuan"
     },
     {
       "multiple": true,
@@ -1928,10 +1898,40 @@
   ],
   "committers": [
     {
+      "name": "Yen Pinhsuan",
+      "username": "ypinhsuan",
+      "startPeriod": "May 2021"
+    },
+    {
+      "name": "Wu Qirui",
+      "username": "hhdqirui",
+      "startPeriod": "May 2021"
+    },
+    {
+      "name": "Li Jianhan",
+      "username": "jianhandev",
+      "startPeriod": "Feb 2021"
+    },
+    {
+      "name": "Lim Zi Wei",
+      "username": "halfwhole",
+      "startPeriod": "Feb 2021"
+    },
+    {
+      "name": "Dao Ngoc Hieu",
+      "username": "daongochieu2810",
+      "startPeriod": "Feb 2021"
+    },
+    {
+      "name": "Mo Zongran",
+      "username": "moziliar",
+      "startPeriod": "Aug 2020"
+    },
+    {
       "name": "Derek Zhuang",
       "username": "Derek-Hardy",
       "startPeriod": "May 2020",
-      "endPeriod": "Jul 2020"
+      "endPeriod": "May 2021"
     },
     {
       "name": "Daryl Chan",
@@ -2127,16 +2127,6 @@
       ]
     },
     {
-      "name": "Xiao Pu",
-      "username": "xpdavid",
-      "currentPosition": "Project Mentor (Aug 2020 - )",
-      "pastPositions": [
-        "Project Lead (Jun 2018 - Aug 2020)",
-        "Area Lead (Jan 2018 - May 2018)",
-        "Committer (Jan 2017 - Apr 2017)"
-      ]
-    },
-    {
       "name": "Rahul Rajesh",
       "username": "rrtheonlyone",
       "currentPosition": "Project Lead (Aug 2020 - )",
@@ -2155,17 +2145,9 @@
       ]
     },
     {
-      "name": "Ni Tianzhen",
-      "username": "niqiukun",
-      "currentPosition": "Area Lead (Aug 2020 - )",
-      "pastPositions": [
-        "Committer (Jan 2020 - May 2020)"
-      ]
-    },
-    {
       "name": "Tiu Wee Han",
       "username": "tiuweehan",
-      "currentPosition": "Area Lead (Aug 2020 - )",
+      "currentPosition": "Snr Developer (Aug 2020 - )",
       "pastPositions": [
         "Committer (Jan 2020 - May 2020)"
       ]
@@ -2187,14 +2169,6 @@
       ]
     },
     {
-      "name": "Jason Tan",
-      "username": "jtankw3",
-      "currentPosition": "Snr Developer (Aug 2020 - )",
-      "pastPositions": [
-        "Committer (Jan 2020 - Jul 2020)"
-      ]
-    },
-    {
       "name": "Chong Chee Yuan",
       "username": "ccyccyccy",
       "currentPosition": "Snr Developer (Aug 2020 - )",
@@ -2208,6 +2182,32 @@
       "currentPosition": "Snr Developer (Aug 2020 - )",
       "pastPositions": [
         "Committer (May 2020 - Jul 2020)"
+      ]
+    },
+    {
+      "name": "Xiao Pu",
+      "username": "xpdavid",
+      "pastPositions": [
+        "Project Mentor (Aug 2020 - Dec 2020)",
+        "Project Lead (Jun 2018 - Aug 2020)",
+        "Area Lead (Jan 2018 - May 2018)",
+        "Committer (Jan 2017 - Apr 2017)"
+      ]
+    },
+    {
+      "name": "Ni Tianzhen",
+      "username": "niqiukun",
+      "pastPositions": [
+        "Snr Developer (Aug 2020 - Dec 2020)",
+        "Committer (Jan 2020 - May 2020)"
+      ]
+    },
+    {
+      "name": "Jason Tan",
+      "username": "jtankw3",
+      "pastPositions": [
+        "Snr Developer (Aug 2020 - Dec 2020)",
+        "Committer (Jan 2020 - Jul 2020)"
       ]
     },
     {

--- a/src/web/data/developers.json
+++ b/src/web/data/developers.json
@@ -77,8 +77,7 @@
       "username": "95adityajain"
     },
     {
-      "name": "Adrian Lachowicz",
-      "username": "Adrian27045"
+      "name": "Adrian Lachowicz"
     },
     {
       "multiple": true,
@@ -133,8 +132,7 @@
       "username": "AlexM9200"
     },
     {
-      "name": "Alexander Levy",
-      "username": "allevy3"
+      "name": "Alexander Levy"
     },
     {
       "name": "Alexandr Kolymago",
@@ -182,7 +180,7 @@
     },
     {
       "name": "Andrew Jefferson",
-      "username": "arkadyt"
+      "username": "iamarkadyt"
     },
     {
       "name": "Andrew Levit",
@@ -379,6 +377,11 @@
       "username": "vertigogarden"
     },
     {
+      "multiple": true,
+      "name": "Chloe Stapleton",
+      "username": "stapletonce"
+    },
+    {
       "name": "Chng Zhi Xuan",
       "username": "Chng-Zhi-Xuan"
     },
@@ -472,6 +475,7 @@
       "username": "dp80"
     },
     {
+      "name": "Diana Ramos",
       "username": "Diana-Ramos"
     },
     {
@@ -557,6 +561,9 @@
       "multiple": true,
       "name": "Foo Yong Jie",
       "username": "jadow"
+    },
+    {
+      "username": "frankelsf"
     },
     {
       "name": "Fred Xu",
@@ -682,8 +689,7 @@
       "username": "Malkone"
     },
     {
-      "name": "Irene Tenison",
-      "username": "ireneten"
+      "name": "Irene Tenison"
     },
     {
       "name": "Ivan Rocha",
@@ -691,7 +697,7 @@
     },
     {
       "name": "Jackson Hoggard",
-      "username": "CremBluRay"
+      "username": "JacksonHoggard"
     },
     {
       "name": "Jaikirat Singh Sandhu",
@@ -777,8 +783,7 @@
       "username": "lehighjcut"
     },
     {
-      "name": "Jordan Niskanen",
-      "username": "jnisky"
+      "name": "Jordan Niskanen"
     },
     {
       "name": "Jorge André",
@@ -996,7 +1001,7 @@
     },
     {
       "name": "Mac Knight",
-      "username": "Shels1909"
+      "username": "mfdooom"
     },
     {
       "name": "Madhav Thakker",
@@ -1242,7 +1247,7 @@
     {
       "multiple": true,
       "name": "Peh Shao Hong",
-      "username": "pshken"
+      "username": "sh-ao"
     },
     {
       "multiple": true,
@@ -1310,8 +1315,7 @@
       "username": "Progyan1997"
     },
     {
-      "name": "Pulasthi Harasgama",
-      "username": "Pulasthih"
+      "name": "Pulasthi Harasgama"
     },
     {
       "multiple": true,
@@ -1373,7 +1377,7 @@
     },
     {
       "name": "Rohith Mukku",
-      "username": "Naruto8"
+      "username": "rohithmukku"
     },
     {
       "username": "RonMosenzon"
@@ -1419,9 +1423,6 @@
     {
       "name": "Sandeep Choudhary",
       "username": "Skchoudhary"
-    },
-    {
-      "username": "sandysingh11918"
     },
     {
       "name": "Sanjeev Kumar",
@@ -1721,6 +1722,9 @@
       "username": "thngkaiyuan"
     },
     {
+      "username": "tlhuynh"
+    },
+    {
       "name": "Tom Elliott",
       "username": "tomelliott1988"
     },
@@ -1920,19 +1924,6 @@
     {
       "name": "Zhu Yilun",
       "username": "yilun-zhu"
-    },
-    {
-      "name": "sofefr",
-      "username": "sofefr"
-    },
-    {
-      "multiple": true,
-      "name": "stapletonce",
-      "username": "stapletonce"
-    },
-    {
-      "name": "tlhuynh",
-      "username": "tlhuynh"
     }
   ],
   "committers": [

--- a/src/web/environments/config.template.ts
+++ b/src/web/environments/config.template.ts
@@ -29,4 +29,10 @@ export const config: any = {
    * Under maintenance mode, all requests to the front-end will be routed to the "under maintenance" page.
    */
   maintenance: false,
+
+  /**
+   * Indicates whether search feature warning should be displayed.
+   */
+  searchWarningDisplayed: false,
+
 };

--- a/src/web/environments/config.template.ts
+++ b/src/web/environments/config.template.ts
@@ -5,7 +5,7 @@ export const config: any = {
   /**
    * The application version.
    */
-  version: '7.0.0',
+  version: '8.0.0',
 
   /**
    * The URL of page to be loaded for the account request page.


### PR DESCRIPTION
Part of #11329 

- Two minor backend updates: connection timeout values for Solr and slightly more secure `img-src` CSP rule
- Fixed L&P test failures introduced by upgrading to Java 11 (due to timestamp now being calculated in microsecond precision)
- Updated `developers.json`:
  - Updated committers/core team members after a long while
  - Added new contributors
  - Updated some outdated GH usernames; many past contributors unfortunately became @ghost and are subsequently removed
- Some documentation update
  - In particular, Python is no longer a requirement as we have decoupled from Cloud SDK
  - Python is needed if deployment is involved, but this is a separate requirement and will be reflected in the ops repository instead
- Added note for search feature brownout while we're indexing data (note that the date is changed to Aug 15 in code; can always be changed to any other date)
  <img width="1242" alt="Screenshot 2021-08-07 at 8 10 39 PM" src="https://user-images.githubusercontent.com/7261051/128599936-bcc6b0af-2072-41eb-b98c-9a3a2b995e8d.png">
