### PR TITLE
[#11492] Support configuring separate front-end URL for E2E testing

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/AdminAccountsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminAccountsPageE2ETest.java
@@ -28,7 +28,7 @@ public class AdminAccountsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("verify loaded data");
 
-        AppUrl accountsPageUrl = createUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
+        AppUrl accountsPageUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
                 .withParam(Const.ParamsNames.INSTRUCTOR_ID, googleId);
         AdminAccountsPage accountsPage = loginAdminToPage(accountsPageUrl, AdminAccountsPage.class);
 

--- a/src/e2e/java/teammates/e2e/cases/AdminHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminHomePageE2ETest.java
@@ -20,7 +20,7 @@ public class AdminHomePageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.ADMIN_HOME_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_HOME_PAGE);
         AdminHomePage homePage = loginAdminToPage(url, AdminHomePage.class);
 
         String name = "AHPUiT Instrúctör WithPlusInEmail";

--- a/src/e2e/java/teammates/e2e/cases/AdminSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminSearchPageE2ETest.java
@@ -36,7 +36,7 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
             return;
         }
 
-        AppUrl url = createUrl(Const.WebPageURIs.ADMIN_SEARCH_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_SEARCH_PAGE);
         AdminSearchPage searchPage = loginAdminToPage(url, AdminSearchPage.class);
 
         StudentAttributes student = testData.students.get("student1InCourse1");
