### PR TITLE
[#11540] Make maintainer logs interface scrollable

### DIFF
--- a/src/web/app/components/logs-table/logs-table.component.html
+++ b/src/web/app/components/logs-table/logs-table.component.html
@@ -12,17 +12,19 @@
       <tbody>
         <ng-container *ngFor="let log of logs">
           <tr (click)="expandDetails(log)" [ngClass]="getClassForSeverity(log.logEntry.severity)">
-            <td style="font-family: monospace;">{{ log.timestampForDisplay }}</td>
-            <td>{{ log.logEntry.severity }}</td>
-            <td>
+            <td class="width-20" style="font-family: monospace;">{{ log.timestampForDisplay }}</td>
+            <td class="width-10">{{ log.logEntry.severity }}</td>
+            <td class="width-10">
               <span class="clickable" ngbTooltip="Click to add to filter" (click)="addTraceToFilter(log.logEntry.trace)">{{ log.traceIdForDisplay }}</span>
             </td>
-            <td class="ellipsis">
-              <tm-request-log-line *ngIf="log.logEntry.details && log.logEntry.details.event === LogEvent.REQUEST_LOG" [log]="log.logEntry"
+            <td class="width-60">
+              <div class="ellipsis">
+                <tm-request-log-line *ngIf="log.logEntry.details && log.logEntry.details.event === LogEvent.REQUEST_LOG" [log]="log.logEntry"
                   (addActionClassEvent)="addActionClassToFilter($event)"></tm-request-log-line>
-              <tm-exception-log-line *ngIf="log.logEntry.details && log.logEntry.details.event === LogEvent.EXCEPTION_LOG" [log]="log.logEntry"
+                <tm-exception-log-line *ngIf="log.logEntry.details && log.logEntry.details.event === LogEvent.EXCEPTION_LOG" [log]="log.logEntry"
                   (addExceptionClassEvent)="addExceptionClassToFilter($event)"></tm-exception-log-line>
-              <tm-generic-log-line *ngIf="!log.logEntry.details || log.logEntry.details.event !== LogEvent.REQUEST_LOG && log.logEntry.details.event !== LogEvent.EXCEPTION_LOG" [log]="log.logEntry"></tm-generic-log-line>
+                <tm-generic-log-line *ngIf="!log.logEntry.details || log.logEntry.details.event !== LogEvent.REQUEST_LOG && log.logEntry.details.event !== LogEvent.EXCEPTION_LOG" [log]="log.logEntry"></tm-generic-log-line>
+              </div>
             </td>
           </tr>
           <tr *ngIf="log.isDetailsExpanded">

--- a/src/web/app/components/logs-table/logs-table.component.scss
+++ b/src/web/app/components/logs-table/logs-table.component.scss
@@ -21,7 +21,7 @@
   width: 100%;
   height: 100%;
   word-break: break-all;
-  max-height: 80vh;
+  max-height: 90vh;
 }
 
 .logs-table thead {

--- a/src/web/app/components/logs-table/logs-table.component.scss
+++ b/src/web/app/components/logs-table/logs-table.component.scss
@@ -16,9 +16,36 @@
 }
 
 .logs-table {
-  table-layout: fixed;
+  display: flex;
+  flex-flow: column;
   width: 100%;
+  height: 100%;
   word-break: break-all;
+  max-height: 80vh;
+}
+
+.logs-table thead {
+  flex: 0 0 auto;
+}
+
+.logs-table tbody {
+  flex: 1 1 auto;
+  display: block;
+  overflow-y: scroll;
+}
+
+.logs-table tbody tr {
+  width: 100%;
+}
+
+.logs-table tbody tr:first-child td {
+  border-top: 0;
+}
+
+.logs-table thead,
+.logs-table tbody tr {
+  display: table;
+  table-layout: fixed;
 }
 
 .wrap {


### PR DESCRIPTION
**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Made maintainer logs scrollable.

<img width="1552" alt="Screenshot 2022-01-31 at 1 02 27 PM" src="https://user-images.githubusercontent.com/60355570/151741924-bda119a7-9b98-4c0a-9c6d-90081becb5f6.png">


Even though we are not focused on UX for this (see #11540), best to try it out to see if it is an improvement before approving. Although it does solve the problem, in my opinion nested scrollbars can sometimes lead to a worst UX which may not be desirable here.