### PR TITLE
[#11572] Enable workflow for notification feature branch

### DIFF
--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master 
       - release
+      - notification-feature
   pull_request:
     branches:
       - master 
       - release
+      - notification-feature
   schedule:
     - cron: "0 0 * * *" #end of every day
 jobs:

--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release
+      - notification-feature
   schedule:
     - cron: "0 0 * * *" # end of every day
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master 
       - release
+      - notification-feature
   pull_request:
     branches:
       - master 
       - release
+      - notification-feature
   schedule:
     - cron: "0 0 * * *" #end of every day
 jobs:

--- a/.github/workflows/lnp.yml
+++ b/.github/workflows/lnp.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master 
       - release
+      - notification-feature
   schedule:
     - cron: "0 0 * * *" # end of every day
 jobs:


### PR DESCRIPTION
Part of #11572 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

This PR adds the branch information to the GitHub workflow configuration files. This will enable workflow auto tasks to be run upon new PR or push against the notification feature branch.