### PR TITLE
[#11490] Add property to support custom base URL

### DIFF
--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -21,6 +21,9 @@ public final class Config {
     /** The value of the "app.version" in build.properties file. */
     public static final String APP_VERSION;
 
+    /** The value of the "app.production.url" in build.properties file. */
+    public static final String APP_PRODUCTION_URL;
+
     /** The value of the "app.frontenddev.url" in build.properties file. */
     public static final String APP_FRONTENDDEV_URL;
 
@@ -112,6 +115,7 @@ public final class Config {
         APP_ID = properties.getProperty("app.id");
         APP_REGION = properties.getProperty("app.region");
         APP_VERSION = properties.getProperty("app.version");
+        APP_PRODUCTION_URL = properties.getProperty("app.production.url", "");
         APP_FRONTENDDEV_URL = properties.getProperty("app.frontenddev.url");
         APP_LOCALDATASTORE_PORT = Integer.parseInt(properties.getProperty("app.localdatastore.port", "8484"));
         TASKQUEUE_ACTIVE = Boolean.parseBoolean(properties.getProperty("app.taskqueue.active", "true"));
@@ -146,7 +150,8 @@ public final class Config {
     }
 
     static String getBaseAppUrl() {
-        return isDevServer() ? "http://localhost:" + getPort() : "https://" + APP_ID + ".appspot.com";
+        return isDevServer() ? "http://localhost:" + getPort()
+                : (APP_PRODUCTION_URL.isBlank() ? "https://" + APP_ID + ".appspot.com" : APP_PRODUCTION_URL);
     }
 
     /**

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -22,8 +22,10 @@ app.version = 8-0-0
 # This is the base URL for production environment.
 # It should not contain trailing slashes ('/').
 # This is mainly used as the prefix for links sent in outbound emails.
-# If using GAE, the default domain name will be https://{app_id}.appspot.com
-app.production.url = https\://teammates-john.appspot.com
+# When using GAE, the default domain name is https://{app_id}.appspot.com
+# If this property is left empty, this default domain name will be used.
+# e.g. app.production.url = https\://teammates-john.appspot.com
+app.production.url =
 
 # This is the URL for the front-end dev server.
 # This should be used only during development mode where the dev server needs to be whitelisted for CORS.

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -19,8 +19,9 @@ app.region=us-central1
 # e.g. app.version = 8-0-0
 app.version = 8-0-0
 
-# This is the base URL for production environment
-# This will be the URL for both backend and frontend as they are not separately served for production
+# This is the base URL for production environment.
+# It should not contain trailing slashes ('/').
+# This is mainly used as the prefix for links sent in outbound emails.
 # If using GAE, the default domain name will be https://{app_id}.appspot.com
 app.production.url = https\://teammates-john.appspot.com
 

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -19,6 +19,11 @@ app.region=us-central1
 # e.g. app.version = 8-0-0
 app.version = 8-0-0
 
+# This is the base URL for production environment
+# This will be the URL for both backend and frontend as they are not separately served for production
+# If using GAE, the default domain name will be https://{app_id}.appspot.com
+app.production.url = https\://teammates-john.appspot.com
+
 # This is the URL for the front-end dev server.
 # This should be used only during development mode where the dev server needs to be whitelisted for CORS.
 app.frontenddev.url=http\://localhost:4200


### PR DESCRIPTION
Fixes #11490

**PR Checklist**

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Basically added one new properties to server.properties: "app.production.url" which specifies the base url for production environment. It is tested on staging server that emails sent out uses the correct base URL.

Backward compatibility is provided. If using old server.properties, the original `<app_id>.appspot.com` will be used.

I did a check on the test cases and there wasn't a need to update any of them for this change. CORS is also not affected as frontend and backend share the same URL and all requests will be for the same origin. This should be ready for review.