### PR TITLE
[#11597] Silence npm messages when linting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel="warn"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:json": "jsonlint-cli ./*.json src/web/**/*.json src/main/resources/*.json src/test/resources/data/*.json",
     "lint:css": "stylelint \"src/web/**/*.css\" \"src/web/**/*.scss\" \"src/web/**/*.html\" --config static-analysis/teammates-stylelint.yml",
     "lint:spaces": "lintspaces -n -t -d spaces -l 1 -. \"src/main/**/*.html\" \"src/web/**/*.html\" \"src/**/*.xml\" \"src/**/*.json\" \"src/**/*.properties\" \"*.yml\" \"*.json\" \"*.gradle\" \"static-analysis/*.*ml\" \".gitattributes\"",
-    "lint": "npm-run-all lint:* -c"
+    "lint": "npm-run-all --silent lint:* -c"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:json": "jsonlint-cli ./*.json src/web/**/*.json src/main/resources/*.json src/test/resources/data/*.json",
     "lint:css": "stylelint \"src/web/**/*.css\" \"src/web/**/*.scss\" \"src/web/**/*.html\" --config static-analysis/teammates-stylelint.yml",
     "lint:spaces": "lintspaces -n -t -d spaces -l 1 -. \"src/main/**/*.html\" \"src/web/**/*.html\" \"src/**/*.xml\" \"src/**/*.json\" \"src/**/*.properties\" \"*.yml\" \"*.json\" \"*.gradle\" \"static-analysis/*.*ml\" \".gitattributes\"",
-    "lint": "npm-run-all --silent lint:* -c"
+    "lint": "npm-run-all lint:* -c"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #11597 

Developers shouldn't need to scroll through hundreds of line to find their errors in linting.
With the --silence command, the linting errors can be cut to only the useful parts.
Counting from `> lint` onwards, the original command spans 150 lines. The image is only 18 lines: 
![image](https://user-images.githubusercontent.com/10182564/155767858-fd32d4a4-5d02-49ca-bbc6-960c080ff4ca.png)

