### PR TITLE
[#11150] Search page: Remove unnecessary panel

### DIFF
--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`InstructorSearchPageComponent should snap with a search key 1`] = `
         <div
           class="text-muted"
         >
-           You can search for students from all your courses here. 
+           You can search for students (by name or email) from all your courses here. 
         </div>
         <div
           class="text-muted"
@@ -35,7 +35,7 @@ exports[`InstructorSearchPageComponent should snap with a search key 1`] = `
               <b>
                 "[any word]"
               </b>
-               to search for an exact phrase in an exact order.
+               to search for an exact phrase in an exact order, e.g., "John Doe".
             </li>
           </ul>
         </div>
@@ -90,7 +90,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
         <div
           class="text-muted"
         >
-           You can search for students from all your courses here. 
+           You can search for students (by name or email) from all your courses here. 
         </div>
         <div
           class="text-muted"
@@ -106,7 +106,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
               <b>
                 "[any word]"
               </b>
-               to search for an exact phrase in an exact order.
+               to search for an exact phrase in an exact order, e.g., "John Doe".
             </li>
           </ul>
         </div>
@@ -143,11 +143,6 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
       <div
         class="card border border-primary mb-4"
       >
-        <div
-          class="card-header text-white bg-primary font-weight-bold"
-        >
-          Students
-        </div>
         <div
           class="card-body p-3"
         >
@@ -619,7 +614,7 @@ exports[`InstructorSearchPageComponent should snap with default fields 1`] = `
         <div
           class="text-muted"
         >
-           You can search for students from all your courses here. 
+           You can search for students (by name or email) from all your courses here. 
         </div>
         <div
           class="text-muted"
@@ -635,7 +630,7 @@ exports[`InstructorSearchPageComponent should snap with default fields 1`] = `
               <b>
                 "[any word]"
               </b>
-               to search for an exact phrase in an exact order.
+               to search for an exact phrase in an exact order, e.g., "John Doe".
             </li>
           </ul>
         </div>

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.html
@@ -1,13 +1,13 @@
 <div class="card bg-light mb-4">
   <div class="card-body">
     <div class="text-muted">
-      You can search for students from all your courses here.
+      You can search for students (by name or email) from all your courses here.
     </div>
     <div class="text-muted">
       Search Tips:<br>
       <ul>
         <li>Put more keywords to search for more precise results.</li>
-        <li>Put quotation marks around words <b>"[any word]"</b> to search for an exact phrase in an exact order.</li>
+        <li>Put quotation marks around words <b>"[any word]"</b> to search for an exact phrase in an exact order, e.g., "John Doe".</li>
       </ul>
     </div>
     <div class="form-group">

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
@@ -1,5 +1,4 @@
 <div class="card border border-primary mb-4">
-  <div class="card-header text-white bg-primary font-weight-bold">Students</div>
   <div class="card-body p-3">
     <div *ngFor="let course of studentTables" class="card border border-light-blue mb-3 student-course-table">
       <div class="card-header alert-primary font-weight-bold text-break">[{{course.courseId}}]</div>


### PR DESCRIPTION
Fixes #11150

**PR Checklist**
- Rephrase as You can search for students (by name or email) from all your courses here.
- Give an example at the end e.g., "John Doe"
- Remove this outer panel as all results are students anyway.