### PR TITLE
[#10843] Instructor viewing results: incorrect state shown briefly when expanding the non-submitters panel 

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -9,46 +9,48 @@
   </div>
 </div>
 <div *ngIf="isTabExpanded" @collapseAnim>
-  <div class="card-body p-0">
-    <div *ngIf="noResponseStudentsInSection.length">
-      <table id="no-response-table" class="table table-striped">
-        <thead>
-        <tr>
-          <th class="cursor-pointer" (click)="sortParticipantsBy(SortBy.TEAM_NAME)">
-            Team
-            <span class="fa-stack"><i class="fas fa-sort"></i>
-              <i *ngIf="sortBy === SortBy.TEAM_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-              <i *ngIf="sortBy === SortBy.TEAM_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-            </span>
-          </th>
-          <th id="sort-by-name" class="cursor-pointer" (click)="sortParticipantsBy(SortBy.RESPONDENT_NAME)">
-            Name
-            <span class="fa-stack"><i class="fas fa-sort"></i>
-              <i *ngIf="sortBy === SortBy.RESPONDENT_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-              <i *ngIf="sortBy === SortBy.RESPONDENT_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-            </span>
-          </th>
-          <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr *ngFor="let noResponseStudent of noResponseStudentsInSection">
-          <td>{{ noResponseStudent.teamName }}</td>
-          <td>{{ noResponseStudent.name }}</td>
-          <td>
-            <a *ngIf="!isDisplayOnly; else displayOnlySubmitResponseButton" tmRouterLink="/web/sessions/submission" rel="noopener noreferrer" target="_blank"
-               [queryParams]="{courseid: session.courseId, fsname: session.feedbackSessionName, moderatedperson: noResponseStudent.email}"
-               class="btn btn-light btn-sm button">
-              Submit responses
-            </a>
-            <ng-template #displayOnlySubmitResponseButton><a class="btn btn-light btn-sm button">Submit response</a></ng-template>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
-    <div *ngIf="!noResponseStudentsInSection.length">
-      <i>All students have responded to some questions in this session.</i>
+  <div *tmIsLoading="!isNoStudentsLoaded" class="card-body">
+    <div class="card-body p-0">
+      <div *ngIf="noResponseStudentsInSection.length">
+        <table id="no-response-table" class="table table-striped">
+          <thead>
+          <tr>
+            <th class="cursor-pointer" (click)="sortParticipantsBy(SortBy.TEAM_NAME)">
+              Team
+              <span class="fa-stack"><i class="fas fa-sort"></i>
+                <i *ngIf="sortBy === SortBy.TEAM_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                <i *ngIf="sortBy === SortBy.TEAM_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+              </span>
+            </th>
+            <th id="sort-by-name" class="cursor-pointer" (click)="sortParticipantsBy(SortBy.RESPONDENT_NAME)">
+              Name
+              <span class="fa-stack"><i class="fas fa-sort"></i>
+                <i *ngIf="sortBy === SortBy.RESPONDENT_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                <i *ngIf="sortBy === SortBy.RESPONDENT_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+              </span>
+            </th>
+            <th>Actions</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr *ngFor="let noResponseStudent of noResponseStudentsInSection">
+            <td>{{ noResponseStudent.teamName }}</td>
+            <td>{{ noResponseStudent.name }}</td>
+            <td>
+              <a *ngIf="!isDisplayOnly; else displayOnlySubmitResponseButton" tmRouterLink="/web/sessions/submission" rel="noopener noreferrer" target="_blank"
+                [queryParams]="{courseid: session.courseId, fsname: session.feedbackSessionName, moderatedperson: noResponseStudent.email}"
+                class="btn btn-light btn-sm button">
+                Submit responses
+              </a>
+              <ng-template #displayOnlySubmitResponseButton><a class="btn btn-light btn-sm button">Submit response</a></ng-template>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <div *ngIf="!noResponseStudentsInSection.length">
+        <i>All students have responded to some questions in this session.</i>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -9,7 +9,7 @@
   </div>
 </div>
 <div *ngIf="isTabExpanded" @collapseAnim>
-  <div *tmIsLoading="!isNoStudentsLoaded" class="card-body">
+  <div *tmIsLoading="!isNoResponseStudentsLoaded" class="card-body">
     <div class="card-body p-0">
       <div *ngIf="noResponseStudentsInSection.length">
         <table id="no-response-table" class="table table-striped">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
 import { InstructorSessionNoResponsePanelComponent } from './instructor-session-no-response-panel.component';
@@ -19,6 +19,7 @@ describe('InstructorSessionNoResponsePanelComponent', () => {
         HttpClientTestingModule,
         NgbModule,
         PanelChevronModule,
+        LoadingSpinnerModule,
         TeammatesRouterModule,
       ],
     })

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -34,6 +34,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
   SortBy: typeof SortBy = SortBy;
   SortOrder: typeof SortOrder = SortOrder;
 
+  @Input() isNoStudentsLoaded: boolean = false;
   @Input() isDisplayOnly: boolean = false;
   @Input() allStudents: Student[] = [];
   @Input() noResponseStudents: Student[] = [];

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -34,7 +34,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
   SortBy: typeof SortBy = SortBy;
   SortOrder: typeof SortOrder = SortOrder;
 
-  @Input() isNoStudentsLoaded: boolean = false;
+  @Input() isNoResponseStudentsLoaded: boolean = false;
   @Input() isDisplayOnly: boolean = false;
   @Input() allStudents: Student[] = [];
   @Input() noResponseStudents: Student[] = [];

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -110,6 +110,7 @@
     <tm-instructor-session-no-response-panel [allStudents]="allStudentsInCourse"
                                              [noResponseStudents]="noResponseStudents"
                                              [section]="section" [session]="session"
