### PR TITLE
[#11592] Wrong argument order in populateFieldsToGenerateInQuestion causes NPE

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -623,7 +623,7 @@ public final class FeedbackQuestionsLogic {
             if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
                 String courseId = feedbackQuestionAttributes.getCourseId();
                 StudentAttributes studentAttributes =
-                        studentsLogic.getStudentForEmail(emailOfEntityDoingQuestion, courseId);
+                        studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
                 studentList = studentsLogic.getStudentsForSection(studentAttributes.getSection(), courseId);
             } else {
                 studentList = studentsLogic.getStudentsForCourse(feedbackQuestionAttributes.getCourseId());
@@ -647,7 +647,7 @@ public final class FeedbackQuestionsLogic {
                 if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
                     String courseId = feedbackQuestionAttributes.getCourseId();
                     StudentAttributes studentAttributes =
-                            studentsLogic.getStudentForEmail(emailOfEntityDoingQuestion, courseId);
+                            studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
                     teams = coursesLogic.getTeamsForSection(studentAttributes.getSection(), courseId);
                 } else {
                     teams = coursesLogic.getTeamsForCourse(feedbackQuestionAttributes.getCourseId());

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -714,6 +714,19 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalInstructor.getEmail(), null);
         assertEquals(expected, ((FeedbackMcqQuestionDetails) fqa.getQuestionDetailsCopy()).getMcqChoices());
 
+        // STUDENTS_IN_SAME_SECTION
+        expected = Arrays.asList("student1 In Course1</td></div>'\" (Team 1.1</td></div>'\")",
+                        "student2 In Course1 (Team 1.1</td></div>'\")",
+                        "student3 In Course1 (Team 1.1</td></div>'\")",
+                        "student4 In Course1 (Team 1.1</td></div>'\")");
+
+        feedbackMcqQuestionDetails.setMcqChoices(new ArrayList<>());
+        feedbackMcqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.STUDENTS_IN_SAME_SECTION);
+        fqa.setQuestionDetails(feedbackMcqQuestionDetails);
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam());
+        assertEquals(expected, ((FeedbackMcqQuestionDetails) fqa.getQuestionDetailsCopy()).getMcqChoices());
+
         // STUDENTS_EXCLUDING_SELF
         feedbackMcqQuestionDetails.setMcqChoices(new ArrayList<>());
         feedbackMcqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.STUDENTS_EXCLUDING_SELF);
@@ -790,6 +803,16 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         fqa.setQuestionDetails(feedbackMcqQuestionDetails);
 
         fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalInstructor.getEmail(), null);
+        assertEquals(expected, ((FeedbackMcqQuestionDetails) fqa.getQuestionDetailsCopy()).getMcqChoices());
+
+        // TEAMS_IN_SAME_SECTION
+        expected = Arrays.asList("Team 1.1</td></div>'\"");
+
+        feedbackMcqQuestionDetails.setMcqChoices(new ArrayList<>());
+        feedbackMcqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.TEAMS_IN_SAME_SECTION);
+        fqa.setQuestionDetails(feedbackMcqQuestionDetails);
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam());
         assertEquals(expected, ((FeedbackMcqQuestionDetails) fqa.getQuestionDetailsCopy()).getMcqChoices());
 
         // TEAMS_EXCLUDING_SELF


### PR DESCRIPTION
Fixes #11592

**Outline of Solution**
Arguments in populateFieldsToGenerateInQuestion are now in the correct order

Also included two new tests in FeedbackQuestionsLogicTest to ensure the code runs and does not produce any NullPointerExceptions.
