### PR TITLE
[#11362] Add institute field to Course object

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForCourseInstitutes.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForCourseInstitutes.java
@@ -1,0 +1,64 @@
+package teammates.client.scripts;
+
+import java.lang.reflect.Field;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.logic.core.AccountsLogic;
+import teammates.storage.entity.Course;
+
+/**
+ * Script to set institute in course objects.
+ *
+ * <p>See issue #11362
+ */
+public class DataMigrationForCourseInstitutes extends DataMigrationEntitiesBaseScript<Course> {
+
+    private final AccountsLogic accountsLogic = AccountsLogic.inst();
+
+    public static void main(String[] args) {
+        new DataMigrationForCourseInstitutes().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<Course> getFilterQuery() {
+        return ofy().load().type(Course.class);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(Course course) {
+        try {
+            Field institute = course.getClass().getDeclaredField("institute");
+            institute.setAccessible(true);
+            return institute.get(course) == null;
+        } catch (ReflectiveOperationException e) {
+            return true;
+        }
+    }
+
+    @Override
+    protected void migrateEntity(Course course) {
+        String institute = Const.UNKNOWN_INSTITUTION;
+        try {
+            String retrievedInstitute = accountsLogic.getCourseInstitute(course.getUniqueId());
+            if (!StringHelper.isEmpty(retrievedInstitute) && !"undefined".equals(retrievedInstitute)
+                    && !"null".equals(retrievedInstitute)) {
+                institute = retrievedInstitute;
+            }
+        } catch (AssertionError e) {
+            // institute cannot be found; use default "Unknown Institution" instead
+        }
+
+        course.setInstitute(institute);
+
+        saveEntityDeferred(course);
+    }
+
+}

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.Logger;
+import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.Course;
 
 /**
@@ -25,10 +26,12 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     private String name;
     private ZoneId timeZone;
     private String id;
+    private String institute;
 
     private CourseAttributes(String courseId) {
         this.id = courseId;
         this.timeZone = Const.DEFAULT_TIME_ZONE;
+        this.institute = null;
         this.createdAt = Instant.now();
         this.deletedAt = null;
     }
@@ -50,6 +53,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
             courseTimeZone = Const.DEFAULT_TIME_ZONE;
         }
         courseAttributes.timeZone = courseTimeZone;
+        courseAttributes.institute = course.getInstitute();
 
         if (course.getCreatedAt() != null) {
             courseAttributes.createdAt = course.getCreatedAt();
@@ -86,6 +90,10 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         this.timeZone = timeZone;
     }
 
+    public String getInstitute() {
+        return institute;
+    }
+
     public Instant getCreatedAt() {
         return createdAt;
     }
@@ -115,25 +123,28 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
         addNonEmptyError(FieldValidator.getInvalidityInfoForCourseName(getName()), errors);
 
+        // TODO remove condition check after data migration
+        if (getInstitute() != null) {
+            addNonEmptyError(FieldValidator.getInvalidityInfoForInstituteName(getInstitute()), errors);
+        }
+
         return errors;
     }
 
     @Override
     public Course toEntity() {
-        return new Course(getId(), getName(), getTimeZone().getId(), createdAt, deletedAt);
+        return new Course(getId(), getName(), getTimeZone().getId(), getInstitute(), createdAt, deletedAt);
     }
 
     @Override
     public String toString() {
         return "[" + CourseAttributes.class.getSimpleName() + "] id: " + getId() + " name: " + getName()
-               + " timeZone: " + getTimeZone();
+               + " institute: " + getInstitute() + " timeZone: " + getTimeZone();
     }
 
     @Override
     public int hashCode() {
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(this.id).append(this.name);
-        return stringBuilder.toString().hashCode();
+        return (this.id + this.name + this.institute).hashCode();
     }
 
     @Override
@@ -145,6 +156,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         } else if (this.getClass() == other.getClass()) {
             CourseAttributes otherCourse = (CourseAttributes) other;
             return Objects.equals(this.id, otherCourse.id)
+                    && Objects.equals(this.institute, otherCourse.institute)
                     && Objects.equals(this.name, otherCourse.name);
         } else {
             return false;
@@ -153,7 +165,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     @Override
     public void sanitizeForSaving() {
-        // no additional sanitization required
+        this.institute = SanitizationHelper.sanitizeTitle(institute);
     }
 
     @Override
@@ -177,6 +189,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     public void update(UpdateOptions updateOptions) {
         updateOptions.nameOption.ifPresent(s -> name = s);
         updateOptions.timeZoneOption.ifPresent(s -> timeZone = s);
+        updateOptions.instituteOption.ifPresent(s -> institute = s);
     }
 
     /**
@@ -216,6 +229,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
         private UpdateOption<String> nameOption = UpdateOption.empty();
         private UpdateOption<ZoneId> timeZoneOption = UpdateOption.empty();
+        private UpdateOption<String> instituteOption = UpdateOption.empty();
 
         private UpdateOptions(String courseId) {
             assert courseId != null;
@@ -233,6 +247,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
                     + "courseId = " + courseId
                     + ", name = " + nameOption
                     + ", timezone = " + timeZoneOption
+                    + ", institute = " + instituteOption
                     + "]";
         }
 
@@ -281,6 +296,13 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
             assert timezone != null;
 
             updateOptions.timeZoneOption = UpdateOption.of(timezone);
+            return thisBuilder;
+        }
+
+        public B withInstitute(String institute) {
+            assert institute != null;
+
+            updateOptions.instituteOption = UpdateOption.of(institute);
             return thisBuilder;
         }
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -25,6 +25,8 @@ public final class Const {
 
     public static final String DEFAULT_SECTION = "None";
 
+    public static final String UNKNOWN_INSTITUTION = "Unknown Institution";
+
     public static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("UTC");
     public static final String ENCODING = "UTF8";
 

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -9,6 +9,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.storage.api.AccountsDb;
 
@@ -159,6 +160,20 @@ public final class AccountsLogic {
             }
         } else {
             makeAccountInstructor(googleId);
+        }
+
+        // TODO remove this block 30 days after release of V8.1.0
+        if (instituteToSave != null) {
+            CourseAttributes course = coursesLogic.getCourse(instructor.getCourseId());
+
+            // Note that this bypasses access control check (i.e. the instructor may not have permission to update course),
+            // however since this update only happens when the institute is still unknown, the risk of misuse is minimum.
+
+            if (course.getInstitute() == null || Const.UNKNOWN_INSTITUTION.equals(course.getInstitute())) {
+                coursesLogic.updateCourseCascade(CourseAttributes.updateOptionsBuilder(instructor.getCourseId())
+                        .withInstitute(instituteToSave)
+                        .build());
+            }
         }
 
         // Update the googleId of the student entity for the instructor which was created from sample data.

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -79,6 +79,7 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         // update only if change
         boolean hasSameAttributes =
                 this.<String>hasSameValue(course.getName(), newAttributes.getName())
+                && this.<String>hasSameValue(course.getInstitute(), newAttributes.getInstitute())
                 && this.<String>hasSameValue(course.getTimeZone(), newAttributes.getTimeZone().getId());
         if (hasSameAttributes) {
             log.info(String.format(OPTIMIZED_SAVING_POLICY_APPLIED, Course.class.getSimpleName(), updateOptions));
@@ -87,6 +88,7 @@ public final class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
 
         course.setName(newAttributes.getName());
         course.setTimeZone(newAttributes.getTimeZone().getId());
+        course.setInstitute(newAttributes.getInstitute());
 
         saveEntity(course);
 

--- a/src/main/java/teammates/storage/entity/Course.java
+++ b/src/main/java/teammates/storage/entity/Course.java
@@ -29,12 +29,15 @@ public class Course extends BaseEntity {
 
     private String timeZone;
 
+    private String institute;
+
     @SuppressWarnings("unused")
     private Course() {
         // required by Objectify
     }
 
-    public Course(String courseId, String courseName, String courseTimeZone, Instant createdAt, Instant deletedAt) {
+    public Course(String courseId, String courseName, String courseTimeZone, String institute,
+            Instant createdAt, Instant deletedAt) {
         this.setUniqueId(courseId);
         this.setName(courseName);
         if (courseTimeZone == null) {
@@ -42,6 +45,7 @@ public class Course extends BaseEntity {
         } else {
             this.setTimeZone(courseTimeZone);
         }
+        this.setInstitute(institute);
         if (createdAt == null) {
             this.setCreatedAt(Instant.now());
         } else {
@@ -89,4 +93,13 @@ public class Course extends BaseEntity {
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
     }
+
+    public String getInstitute() {
+        return institute;
+    }
+
+    public void setInstitute(String institute) {
+        this.institute = institute;
+    }
+
 }

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -29,14 +29,14 @@ class CreateAccountAction extends AdminOnlyAction {
 
         String instructorName = createRequest.getInstructorName().trim();
         String instructorEmail = createRequest.getInstructorEmail().trim();
-        String courseId = null;
+        String instructorInstitution = createRequest.getInstructorInstitution().trim();
+        String courseId;
 
         try {
-            courseId = importDemoData(instructorEmail, instructorName);
+            courseId = importDemoData(instructorEmail, instructorName, instructorInstitution);
         } catch (InvalidParametersException e) {
             return new JsonResult(e.getMessage(), HttpStatus.SC_BAD_REQUEST);
         }
-        String instructorInstitution = createRequest.getInstructorInstitution().trim();
         List<InstructorAttributes> instructorList = logic.getInstructorsForCourse(courseId);
         String joinLink = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(StringHelper.encrypt(instructorList.get(0).getKey()))
@@ -57,7 +57,7 @@ class CreateAccountAction extends AdminOnlyAction {
      *
      * @return the ID of demo course
      */
-    private String importDemoData(String instructorEmail, String instructorName)
+    private String importDemoData(String instructorEmail, String instructorName, String instructorInstitute)
             throws InvalidParametersException {
 
         String courseId = generateDemoCourseId(instructorEmail);
@@ -68,7 +68,9 @@ class CreateAccountAction extends AdminOnlyAction {
                 // replace name
                 "Demo_Instructor", instructorName,
                 // replace course
-                "demo.course", courseId);
+                "demo.course", courseId,
+                // replace institute
+                "demo.institute", instructorInstitute);
 
         DataBundle data = JsonUtils.fromJson(jsonString, DataBundle.class);
 

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -4,11 +4,13 @@ import java.time.ZoneId;
 
 import org.apache.http.HttpStatus;
 
+import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.FieldValidator;
+import teammates.common.util.StringHelper;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseCreateRequest;
 
@@ -43,10 +45,17 @@ class CreateCourseAction extends Action {
         String newCourseId = courseCreateRequest.getCourseId();
         String newCourseName = courseCreateRequest.getCourseName();
 
+        String institute = "Unknown Institution";
+        AccountAttributes account = logic.getAccount(userInfo.getId());
+        if (account != null && !StringHelper.isEmpty(account.getInstitute())) {
+            institute = account.getInstitute();
+        }
+
         CourseAttributes courseAttributes =
                 CourseAttributes.builder(newCourseId)
                         .withName(newCourseName)
                         .withTimezone(ZoneId.of(newCourseTimeZone))
+                        .withInstitute(institute)
                         .build();
 
         try {

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -9,6 +9,7 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.StringHelper;
 import teammates.ui.output.CourseData;
@@ -45,7 +46,7 @@ class CreateCourseAction extends Action {
         String newCourseId = courseCreateRequest.getCourseId();
         String newCourseName = courseCreateRequest.getCourseName();
 
-        String institute = "Unknown Institution";
+        String institute = Const.UNKNOWN_INSTITUTION;
         AccountAttributes account = logic.getAccount(userInfo.getId());
         if (account != null && !StringHelper.isEmpty(account.getInstitute())) {
             institute = account.getInstitute();

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -22,8 +22,6 @@ import teammates.ui.output.OngoingSessionsData;
  */
 class GetOngoingSessionsAction extends AdminOnlyAction {
 
-    private static final String UNKNOWN_INSTITUTION = "Unknown Institution";
-
     @Override
     public JsonResult execute() {
         String startTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME);
@@ -81,7 +79,7 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
             List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
             AccountAttributes account = getRegisteredInstructorAccountFromInstructors(instructors);
 
-            String institute = account == null ? UNKNOWN_INSTITUTION : account.getInstitute();
+            String institute = account == null ? Const.UNKNOWN_INSTITUTION : account.getInstitute();
             List<OngoingSession> sessions = courseIdToFeedbackSessionsMap.get(courseId).stream()
                     .map(session -> new OngoingSession(session, account))
                     .collect(Collectors.toList());
@@ -90,7 +88,7 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         }
 
         long totalInstitutes = instituteToFeedbackSessionsMap.keySet().stream()
-                .filter(key -> !key.equals(UNKNOWN_INSTITUTION))
+                .filter(key -> !key.equals(Const.UNKNOWN_INSTITUTION))
                 .count();
 
         OngoingSessionsData output = new OngoingSessionsData();

--- a/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
@@ -20,7 +20,7 @@ class SearchInstructorsAction extends AdminOnlyAction {
         if (googleId != null) {
             AccountAttributes account = logic.getAccount(googleId);
             if (account != null) {
-                return StringHelper.isEmpty(account.getInstitute()) ? "None" : account.getInstitute();
+                return StringHelper.isEmpty(account.getInstitute()) ? Const.UNKNOWN_INSTITUTION : account.getInstitute();
             }
         }
         return null;

--- a/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
@@ -43,7 +43,7 @@ class SearchStudentsAction extends Action {
             return null;
         }
 
-        return StringHelper.isEmpty(account.getInstitute()) ? "None" : account.getInstitute();
+        return StringHelper.isEmpty(account.getInstitute()) ? Const.UNKNOWN_INSTITUTION : account.getInstitute();
     }
 
     /**

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -4,6 +4,7 @@
     "Demo Course": {
       "id": "demo.course",
       "name": "Sample Course 101",
+      "institute": "demo.institute",
       "timeZone": "UTC"
     }
   },

--- a/src/test/java/teammates/common/datatransfer/attributes/CourseAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/CourseAttributesTest.java
@@ -20,13 +20,14 @@ public class CourseAttributesTest extends BaseTestCase {
     @Test
     public void testValueOf_withTypicalData_shouldGenerateAttributesCorrectly() {
         Instant typicalInstant = Instant.now();
-        Course course = new Course("testId", "testName", "UTC", typicalInstant, typicalInstant);
+        Course course = new Course("testId", "testName", "UTC", "institute", typicalInstant, typicalInstant);
 
         CourseAttributes courseAttributes = CourseAttributes.valueOf(course);
 
         assertEquals("testId", courseAttributes.getId());
         assertEquals("testName", courseAttributes.getName());
         assertEquals("UTC", courseAttributes.getTimeZone().getId());
+        assertEquals("institute", courseAttributes.getInstitute());
         assertEquals(typicalInstant, courseAttributes.getCreatedAt());
         assertEquals(typicalInstant, courseAttributes.getDeletedAt());
     }
@@ -34,7 +35,7 @@ public class CourseAttributesTest extends BaseTestCase {
     @Test
     public void testValueOf_withInvalidTimezoneStr_shouldFallbackToDefaultTimezone() {
         Instant typicalInstant = Instant.now();
-        Course course = new Course("testId", "testName", "invalid", typicalInstant, typicalInstant);
+        Course course = new Course("testId", "testName", "invalid", "institute", typicalInstant, typicalInstant);
 
         CourseAttributes courseAttributes = CourseAttributes.valueOf(course);
 
@@ -43,7 +44,7 @@ public class CourseAttributesTest extends BaseTestCase {
 
     @Test
     public void testValueOf_withSomeFieldsPopulatedAsNull_shouldUseDefaultValues() {
-        Course course = new Course("testId", "testName", "UTC", null, null);
+        Course course = new Course("testId", "testName", "UTC", "institute", null, null);
         course.setCreatedAt(null);
         course.setDeletedAt(null);
         assertNull(course.getCreatedAt());
@@ -54,6 +55,7 @@ public class CourseAttributesTest extends BaseTestCase {
         assertEquals("testId", courseAttributes.getId());
         assertEquals("testName", courseAttributes.getName());
         assertEquals("UTC", courseAttributes.getTimeZone().getId());
+        assertEquals("institute", courseAttributes.getInstitute());
         assertNotNull(courseAttributes.getCreatedAt());
         assertNull(courseAttributes.getDeletedAt());
     }
@@ -151,7 +153,8 @@ public class CourseAttributesTest extends BaseTestCase {
     @Test
     public void testToString() {
         CourseAttributes c = generateValidCourseAttributesObject();
-        assertEquals("[CourseAttributes] id: valid-id-$_abc name: valid-name timeZone: UTC", c.toString());
+        assertEquals("[CourseAttributes] id: valid-id-$_abc name: valid-name institute: valid-institute timeZone: UTC",
+                c.toString());
     }
 
     @Test
@@ -195,6 +198,7 @@ public class CourseAttributesTest extends BaseTestCase {
         return CourseAttributes.builder("valid-id-$_abc")
                 .withName("valid-name")
                 .withTimezone(ZoneId.of("UTC"))
+                .withInstitute("valid-institute")
                 .build();
     }
 

--- a/src/test/java/teammates/logic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicTest.java
@@ -4,6 +4,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
@@ -386,6 +387,9 @@ public class AccountsLogicTest extends BaseLogicTest {
 
         AccountAttributes accountCreated = accountsLogic.getAccount(loggedInGoogleId);
         assertNotNull(accountCreated);
+
+        CourseAttributes course = coursesLogic.getCourse(instructor.getCourseId());
+        assertEquals(institute, course.getInstitute());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/CreateAccountActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountActionTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.InvalidHttpRequestBodyException;
@@ -70,6 +71,12 @@ public class CreateAccountActionTest extends BaseActionTest<CreateAccountAction>
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
 
         String courseId = generateNextDemoCourseId(email, FieldValidator.COURSE_ID_MAX_LENGTH);
+
+        CourseAttributes course = logic.getCourse(courseId);
+        assertNotNull(course);
+        assertEquals("Sample Course 101", course.getName());
+        assertEquals(institute, course.getInstitute());
+
         InstructorAttributes instructor = logic.getInstructorForEmail(courseId, email);
 
         String joinLink = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)

--- a/src/test/java/teammates/ui/webapi/CreateCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateCourseActionTest.java
@@ -1,8 +1,11 @@
 package teammates.ui.webapi;
 
+import java.time.ZoneId;
+
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
 import teammates.test.AssertHelper;
@@ -58,7 +61,12 @@ public class CreateCourseActionTest extends BaseActionTest<CreateCourseAction> {
         assertEquals(courseData.getTimeZone(), "UTC");
 
         assertEquals(HttpStatus.SC_OK, result.getStatusCode());
-        assertNotNull(logic.getCourse("new-course"));
+
+        CourseAttributes createdCourse = logic.getCourse("new-course");
+        assertNotNull(createdCourse);
+        assertEquals("New Course", createdCourse.getName());
+        assertEquals(ZoneId.of("UTC"), createdCourse.getTimeZone());
+        assertEquals("TEAMMATES Test Institute 1", createdCourse.getInstitute());
 
         ______TS("Typical case with existing course id");
 


### PR DESCRIPTION
First part of #11362 

This is only the preparatory step.

- Added `institute` field to `Course` object. This field is not yet used by any business logic, i.e. retrieval of institute will still use `Account` object, however newly created courses from this point onwards will have `institute` field reflected.
  - For courses created by admin, the `institute` will be set right from the start.
  - For courses created by instructors, the `institute` will be set using the institute from their `Account` object.
  - For existing courses yet to be joined by the first instructor (i.e. freshly created), the `institute` will be set when the first instructor joins.
- Added script to populate institute of courses. If institute cannot be found, the default `Unknown Institution` will be used instead. This `Unknown Institution` can be overridden by the first instructor who joins the course.
