### PR TITLE
[#11578] Make user cookie time sensitive

### DIFF
--- a/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
@@ -60,8 +60,8 @@ public class UserInfoCookie {
         return expiryTime;
     }
 
-    public void setExpiryTime(Instant expiryTime) {
-        this.expiryTime = expiryTime.toEpochMilli();
+    public void setExpiryTime(long expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
@@ -1,5 +1,8 @@
 package teammates.common.datatransfer;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import com.google.gson.JsonSyntaxException;
 
 import teammates.common.exception.InvalidParametersException;
@@ -14,9 +17,12 @@ public class UserInfoCookie {
     private String userId;
     private String verificationCode;
 
+    private Instant expiryTime;
+
     public UserInfoCookie(String userId) {
         this.userId = userId;
         this.verificationCode = StringHelper.generateSignature(userId);
+        this.expiryTime = Instant.now().plus(7, ChronoUnit.DAYS);
     }
 
     /**
@@ -50,11 +56,19 @@ public class UserInfoCookie {
         this.verificationCode = verificationCode;
     }
 
+    public Instant getExpiryTime() {
+        return expiryTime;
+    }
+
+    public void setExpiryTime(Instant expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+
     /**
      * Returns true if the object represents a valid user info.
      */
     public boolean isValid() {
-        return StringHelper.isCorrectSignature(userId, verificationCode);
+        return StringHelper.isCorrectSignature(userId, verificationCode) && Instant.now().isBefore(expiryTime);
     }
 
 }

--- a/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfoCookie.java
@@ -1,11 +1,11 @@
 package teammates.common.datatransfer;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import com.google.gson.JsonSyntaxException;
 
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.StringHelper;
 
@@ -17,12 +17,12 @@ public class UserInfoCookie {
     private String userId;
     private String verificationCode;
 
-    private Instant expiryTime;
+    private long expiryTime;
 
     public UserInfoCookie(String userId) {
         this.userId = userId;
         this.verificationCode = StringHelper.generateSignature(userId);
-        this.expiryTime = Instant.now().plus(7, ChronoUnit.DAYS);
+        this.expiryTime = Instant.now().plus(Const.COOKIE_VALIDITY_PERIOD).toEpochMilli();
     }
 
     /**
@@ -56,19 +56,20 @@ public class UserInfoCookie {
         this.verificationCode = verificationCode;
     }
 
-    public Instant getExpiryTime() {
+    public long getExpiryTime() {
         return expiryTime;
     }
 
     public void setExpiryTime(Instant expiryTime) {
-        this.expiryTime = expiryTime;
+        this.expiryTime = expiryTime.toEpochMilli();
     }
 
     /**
-     * Returns true if the object represents a valid user info.
+     * Returns true if the object represents a valid user info and the object has not expired.
      */
     public boolean isValid() {
-        return StringHelper.isCorrectSignature(userId, verificationCode) && Instant.now().isBefore(expiryTime);
+        return StringHelper.isCorrectSignature(userId, verificationCode)
+            && Instant.now().isBefore(Instant.ofEpochMilli(expiryTime));
     }
 
 }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -31,6 +31,7 @@ public final class Const {
 
     public static final Duration FEEDBACK_SESSIONS_SEARCH_WINDOW = Duration.ofDays(30);
     public static final Duration LOGS_RETENTION_PERIOD = Duration.ofDays(30);
+    public static final Duration COOKIE_VALIDITY_PERIOD = Duration.ofDays(7);
 
     public static final int SEARCH_QUERY_SIZE_LIMIT = 50;
 

--- a/src/main/java/teammates/ui/servlets/AuthServlet.java
+++ b/src/main/java/teammates/ui/servlets/AuthServlet.java
@@ -69,7 +69,7 @@ abstract class AuthServlet extends HttpServlet {
         cookie.setPath("/");
         cookie.setSecure(!Config.isDevServer());
         cookie.setHttpOnly(true);
-        cookie.setMaxAge(7 * 24 * 60 * 60); // one week
+        cookie.setMaxAge((int) Const.COOKIE_VALIDITY_PERIOD.toSeconds()); // one week
         return cookie;
     }
 

--- a/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
+++ b/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
@@ -22,5 +22,10 @@ public class UserInfoCookieTest extends BaseTestCase {
         ______TS("Cookie expired");
         uc.setExpiryTime(Instant.now().minus(1, ChronoUnit.DAYS));
         assertFalse(uc.isValid());
+
+        ______TS("Invalid Signature");
+        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS));
+        uc.setVerificationCode("WrongCode");
+        assertFalse(uc.isValid());
     }
 }

--- a/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
+++ b/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
@@ -1,0 +1,26 @@
+package teammates.common.datatransfer;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.testng.annotations.Test;
+
+import teammates.test.BaseTestCase;
+
+/**
+ * SUT: {@link UserInfoCookie}.
+ */
+public class UserInfoCookieTest extends BaseTestCase {
+    private UserInfoCookie uc = new UserInfoCookie("MockId");
+
+    @Test
+    public void testIsValid() {
+        ______TS("Cookie not expired");
+        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS));
+        assertTrue(uc.isValid());
+
+        ______TS("Cookie expired");
+        uc.setExpiryTime(Instant.now().minus(1, ChronoUnit.DAYS));
+        assertFalse(uc.isValid());
+    }
+}

--- a/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
+++ b/src/test/java/teammates/common/datatransfer/UserInfoCookieTest.java
@@ -16,15 +16,15 @@ public class UserInfoCookieTest extends BaseTestCase {
     @Test
     public void testIsValid() {
         ______TS("Cookie not expired");
-        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS));
+        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli());
         assertTrue(uc.isValid());
 
         ______TS("Cookie expired");
-        uc.setExpiryTime(Instant.now().minus(1, ChronoUnit.DAYS));
+        uc.setExpiryTime(Instant.now().minus(1, ChronoUnit.DAYS).toEpochMilli());
         assertFalse(uc.isValid());
 
         ______TS("Invalid Signature");
-        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS));
+        uc.setExpiryTime(Instant.now().plus(1, ChronoUnit.DAYS).toEpochMilli());
         uc.setVerificationCode("WrongCode");
         assertFalse(uc.isValid());
     }


### PR DESCRIPTION
Fixes #11578 

**Outline of Solution**

Added expiration time to UserInfoCookie, 7 days from when cookie is created, invalidates cookie if after this time.
