### PR TITLE
[#11571] Add selective-deadline-extension to CI workflow

### DIFF
--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master 
       - release
+      - selective-deadline-extension
   pull_request:
     branches:
       - master 
       - release
+      - selective-deadline-extension
   schedule:
     - cron: "0 0 * * *" #end of every day
 jobs:

--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - selective-deadline-extension
   schedule:
     - cron: "0 0 * * *" # end of every day
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master 
       - release
+      - selective-deadline-extension
   pull_request:
     branches:
       - master 
       - release
+      - selective-deadline-extension
   schedule:
     - cron: "0 0 * * *" #end of every day
 jobs:

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master 
       - release
+      - selective-deadline-extension
   schedule:
     - cron: "0 0 * * *" # end of every day
 jobs:


### PR DESCRIPTION
Part of #11571 

This allows CI to run on the `selective-deadline-extension` feature branch.