+                                             [isNoStudentsLoaded]="isNoStudentsLoaded"
                                              (studentsToRemindEvent)="sendReminderToStudents($event)" ></tm-instructor-session-no-response-panel>
   </div>
 </tm-loading-retry>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -110,7 +110,7 @@
     <tm-instructor-session-no-response-panel [allStudents]="allStudentsInCourse"
                                              [noResponseStudents]="noResponseStudents"
                                              [section]="section" [session]="session"
-                                             [isNoStudentsLoaded]="isNoStudentsLoaded"
+                                             [isNoResponseStudentsLoaded]="isNoResponseStudentsLoaded"
                                              (studentsToRemindEvent)="sendReminderToStudents($event)" ></tm-instructor-session-no-response-panel>
   </div>
 </tm-loading-retry>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -16,20 +16,21 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TableComparatorService } from '../../../services/table-comparator.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import {
-  CourseSectionNames,
-  FeedbackQuestion,
-  FeedbackQuestions,
-  FeedbackSession,
-  FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
-  FeedbackSessionSubmittedGiverSet,
-  Instructor,
-  QuestionOutput,
-  ResponseOutput, ResponseVisibleSetting,
-  SessionResults, SessionVisibleSetting,
-  Student,
-  Students,
-} from '../../../types/api-output';
+import
+  {
+    CourseSectionNames,
+    FeedbackQuestion,
+    FeedbackQuestions,
+    FeedbackSession,
+    FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+    FeedbackSessionSubmittedGiverSet,
+    Instructor,
+    QuestionOutput,
+    ResponseOutput, ResponseVisibleSetting,
+    SessionResults, SessionVisibleSetting,
+    Student,
+    Students
+  } from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
 import { CommentToCommentRowModelPipe } from '../../components/comment-box/comment-to-comment-row-model.pipe';
 import { CommentsToCommentTableModelPipe } from '../../components/comment-box/comments-to-comment-table-model.pipe';
@@ -101,6 +102,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   questionsModel: Record<string, QuestionTabModel> = {};
   isQuestionsLoaded: boolean = false;
   hasQuestionsLoadingFailed: boolean = false;
+  isNoStudentsLoaded: boolean = false;
 
   isFeedbackSessionLoading: boolean = false;
   hasFeedbackSessionLoadingFailed: boolean = false;
@@ -270,6 +272,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       // TODO team is missing
       this.noResponseStudents = this.allStudentsInCourse.filter((student: Student) =>
         !feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(student.email));
+      this.isNoStudentsLoaded = true;
     }, (resp: ErrorMessageOutput) => {
       this.hasNoResponseLoadingFailed = true;
       this.statusMessageService.showErrorToast(resp.error.message);

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -101,7 +101,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   questionsModel: Record<string, QuestionTabModel> = {};
   isQuestionsLoaded: boolean = false;
   hasQuestionsLoadingFailed: boolean = false;
-  isNoStudentsLoaded: boolean = false;
+  isNoResponseStudentsLoaded: boolean = false;
 
   isFeedbackSessionLoading: boolean = false;
   hasFeedbackSessionLoadingFailed: boolean = false;
@@ -271,7 +271,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
       // TODO team is missing
       this.noResponseStudents = this.allStudentsInCourse.filter((student: Student) =>
         !feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(student.email));
-      this.isNoStudentsLoaded = true;
+      this.isNoResponseStudentsLoaded = true;
     }, (resp: ErrorMessageOutput) => {
       this.hasNoResponseLoadingFailed = true;
       this.statusMessageService.showErrorToast(resp.error.message);

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -16,21 +16,20 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TableComparatorService } from '../../../services/table-comparator.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import
-  {
-    CourseSectionNames,
-    FeedbackQuestion,
-    FeedbackQuestions,
-    FeedbackSession,
-    FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
-    FeedbackSessionSubmittedGiverSet,
-    Instructor,
-    QuestionOutput,
-    ResponseOutput, ResponseVisibleSetting,
-    SessionResults, SessionVisibleSetting,
-    Student,
-    Students
-  } from '../../../types/api-output';
+import {
+  CourseSectionNames,
+  FeedbackQuestion,
+  FeedbackQuestions,
+  FeedbackSession,
+  FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+  FeedbackSessionSubmittedGiverSet,
+  Instructor,
+  QuestionOutput,
+  ResponseOutput, ResponseVisibleSetting,
+  SessionResults, SessionVisibleSetting,
+  Student,
+  Students,
+} from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
 import { CommentToCommentRowModelPipe } from '../../components/comment-box/comment-to-comment-row-model.pipe';
 import { CommentsToCommentTableModelPipe } from '../../components/comment-box/comments-to-comment-table-model.pipe';


### PR DESCRIPTION
Fixes #10843 

**Outline of Solution**
Added a loading spinner for instructors no response panel.
The spinner will show until loading of students finishes, and show the appropriate message.
In the event of failure of loading the students, there'll be a message to show "Failed to load students who have not responded". (So there's no infinite spinning).

Happy Path:
(Personally I'm unable to replicate the problem myself on both production and dev server due to speed, so this video is simulated with a 5s timer)
https://user-images.githubusercontent.com/10182564/155762223-c84d4181-6d92-4149-a903-a433ef314460.mp4
