### PR TITLE
[#11539] Feedback response submission: Requests sent to backend despite invalid response

### DIFF
--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -981,6 +981,47 @@ describe('SessionSubmissionPageComponent', () => {
     expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({});
   });
 
+  it('should not save invalid feedback responses', () => {
+    const mockModalRef: any = { componentInstance: {} };
+    const testResponseDetails1: any = deepCopy(testMcqRecipientSubmissionForm.responseDetails);
+    const testResponseDetails2: any = deepCopy(testConstsumRecipientSubmissionForm.responseDetails);
+    const testQuestionSubmissionForm1: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
+    const testQuestionSubmissionForm2: QuestionSubmissionFormModel = deepCopy(testConstsumQuestionSubmissionForm);
+    testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
+    testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
+    // invalid response
+    testQuestionSubmissionForm2.recipientSubmissionForms[0].isValid = false;
+    component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
+
+    const responseSpy: Spy = spyOn(feedbackResponsesService, 'submitFeedbackResponses').and.callFake(() => {
+      return of({ responses: [testResponse1], requestId: '10' });
+    });
+    spyOn(feedbackResponseCommentService, 'createComment').and.returnValue(of({}));
+    spyOn(feedbackResponseCommentService, 'updateComment').and.returnValue(of({}));
+    spyOn(ngbModal, 'open').and.returnValue(mockModalRef);
+
+    component.saveFeedbackResponses();
+
+    expect(responseSpy).toBeCalledTimes(1);
+    expect(responseSpy.calls.first().args[0]).toEqual(testQuestionSubmissionForm1.feedbackQuestionId);
+    expect(responseSpy.calls.first().args[2].responses[0].responseDetails).toEqual(testResponseDetails1);
+
+    // only the valid response is saved
+    expect(mockModalRef.componentInstance.requestIds).toEqual({
+      [testQuestionSubmissionForm1.feedbackQuestionId]: '10',
+    });
+    expect(mockModalRef.componentInstance.questions).toEqual([
+      testQuestionSubmissionForm1,
+      testQuestionSubmissionForm2,
+    ]);
+    expect(mockModalRef.componentInstance.answers).toEqual({
+      [testQuestionSubmissionForm1.feedbackQuestionId]: [testResponse1],
+    });
+    expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({
+      [testQuestionSubmissionForm2.questionNumber]: 'Invalid responses provided. Please check question constraints.',
+    });
+  });
+
   it('should create comment request to create new comment when submission form has no original comment', () => {
     const testSubmissionForm: FeedbackResponseRecipientSubmissionFormModel = deepCopy(testTextRecipientSubmissionForm);
     const commentSpy: Spy = spyOn(feedbackResponseCommentService, 'createComment').and.returnValue(of(testComment));


### PR DESCRIPTION
Fixes #11539 

**Outline of Solution**

Added check that prevents `feedbackResponsesService` from submitting the question feedback response if said response is invalid, as well as testcases for this.
