### PR TITLE
[#11202] Instructor checking activity logs: start time is not used correctly

### DIFF
--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
@@ -247,7 +247,7 @@ describe('InstructorAuditLogsPageComponent', () => {
     const logSpy: Spy = spyOn(logService, 'searchFeedbackSessionLog').and
         .returnValue(of({ feedbackSessionLogs: [testLogs1, testLogs2] }));
     const timeSpy: Spy = spyOn(timezoneService, 'resolveLocalDateTime').and.callThrough();
-    const tzOffset: number = timezoneService.getTzOffsets()['Asia/Singapore'];
+    const tzOffset: number = timezoneService.getTzOffsets()[testCourse1.timeZone];
 
     component.isLoading = false;
     component.isSearching = false;

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -112,10 +112,13 @@ export class InstructorAuditLogsPageComponent implements OnInit {
   search(): void {
     this.isSearching = true;
     this.searchResults = [];
+    const selectedCourse: Course | undefined =
+      this.courses.find((course: Course) => course.courseId === this.formModel.courseId);
+    const timeZone: string = selectedCourse ? selectedCourse.timeZone : this.timezoneService.guessTimezone();
     const searchFrom: number = this.timezoneService.resolveLocalDateTime(
-        this.formModel.logsDateFrom, this.formModel.logsTimeFrom);
+        this.formModel.logsDateFrom, this.formModel.logsTimeFrom, timeZone);
     const searchUntil: number = this.timezoneService.resolveLocalDateTime(
-        this.formModel.logsDateTo, this.formModel.logsTimeTo);
+        this.formModel.logsDateTo, this.formModel.logsTimeTo, timeZone);
 
     this.logsService.searchFeedbackSessionLog({
       courseId: this.formModel.courseId,


### PR DESCRIPTION
Fixes #11202 

Changes the search to use the timezone of the feedback course/session, instead of the user web browser's timezone.

This assumes that the feedback course timezone is the same as that of its feedback sessions, which makes sense (I hope) as setting the timezone of a course changes those of its sessions too.

Before (browser in UTC+8, course in UTC):

<img width="1233" alt="Screenshot 2021-08-12 at 9 46 33 AM" src="https://user-images.githubusercontent.com/41856541/129125939-51b279f3-e6cb-4807-b9e6-728bb1abb66d.png">

After (browser in UTC+8, course in UTC):

<img width="1233" alt="Screenshot 2021-08-12 at 9 50 55 AM" src="https://user-images.githubusercontent.com/41856541/129126162-339aaf33-c1ab-4340-8166-900fc1266208.png">
