### PR TITLE
[#11474] Fix feedback path event bubbleup error

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -47,12 +47,14 @@ jobs:
         run: npm ci
       - name: Build Frontend Bundle
         run: npm run build -- --progress=false --serviceWorker=false
-      - name: Start Server and Tests
+      - name: Start Server
         if: matrix.os == 'ubuntu-latest'
         run: |
           ./gradlew serverRun &
           ./wait-for-server.sh
-          xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew e2eTests
+      - name: Start Tests
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew e2eTests
       - name: Start Server and Tests
         if: matrix.os == 'windows-latest'
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Build Frontend Bundle 
         run: npm run build -- --progress=false --serviceWorker=false 
       - name: Start Server
-        run: ./gradlew serverRun & 
-      - name: Wait until server is running
-        run: ./wait-for-server.sh
+        run: |
+          ./gradlew serverRun &
+          ./wait-for-server.sh
       - name: Start Tests 
         run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew e2eTests 

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -65,19 +65,19 @@
         <div class="input-group-prepend">
           <div class="input-group-text">
             <input id="custom-recipients" type="radio" [name]="model.feedbackQuestionId + 'numOfRecipients'" [ngModel]="model.numberOfEntitiesToGiveFeedbackToSetting"
-                   (ngModelChange)="triggerModelChangeHandler($event)"
+                   (ngModelChange)="triggerNumberOfEntitiesSetting($event)"
                    [value]="NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM"
                    [disabled]="!model.isEditable">
           </div>
         </div>
-        <input id="custom-recipients-number" type="number" min="1" class="form-control" [ngModel]="model.customNumberOfEntitiesToGiveFeedbackTo" (ngModelChange)="triggerModelChangeHandler($event)" [disabled]="model.numberOfEntitiesToGiveFeedbackToSetting != NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM || !model.isEditable">
+        <input id="custom-recipients-number" type="number" min="1" class="form-control" [ngModel]="model.customNumberOfEntitiesToGiveFeedbackTo" (ngModelChange)="triggerCustomNumberOfEntities($event)" [disabled]="model.numberOfEntitiesToGiveFeedbackToSetting != NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM || !model.isEditable">
       </div>
     </div>
     <div class="col-md-2">
       <div class="form-check">
         <label class="form-check-label">
           <input id="unlimited-recipients" class="form-check-input" type="radio" [name]="model.feedbackQuestionId + 'numOfRecipients'"
-                 [ngModel]="model.numberOfEntitiesToGiveFeedbackToSetting" (ngModelChange)="triggerModelChangeHandler($event)"
+                 [ngModel]="model.numberOfEntitiesToGiveFeedbackToSetting" (ngModelChange)="triggerNumberOfEntitiesSetting($event)"
                  [value]="NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED"
                  [disabled]="!model.isEditable">
           Unlimited

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -76,6 +76,9 @@ export class FeedbackPathPanelComponent implements OnInit {
   customFeedbackPath: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @Output()
+  customNumberOfEntitiesToGiveFeedbackTo: EventEmitter<number> = new EventEmitter<number>();
+
+  @Output()
   numberOfEntitiesToGiveFeedbackToSetting: EventEmitter<NumberOfEntitiesToGiveFeedbackToSetting> =
     new EventEmitter<NumberOfEntitiesToGiveFeedbackToSetting>();
 
@@ -88,10 +91,12 @@ export class FeedbackPathPanelComponent implements OnInit {
   ngOnInit(): void {
   }
 
-  triggerModelChangeHandler(data: NumberOfEntitiesToGiveFeedbackToSetting): void {
-    if (this.saveChangeClicked) {
-      this.numberOfEntitiesToGiveFeedbackToSetting.emit(data);
-    }
+  triggerCustomNumberOfEntities(data: number): void {
+    this.customNumberOfEntitiesToGiveFeedbackTo.emit(data);
+  }
+
+  triggerNumberOfEntitiesSetting(data: NumberOfEntitiesToGiveFeedbackToSetting): void {
+    this.numberOfEntitiesToGiveFeedbackToSetting.emit(data);
   }
 
   triggerCustomFeedbackPath(): void {

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -64,9 +64,6 @@ export class FeedbackPathPanelComponent implements OnInit {
   };
 
   @Input()
-  saveChangeClicked: boolean = false;
-
-  @Input()
   commonFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
   @Input()

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -22,7 +22,6 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
   isDisplayOnly="false"
   model={[Function Object]}
   numOfQuestions="0"
-  saveChangeClicked="false"
   saveExistingQuestionEvent={[Function EventEmitter]}
   simpleModalService={[Function SimpleModalService]}
   visibilityStateMachine={[Function VisibilityStateMachine]}

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -98,6 +98,7 @@
                               [saveChangeClicked]="saveChangeClicked"
                               [allowedFeedbackPaths]="allowedFeedbackPaths"
                               (customFeedbackPath)="triggerModelChange('isUsingOtherFeedbackPath', $event)"
+                              (customNumberOfEntitiesToGiveFeedbackTo)="triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)"
                               (numberOfEntitiesToGiveFeedbackToSetting)="triggerModelChange('numberOfEntitiesToGiveFeedbackToSetting', $event)"
                               (triggerModelChangeBatch)="triggerModelChangeBatch($event)"></tm-feedback-path-panel>
       <tm-visibility-panel [model]="model" [isCustomFeedbackVisibilitySettingAllowed]="isCustomFeedbackVisibilitySettingAllowed"

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -95,7 +95,6 @@
         </div>
       </div>
       <tm-feedback-path-panel [model]="model" [commonFeedbackPaths]="commonFeedbackPaths"
-                              [saveChangeClicked]="saveChangeClicked"
                               [allowedFeedbackPaths]="allowedFeedbackPaths"
                               (customFeedbackPath)="triggerModelChange('isUsingOtherFeedbackPath', $event)"
                               (customNumberOfEntitiesToGiveFeedbackTo)="triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)"

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -179,8 +179,6 @@ export class QuestionEditFormComponent implements OnInit {
   @Output()
   createNewQuestionEvent: EventEmitter<void> = new EventEmitter();
 
-  saveChangeClicked: boolean = false;
-
   commonFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
   allowedFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
@@ -279,7 +277,6 @@ export class QuestionEditFormComponent implements OnInit {
    * Saves the question.
    */
   saveQuestionHandler(): void {
-    this.saveChangeClicked = true;
     if (this.formMode === QuestionEditFormMode.EDIT) {
       const doChangesNeedWarning: boolean = this.model.isQuestionDetailsChanged
         || this.model.isVisibilityChanged


### PR DESCRIPTION
Fixes #11474 

Root cause: wrong attribute being bubbled up in the event of modifying the custom number of entities to give responses to.
This also removes the need for `saveChangeClicked` which was a wrong attempt to circumvent the problem.