### PR TITLE
[#11494] Make 'Download proof of submission' button more prominent

### DIFF
--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -35,15 +35,15 @@
     Note that you can change your responses and submit them again any time before the session closes.
   </p>
   <p *ngIf="!hasFailToSaveQuestions">
-    You are encouraged to download the proof of submission, which will also contain your latest responses.
+    You are <b>encouraged to download the proof of submission</b>, which will also contain your latest responses.
   </p>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-info"
           (click)="downloadProofOfSubmission()"
           [disabled]="isAllQuestionSavingFailed">Download proof of submission</button>
-  <button type="button" class="btn modal-btn-ok"
+  <button type="button" class="btn btn-info"
           [ngClass]="
                 {'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions}"
-          (click)="activeModal.close()">OK</button>
+          (click)="activeModal.close()">Don't download proof-of-submission</button>
 </div>

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -40,10 +40,10 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-info"
+            [ngClass]="
+                {'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions}"
+          (click)="activeModal.close()">Don't download proof of submission</button>
+  <button type="button" class="btn btn-info"
           (click)="downloadProofOfSubmission()"
           [disabled]="isAllQuestionSavingFailed">Download proof of submission</button>
-  <button type="button" class="btn btn-info"
-          [ngClass]="
-                {'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions}"
-          (click)="activeModal.close()">Don't download proof-of-submission</button>
 </div>


### PR DESCRIPTION
Fixes #11494 
ready for review
**Outline of Solution**
Changed position of buttons, changed button color, changed text from Ok-> Don't download proof of submission
![image](https://user-images.githubusercontent.com/98576209/151721141-5eea7528-0150-4e36-8c43-34bc6daa005e.png)

