### PR TITLE
[#11235] Instructor audit logs: ensure end date is not before start date

### DIFF
--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.html
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.html
@@ -54,7 +54,7 @@
         </div>
         <div class="input-group">
           <div class="col-md-6 input-group">
-            <input id="logs-to-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="earliestSearchDate" [maxDate]="dateToday" [(ngModel)]="formModel.logsDateTo" #logsToDp="ngbDatepicker"/>
+            <input id="logs-to-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="formModel.logsDateFrom" [maxDate]="dateToday" [(ngModel)]="formModel.logsDateTo" #logsToDp="ngbDatepicker"/>
             <button class="btn btn-light" (click)="logsToDp.toggle()" type="button">
               <i class="fas fa-calendar-alt"></i>
             </button>


### PR DESCRIPTION
Fixes #11235

Restricted the 'Search period until' date-picker with 'Search period from' 