### PR TITLE
[#11372] Add more system logs

### DIFF
--- a/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackQuestionUpdateLNPTest.java
@@ -278,7 +278,7 @@ public class FeedbackQuestionUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/FeedbackSessionSubmitLNPTest.java
@@ -224,7 +224,7 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new LinkedHashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorCourseUpdateLNPTest.java
@@ -150,7 +150,7 @@ public class InstructorCourseUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
@@ -224,7 +224,7 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "text/csv");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentEnrollmentLNPTest.java
@@ -134,7 +134,7 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "text/csv");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorUpdateLNPTest.java
@@ -277,7 +277,7 @@ public class InstructorUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentEmailUpdateLNPTest.java
@@ -249,7 +249,7 @@ public class StudentEmailUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentSectionUpdateLNPTest.java
@@ -249,7 +249,7 @@ public class StudentSectionUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/StudentTeamUpdateLNPTest.java
@@ -249,7 +249,7 @@ public class StudentTeamUpdateLNPTest extends BaseLNPTestCase {
     private Map<String, String> getRequestHeaders() {
         Map<String, String> headers = new HashMap<>();
 
-        headers.put("X-CSRF-TOKEN", "${csrfToken}");
+        headers.put(Const.HeaderNames.CSRF_TOKEN, "${csrfToken}");
         headers.put("Content-Type", "application/json");
 
         return headers;

--- a/src/main/java/teammates/common/datatransfer/logs/InstanceLogDetails.java
+++ b/src/main/java/teammates/common/datatransfer/logs/InstanceLogDetails.java
@@ -1,0 +1,36 @@
+package teammates.common.datatransfer.logs;
+
+/**
+ * Contains specific structure and processing logic for instance log.
+ */
+public class InstanceLogDetails extends LogDetails {
+
+    private String instanceId;
+    private String instanceEvent;
+
+    public InstanceLogDetails() {
+        super(LogEvent.INSTANCE_LOG);
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public String getInstanceEvent() {
+        return instanceEvent;
+    }
+
+    public void setInstanceEvent(String instanceEvent) {
+        this.instanceEvent = instanceEvent;
+    }
+
+    @Override
+    public void hideSensitiveInformation() {
+        // no fields need to be hidden
+    }
+
+}

--- a/src/main/java/teammates/common/datatransfer/logs/LogEvent.java
+++ b/src/main/java/teammates/common/datatransfer/logs/LogEvent.java
@@ -7,6 +7,7 @@ package teammates.common.datatransfer.logs;
 public enum LogEvent {
     REQUEST_LOG(RequestLogDetails.class),
     EXCEPTION_LOG(ExceptionLogDetails.class),
+    INSTANCE_LOG(InstanceLogDetails.class),
     EMAIL_SENT(EmailSentLogDetails.class),
     FEEDBACK_SESSION_AUDIT(FeedbackSessionAuditLogDetails.class),
     DEFAULT_LOG(DefaultLogDetails.class);

--- a/src/main/java/teammates/common/datatransfer/logs/RequestLogDetails.java
+++ b/src/main/java/teammates/common/datatransfer/logs/RequestLogDetails.java
@@ -15,6 +15,8 @@ public class RequestLogDetails extends LogDetails {
     private String requestUrl;
     private String userAgent;
     @Nullable // TODO remove nullable annotation 30 days after release of V8.1.0
+    private String instanceId;
+    @Nullable // TODO remove nullable annotation 30 days after release of V8.1.0
     private String webVersion;
     @Nullable
     private Map<String, Object> requestParams;
@@ -59,6 +61,14 @@ public class RequestLogDetails extends LogDetails {
 
     public void setRequestUrl(String requestUrl) {
         this.requestUrl = requestUrl;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
     }
 
     public String getWebVersion() {

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -157,6 +157,17 @@ public final class Config {
     }
 
     /**
+     * Returns the GAE instance ID.
+     */
+    public static String getInstanceId() {
+        String instanceId = System.getenv("GAE_INSTANCE");
+        if (instanceId == null) {
+            return "dev_server_instance_id";
+        }
+        return instanceId;
+    }
+
+    /**
      * Returns true if the server is configured to be the dev server.
      */
     public static boolean isDevServer() {

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -172,6 +172,16 @@ public final class Const {
     }
 
     /**
+     * Represents custom header names used by the system.
+     */
+    public static class HeaderNames {
+        public static final String BACKDOOR_KEY = "Backdoor-Key";
+        public static final String CSRF_KEY = "CSRF-Key";
+        public static final String WEB_VERSION = "X-WEB-VERSION";
+        public static final String CSRF_TOKEN = "X-CSRF-TOKEN";
+    }
+
+    /**
      * The course status respect to the instructor's point of view.
      * This parameter is used to get a course list for instructor.
      */
@@ -198,7 +208,6 @@ public final class Const {
      */
     public static class SecurityConfig {
 
-        public static final String CSRF_HEADER_NAME = "X-CSRF-TOKEN";
         public static final String CSRF_COOKIE_NAME = "CSRF-TOKEN";
         public static final String AUTH_COOKIE_NAME = "AUTH-TOKEN";
 

--- a/src/main/java/teammates/common/util/HttpRequestHelper.java
+++ b/src/main/java/teammates/common/util/HttpRequestHelper.java
@@ -42,8 +42,10 @@ public final class HttpRequestHelper {
     static Map<String, Object> getRequestHeaders(HttpServletRequest req) {
         Map<String, Object> headers = new HashMap<>();
         Collections.list(req.getHeaderNames()).stream()
-                // Do not include cookie header in production for privacy reasons
+                // Do not include cookie header/secret keys in production for privacy reasons
                 .filter(headerName -> Config.isDevServer() || !"cookie".equalsIgnoreCase(headerName))
+                .filter(headerName -> Config.isDevServer() || !"Backdoor-Key".equalsIgnoreCase(headerName))
+                .filter(headerName -> Config.isDevServer() || !"CSRF-Key".equalsIgnoreCase(headerName))
                 .forEach(headerName -> {
                     List<String> headerValues = Collections.list(req.getHeaders(headerName));
                     if (headerValues.size() == 1) {

--- a/src/main/java/teammates/common/util/HttpRequestHelper.java
+++ b/src/main/java/teammates/common/util/HttpRequestHelper.java
@@ -44,8 +44,8 @@ public final class HttpRequestHelper {
         Collections.list(req.getHeaderNames()).stream()
                 // Do not include cookie header/secret keys in production for privacy reasons
                 .filter(headerName -> Config.isDevServer() || !"cookie".equalsIgnoreCase(headerName))
-                .filter(headerName -> Config.isDevServer() || !"Backdoor-Key".equalsIgnoreCase(headerName))
-                .filter(headerName -> Config.isDevServer() || !"CSRF-Key".equalsIgnoreCase(headerName))
+                .filter(headerName -> Config.isDevServer() || !Const.HeaderNames.BACKDOOR_KEY.equalsIgnoreCase(headerName))
+                .filter(headerName -> Config.isDevServer() || !Const.HeaderNames.CSRF_KEY.equalsIgnoreCase(headerName))
                 .forEach(headerName -> {
                     List<String> headerValues = Collections.list(req.getHeaders(headerName));
                     if (headerValues.size() == 1) {

--- a/src/main/java/teammates/common/util/Logger.java
+++ b/src/main/java/teammates/common/util/Logger.java
@@ -76,7 +76,7 @@ public final class Logger {
         details.setRequestMethod(method);
         details.setRequestUrl(requestUrl);
         details.setUserAgent(request.getHeader("User-Agent"));
-        details.setWebVersion(request.getHeader("X-WEB-VERSION"));
+        details.setWebVersion(request.getHeader(Const.HeaderNames.WEB_VERSION));
         details.setInstanceId(getInstanceId());
         details.setRequestParams(HttpRequestHelper.getRequestParameters(request));
         details.setRequestHeaders(HttpRequestHelper.getRequestHeaders(request));

--- a/src/main/java/teammates/common/util/Logger.java
+++ b/src/main/java/teammates/common/util/Logger.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.google.common.reflect.TypeToken;
 
 import teammates.common.datatransfer.logs.ExceptionLogDetails;
+import teammates.common.datatransfer.logs.InstanceLogDetails;
 import teammates.common.datatransfer.logs.LogDetails;
 import teammates.common.datatransfer.logs.LogSeverity;
 import teammates.common.datatransfer.logs.RequestLogDetails;
@@ -56,6 +57,46 @@ public final class Logger {
     }
 
     /**
+     * Logs an instance startup event.
+     */
+    public void startup() {
+        instance("STARTUP");
+    }
+
+    /**
+     * Logs an instance shutdown event.
+     */
+    public void shutdown() {
+        instance("SHUTDOWN");
+    }
+
+    @SuppressWarnings("PMD.SystemPrintln")
+    private void instance(String instanceEvent) {
+        String instanceId = Config.getInstanceId();
+        String shortenedInstanceId = instanceId;
+        if (shortenedInstanceId.length() > 32) {
+            shortenedInstanceId = shortenedInstanceId.substring(0, 32);
+        }
+
+        InstanceLogDetails details = new InstanceLogDetails();
+        details.setInstanceId(instanceId);
+        details.setInstanceEvent(instanceEvent);
+
+        String message = "Instance " + instanceEvent.toLowerCase() + ": " + shortenedInstanceId;
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("message", message);
+        payload.put("severity", LogSeverity.INFO);
+
+        Map<String, Object> detailsSpecificPayload =
+                JsonUtils.fromJson(JsonUtils.toCompactJson(details), new TypeToken<Map<String, Object>>(){}.getType());
+        payload.putAll(detailsSpecificPayload);
+
+        // Need to use println as the logger is disabled when the instance is shutting down
+        System.out.println(JsonUtils.toCompactJson(payload));
+    }
+
+    /**
      * Logs an HTTP request.
      */
     public void request(HttpServletRequest request, int statusCode, String message) {
@@ -77,7 +118,7 @@ public final class Logger {
         details.setRequestUrl(requestUrl);
         details.setUserAgent(request.getHeader("User-Agent"));
         details.setWebVersion(request.getHeader(Const.HeaderNames.WEB_VERSION));
-        details.setInstanceId(getInstanceId());
+        details.setInstanceId(Config.getInstanceId());
         details.setRequestParams(HttpRequestHelper.getRequestParameters(request));
         details.setRequestHeaders(HttpRequestHelper.getRequestHeaders(request));
 
@@ -91,14 +132,6 @@ public final class Logger {
                 statusCode, timeElapsed, method, requestUrl, message);
 
         event(logMessage, details);
-    }
-
-    private static String getInstanceId() {
-        String instanceId = System.getenv("GAE_INSTANCE");
-        if (instanceId == null) {
-            return "dev_server_instance_id";
-        }
-        return instanceId;
     }
 
     /**

--- a/src/main/java/teammates/common/util/Logger.java
+++ b/src/main/java/teammates/common/util/Logger.java
@@ -77,6 +77,7 @@ public final class Logger {
         details.setRequestUrl(requestUrl);
         details.setUserAgent(request.getHeader("User-Agent"));
         details.setWebVersion(request.getHeader("X-WEB-VERSION"));
+        details.setInstanceId(getInstanceId());
         details.setRequestParams(HttpRequestHelper.getRequestParameters(request));
         details.setRequestHeaders(HttpRequestHelper.getRequestHeaders(request));
 
@@ -90,6 +91,14 @@ public final class Logger {
                 statusCode, timeElapsed, method, requestUrl, message);
 
         event(logMessage, details);
+    }
+
+    private static String getInstanceId() {
+        String instanceId = System.getenv("GAE_INSTANCE");
+        if (instanceId == null) {
+            return "dev_server_instance_id";
+        }
+        return instanceId;
     }
 
     /**

--- a/src/main/java/teammates/main/Application.java
+++ b/src/main/java/teammates/main/Application.java
@@ -5,11 +5,14 @@ import java.io.File;
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.log.StdErrLog;
 import org.eclipse.jetty.webapp.Configuration.ClassList;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import teammates.common.util.Config;
+import teammates.common.util.Logger;
 import teammates.ui.servlets.DevServerLoginServlet;
 
 /**
@@ -20,13 +23,15 @@ import teammates.ui.servlets.DevServerLoginServlet;
 // CHECKSTYLE.OFF:UncommentedMain this is the entrypoint class
 public final class Application {
 
+    private static final Logger log = Logger.getLogger();
+
     private Application() {
         // prevent initialization
     }
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException") // ok to ignore as this is a startup method
     public static void main(String[] args) throws Exception {
-        System.setProperty("org.eclipse.jetty.util.log.class", org.eclipse.jetty.util.log.StdErrLog.class.getName());
+        System.setProperty("org.eclipse.jetty.util.log.class", StdErrLog.class.getName());
         System.setProperty("org.eclipse.jetty.LEVEL", "INFO");
 
         Server server = new Server(Config.getPort());
@@ -52,6 +57,33 @@ public final class Application {
                 AnnotationConfiguration.class.getName());
 
         server.setHandler(webapp);
+        server.setStopAtShutdown(true);
+        server.addLifeCycleListener(new LifeCycle.Listener() {
+            @Override
+            public void lifeCycleStarting(LifeCycle event) {
+                log.startup();
+            }
+
+            @Override
+            public void lifeCycleStarted(LifeCycle event) {
+                // do nothing
+            }
+
+            @Override
+            public void lifeCycleFailure(LifeCycle event, Throwable cause) {
+                log.severe("Instance failed to start/stop: " + Config.getInstanceId());
+            }
+
+            @Override
+            public void lifeCycleStopping(LifeCycle event) {
+                log.shutdown();
+            }
+
+            @Override
+            public void lifeCycleStopped(LifeCycle event) {
+                // do nothing
+            }
+        });
 
         server.start();
 

--- a/src/main/java/teammates/ui/servlets/LegacyUrlMapper.java
+++ b/src/main/java/teammates/ui/servlets/LegacyUrlMapper.java
@@ -6,9 +6,12 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
+
 import teammates.common.util.AppUrl;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
+import teammates.common.util.Logger;
 import teammates.common.util.StringHelper;
 
 /**
@@ -19,12 +22,15 @@ import teammates.common.util.StringHelper;
 @Deprecated
 public class LegacyUrlMapper extends HttpServlet {
 
+    private static final Logger log = Logger.getLogger();
+
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         String uri = req.getRequestURI();
         if (uri.contains(";")) {
             uri = uri.split(";")[0];
         }
+        String baseRedirectUrl;
         String redirectUrl;
         String key;
         String courseId;
@@ -32,6 +38,7 @@ public class LegacyUrlMapper extends HttpServlet {
 
         switch (uri) {
         case Const.LegacyURIs.INSTRUCTOR_COURSE_JOIN:
+            baseRedirectUrl = Const.WebPageURIs.JOIN_PAGE;
             key = req.getParameter(Const.ParamsNames.REGKEY);
             String institute = req.getParameter(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
             AppUrl newUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
@@ -46,6 +53,7 @@ public class LegacyUrlMapper extends HttpServlet {
             break;
         case Const.LegacyURIs.STUDENT_COURSE_JOIN:
         case Const.LegacyURIs.STUDENT_COURSE_JOIN_NEW:
+            baseRedirectUrl = Const.WebPageURIs.JOIN_PAGE;
             key = req.getParameter(Const.ParamsNames.REGKEY);
             redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
                     .withRegistrationKey(key)
@@ -53,14 +61,17 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         case Const.LegacyURIs.STUDENT_HOME_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.STUDENT_HOME_PAGE;
             redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.STUDENT_HOME_PAGE)
                     .toString();
             break;
         case Const.LegacyURIs.INSTRUCTOR_HOME_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.INSTRUCTOR_HOME_PAGE;
             redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
                     .toString();
             break;
         case Const.LegacyURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.SESSION_SUBMISSION_PAGE;
             key = req.getParameter(Const.ParamsNames.REGKEY);
             courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
             fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
@@ -71,6 +82,7 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         case Const.LegacyURIs.INSTRUCTOR_FEEDBACK_SUBMISSION_EDIT_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE;
             courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
             fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
             redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
@@ -79,6 +91,7 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         case Const.LegacyURIs.STUDENT_FEEDBACK_RESULTS_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.SESSION_RESULTS_PAGE;
             key = req.getParameter(Const.ParamsNames.REGKEY);
             courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
             fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
@@ -89,6 +102,7 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         case Const.LegacyURIs.INSTRUCTOR_FEEDBACK_RESULTS_PAGE:
+            baseRedirectUrl = Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE;
             courseId = req.getParameter(Const.ParamsNames.COURSE_ID);
             fsName = req.getParameter(Const.ParamsNames.FEEDBACK_SESSION_NAME);
             redirectUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
@@ -97,9 +111,14 @@ public class LegacyUrlMapper extends HttpServlet {
                     .toString();
             break;
         default:
+            baseRedirectUrl = "/";
             redirectUrl = "/";
+            log.warning("Unmapped legacy URL: " + uri);
             break;
         }
+
+        log.request(req, HttpStatus.SC_MOVED_PERMANENTLY,
+                "Redirect legacy URL from " + uri + " to " + baseRedirectUrl);
 
         resp.sendRedirect(redirectUrl);
     }

--- a/src/main/java/teammates/ui/servlets/LoginServlet.java
+++ b/src/main/java/teammates/ui/servlets/LoginServlet.java
@@ -14,12 +14,15 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.Logger;
 import teammates.common.util.StringHelper;
 
 /**
  * Servlet that handles login.
  */
 public class LoginServlet extends AuthServlet {
+
+    private static final Logger log = Logger.getLogger();
 
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -30,6 +33,7 @@ public class LoginServlet extends AuthServlet {
         if (Config.isDevServer()) {
             resp.setStatus(HttpStatus.SC_MOVED_PERMANENTLY);
             resp.setHeader("Location", "/devServerLogin?nextUrl=" + nextUrl.replace("&", "%26"));
+            log.request(req, HttpStatus.SC_MOVED_PERMANENTLY, "Redirect to dev server login page");
             return;
         }
 
@@ -37,6 +41,7 @@ public class LoginServlet extends AuthServlet {
         UserInfoCookie uic = UserInfoCookie.fromCookie(cookie);
         boolean isLoginNeeded = uic == null || !uic.isValid();
         if (!isLoginNeeded) {
+            log.request(req, HttpStatus.SC_MOVED_TEMPORARILY, "Redirect to next URL");
             resp.sendRedirect(nextUrl);
             return;
         }
@@ -45,6 +50,9 @@ public class LoginServlet extends AuthServlet {
         AuthorizationCodeRequestUrl authorizationUrl = getAuthorizationFlow().newAuthorizationUrl();
         authorizationUrl.setRedirectUri(getRedirectUri(req));
         authorizationUrl.setState(StringHelper.encrypt(JsonUtils.toCompactJson(state)));
+
+        log.request(req, HttpStatus.SC_MOVED_TEMPORARILY, "Redirect to Google sign-in page");
+
         resp.sendRedirect(authorizationUrl.build());
     }
 

--- a/src/main/java/teammates/ui/servlets/LogoutServlet.java
+++ b/src/main/java/teammates/ui/servlets/LogoutServlet.java
@@ -6,10 +6,16 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
+
+import teammates.common.util.Logger;
+
 /**
  * Servlet that handles logout.
  */
 public class LogoutServlet extends AuthServlet {
+
+    private static final Logger log = Logger.getLogger();
 
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -22,6 +28,7 @@ public class LogoutServlet extends AuthServlet {
         if (frontendUrl == null) {
             frontendUrl = "";
         }
+        log.request(req, HttpStatus.SC_MOVED_TEMPORARILY, "Redirect to home page after logging out");
         resp.sendRedirect(frontendUrl + "/web");
     }
 

--- a/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
+++ b/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
@@ -22,12 +22,15 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.HttpRequest;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.Logger;
 import teammates.common.util.StringHelper;
 
 /**
  * Servlet that handles the OAuth2 callback.
  */
 public class OAuth2CallbackServlet extends AuthServlet {
+
+    private static final Logger log = Logger.getLogger();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -42,15 +45,13 @@ public class OAuth2CallbackServlet extends AuthServlet {
         AuthorizationCodeResponseUrl responseUrl =
                 new AuthorizationCodeResponseUrl(buf.toString().replaceFirst("^http://", "https://"));
         if (responseUrl.getError() != null) {
-            resp.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            resp.getWriter().print(responseUrl.getError());
+            logAndPrintError(req, resp, HttpStatus.SC_INTERNAL_SERVER_ERROR, responseUrl.getError());
             return;
         }
         String code = responseUrl.getCode();
         String state = responseUrl.getState();
         if (code == null || state == null) {
-            resp.setStatus(HttpStatus.SC_BAD_REQUEST);
-            resp.getWriter().print("Missing authorization code");
+            logAndPrintError(req, resp, HttpStatus.SC_BAD_REQUEST, "Missing authorization code");
             return;
         }
 
@@ -63,13 +64,11 @@ public class OAuth2CallbackServlet extends AuthServlet {
             String sessionId = authState.getSessionId();
             if (!sessionId.equals(req.getSession().getId())) {
                 // Invalid session ID
-                resp.setStatus(HttpStatus.SC_BAD_REQUEST);
-                resp.getWriter().print("Invalid authorization code");
+                logAndPrintError(req, resp, HttpStatus.SC_BAD_REQUEST, "Invalid authorization code");
                 return;
             }
         } catch (JsonParseException | InvalidParametersException e) {
-            resp.setStatus(HttpStatus.SC_BAD_REQUEST);
-            resp.getWriter().print("Invalid authorization code");
+            logAndPrintError(req, resp, HttpStatus.SC_BAD_REQUEST, "Invalid authorization code");
             return;
         }
 
@@ -89,6 +88,7 @@ public class OAuth2CallbackServlet extends AuthServlet {
             }
         } catch (URISyntaxException | IOException | JsonSyntaxException e) {
             // if any of the operation fail, googleId is kept at null
+            log.warning("Failed to get Google ID", e);
         }
 
         Cookie cookie;
@@ -102,8 +102,20 @@ public class OAuth2CallbackServlet extends AuthServlet {
             cookie = getLoginCookie(uic);
         }
 
+        log.info("Going to redirect to: " + nextUrl);
+
+        log.request(req, HttpStatus.SC_MOVED_TEMPORARILY, "Login successful");
+
         resp.addCookie(cookie);
         resp.sendRedirect(nextUrl);
+    }
+
+    private void logAndPrintError(HttpServletRequest req, HttpServletResponse resp, int status, String message)
+            throws IOException {
+        resp.setStatus(status);
+        resp.getWriter().print(message);
+
+        log.request(req, status, message);
     }
 
 }

--- a/src/main/java/teammates/ui/servlets/OriginCheckFilter.java
+++ b/src/main/java/teammates/ui/servlets/OriginCheckFilter.java
@@ -43,9 +43,9 @@ public class OriginCheckFilter implements Filter {
     ));
 
     private static final String ALLOWED_HEADERS = String.join(", ", Arrays.asList(
-            Const.SecurityConfig.CSRF_HEADER_NAME,
+            Const.HeaderNames.CSRF_TOKEN,
             "Content-Type",
-            "X-WEB-VERSION",
+            Const.HeaderNames.WEB_VERSION,
             "ngsw-bypass"
     ));
 
@@ -66,7 +66,7 @@ public class OriginCheckFilter implements Filter {
             response.setHeader("Access-Control-Allow-Credentials", "true");
         }
 
-        if (Config.CSRF_KEY.equals(request.getHeader("CSRF-Key"))) {
+        if (Config.CSRF_KEY.equals(request.getHeader(Const.HeaderNames.CSRF_KEY))) {
             // Can bypass CSRF check with the correct key
             chain.doFilter(req, res);
             return;
@@ -155,7 +155,7 @@ public class OriginCheckFilter implements Filter {
     }
 
     private String getCsrfTokenErrorIfAny(HttpServletRequest request) {
-        String csrfToken = request.getHeader(Const.SecurityConfig.CSRF_HEADER_NAME);
+        String csrfToken = request.getHeader(Const.HeaderNames.CSRF_TOKEN);
         if (csrfToken == null || csrfToken.isEmpty()) {
             return "Missing CSRF token.";
         }

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -132,7 +132,7 @@ public abstract class Action {
     }
 
     private void initAuthInfo() {
-        if (Config.BACKDOOR_KEY.equals(req.getHeader("Backdoor-Key"))) {
+        if (Config.BACKDOOR_KEY.equals(req.getHeader(Const.HeaderNames.BACKDOOR_KEY))) {
             authType = AuthType.ALL_ACCESS;
             userInfo = userProvision.getAdminOnlyUser(getRequestParamValue(Const.ParamsNames.USER_ID));
             userInfo.isStudent = true;

--- a/src/main/resources/logsForLocalDev.json
+++ b/src/main/resources/logsForLocalDev.json
@@ -1890,5 +1890,28 @@
       "line": "59",
       "function": "execute"
     }
+  },
+  {
+    "insertId": "123454d20006fcaeaf8dcc52",
+    "details": {
+      "message": "Instance startup: 954845e59212724cae605b074c8c7f5c",
+      "event": "INSTANCE_LOG",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
+      "instanceEvent": "STARTUP"
+    },
+    "resourceIdentifier": {
+      "module_id": "default",
+      "project_id": "teammates-john",
+      "zone": "asia-east2-3",
+      "version_id": "8-0-0"
+    },
+    "severity": "INFO",
+    "logName": "projects/teammates-john/logs/stdout",
+    "trace": "951f19331e63e19deebf52e6c21577e5",
+    "sourceLocation": {
+      "file": "teammates.main.Application",
+      "line": "59",
+      "function": "execute"
+    }
   }
 ]

--- a/src/main/resources/logsForLocalDev.json
+++ b/src/main/resources/logsForLocalDev.json
@@ -625,6 +625,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "responseStatus": 200,
       "requestMethod": "GET",
       "actionClass": "QueryLogsAction"
@@ -687,6 +688,7 @@
       "message": "[200] [144ms] [GET /webapi/auth] GetAuthInfoAction",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "userInfo": {
         "googleId": "john"
       },
@@ -713,6 +715,7 @@
       "requestMethod": "GET",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestParams": {},
       "message": "[200] [115ms] [GET /webapi/actionclass] GetActionClassesAction",
       "responseStatus": 200,
@@ -812,6 +815,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "responseTime": 2111,
       "requestUrl": "/webapi/logs/query",
       "requestMethod": "GET",
@@ -876,6 +880,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "message": "[200] [2525ms] [GET /webapi/logs/query] QueryLogsAction",
       "requestMethod": "GET",
       "userInfo": {
@@ -910,6 +915,7 @@
       "requestParams": {},
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestHeaders": {
         "Accept-Encoding": "gzip, deflate, br",
         "X-AppEngine-Timeout-Ms": "599999",
@@ -1013,6 +1019,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "event": "REQUEST_LOG",
       "responseStatus": 200,
       "actionClass": "GetCoursesAction",
@@ -1081,6 +1088,7 @@
       "actionClass": "GetFeedbackSessionsAction",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestUrl": "/webapi/sessions",
       "message": "[200] [612ms] [GET /webapi/sessions] GetFeedbackSessionsAction"
     },
@@ -1104,6 +1112,7 @@
     "details": {
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "userInfo": {
         "googleId": "john"
       },
@@ -1207,6 +1216,7 @@
       "requestUrl": "/webapi/sessions",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "responseTime": 5620,
       "message": "[200] [5620ms] [GET /webapi/sessions] GetFeedbackSessionsAction",
       "event": "REQUEST_LOG",
@@ -1237,6 +1247,7 @@
       "requestUrl": "/webapi/auth",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "actionClass": "GetAuthInfoAction",
       "responseStatus": 200,
       "requestMethod": "GET",
@@ -1302,6 +1313,7 @@
       "responseStatus": 200,
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "actionClass": "GetCoursesAction",
       "responseTime": 384,
       "message": "[200] [384ms] [GET /webapi/courses] GetCoursesAction",
@@ -1405,6 +1417,7 @@
       "event": "REQUEST_LOG",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestHeaders": {
         "X-AppEngine-Api-Ticket": "ChA2YWVlOGRhNDNhZjQ1MDJiGhMIqOOr0IyA8gIVagJYCB35awGd",
         "Accept-Encoding": "gzip, deflate, br",
@@ -1471,6 +1484,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestHeaders": {
         "X-AppEngine-Country": "SG",
         "X-AppEngine-Default-Version-Hostname": "teammates-john.df.r.appspot.com",
@@ -1558,6 +1572,7 @@
       "requestUrl": "/webapi/responses",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "actionClass": "GetFeedbackResponsesAction",
       "requestMethod": "GET",
       "responseTime": 609,
@@ -1596,6 +1611,7 @@
       "event": "REQUEST_LOG",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "userInfo": {
         "googleId": "john"
       },
@@ -1667,6 +1683,7 @@
       },
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "message": "[200] [156ms] [GET /webapi/auth] GetAuthInfoAction",
       "requestHeaders": {
         "X-AppEngine-City": "singapore",
@@ -1720,6 +1737,7 @@
     "details": {
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "requestParams": {
         "courseid": "john.gma-demo",
         "intent": "STUDENT_RESULT",
@@ -1829,6 +1847,7 @@
       "actionClass": "GetStudentAction",
       "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36",
       "webVersion": "8.0.0",
+      "instanceId": "954845e59212724cae605b074c8c7f5c08f7d6cffad8638bf19bbf88d7dab5a1da1921b1",
       "responseStatus": 200,
       "message": "[200] [408ms] [GET /webapi/student] GetStudentAction"
     },

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -20,6 +20,10 @@
     </filter>
     <filter-mapping>
         <filter-name>RequestTraceFilter</filter-name>
+        <url-pattern>/login</url-pattern>
+        <url-pattern>/logout</url-pattern>
+        <url-pattern>/oauth2callback/*</url-pattern>
+        <url-pattern>/page/*</url-pattern>
         <url-pattern>/webapi/*</url-pattern>
         <url-pattern>/auto/*</url-pattern>
         <url-pattern>/worker/*</url-pattern>

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -218,8 +218,8 @@ public abstract class AbstractBackDoor {
     }
 
     private void addAuthKeys(HttpRequestBase request) {
-        request.addHeader("Backdoor-Key", getBackdoorKey());
-        request.addHeader("CSRF-Key", getCsrfKey());
+        request.addHeader(Const.HeaderNames.BACKDOOR_KEY, getBackdoorKey());
+        request.addHeader(Const.HeaderNames.CSRF_KEY, getCsrfKey());
     }
 
     /**

--- a/src/test/java/teammates/ui/servlets/OriginCheckFilterTest.java
+++ b/src/test/java/teammates/ui/servlets/OriginCheckFilterTest.java
@@ -62,7 +62,7 @@ public class OriginCheckFilterTest extends BaseTestCase {
         setupMocks(HttpGet.METHOD_NAME);
 
         mockRequest.addHeader("referer", "http://localhost:9090");
-        mockRequest.addHeader("CSRF-Key", Config.CSRF_KEY);
+        mockRequest.addHeader(Const.HeaderNames.CSRF_KEY, Config.CSRF_KEY);
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
 
@@ -77,7 +77,7 @@ public class OriginCheckFilterTest extends BaseTestCase {
 
         setupMocks(HttpPost.METHOD_NAME);
 
-        mockRequest.addHeader("CSRF-Key", Config.CSRF_KEY);
+        mockRequest.addHeader(Const.HeaderNames.CSRF_KEY, Config.CSRF_KEY);
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
 
@@ -85,13 +85,13 @@ public class OriginCheckFilterTest extends BaseTestCase {
 
         setupMocks(HttpPost.METHOD_NAME);
 
-        mockRequest.addHeader(Const.SecurityConfig.CSRF_HEADER_NAME, StringHelper.encrypt("wrongtoken"));
+        mockRequest.addHeader(Const.HeaderNames.CSRF_TOKEN, StringHelper.encrypt("wrongtoken"));
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_FORBIDDEN, mockResponse.getStatus());
 
         setupMocks(HttpPost.METHOD_NAME);
 
-        mockRequest.addHeader(Const.SecurityConfig.CSRF_HEADER_NAME, "JZBCKJZXBKJBZJSDJNJKADSA");
+        mockRequest.addHeader(Const.HeaderNames.CSRF_TOKEN, "JZBCKJZXBKJBZJSDJNJKADSA");
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_FORBIDDEN, mockResponse.getStatus());
 
@@ -99,8 +99,8 @@ public class OriginCheckFilterTest extends BaseTestCase {
 
         setupMocks(HttpPost.METHOD_NAME);
 
-        mockRequest.addHeader("CSRF-Key", Config.CSRF_KEY);
-        mockRequest.addHeader(Const.SecurityConfig.CSRF_HEADER_NAME, StringHelper.encrypt("wrongtoken"));
+        mockRequest.addHeader(Const.HeaderNames.CSRF_KEY, Config.CSRF_KEY);
+        mockRequest.addHeader(Const.HeaderNames.CSRF_TOKEN, StringHelper.encrypt("wrongtoken"));
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
 
@@ -108,7 +108,7 @@ public class OriginCheckFilterTest extends BaseTestCase {
 
         setupMocks(HttpPost.METHOD_NAME);
 
-        mockRequest.addHeader(Const.SecurityConfig.CSRF_HEADER_NAME, StringHelper.encrypt("requestedsessionid"));
+        mockRequest.addHeader(Const.HeaderNames.CSRF_TOKEN, StringHelper.encrypt("requestedsessionid"));
         FILTER.doFilter(mockRequest, mockResponse, mockFilterChain);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
 

--- a/src/test/java/teammates/ui/webapi/ActionFactoryTest.java
+++ b/src/test/java/teammates/ui/webapi/ActionFactoryTest.java
@@ -21,7 +21,7 @@ public class ActionFactoryTest extends BaseTestCase {
 
         MockHttpServletRequest existingActionServletRequest = new MockHttpServletRequest(
                 HttpGet.METHOD_NAME, Const.ResourceURIs.AUTH);
-        existingActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
+        existingActionServletRequest.addHeader(Const.HeaderNames.BACKDOOR_KEY, Config.BACKDOOR_KEY);
         Action existingAction = ActionFactory.getAction(existingActionServletRequest, HttpGet.METHOD_NAME);
         assertTrue(existingAction instanceof GetAuthInfoAction);
 
@@ -29,7 +29,7 @@ public class ActionFactoryTest extends BaseTestCase {
 
         MockHttpServletRequest nonExistentActionServletRequest = new MockHttpServletRequest(
                 HttpGet.METHOD_NAME, "/blahblahblah");
-        nonExistentActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
+        nonExistentActionServletRequest.addHeader(Const.HeaderNames.BACKDOOR_KEY, Config.BACKDOOR_KEY);
         ActionMappingException nonExistentActionException = assertThrows(ActionMappingException.class,
                 () -> ActionFactory.getAction(nonExistentActionServletRequest, HttpGet.METHOD_NAME));
         assertTrue(nonExistentActionException.getMessage()
@@ -39,7 +39,7 @@ public class ActionFactoryTest extends BaseTestCase {
 
         MockHttpServletRequest nonExistentMethodOnActionServletRequest = new MockHttpServletRequest(
                 HttpGet.METHOD_NAME, Const.ResourceURIs.AUTH);
-        nonExistentMethodOnActionServletRequest.addHeader("Backdoor-Key", Config.BACKDOOR_KEY);
+        nonExistentMethodOnActionServletRequest.addHeader(Const.HeaderNames.BACKDOOR_KEY, Config.BACKDOOR_KEY);
         ActionMappingException nonExistentMethodOnActionException = assertThrows(ActionMappingException.class,
                 () -> ActionFactory.getAction(nonExistentMethodOnActionServletRequest, HttpPost.METHOD_NAME));
         assertTrue(nonExistentMethodOnActionException.getMessage()

--- a/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-logs/__snapshots__/logs-page.component.spec.ts.snap
@@ -420,6 +420,11 @@ exports[`LogsPageComponent should snap when searching for details in search form
                   >
                     FEEDBACK_SESSION_AUDIT
                   </option>
+                  <option
+                    value="INSTANCE_LOG"
+                  >
+                    INSTANCE_LOG
+                  </option>
                 </select>
               </div>
               <br />

--- a/src/web/app/pages-logs/logs-page.component.ts
+++ b/src/web/app/pages-logs/logs-page.component.ts
@@ -56,6 +56,7 @@ export class LogsPageComponent implements OnInit {
   ];
   readonly EVENTS: LogEvent[] = [
     LogEvent.REQUEST_LOG, LogEvent.EXCEPTION_LOG, LogEvent.EMAIL_SENT, LogEvent.FEEDBACK_SESSION_AUDIT,
+    LogEvent.INSTANCE_LOG,
   ];
   filterType: 'SEVERITY' | 'MIN_SEVERITY' | 'EVENT' = 'EVENT';
   ACTION_CLASSES: string[] = [];

--- a/src/web/robots.txt
+++ b/src/web/robots.txt
@@ -4,4 +4,7 @@ Disallow: /webapi/
 Disallow: /web/admin/
 Disallow: /web/student/
 Disallow: /web/instructor/
+Disallow: /login
+Disallow: /logout
+Disallow: /oauth2callback/*
 Sitemap: http://teammatesv4.appspot.com/sitemap.xml


### PR DESCRIPTION
Fixes #11372 

- Added `3XX` logs for pages which will result in redirects
- Added instance ID field for request logs
- Added instance startup/shutdown logs
- Removed `Backdoor-Key` and `CSRF-Key` from logged request headers because just like cookies they are private information that do not really help us in troubleshooting
