### PR TITLE
[#11414] Student viewing results: show an explanation when there is nothing to see 

### DIFF
--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -203,6 +203,10 @@ export class SessionResultPageComponent implements OnInit {
       })
           .pipe(finalize(() => this.isFeedbackSessionResultsLoading = false))
           .subscribe((sessionResults: SessionResults) => {
+            if (sessionResults.questions.length === 0) {
+              this.statusMessageService.showWarningToast(
+                  'There are currently no responses to show as no responses have been submitted yet.');
+            }
             this.questions = sessionResults.questions.sort(
                 (a: QuestionOutput, b: QuestionOutput) =>
                     a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber);


### PR DESCRIPTION
Fixes #11414 

**Outline of Solution**

Added an error message for when a student views results and there are no responses yet.

The current error message says `There are currently no responses to show as no responses have been submitted yet.`, do seek any input if the current message is not informative enough!

![image](https://user-images.githubusercontent.com/65604398/133127704-a299abac-cdde-4dc9-b8ff-1bb9b81457a0.png)

