### PR TITLE
[#11235] Instructor audit logs: ensure end date is not before start date

### DIFF
--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -103,7 +103,11 @@ export class InstructorAuditLogsPageComponent implements OnInit {
     this.formModel.logsTimeFrom = { hour: 23, minute: 59 };
     this.formModel.logsTimeTo = { hour: 23, minute: 59 };
     if (this.formModel.logsDateTo <= this.formModel.logsDateFrom) {
-      this.formModel.logsDateFrom = this.formModel.logsDateTo
+      this.formModel.logsDateTo = {
+        year: this.formModel.logsDateFrom.year,
+        month: this.formModel.logsDateFrom.month,
+        day:  this.formModel.logsDateFrom.day,
+      };
     }
     this.loadCourses();
   }

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -102,6 +102,9 @@ export class InstructorAuditLogsPageComponent implements OnInit {
     this.formModel.logsDateTo = { ...this.dateToday };
     this.formModel.logsTimeFrom = { hour: 23, minute: 59 };
     this.formModel.logsTimeTo = { hour: 23, minute: 59 };
+    if (this.formModel.logsDateTo <= this.formModel.logsDateFrom) {
+      this.formModel.logsDateFrom = this.formModel.logsDateTo
+    }
     this.loadCourses();
   }
 


### PR DESCRIPTION
Fixes #11235

If end date is less than start date, then set end date equal to start date, so that end date is never before start date. 