### PR TITLE
[#11520] Infinite loop when logging in using Google account on a Chromium-based browser

### DIFF
--- a/src/main/java/teammates/ui/servlets/AuthServlet.java
+++ b/src/main/java/teammates/ui/servlets/AuthServlet.java
@@ -50,6 +50,7 @@ abstract class AuthServlet extends HttpServlet {
     String getRedirectUri(HttpServletRequest req) {
         GenericUrl url = new GenericUrl(req.getRequestURL().toString().replaceFirst("^http://", "https://"));
         url.setRawPath("/oauth2callback");
+        url.set("ngsw-bypass", "true");
         return url.build();
     }
 


### PR DESCRIPTION
Fixes #11520 

**Outline of Solution**

Add `ngsw-bypass` to the redirect URI to bypass service worker when callback page is loaded, in light of the change of service worker as suggested by https://github.com/TEAMMATES/teammates/issues/11520#issuecomment-1013286861, 