### PR TITLE
[#9152] Add more SpotBugs rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: "cz.habarta.typescript-generator"
 
 def checkstyleVersion = "8.33"
 def pmdVersion = "6.24.0"
-def spotbugsVersion = "4.0.6"
+def spotbugsVersion = "4.5.3"
 def jacocoVersion = "0.8.5"
 
 buildscript {
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         classpath "com.google.cloud.tools:appengine-gradle-plugin:2.3.0"
-        classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.4.3"
+        classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.6"
         classpath("cz.habarta.typescript-generator:typescript-generator-gradle-plugin:2.24.612") {
             exclude group: "org.gradle"
         }
@@ -57,6 +57,7 @@ dependencies {
     implementation("com.google.guava:guava:30.1.1-jre")
     implementation(objectify)
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2")
+    implementation("com.helger:ph-commons:9.5.1") // necessary to add SpotBugs suppression
     implementation("com.mailjet:mailjet-client:4.5.0")
     implementation("com.sendgrid:sendgrid-java:4.6.0")
     implementation("com.sun.jersey:jersey-client:1.19.4")

--- a/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
+++ b/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
@@ -28,6 +28,9 @@ public final class DataBundleRegenerator {
 
     private static void regenerateDataBundleJson(File folder) throws IOException {
         File[] listOfFiles = folder.listFiles();
+        if (listOfFiles == null) {
+            listOfFiles = new File[] {};
+        }
         for (File file : listOfFiles) {
             if (!file.getName().endsWith(".json") || NON_DATA_BUNDLE_JSON.contains(file.getName())) {
                 continue;
@@ -69,6 +72,9 @@ public final class DataBundleRegenerator {
 
     private static void regenerateWebsiteDataJson() throws IOException {
         File[] listOfFiles = new File("./src/main/webapp/data").listFiles();
+        if (listOfFiles == null) {
+            listOfFiles = new File[] {};
+        }
         for (File file : listOfFiles) {
             if (!file.getName().endsWith(".json")) {
                 continue;

--- a/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationEntitiesBaseScript.java
@@ -19,6 +19,7 @@ import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.Query;
 
 import teammates.client.connector.DatastoreClient;
+import teammates.common.util.Const;
 import teammates.storage.entity.BaseEntity;
 import teammates.test.FileHelper;
 
@@ -266,7 +267,7 @@ public abstract class DataMigrationEntitiesBaseScript<T extends BaseEntity> exte
         Path logPath = Paths.get(BASE_LOG_URI + this.getClass().getSimpleName() + ".log");
         try (OutputStream logFile = Files.newOutputStream(logPath,
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
-            logFile.write((logLine + System.lineSeparator()).getBytes());
+            logFile.write((logLine + System.lineSeparator()).getBytes(Const.ENCODING));
         } catch (Exception e) {
             System.err.println("Error writing log line: " + logLine);
             System.err.println(e.getMessage());

--- a/src/client/java/teammates/client/scripts/statistics/FileStore.java
+++ b/src/client/java/teammates/client/scripts/statistics/FileStore.java
@@ -31,6 +31,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import teammates.common.util.Config;
+import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.test.FileHelper;
 
@@ -138,7 +139,7 @@ public class FileStore {
 
         try (OutputStream os = Files.newOutputStream(Paths.get(fileName))) {
             CipherOutputStream out = new CipherOutputStream(os, cipher);
-            JsonWriter writer = new JsonWriter(new OutputStreamWriter(out));
+            JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, Const.ENCODING));
             getSerializer().toJson(object, typeOfObject, writer);
             writer.close();
             out.close();
@@ -152,7 +153,7 @@ public class FileStore {
 
         try (InputStream is = Files.newInputStream(Paths.get(fileName))) {
             CipherInputStream in = new CipherInputStream(is, cipher);
-            JsonReader reader = new JsonReader(new InputStreamReader(in));
+            JsonReader reader = new JsonReader(new InputStreamReader(in, Const.ENCODING));
             T result = parser.apply(reader);
             reader.close();
             in.close();

--- a/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
@@ -408,10 +408,10 @@ public class AdminSearchPage extends AppPage {
         assertEquals(accountRequest.getEmail(), actualEmail);
         assertEquals(accountRequest.getInstitute(), actualInstitute);
         assertFalse(actualCreatedAt.isBlank());
-        if (actualRegisteredAt == null) {
+        if (accountRequest.getRegisteredAt() == null) {
             assertEquals("Not Registered Yet", actualRegisteredAt);
         } else {
-            assertFalse(actualCreatedAt.isBlank());
+            assertFalse(actualRegisteredAt.isBlank());
         }
     }
 

--- a/src/e2e/java/teammates/e2e/util/GmailServiceMaker.java
+++ b/src/e2e/java/teammates/e2e/util/GmailServiceMaker.java
@@ -24,6 +24,8 @@ import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.GmailScopes;
 
+import teammates.common.util.Const;
+
 /**
  * Class that builds a Gmail service for use in Gmail API.
  */
@@ -87,7 +89,7 @@ final class GmailServiceMaker {
 
     private GoogleClientSecrets loadClientSecretFromJson() throws IOException {
         try (InputStream in = Files.newInputStream(Paths.get(TestProperties.TEST_GMAIL_API_FOLDER, "client_secret.json"))) {
-            return GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
+            return GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in, Const.ENCODING));
         } catch (FileNotFoundException e) {
             throw new RuntimeException("You need to set up your Gmail API credentials." + System.lineSeparator()
                     + "See docs/development.md section \"Deploying to a staging server\".", e);

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -20,6 +20,8 @@ import teammates.common.util.JsonUtils;
 import teammates.test.BaseTestCase;
 import teammates.test.FileHelper;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Checks for test data validity.
  *
@@ -40,6 +42,8 @@ import teammates.test.FileHelper;
 public class TestDataValidityTest extends BaseTestCase {
 
     @Test
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+    // SpotBugs false positive: https://github.com/spotbugs/spotbugs/issues/1694
     public void checkTestDataValidity() throws IOException {
         Map<String, List<String>> errors = new HashMap<>();
         try (Stream<Path> paths = Files.walk(Paths.get(TestProperties.TEST_DATA_FOLDER))) {
@@ -50,6 +54,9 @@ public class TestDataValidityTest extends BaseTestCase {
                     jsonString = FileHelper.readFile(pathString);
                 } catch (IOException e) {
                     errors.put(pathString, Collections.singletonList("Error reading file: " + e.getMessage()));
+                    return;
+                }
+                if (path.getFileName() == null) {
                     return;
                 }
 

--- a/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
+++ b/src/lnp/java/teammates/lnp/cases/BaseLNPTestCase.java
@@ -321,6 +321,9 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
                 .listFiles((d, s) -> {
                     return s.contains(this.getClass().getSimpleName());
                 });
+        if (fileList == null) {
+            fileList = new File[] {};
+        }
         Arrays.sort(fileList, (a, b) -> {
             return b.getName().compareTo(a.getName());
         });

--- a/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
+++ b/src/lnp/java/teammates/lnp/cases/InstructorStudentCascadingUpdateLNPTest.java
@@ -61,8 +61,8 @@ public class InstructorStudentCascadingUpdateLNPTest extends BaseLNPTestCase {
     private static final double MEAN_RESP_TIME_LIMIT = 60;
 
     // To generate multiple csv files for multiple sections
-    private static int csvTestDataIndex;
-    private static LNPTestData testData;
+    private int csvTestDataIndex;
+    private LNPTestData testData;
 
     @Override
     protected LNPTestData getTestData() {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -373,5 +373,21 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             this.claimedOthers = claimedOthers;
             this.perceivedOthers = perceivedOthers;
         }
+
+        public int getClaimed() {
+            return claimed;
+        }
+
+        public int getPerceived() {
+            return perceived;
+        }
+
+        public Map<String, Integer> getClaimedOthers() {
+            return claimedOthers;
+        }
+
+        public int[] getPerceivedOthers() {
+            return perceivedOthers;
+        }
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -157,7 +157,8 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
             }
 
             if (details.getAnswer().stream().anyMatch(choice ->
-                    choice != RUBRIC_ANSWER_NOT_CHOSEN
+                    choice == null
+                            || choice != RUBRIC_ANSWER_NOT_CHOSEN
                             && (choice < 0 || choice >= rubricChoices.size()))) {
                 errors.add(RUBRIC_INVALID_ANSWER);
             }

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -3,6 +3,7 @@ package teammates.common.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -124,8 +125,10 @@ public final class Config {
         OAUTH2_CLIENT_SECRET = properties.getProperty("app.oauth2.client.secret");
         ENABLE_DEVSERVER_LOGIN = Boolean.parseBoolean(properties.getProperty("app.enable.devserver.login", "true"));
         CAPTCHA_SECRET_KEY = properties.getProperty("app.captcha.secretkey");
-        APP_ADMINS = Arrays.asList(properties.getProperty("app.admins", "").split(","));
-        APP_MAINTAINERS = Arrays.asList(properties.getProperty("app.maintainers", "").split(","));
+        APP_ADMINS = Collections.unmodifiableList(
+                Arrays.asList(properties.getProperty("app.admins", "").split(",")));
+        APP_MAINTAINERS = Collections.unmodifiableList(
+                Arrays.asList(properties.getProperty("app.maintainers", "").split(",")));
         SUPPORT_EMAIL = properties.getProperty("app.crashreport.email");
         EMAIL_SENDEREMAIL = properties.getProperty("app.email.senderemail");
         EMAIL_SENDERNAME = properties.getProperty("app.email.sendername");

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1,5 +1,7 @@
 package teammates.common.util;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -27,7 +29,7 @@ public final class Const {
     public static final String UNKNOWN_INSTITUTION = "Unknown Institution";
 
     public static final String DEFAULT_TIME_ZONE = "UTC";
-    public static final String ENCODING = "UTF8";
+    public static final Charset ENCODING = StandardCharsets.UTF_8;
 
     public static final Duration FEEDBACK_SESSIONS_SEARCH_WINDOW = Duration.ofDays(30);
     public static final Duration LOGS_RETENTION_PERIOD = Duration.ofDays(30);

--- a/src/main/java/teammates/common/util/SanitizationHelper.java
+++ b/src/main/java/teammates/common/util/SanitizationHelper.java
@@ -1,6 +1,5 @@
 package teammates.common.util;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 import org.owasp.html.HtmlPolicyBuilder;
@@ -34,7 +33,6 @@ public final class SanitizationHelper {
                 .allowElements("quote", "ecode")
                 .allowStyling()
                 .toFactory();
-    private static final Logger log = Logger.getLogger();
 
     private SanitizationHelper() {
         // utility class
@@ -128,13 +126,7 @@ public final class SanitizationHelper {
      * Converts a string to be put in URL (replaces some characters).
      */
     public static String sanitizeForUri(String uri) {
-        try {
-            return URLEncoder.encode(uri, Const.ENCODING).replaceAll("\\+", "%20");
-        } catch (UnsupportedEncodingException wontHappen) {
-            log.warning("Unexpected UnsupportedEncodingException in "
-                        + "SanitizationHelper.sanitizeForUri(" + uri + ", " + Const.ENCODING + ")");
-            return uri;
-        }
+        return URLEncoder.encode(uri, Const.ENCODING).replaceAll("\\+", "%20");
     }
 
 }

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -89,7 +89,7 @@ public final class StringHelper {
                     new SecretKeySpec(hexStringToByteArray(Config.ENCRYPTION_KEY), "HmacSHA1");
             Mac mac = Mac.getInstance("HmacSHA1");
             mac.init(signingKey);
-            byte[] value = mac.doFinal(data.getBytes());
+            byte[] value = mac.doFinal(data.getBytes(Const.ENCODING));
             return byteArrayToHexString(value);
         } catch (Exception e) {
             assert false;
@@ -123,7 +123,7 @@ public final class StringHelper {
             SecretKeySpec sks = new SecretKeySpec(hexStringToByteArray(Config.ENCRYPTION_KEY), "AES");
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             cipher.init(Cipher.ENCRYPT_MODE, sks, cipher.getParameters());
-            byte[] encrypted = cipher.doFinal(value.getBytes());
+            byte[] encrypted = cipher.doFinal(value.getBytes(Const.ENCODING));
             return byteArrayToHexString(encrypted);
         } catch (Exception e) {
             assert false;
@@ -145,7 +145,7 @@ public final class StringHelper {
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             cipher.init(Cipher.DECRYPT_MODE, sks);
             byte[] decrypted = cipher.doFinal(hexStringToByteArray(message));
-            return new String(decrypted);
+            return new String(decrypted, Const.ENCODING);
         } catch (NumberFormatException | IllegalBlockSizeException | BadPaddingException e) {
             log.warning("Attempted to decrypt invalid ciphertext: " + message);
             throw new InvalidParametersException(e);

--- a/src/main/java/teammates/logic/core/GoogleCloudTasksService.java
+++ b/src/main/java/teammates/logic/core/GoogleCloudTasksService.java
@@ -1,7 +1,6 @@
 package teammates.logic.core;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.time.Instant;
 
 import com.google.cloud.tasks.v2.AppEngineHttpRequest;
@@ -49,7 +48,7 @@ public class GoogleCloudTasksService implements TaskQueueService {
                 String requestBody = JsonUtils.toCompactJson(task.getRequestBody());
                 requestBuilder.putHeaders("Content-Type", "application/json; charset=UTF-8")
                         .setRelativeUri(task.getWorkerUrl())
-                        .setBody(ByteString.copyFrom(requestBody, Charset.forName(Const.ENCODING)));
+                        .setBody(ByteString.copyFrom(requestBody, Const.ENCODING));
             }
 
             Task.Builder taskBuilder = Task.newBuilder().setAppEngineHttpRequest(requestBuilder.build());

--- a/src/main/java/teammates/logic/core/LocalTaskQueueService.java
+++ b/src/main/java/teammates/logic/core/LocalTaskQueueService.java
@@ -3,7 +3,6 @@ package teammates.logic.core;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ public class LocalTaskQueueService implements TaskQueueService {
 
         if (task.getRequestBody() != null) {
             StringEntity entity = new StringEntity(
-                    JsonUtils.toCompactJson(task.getRequestBody()), Charset.forName(Const.ENCODING));
+                    JsonUtils.toCompactJson(task.getRequestBody()), Const.ENCODING);
             post.setEntity(entity);
         }
 

--- a/src/main/java/teammates/ui/servlets/DevServerLoginServlet.java
+++ b/src/main/java/teammates/ui/servlets/DevServerLoginServlet.java
@@ -26,6 +26,8 @@ public class DevServerLoginServlet extends AuthServlet {
         if (nextUrl == null) {
             nextUrl = "/";
         }
+        // Prevent HTTP response splitting
+        nextUrl = resp.encodeRedirectURL(nextUrl.replace("\r\n", ""));
         if (!Config.isDevServerLoginEnabled()) {
             resp.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
             resp.setHeader("Location", Const.WebPageURIs.LOGIN + "?nextUrl=" + nextUrl.replace("&", "%26"));
@@ -66,6 +68,8 @@ public class DevServerLoginServlet extends AuthServlet {
         if (nextUrl == null) {
             nextUrl = "/";
         }
+        // Prevent HTTP response splitting
+        nextUrl = resp.encodeRedirectURL(nextUrl.replace("\r\n", ""));
         resp.sendRedirect(nextUrl);
     }
 

--- a/src/main/java/teammates/ui/servlets/LoginServlet.java
+++ b/src/main/java/teammates/ui/servlets/LoginServlet.java
@@ -30,6 +30,8 @@ public class LoginServlet extends AuthServlet {
         if (nextUrl == null) {
             nextUrl = "/";
         }
+        // Prevent HTTP response splitting
+        nextUrl = resp.encodeRedirectURL(nextUrl.replace("\r\n", ""));
         if (Config.isDevServerLoginEnabled()) {
             resp.setStatus(HttpStatus.SC_MOVED_PERMANENTLY);
             resp.setHeader("Location", "/devServerLogin?nextUrl=" + nextUrl.replace("&", "%26"));

--- a/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
+++ b/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
@@ -80,8 +80,8 @@ public class OAuth2CallbackServlet extends AuthServlet {
 
             Map<String, Object> parsedResponse =
                     JsonUtils.fromJson(userInfoResponse, new TypeToken<Map<String, Object>>(){}.getType());
-            String email = String.valueOf(parsedResponse.get("email"));
-            if (email != null) {
+            if (parsedResponse.containsKey("email")) {
+                String email = String.valueOf(parsedResponse.get("email"));
                 googleId = email.replaceFirst("@gmail\\.com$", "");
             }
         } catch (URISyntaxException | IOException | JsonSyntaxException e) {

--- a/src/main/java/teammates/ui/webapi/DatastoreBackupAction.java
+++ b/src/main/java/teammates/ui/webapi/DatastoreBackupAction.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,12 +63,13 @@ class DatastoreBackupAction extends AdminOnlyAction {
         // Documentation is wrong; the param name is output_url_prefix instead of outputUrlPrefix
         body.put("output_url_prefix", "gs://" + Config.BACKUP_GCS_BUCKETNAME + "/datastore-backups/" + timestamp);
 
-        StringEntity entity = new StringEntity(JsonUtils.toCompactJson(body), Charset.forName(Const.ENCODING));
+        StringEntity entity = new StringEntity(JsonUtils.toCompactJson(body), Const.ENCODING);
         post.setEntity(entity);
 
         try (CloseableHttpClient client = HttpClients.createDefault();
                 CloseableHttpResponse resp = client.execute(post);
-                BufferedReader br = new BufferedReader(new InputStreamReader(resp.getEntity().getContent()))) {
+                BufferedReader br = new BufferedReader(
+                        new InputStreamReader(resp.getEntity().getContent(), Const.ENCODING))) {
             String output = br.lines().collect(Collectors.joining(System.lineSeparator()));
             if (resp.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                 log.info("Backup request successful:" + System.lineSeparator() + output);

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -61,8 +61,10 @@ class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
         case INSTRUCTOR_RESULT:
             gateKeeper.verifyLoggedInUserPrivileges(userInfo);
             InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
-
-            if (instructor != null && frc.getCommentGiver().equals(instructor.getEmail())) { // giver, allowed by default
+            if (instructor == null) {
+                throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
+            }
+            if (frc.getCommentGiver().equals(instructor.getEmail())) { // giver, allowed by default
                 return;
             }
 

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -62,7 +62,7 @@ class GetAuthInfoAction extends Action {
 
         String csrfToken = StringHelper.encrypt(req.getSession().getId());
         String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
-        if (csrfToken != null && csrfToken.equals(existingCsrfToken)) {
+        if (csrfToken.equals(existingCsrfToken)) {
             return new JsonResult(output);
         }
         Cookie csrfTokenCookie = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, csrfToken);

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -48,10 +48,6 @@ class GetHasResponsesAction extends Action {
             }
 
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-            if (courseId == null) {
-                return;
-            }
-
             gateKeeper.verifyAccessible(
                     logic.getInstructorForGoogleId(courseId, userInfo.getId()),
                     logic.getCourse(courseId));

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -81,7 +81,10 @@ class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
         case INSTRUCTOR_RESULT:
             gateKeeper.verifyLoggedInUserPrivileges(userInfo);
             InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
-            if (instructor != null && frc.getCommentGiver().equals(instructor.getEmail())) { // giver, allowed by default
+            if (instructor == null) {
+                throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
+            }
+            if (frc.getCommentGiver().equals(instructor.getEmail())) { // giver, allowed by default
                 return;
             }
             gateKeeper.verifyAccessible(instructor, session, response.getGiverSection(),

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackQuestionDetailsTest.java
@@ -13,14 +13,12 @@ public class FeedbackQuestionDetailsTest extends BaseTestCase {
     public void testEquals() {
 
         ______TS("Same object with different references, should be same");
-        FeedbackQuestionDetails ftqd1 = new FeedbackTextQuestionDetails("text question");
+        FeedbackTextQuestionDetails ftqd1 = new FeedbackTextQuestionDetails("text question");
         FeedbackQuestionDetails ftqd2 = ftqd1;
         assertEquals(ftqd1, ftqd2);
 
         ______TS("One input is null, should be different");
-        ftqd1 = new FeedbackTextQuestionDetails("text question");
-        ftqd2 = null;
-        assertNotEquals(ftqd1, ftqd2);
+        assertNotEquals(ftqd1, null);
 
         ______TS("Different classes, should be different");
         ftqd1 = new FeedbackTextQuestionDetails("text question");
@@ -33,7 +31,7 @@ public class FeedbackQuestionDetailsTest extends BaseTestCase {
         assertNotEquals(ftqd1, ftqd2);
 
         ftqd2 = new FeedbackTextQuestionDetails("first question");
-        ((FeedbackTextQuestionDetails) ftqd1).setRecommendedLength(50);
+        ftqd1.setRecommendedLength(50);
         assertNotEquals(ftqd1, ftqd2);
 
         ______TS("All attributes are same, should be same");

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetailsTest.java
@@ -100,6 +100,9 @@ public class FeedbackRubricQuestionDetailsTest extends BaseTestCase {
 
         responseDetails.setAnswer(Arrays.asList(0, 1, 0));
         assertFalse(rubricQuestionDetails.validateResponsesDetails(Collections.singletonList(responseDetails), 0).isEmpty());
+
+        responseDetails.setAnswer(Arrays.asList(0, null, 0));
+        assertFalse(rubricQuestionDetails.validateResponsesDetails(Collections.singletonList(responseDetails), 0).isEmpty());
     }
 
     @Test

--- a/src/test/java/teammates/common/util/StringHelperTest.java
+++ b/src/test/java/teammates/common/util/StringHelperTest.java
@@ -107,7 +107,7 @@ public class StringHelperTest extends BaseTestCase {
         SecretKeySpec sks = new SecretKeySpec(StringHelper.hexStringToByteArray(Config.ENCRYPTION_KEY), "AES");
         Cipher cipher = Cipher.getInstance("AES");
         cipher.init(Cipher.ENCRYPT_MODE, sks, cipher.getParameters());
-        byte[] encrypted = cipher.doFinal(plaintext.getBytes());
+        byte[] encrypted = cipher.doFinal(plaintext.getBytes(Const.ENCODING));
         return StringHelper.byteArrayToHexString(encrypted);
     }
 
@@ -116,7 +116,7 @@ public class StringHelperTest extends BaseTestCase {
                 new SecretKeySpec(StringHelper.hexStringToByteArray(Config.ENCRYPTION_KEY), "HmacSHA1");
         Mac mac = Mac.getInstance("HmacSHA1");
         mac.init(signingKey);
-        byte[] value = mac.doFinal(data.getBytes());
+        byte[] value = mac.doFinal(data.getBytes(Const.ENCODING));
         return StringHelper.byteArrayToHexString(value);
     }
 

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -156,7 +155,8 @@ public abstract class AbstractBackDoor {
             String responseBody = null;
             HttpEntity entity = response.getEntity();
             if (entity != null) {
-                try (BufferedReader br = new BufferedReader(new InputStreamReader(entity.getContent()))) {
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(entity.getContent(), Const.ENCODING))) {
                     responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
                 }
             }
@@ -180,7 +180,7 @@ public abstract class AbstractBackDoor {
         HttpPost post = new HttpPost(createBasicUri(url, params));
 
         if (body != null) {
-            StringEntity entity = new StringEntity(body, Charset.forName(Const.ENCODING));
+            StringEntity entity = new StringEntity(body, Const.ENCODING);
             post.setEntity(entity);
         }
 
@@ -191,7 +191,7 @@ public abstract class AbstractBackDoor {
         HttpPut put = new HttpPut(createBasicUri(url, params));
 
         if (body != null) {
-            StringEntity entity = new StringEntity(body, Charset.forName(Const.ENCODING));
+            StringEntity entity = new StringEntity(body, Const.ENCODING);
             put.setEntity(entity);
         }
 

--- a/src/test/java/teammates/test/MockHttpServletRequest.java
+++ b/src/test/java/teammates/test/MockHttpServletRequest.java
@@ -28,6 +28,8 @@ import javax.servlet.http.HttpSessionContext;
 import javax.servlet.http.HttpUpgradeHandler;
 import javax.servlet.http.Part;
 
+import teammates.common.util.Const;
+
 /**
  * Mocks {@link HttpServletRequest} for testing purpose.
  *
@@ -420,8 +422,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public BufferedReader getReader() {
-        byte[] bytes = this.body == null ? new byte[] {} : this.body.getBytes();
-        return new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
+        byte[] bytes = this.body == null ? new byte[] {} : this.body.getBytes(Const.ENCODING);
+        return new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes), Const.ENCODING));
     }
 
     public void setBody(String body) {

--- a/src/test/java/teammates/test/MockHttpServletResponse.java
+++ b/src/test/java/teammates/test/MockHttpServletResponse.java
@@ -12,6 +12,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Mocks {@link HttpServletResponse} for testing purpose.
  *
@@ -148,6 +150,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
     }
 
     @Override
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public PrintWriter getWriter() {
         return new PrintWriter(System.out);
     }

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -4,10 +4,43 @@
         <Bug pattern="BC_VACUOUS_INSTANCEOF" />
     </Match>
     <Match>
+        <Bug pattern="CD_CIRCULAR_DEPENDENCY" />
+    </Match>
+    <Match>
+        <Bug pattern="CI_CONFUSED_INHERITANCE" />
+    </Match>
+    <Match>
+        <Bug pattern="CO_ABSTRACT_SELF" />
+    </Match>
+    <Match>
+        <Bug pattern="CO_COMPARETO_INCORRECT_FLOATING" />
+    </Match>
+    <Match>
+        <Bug pattern="CO_COMPARETO_RESULTS_MIN_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="CO_SELF_NO_OBJECT" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_DEAD_LOCAL_INCREMENT_IN_RETURN" />
+    </Match>
+    <Match>
         <Bug pattern="DLS_DEAD_LOCAL_STORE" />
     </Match>
     <Match>
         <Bug pattern="DLS_DEAD_LOCAL_STORE_IN_RETURN" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_DEAD_LOCAL_STORE_OF_NULL" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_DEAD_LOCAL_STORE_SHADOWS_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_DEAD_STORE_OF_CLASS_LITERAL" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_OVERWRITTEN_INCREMENT" />
     </Match>
     <Match>
         <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING" />
@@ -22,6 +55,9 @@
         <Bug pattern="EC_UNRELATED_TYPES" />
     </Match>
     <Match>
+        <Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ" />
+    </Match>
+    <Match>
         <Bug pattern="ES_COMPARING_STRINGS_WITH_EQ" />
     </Match>
     <Match>
@@ -31,16 +67,52 @@
         <Bug pattern="HRS_REQUEST_PARAMETER_TO_HTTP_HEADER" />
     </Match>
     <Match>
+        <Bug pattern="IC_INIT_CIRCULARITY" />
+    </Match>
+    <Match>
+        <Bug pattern="IC_SUPERCLASS_USES_SUBCLASS_DURING_INITIALIZATION" />
+    </Match>
+    <Match>
+        <Bug pattern="IL_CONTAINER_ADDED_TO_ITSELF" />
+    </Match>
+    <Match>
+        <Bug pattern="IL_INFINITE_LOOP" />
+    </Match>
+    <Match>
+        <Bug pattern="IL_INFINITE_RECURSIVE_LOOP" />
+    </Match>
+    <Match>
+        <Bug pattern="ISC_INSTANTIATE_STATIC_CLASS" />
+    </Match>
+    <Match>
+        <Bug pattern="ITA_INEFFICIENT_TO_ARRAY" />
+    </Match>
+    <Match>
         <Bug pattern="LI_LAZY_INIT_STATIC" />
     </Match>
     <Match>
         <Bug pattern="LI_LAZY_INIT_UPDATE_STATIC" />
     </Match>
     <Match>
+        <Bug pattern="ME_ENUM_FIELD_SETTER" />
+    </Match>
+    <Match>
+        <Bug pattern="ME_MUTABLE_ENUM_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="MS_MUTABLE_ARRAY" />
+    </Match>
+    <Match>
         <Bug pattern="MS_MUTABLE_COLLECTION" />
     </Match>
     <Match>
+        <Bug pattern="MS_MUTABLE_HASHTABLE" />
+    </Match>
+    <Match>
         <Bug pattern="MS_SHOULD_BE_FINAL" />
+    </Match>
+    <Match>
+        <Bug pattern="MS_SHOULD_BE_REFACTORED_TO_BE_FINAL" />
     </Match>
     <Match>
         <Bug pattern="NP_ALWAYS_NULL" />
@@ -73,6 +145,27 @@
         <Bug pattern="NP_STORE_INTO_NONNULL_FIELD" />
     </Match>
     <Match>
+        <Bug pattern="PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS" />
+    </Match>
+    <Match>
+        <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+    </Match>
+    <Match>
+        <Bug pattern="QBA_QUESTIONABLE_BOOLEAN_ASSIGNMENT" />
+    </Match>
+    <Match>
+        <Bug pattern="QF_QUESTIONABLE_FOR_LOOP" />
+    </Match>
+    <Match>
+        <Bug pattern="RANGE_ARRAY_INDEX" />
+    </Match>
+    <Match>
+        <Bug pattern="RANGE_ARRAY_LENGTH" />
+    </Match>
+    <Match>
+        <Bug pattern="RANGE_ARRAY_OFFSET" />
+    </Match>
+    <Match>
         <Bug pattern="RANGE_STRING_INDEX" />
     </Match>
     <Match>
@@ -91,13 +184,55 @@
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
     </Match>
     <Match>
+        <Bug pattern="RI_REDUNDANT_INTERFACES" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH_TO_THROW" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_SWITCH_FALLTHROUGH" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+    </Match>
+    <Match>
+        <Bug pattern="SI_INSTANCE_BEFORE_FINALS_ASSIGNED" />
+    </Match>
+    <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
+    </Match>
+    <Match>
+        <Bug pattern="SIO_SUPERFLUOUS_INSTANCEOF" />
+    </Match>
+    <Match>
+        <Bug pattern="SS_SHOULD_BE_STATIC" />
     </Match>
     <Match>
         <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
     </Match>
     <Match>
+        <Bug pattern="UC_USELESS_CONDITION" />
+    </Match>
+    <Match>
+        <Bug pattern="UC_USELESS_CONDITION_TYPE" />
+    </Match>
+    <Match>
         <Bug pattern="UC_USELESS_OBJECT" />
+    </Match>
+    <Match>
+        <Bug pattern="UC_USELESS_OBJECT_STACK" />
+    </Match>
+    <Match>
+        <Bug pattern="UC_USELESS_VOID_METHOD" />
+    </Match>
+    <Match>
+        <Bug pattern="UCF_USELESS_CONTROL_FLOW" />
+    </Match>
+    <Match>
+        <Bug pattern="UCF_USELESS_CONTROL_FLOW_NEXT_LINE" />
     </Match>
     <Match>
         <Bug pattern="URF_UNREAD_FIELD" />
@@ -107,6 +242,9 @@
     </Match>
     <Match>
         <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
+    </Match>
+    <Match>
+        <Bug pattern="VA_PRIMITIVE_ARRAY_PASSED_TO_OBJECT_VARARG" />
     </Match>
     <Match>
         <Bug pattern="WMI_WRONG_MAP_ITERATOR" />

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -25,6 +25,12 @@
         <Bug pattern="ES_COMPARING_STRINGS_WITH_EQ" />
     </Match>
     <Match>
+        <Bug pattern="HRS_REQUEST_PARAMETER_TO_COOKIE" />
+    </Match>
+    <Match>
+        <Bug pattern="HRS_REQUEST_PARAMETER_TO_HTTP_HEADER" />
+    </Match>
+    <Match>
         <Bug pattern="LI_LAZY_INIT_STATIC" />
     </Match>
     <Match>

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -25,6 +25,9 @@
         <Bug pattern="ES_COMPARING_STRINGS_WITH_EQ" />
     </Match>
     <Match>
+        <Bug pattern="MS_MUTABLE_COLLECTION" />
+    </Match>
+    <Match>
         <Bug pattern="MS_SHOULD_BE_FINAL" />
     </Match>
     <Match>

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -49,6 +49,12 @@
         <Bug pattern="UC_USELESS_OBJECT" />
     </Match>
     <Match>
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+    </Match>
+    <Match>
         <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
     </Match>
     <Match>

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -43,7 +43,52 @@
         <Bug pattern="MS_SHOULD_BE_FINAL" />
     </Match>
     <Match>
+        <Bug pattern="NP_ALWAYS_NULL" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_ARGUMENT_MIGHT_BE_NULL" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_GUARANTEED_DEREF" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_INSTANCEOF" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_ON_SOME_PATH" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_PARAM_DEREF" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_OPTIONAL_RETURN_NULL" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_STORE_INTO_NONNULL_FIELD" />
+    </Match>
+    <Match>
         <Bug pattern="RANGE_STRING_INDEX" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_COMPARISON_OF_NULL_AND_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_COMPARISON_TWO_NULL_VALUES" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
     </Match>
     <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -13,6 +13,9 @@
         <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING" />
     </Match>
     <Match>
+        <Bug pattern="DM_DEFAULT_ENCODING" />
+    </Match>
+    <Match>
         <Bug pattern="DM_STRING_TOSTRING" />
     </Match>
     <Match>

--- a/static-analysis/teammates-spotbugs.xml
+++ b/static-analysis/teammates-spotbugs.xml
@@ -25,6 +25,12 @@
         <Bug pattern="ES_COMPARING_STRINGS_WITH_EQ" />
     </Match>
     <Match>
+        <Bug pattern="LI_LAZY_INIT_STATIC" />
+    </Match>
+    <Match>
+        <Bug pattern="LI_LAZY_INIT_UPDATE_STATIC" />
+    </Match>
+    <Match>
         <Bug pattern="MS_MUTABLE_COLLECTION" />
     </Match>
     <Match>
@@ -35,6 +41,9 @@
     </Match>
     <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
+    </Match>
+    <Match>
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
     </Match>
     <Match>
         <Bug pattern="UC_USELESS_OBJECT" />


### PR DESCRIPTION
Fixes #9152 

Admittedly, adding SpotBugs rules is harder than adding the rules to any of the previous lint tools as (1) many of its rules are situational, (2) lack of feature to add rules by groups, and (3) the way the rules work are not really visible to us because there are no existing violations. This is so far my best attempt to add some sensible rules.

- The first thing I did was running SpotBugs with ALL rules active, and checking and fixing high priority warnings. There are just few of them and they come from `DM_DEFAULT_ENCODING` and `MS_MUTABLE_COLLECTION` rules, both of which are sensible.
- The medium priority warnings are more debatable. The ones that I think are sensible to fix and add to rulesets: `LI` (lazy init), `ST` (static fields), `URF` (unread fields), `HRS` (HTTP response splitting; this is also a security check), `NP` (null pointer), `RCN` (redundant check for null)
- Everything past that is really experimental, as they are as previously described in points (1) and (3).
