### PR TITLE
[#11468] Fix instructor view all records not showing results

### DIFF
--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -149,7 +149,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
             courseId: this.courseId,
             feedbackSessionName: feedbackSession.feedbackSessionName,
             groupBySection: this.studentSection,
-            intent: Intent.INSTRUCTOR_RESULT,
+            intent: Intent.FULL_DETAIL,
           }).pipe(map((results: SessionResults) => {
             // sort questions by question number
             results.questions.sort((a: QuestionOutput, b: QuestionOutput) =>


### PR DESCRIPTION
Fixes #11468

**Outline of Solution**

- Change intent from INSTRUCTOR_RESULT to FULL_DETAIL when viewing all student records

Note: I didn't find `loadStudentResults()` used anywhere else other than in instructor-student-records so I suppose this should be a rather safe change. Kindly advice if I have overlooked anything, thank you!