### PR TITLE
[#11385] Docker Compose sometimes failing on Windows because of line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,6 @@
 src/e2e/resources/data/*            linguist-vendored
 src/test/resources/data/*           linguist-vendored
 src/test/resources/emails/*         linguist-vendored
+
+# docker scripts should have LF line-endings, even if checked out on windows:
+*.sh text eol=lf


### PR DESCRIPTION
Fixes #11385

Not much to say about it.... 

Solr was crashing because of line-endings, and this should fix that