@@ -119,14 +119,14 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
     }
 
     private String getExpectedStudentHomePageLink(StudentAttributes student) {
-        return student.isRegistered() ? createUrl(Const.WebPageURIs.STUDENT_HOME_PAGE)
+        return student.isRegistered() ? createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE)
                 .withUserId(student.getGoogleId())
                 .toAbsoluteString()
                 : "";
     }
 
     private String getExpectedStudentManageAccountLink(StudentAttributes student) {
-        return student.isRegistered() ? createUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
+        return student.isRegistered() ? createFrontendUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
                 .withParam(Const.ParamsNames.INSTRUCTOR_ID, student.getGoogleId())
                 .toAbsoluteString()
                 : "";
@@ -147,14 +147,14 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
 
     private String getExpectedInstructorHomePageLink(InstructorAttributes instructor) {
         String googleId = instructor.isRegistered() ? instructor.getGoogleId() : "";
-        return createUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
+        return createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
                 .withUserId(googleId)
                 .toAbsoluteString();
     }
 
     private String getExpectedInstructorManageAccountLink(InstructorAttributes instructor) {
         String googleId = instructor.isRegistered() ? instructor.getGoogleId() : "";
-        return createUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
+        return createFrontendUrl(Const.WebPageURIs.ADMIN_ACCOUNTS_PAGE)
                 .withParam(Const.ParamsNames.INSTRUCTOR_ID, googleId)
                 .toAbsoluteString();
     }

--- a/src/e2e/java/teammates/e2e/cases/AdminSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/AdminSessionsPageE2ETest.java
@@ -72,7 +72,7 @@ public class AdminSessionsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("verify loaded data");
 
-        AppUrl sessionsUrl = createUrl(Const.WebPageURIs.ADMIN_SESSIONS_PAGE);
+        AppUrl sessionsUrl = createFrontendUrl(Const.WebPageURIs.ADMIN_SESSIONS_PAGE);
         AdminSessionsPage sessionsPage = loginAdminToPage(sessionsUrl, AdminSessionsPage.class);
 
         String tableTimezone = sessionsPage.getSessionsTableTimezone();

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -93,11 +93,20 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
 
     /**
      * Creates an {@link AppUrl} for the supplied {@code relativeUrl} parameter.
-     * The base URL will be the value of test.app.url in test.properties.
+     * The base URL will be the value of test.app.frontend.url in test.properties.
      * {@code relativeUrl} must start with a "/".
      */
-    protected static AppUrl createUrl(String relativeUrl) {
+    protected static AppUrl createFrontendUrl(String relativeUrl) {
         return new AppUrl(TestProperties.TEAMMATES_FRONTEND_URL + relativeUrl);
+    }
+
+    /**
+     * Creates an {@link AppUrl} for the supplied {@code relativeUrl} parameter.
+     * The base URL will be the value of test.app.backend.url in test.properties.
+     * {@code relativeUrl} must start with a "/".
+     */
+    protected static AppUrl createBackendUrl(String relativeUrl) {
+        return new AppUrl(TestProperties.TEAMMATES_BACKEND_URL + relativeUrl);
     }
 
     /**
@@ -137,7 +146,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
      * Equivalent to clicking the 'logout' link in the top menu of the page.
      */
     protected void logout() {
-        browser.goToUrl(createUrl(Const.WebPageURIs.LOGOUT).toAbsoluteString());
+        browser.goToUrl(createBackendUrl(Const.WebPageURIs.LOGOUT).toAbsoluteString());
         AppPage.getNewPageInstance(browser, HomePage.class).waitForPageToLoad();
     }
 

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
      * {@code relativeUrl} must start with a "/".
      */
     protected static AppUrl createUrl(String relativeUrl) {
-        return new AppUrl(TestProperties.TEAMMATES_URL + relativeUrl);
+        return new AppUrl(TestProperties.TEAMMATES_FRONTEND_URL + relativeUrl);
     }
 
     /**
@@ -109,7 +109,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         if (!TestProperties.isDevServer()) {
             // In order for the cookie injection to work, we need to be in the domain.
             // Use the home page to minimize the page load time.
-            browser.goToUrl(TestProperties.TEAMMATES_URL);
+            browser.goToUrl(TestProperties.TEAMMATES_FRONTEND_URL);
 
             String cookieValue = BACKDOOR.getUserCookie(userId);
             browser.addCookie(Const.SecurityConfig.AUTH_COOKIE_NAME, cookieValue, true, true);

--- a/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
@@ -33,7 +33,7 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
     abstract void testSubmitPage();
 
     InstructorFeedbackEditPage loginToFeedbackEditPage() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
 
@@ -41,7 +41,7 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
     }
 
     FeedbackSubmitPage loginToFeedbackSubmitPage() {
-        AppUrl url = createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(student.getCourse())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
 
@@ -49,7 +49,7 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
     }
 
     FeedbackSubmitPage getFeedbackSubmitPage() {
-        AppUrl url = createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(student.getCourse())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
 

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -45,7 +45,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("unregistered student: can access results");
         StudentAttributes unregistered = testData.students.get("Unregistered");
-        AppUrl url = createUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
                 .withCourseId(unregistered.getCourse())
                 .withStudentEmail(unregistered.getEmail())
                 .withSessionName(openSession.getFeedbackSessionName())
@@ -59,7 +59,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("registered student: can access results");
         StudentAttributes student = testData.students.get("Alice");
-        url = createUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName());
         resultsPage = loginToPage(url, FeedbackResultsPage.class, student.getGoogleId());
@@ -99,7 +99,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         ______TS("registered instructor: can access results");
         logout();
         InstructorAttributes instructor = testData.instructors.get("FRes.instr");
-        url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName());
         resultsPage = loginToPage(url, FeedbackResultsPage.class, instructor.getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
@@ -47,7 +47,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName());
         FeedbackSubmitPage submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getGoogleId());
@@ -127,7 +127,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
 
         ______TS("preview as instructor");
         logout();
-        url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName())
                 .withParam("previewas", instructor.getEmail());
@@ -139,7 +139,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         submitPage.verifyCannotSubmit();
 
         ______TS("preview as student");
-        url = createUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
                 .withCourseId(openSession.getCourseId())
                 .withSessionName(openSession.getFeedbackSessionName())
                 .withParam("previewas", student.getEmail());
@@ -154,7 +154,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         submitPage.verifyCannotSubmit();
 
         ______TS("moderating instructor cannot see questions without instructor visibility");
-        url = createUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
                 .withCourseId(gracePeriodSession.getCourseId())
                 .withSessionName(gracePeriodSession.getFeedbackSessionName())
                 .withParam("moderatedperson", student.getEmail())
@@ -174,7 +174,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
     }
 
     private AppUrl getStudentSubmitPageUrl(StudentAttributes student, FeedbackSessionAttributes session) {
-        return createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
+        return createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(student.getCourse())
                 .withSessionName(session.getFeedbackSessionName());
     }

--- a/src/e2e/java/teammates/e2e/cases/InstructorAuditLogsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorAuditLogsPageE2ETest.java
@@ -43,7 +43,7 @@ public class InstructorAuditLogsPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_AUDIT_LOGS_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_AUDIT_LOGS_PAGE);
         InstructorAuditLogsPage auditLogsPage = loginToPage(url, InstructorAuditLogsPage.class, instructor.getGoogleId());
 
         ______TS("verify default datetime");
@@ -63,7 +63,7 @@ public class InstructorAuditLogsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("verify logs output");
         logout();
-        AppUrl studentSubmissionPageUrl = createUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
+        AppUrl studentSubmissionPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
         FeedbackSubmitPage studentSubmissionPage = loginToPage(studentSubmissionPageUrl,

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
@@ -47,7 +47,7 @@ public class InstructorCourseDetailsPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl detailsPageUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
+        AppUrl detailsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
                 .withCourseId(course.getId());
         InstructorCourseDetailsPage detailsPage = loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class,
                 testData.instructors.get("ICDet.instr").getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
@@ -33,7 +33,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
     public void testAll() {
         ______TS("verify cannot edit without privilege");
         // log in as instructor with no edit privilege
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
                 .withCourseId(course.getId());
         InstructorCourseEditPage editPage = loginToPage(url, InstructorCourseEditPage.class, instructors[2].getGoogleId());
 
@@ -44,7 +44,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
         ______TS("verify loaded data");
         // re-log in as instructor with edit privilege
         logout();
-        url = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
+        url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
                 .withCourseId(course.getId());
         editPage = loginToPage(url, InstructorCourseEditPage.class, instructors[3].getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEnrollPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEnrollPageE2ETest.java
@@ -20,7 +20,7 @@ public class InstructorCourseEnrollPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_ENROLL_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_ENROLL_PAGE)
                 .withCourseId(testData.courses.get("ICEnroll.CS2104").getId());
         InstructorCourseEnrollPage enrollPage = loginToPage(url, InstructorCourseEnrollPage.class,
                 testData.instructors.get("ICEnroll.teammates.test").getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseJoinConfirmationPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseJoinConfirmationPageE2ETest.java
@@ -28,7 +28,7 @@ public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase
     public void testAll() {
         ______TS("Click join link: invalid key");
         String invalidKey = "invalidKey";
-        AppUrl joinLink = createUrl(Const.WebPageURIs.JOIN_PAGE)
+        AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(invalidKey)
                 .withEntityType(Const.EntityType.INSTRUCTOR);
         CourseJoinConfirmationPage confirmationPage = loginToPage(
@@ -40,7 +40,7 @@ public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase
         ______TS("Click join link: valid key");
         String courseId = testData.courses.get("ICJoinConf.CS1101").getId();
         String instructorEmail = newInstructor.getEmail();
-        joinLink = createUrl(Const.WebPageURIs.JOIN_PAGE)
+        joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(getKeyForInstructor(courseId, instructorEmail))
                 .withEntityType(Const.EntityType.INSTRUCTOR);
         confirmationPage = getNewPageInstance(joinLink, CourseJoinConfirmationPage.class);

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
@@ -30,7 +30,7 @@ public class InstructorCourseStudentDetailsEditPageE2ETest extends BaseE2ETestCa
     @Test
     @Override
     public void testAll() {
-        AppUrl editPageUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT_PAGE)
+        AppUrl editPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT_PAGE)
                 .withCourseId(course.getId())
                 .withStudentEmail(student.getEmail());
         InstructorCourseStudentDetailsEditPage editPage =

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsPageE2ETest.java
@@ -41,7 +41,7 @@ public class InstructorCourseStudentDetailsPageE2ETest extends BaseE2ETestCase {
     }
 
     private AppUrl getStudentDetailsViewPageUrl(String studentEmail) {
-        return createUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE)
+        return createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE)
                 .withCourseId(testData.courses.get("ICSDet.CS2104").getId())
                 .withStudentEmail(studentEmail);
     }

--- a/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
@@ -75,7 +75,7 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         String instructorId = testData.accounts.get("instructor").getGoogleId();
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE);
         InstructorCoursesPage coursesPage = loginToPage(url, InstructorCoursesPage.class, instructorId);
 
         ______TS("verify loaded data");

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
@@ -41,7 +41,7 @@ public class InstructorFeedbackEditPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
         InstructorFeedbackEditPage feedbackEditPage =

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -89,7 +89,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         CourseAttributes course = testData.courses.get("tm.e2e.IFRep.CS2104");
         FeedbackSessionAttributes feedbackSession = testData.feedbackSessions.get("Open Session");
 
-        resultsUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
+        resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
 
@@ -325,7 +325,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         CourseAttributes course = testData.courses.get("tm.e2e.IFRep.CS2103");
         FeedbackSessionAttributes feedbackSession = testData.feedbackSessions.get("Open Session 2");
 
-        AppUrl resultsUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
+        AppUrl resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getFeedbackSessionName());
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
@@ -75,7 +75,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_SESSIONS_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSIONS_PAGE);
         InstructorFeedbackSessionsPage feedbackSessionsPage =
                 loginToPage(url, InstructorFeedbackSessionsPage.class, instructor.getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -66,7 +66,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        AppUrl url = createUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
         InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class, instructor.getGoogleId());
 
         ______TS("verify loaded data");

--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -39,7 +39,7 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
         }
 
         String instructorId = testData.accounts.get("instructor1OfCourse1").getGoogleId();
-        AppUrl searchPageUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_SEARCH_PAGE);
+        AppUrl searchPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SEARCH_PAGE);
 
         InstructorSearchPage searchPage = loginToPage(searchPageUrl, InstructorSearchPage.class, instructorId);
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
@@ -36,7 +36,7 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
         InstructorAttributes instructor = testData.instructors.get("instructorOfCourse1");
         String instructorId = instructor.getGoogleId();
 
-        AppUrl listPageUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_LIST_PAGE);
+        AppUrl listPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_LIST_PAGE);
         InstructorStudentListPage listPage = loginToPage(listPageUrl, InstructorStudentListPage.class, instructorId);
 
         CourseAttributes course1 = testData.courses.get("course1");

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentRecordsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentRecordsPageE2ETest.java
@@ -34,7 +34,7 @@ public class InstructorStudentRecordsPageE2ETest extends BaseE2ETestCase {
         String courseId = instructor.getCourseId();
         String studentEmail = student.getEmail();
 
-        AppUrl recordsPageUrl = createUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE)
+        AppUrl recordsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE)
                 .withCourseId(courseId)
                 .withStudentEmail(studentEmail);
 

--- a/src/e2e/java/teammates/e2e/cases/StudentCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentCourseDetailsPageE2ETest.java
@@ -24,7 +24,7 @@ public class StudentCourseDetailsPageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
 
-        AppUrl url = createUrl(Const.WebPageURIs.STUDENT_COURSE_DETAILS_PAGE)
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_COURSE_DETAILS_PAGE)
                 .withCourseId("tm.e2e.SCDet.CS2104");
         StudentCourseDetailsPage detailsPage = loginToPage(url, StudentCourseDetailsPage.class,
                 testData.students.get("SCDet.alice").getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/StudentCourseJoinConfirmationPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentCourseJoinConfirmationPageE2ETest.java
@@ -29,7 +29,7 @@ public class StudentCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
         ______TS("Click join link: invalid key");
         String courseId = testData.courses.get("SCJoinConf.CS2104").getId();
         String invalidKey = "invalidKey";
-        AppUrl joinLink = createUrl(Const.WebPageURIs.JOIN_PAGE)
+        AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(invalidKey)
                 .withCourseId(courseId)
                 .withEntityType(Const.EntityType.STUDENT);
@@ -40,7 +40,7 @@ public class StudentCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
                 + "entered the URL incorrectly or the URL may correspond to a/an student that does not exist.");
 
         ______TS("Click join link: valid key");
-        joinLink = createUrl(Const.WebPageURIs.JOIN_PAGE)
+        joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(getKeyForStudent(newStudent))
                 .withCourseId(courseId)
                 .withEntityType(Const.EntityType.STUDENT);

--- a/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
@@ -26,7 +26,7 @@ public class StudentHomePageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
 
-        AppUrl url = createUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
         StudentHomePage homePage = loginToPage(url, StudentHomePage.class, "tm.e2e.SHome.student");
 
         List<String> courseIds = getAllVisibleCourseIds();

--- a/src/e2e/java/teammates/e2e/cases/StudentProfilePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentProfilePageE2ETest.java
@@ -24,7 +24,7 @@ public class StudentProfilePageE2ETest extends BaseE2ETestCase {
 
         ______TS("Typical case: Log in with filled profile values");
 
-        AppUrl url = createUrl(Const.WebPageURIs.STUDENT_PROFILE_PAGE);
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_PROFILE_PAGE);
         StudentProfilePage profilePage = loginToPage(url, StudentProfilePage.class, "tm.e2e.SProf.student");
 
         profilePage.ensureProfileContains("Ben", "i.m.benny@gmail.tmt", "TEAMMATES Test Institute 4",

--- a/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
@@ -38,7 +38,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("AssertionError testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, AssertionError.class.getSimpleName())
                 .toString();
 
@@ -52,7 +52,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("NullPointerException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, NullPointerException.class.getSimpleName())
                 .toString();
 
@@ -66,7 +66,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("DeadlineExceededException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName())
                 .toString();
 
@@ -80,7 +80,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("DatastoreException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName())
                 .toString();
 
@@ -94,7 +94,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("UnauthorizedAccessException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "UnauthorizedAccessException")
                 .toString();
 
@@ -108,7 +108,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("InvalidHttpParamException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "InvalidHttpParameterException")
                 .toString();
 
@@ -122,7 +122,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("EntityNotFoundException testing");
 
-        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createBackendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "EntityNotFoundException")
                 .toString();
 

--- a/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/SystemErrorEmailReportE2ETest.java
@@ -38,7 +38,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("AssertionError testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, AssertionError.class.getSimpleName())
                 .toString();
 
@@ -52,7 +52,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("NullPointerException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, NullPointerException.class.getSimpleName())
                 .toString();
 
@@ -66,7 +66,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("DeadlineExceededException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, DeadlineExceededException.class.getSimpleName())
                 .toString();
 
@@ -80,7 +80,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("DatastoreException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, DatastoreException.class.getSimpleName())
                 .toString();
 
@@ -94,7 +94,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("UnauthorizedAccessException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "UnauthorizedAccessException")
                 .toString();
 
@@ -108,7 +108,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("InvalidHttpParamException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "InvalidHttpParameterException")
                 .toString();
 
@@ -122,7 +122,7 @@ public class SystemErrorEmailReportE2ETest extends BaseE2ETestCase {
 
         ______TS("EntityNotFoundException testing");
 
-        String url = createUrl(Const.ResourceURIs.EXCEPTION)
+        String url = createFrontendUrl(Const.ResourceURIs.EXCEPTION)
                 .withParam(Const.ParamsNames.ERROR, "EntityNotFoundException")
                 .toString();
 

--- a/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
+++ b/src/e2e/java/teammates/e2e/cases/TimezoneSyncerTest.java
@@ -33,7 +33,7 @@ public class TimezoneSyncerTest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         AdminTimezonePage timezonePage = loginAdminToPage(
-                createUrl(Const.WebPageURIs.ADMIN_TIMEZONE_PAGE), AdminTimezonePage.class);
+                createFrontendUrl(Const.WebPageURIs.ADMIN_TIMEZONE_PAGE), AdminTimezonePage.class);
 
         ______TS("ensure the front-end and the back-end have the same timezone database version");
         String javaOffsets = timezonePage.getJavaTimezoneOffsets();

--- a/src/e2e/java/teammates/e2e/util/BackDoor.java
+++ b/src/e2e/java/teammates/e2e/util/BackDoor.java
@@ -19,7 +19,7 @@ public final class BackDoor extends AbstractBackDoor {
 
     @Override
     protected String getAppUrl() {
-        return TestProperties.TEAMMATES_URL;
+        return TestProperties.TEAMMATES_BACKEND_URL;
     }
 
     @Override

--- a/src/e2e/java/teammates/e2e/util/TestProperties.java
+++ b/src/e2e/java/teammates/e2e/util/TestProperties.java
@@ -121,7 +121,7 @@ public final class TestProperties {
     }
 
     public static boolean isDevServer() {
-        return TEAMMATES_BACKEND_URL.matches("^https?://localhost:[0-9]+(/.*)?");
+        return TEAMMATES_FRONTEND_URL.matches("^https?://localhost:[0-9]+(/.*)?");
     }
 
 }

--- a/src/e2e/java/teammates/e2e/util/TestProperties.java
+++ b/src/e2e/java/teammates/e2e/util/TestProperties.java
@@ -17,8 +17,11 @@ public final class TestProperties {
     /** The directory where webdriver downloads files to. */
     public static final String TEST_DOWNLOADS_FOLDER = "src/e2e/resources/downloads";
 
-    /** The value of "test.app.url" in test.properties file. */
-    public static final String TEAMMATES_URL;
+    /** The value of "test.app.frontend.url" in test.properties file. */
+    public static final String TEAMMATES_FRONTEND_URL;
+
+    /** The value of "test.app.backend.url" in test.properties file. */
+    public static final String TEAMMATES_BACKEND_URL;
 
     /** The Google ID of user with admin permission. */
     public static final String TEST_ADMIN;
@@ -86,7 +89,8 @@ public final class TestProperties {
                 prop.load(testPropStream);
             }
 
-            TEAMMATES_URL = prop.getProperty("test.app.url");
+            TEAMMATES_FRONTEND_URL = prop.getProperty("test.app.frontend.url");
+            TEAMMATES_BACKEND_URL = prop.getProperty("test.app.backend.url");
 
             TEST_EMAIL = prop.getProperty("test.email");
             TEST_ADMIN = prop.getProperty("test.admin");
@@ -117,7 +121,7 @@ public final class TestProperties {
     }
 
     public static boolean isDevServer() {
-        return TEAMMATES_URL.matches("^https?://localhost:[0-9]+(/.*)?");
+        return TEAMMATES_BACKEND_URL.matches("^https?://localhost:[0-9]+(/.*)?");
     }
 
 }

--- a/src/e2e/java/teammates/e2e/util/TestPropertiesTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestPropertiesTest.java
@@ -11,7 +11,8 @@ public class TestPropertiesTest extends BaseTestCase {
 
     @Test
     public void testContent() {
-        assertNotNull(TestProperties.TEAMMATES_URL);
+        assertNotNull(TestProperties.TEAMMATES_FRONTEND_URL);
+        assertNotNull(TestProperties.TEAMMATES_BACKEND_URL);
     }
 
 }

--- a/src/e2e/resources/test.ci-chrome.properties
+++ b/src/e2e/resources/test.ci-chrome.properties
@@ -2,7 +2,8 @@
 # This file contains specific configuration values for testing on GitHub Actions.
 #-----------------------------------------------------------------------------
 
-test.app.url=http\://localhost\:8080
+test.app.frontend.url=http\://localhost\:8080
+test.app.backend.url=http\://localhost\:8080
 test.csrf.key=samplekey
 test.backdoor.key=samplekey
 test.selenium.browser=chrome

--- a/src/e2e/resources/test.ci-edge.properties
+++ b/src/e2e/resources/test.ci-edge.properties
@@ -2,7 +2,8 @@
 # This file contains specific configuration values for testing on GitHub Actions.
 #-----------------------------------------------------------------------------
 
-test.app.url=http\://localhost\:8080
+test.app.frontend.url=http\://localhost\:8080
+test.app.backend.url=http\://localhost\:8080
 test.csrf.key=samplekey
 test.backdoor.key=samplekey
 test.selenium.browser=edge

--- a/src/e2e/resources/test.ci-firefox.properties
+++ b/src/e2e/resources/test.ci-firefox.properties
@@ -2,7 +2,8 @@
 # This file contains specific configuration values for testing on GitHub Actions.
 #-----------------------------------------------------------------------------
 
-test.app.url=http\://localhost\:8080
+test.app.frontend.url=http\://localhost\:8080
+test.app.backend.url=http\://localhost\:8080
 test.csrf.key=samplekey
 test.backdoor.key=samplekey
 test.selenium.browser=firefox

--- a/src/e2e/resources/test.template.properties
+++ b/src/e2e/resources/test.template.properties
@@ -4,11 +4,17 @@
 # Use '\' to escape ':' e.g., http\://google.com
 #-----------------------------------------------------------------------------
 
-# This is the url of the app we are testing against.
-# e.g. test.app.url=http\://localhost\:8080
-# e.g. test.app.url=https\://8-0-0-dot-teammates-john.appspot.com
+# This is the frontend url of the app we are testing against.
+# e.g. test.app.frontend.url=http\://localhost\:8080
+# e.g. test.app.frontend.url=https\://8-0-0-dot-teammates-john.appspot.com
 # Note: the '.' in the url has been replaced by -dot- to support https connection for the staging server.
-test.app.url=http\://localhost\:8080
+test.app.frontend.url=http\://localhost\:8080
+
+# This is the backend url of the app we are testing against.
+# e.g. test.app.backend.url=http\://localhost\:8080
+# e.g. test.app.backend.url=https\://8-0-0-dot-teammates-john.appspot.com
+# Note: the '.' in the url has been replaced by -dot- to support https connection for the staging server.
+test.app.backend.url=http\://localhost\:8080
 
 # This is the key that the test suite uses to access app endpoints without origin check.
 # It should match app.csrf.key in build.properties of the app being tested.


### PR DESCRIPTION
Fixes #11492 

**Outline of Solution**

Allow separate configuration of frontend and backend url for E2E testing in `test.properties`. All url navigations uses frontend url but logging out uses backend url.
