### PR TITLE
[#9645] Use system property instead of reflection to determine timezone rules provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,8 @@ task copyDistToExplodedWar {
 task serverRun(type: JavaExec) {
     classpath "${explodeWar.destinationDir}/WEB-INF/lib/*", "${explodeWar.destinationDir}/WEB-INF/classes/."
     mainClass = "teammates.main.Application"
-    jvmArgs "-ea", "-Djava.util.logging.config.file=${explodeWar.destinationDir}/WEB-INF/logging-dev.properties"
+    jvmArgs "-ea", "-Djava.util.logging.config.file=${explodeWar.destinationDir}/WEB-INF/logging-dev.properties",
+            "-Djava.time.zone.DefaultZoneRulesProvider=teammates.common.util.TzdbResourceZoneRulesProvider"
     dependsOn explodeWar, copyDistToExplodedWar
 }
 

--- a/src/main/appengine/app.template.yaml
+++ b/src/main/appengine/app.template.yaml
@@ -10,7 +10,10 @@
 runtime: java11
 
 # Command to run the application as how it would be done in command line.
-entrypoint: 'java -ea -Djava.util.logging.config.file=WEB-INF/logging.properties -cp "WEB-INF/lib/*:WEB-INF/classes/." teammates.main.Application'
+entrypoint: >
+  java -ea -Djava.util.logging.config.file=WEB-INF/logging.properties
+  -Djava.time.zone.DefaultZoneRulesProvider=teammates.common.util.TzdbResourceZoneRulesProvider
+  -cp "WEB-INF/lib/*:WEB-INF/classes/." teammates.main.Application
 
 # GAE instance class that determines compute resources available to the application.
 instance_class: F1

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -1,6 +1,5 @@
 package teammates.common.util;
 
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -8,7 +7,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.zone.ZoneRulesProvider;
 
 /**
  * A helper class to hold time-related functions (e.g., converting dates to strings etc.).
@@ -17,44 +15,8 @@ import java.time.zone.ZoneRulesProvider;
  */
 public final class TimeHelper {
 
-    private static final Logger log = Logger.getLogger();
-
     private TimeHelper() {
         // utility class
-    }
-
-    /**
-     * Registers the zone rules loaded from resources via {@link TzdbResourceZoneRulesProvider}.
-     * Some manipulation of the system class loader is required to enable loading of a custom
-     * {@link ZoneRulesProvider} in GAE.
-     */
-    public static void registerResourceZoneRules() {
-        try {
-            ClassLoader originalScl = ClassLoader.getSystemClassLoader();
-
-            // ZoneRulesProvider uses the system class loader for loading a custom provider as the default provider.
-            // However, GAE's system class loader includes only the Java runtime and not the application. Hence, we
-            // use reflection to temporarily replace the system class loader with the class loader for the current context.
-            Field scl = ClassLoader.class.getDeclaredField("scl");
-            scl.setAccessible(true);
-            scl.set(null, Thread.currentThread().getContextClassLoader());
-
-            // ZoneRulesProvider reads this system property to determine which provider to use as the default.
-            System.setProperty("java.time.zone.DefaultZoneRulesProvider",
-                    TzdbResourceZoneRulesProvider.class.getCanonicalName());
-
-            // This first reference to ZoneRulesProvider executes the class's static initialization block,
-            // performing the actual registration of our custom provider named in the system property above.
-            // The system class loader is used to load the class from the name.
-            // If any exceptions occur, an Error is thrown.
-            log.info("Registered zone rules version " + ZoneRulesProvider.getVersions("UTC").firstKey());
-
-            // Restore the original system class loader.
-            scl.set(null, originalScl);
-
-        } catch (ReflectiveOperationException | Error e) {
-            log.severe("Failed to register zone rules", e);
-        }
     }
 
     /**

--- a/src/main/java/teammates/main/Application.java
+++ b/src/main/java/teammates/main/Application.java
@@ -1,6 +1,7 @@
 package teammates.main;
 
 import java.io.File;
+import java.time.zone.ZoneRulesProvider;
 
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
@@ -66,7 +67,7 @@ public final class Application {
 
             @Override
             public void lifeCycleStarted(LifeCycle event) {
-                // do nothing
+                log.info("Using zone rules version " + ZoneRulesProvider.getVersions("UTC").firstKey());
             }
 
             @Override

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -14,7 +14,6 @@ import com.google.cloud.datastore.DatastoreException;
 import teammates.common.datatransfer.logs.RequestLogUser;
 import teammates.common.exception.DeadlineExceededException;
 import teammates.common.util.Logger;
-import teammates.common.util.TimeHelper;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.Action;
 import teammates.ui.webapi.ActionFactory;
@@ -33,11 +32,6 @@ import teammates.ui.webapi.UnauthorizedAccessException;
 public class WebApiServlet extends HttpServlet {
 
     private static final Logger log = Logger.getLogger();
-
-    @Override
-    public void init() {
-        TimeHelper.registerResourceZoneRules();
-    }
 
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {


### PR DESCRIPTION
Fixes #9645

This is now possible because in the new runtime we control exactly how the system is started, including the system property flags.