### PR TITLE
[#11571] Selective Deadline Extensions - Get selective deadlines

### DIFF
--- a/src/e2e/resources/data/AdminSearchPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSearchPageE2ETest.json
@@ -110,7 +110,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
   "session2InCourse1": {
     "feedbackSessionName": "ASearch.Second feedback session",
@@ -132,7 +133,8 @@
     "isOpeningEmailEnabled": true,
     "isClosingEmailEnabled": true,
     "isPublishedEmailEnabled": true,
-    "studentDeadlines": {}
+    "studentDeadlines": {},
+    "instructorDeadlines": {}
     }
   },
   "accountRequests": {

--- a/src/e2e/resources/data/AdminSearchPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSearchPageE2ETest.json
@@ -109,7 +109,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
   "session2InCourse1": {
     "feedbackSessionName": "ASearch.Second feedback session",
@@ -130,7 +131,8 @@
     "sentPublishedEmail": false,
     "isOpeningEmailEnabled": true,
     "isClosingEmailEnabled": true,
-    "isPublishedEmailEnabled": true
+    "isPublishedEmailEnabled": true,
+    "studentDeadlines": {}
     }
   },
   "accountRequests": {

--- a/src/e2e/resources/data/AdminSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSessionsPageE2ETest.json
@@ -61,7 +61,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Awaiting feedback session",
@@ -82,7 +83,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "session3InCourse1": {
       "feedbackSessionName": "Future feedback session",
@@ -103,7 +105,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   }
 }

--- a/src/e2e/resources/data/AdminSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSessionsPageE2ETest.json
@@ -62,7 +62,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Awaiting feedback session",
@@ -84,7 +85,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session3InCourse1": {
       "feedbackSessionName": "Future feedback session",
@@ -106,7 +108,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   }
 }

--- a/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
+++ b/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
@@ -71,7 +71,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "closingSession": {
       "feedbackSessionName": "AutSesRem Closing Session",
@@ -91,7 +92,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "AutSesRem Closed Session",
@@ -111,7 +113,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "publishedSession": {
       "feedbackSessionName": "AutSesRem Published Session",
@@ -131,7 +134,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
+++ b/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
@@ -72,7 +72,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closingSession": {
       "feedbackSessionName": "AutSesRem Closing Session",
@@ -93,7 +94,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "AutSesRem Closed Session",
@@ -114,7 +116,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "publishedSession": {
       "feedbackSessionName": "AutSesRem Published Session",
@@ -135,7 +138,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
@@ -101,7 +101,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -122,7 +123,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
@@ -100,7 +100,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -120,7 +121,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
@@ -150,7 +150,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -170,7 +171,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
@@ -151,7 +151,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -172,7 +173,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
@@ -176,7 +176,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
@@ -175,7 +175,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
@@ -167,7 +167,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Grace Period Session": {
       "feedbackSessionName": "Grace Period Session",
@@ -189,7 +190,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Closed Session": {
       "feedbackSessionName": "Closed Session",
@@ -210,7 +212,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
@@ -166,7 +166,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Grace Period Session": {
       "feedbackSessionName": "Grace Period Session",
@@ -187,7 +188,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Closed Session": {
       "feedbackSessionName": "Closed Session",
@@ -207,7 +209,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
@@ -123,7 +123,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -143,7 +144,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
@@ -124,7 +124,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -145,7 +146,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorAuditLogsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorAuditLogsPageE2ETest.json
@@ -80,7 +80,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },"feedbackQuestions": {
   "qn1": {

--- a/src/e2e/resources/data/InstructorAuditLogsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorAuditLogsPageE2ETest.json
@@ -81,7 +81,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },"feedbackQuestions": {
   "qn1": {

--- a/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
@@ -190,7 +190,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {},

--- a/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
@@ -189,7 +189,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {},

--- a/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
@@ -183,7 +183,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
@@ -182,7 +182,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
@@ -128,7 +128,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -149,7 +150,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
@@ -127,7 +127,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession2": {
       "feedbackSessionName": "Second Session",
@@ -147,7 +148,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
@@ -190,7 +190,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Open Session 2": {
       "feedbackSessionName": "First Session",
@@ -211,7 +212,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
@@ -191,7 +191,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Open Session 2": {
       "feedbackSessionName": "First Session",
@@ -213,7 +214,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
@@ -137,7 +137,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "openSession": {
       "feedbackSessionName": "Second Session",
@@ -158,7 +159,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
@@ -136,7 +136,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "openSession": {
       "feedbackSessionName": "Second Session",
@@ -156,7 +157,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorHomePageE2ETest.json
+++ b/src/e2e/resources/data/InstructorHomePageE2ETest.json
@@ -166,7 +166,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Second Feedback Session": {
       "feedbackSessionName": "Second Feedback Session",
@@ -186,7 +187,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Third Feedback Session": {
       "feedbackSessionName": "Third Feedback Session",
@@ -207,7 +209,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "Fourth Feedback Session": {
       "feedbackSessionName": "Fourth Feedback Session",
@@ -228,7 +231,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "CS1101 Session": {
       "feedbackSessionName": "CS1101 Session",
@@ -249,7 +253,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorHomePageE2ETest.json
+++ b/src/e2e/resources/data/InstructorHomePageE2ETest.json
@@ -167,7 +167,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Second Feedback Session": {
       "feedbackSessionName": "Second Feedback Session",
@@ -188,7 +189,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Third Feedback Session": {
       "feedbackSessionName": "Third Feedback Session",
@@ -210,7 +212,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "Fourth Feedback Session": {
       "feedbackSessionName": "Fourth Feedback Session",
@@ -232,7 +235,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "CS1101 Session": {
       "feedbackSessionName": "CS1101 Session",
@@ -254,7 +258,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/StudentHomePageE2ETest.json
+++ b/src/e2e/resources/data/StudentHomePageE2ETest.json
@@ -194,7 +194,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "SHome.CS2104:Graced Feedback Session": {
       "feedbackSessionName": "Graced Feedback Session",
@@ -216,7 +217,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "SHome.CS2104:No Question Feedback Session": {
       "feedbackSessionName": "No Question Feedback Session",
@@ -238,7 +240,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "SHome.CS2104:Future Feedback Session": {
       "feedbackSessionName": "Future Feedback Session",
@@ -260,7 +263,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "SHome.CS2104:Closed Feedback Session": {
       "feedbackSessionName": "Closed Feedback Session",
@@ -282,7 +286,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "SHome.CS4221:Session with no Student Questions": {
       "feedbackSessionName": "Session without Student Questions",
@@ -304,7 +309,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/StudentHomePageE2ETest.json
+++ b/src/e2e/resources/data/StudentHomePageE2ETest.json
@@ -193,7 +193,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "SHome.CS2104:Graced Feedback Session": {
       "feedbackSessionName": "Graced Feedback Session",
@@ -214,7 +215,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "SHome.CS2104:No Question Feedback Session": {
       "feedbackSessionName": "No Question Feedback Session",
@@ -235,7 +237,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "SHome.CS2104:Future Feedback Session": {
       "feedbackSessionName": "Future Feedback Session",
@@ -256,7 +259,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "SHome.CS2104:Closed Feedback Session": {
       "feedbackSessionName": "Closed Feedback Session",
@@ -277,7 +281,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     },
     "SHome.CS4221:Session with no Student Questions": {
       "feedbackSessionName": "Session without Student Questions",
@@ -298,7 +303,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -42,6 +42,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     private boolean isClosingEmailEnabled;
     private boolean isPublishedEmailEnabled;
     private Map<String, Instant> studentDeadlines;
+    private Map<String, Instant> instructorDeadlines;
 
     private FeedbackSessionAttributes(String feedbackSessionName, String courseId) {
         this.feedbackSessionName = feedbackSessionName;
@@ -55,6 +56,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isPublishedEmailEnabled = true;
 
         this.studentDeadlines = new HashMap<>();
+        this.instructorDeadlines = new HashMap<>();
 
         this.timeZone = Const.DEFAULT_TIME_ZONE;
         this.gracePeriod = Duration.ZERO;
@@ -85,6 +87,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isClosingEmailEnabled = feedbackSession.isClosingEmailEnabled();
         this.isPublishedEmailEnabled = feedbackSession.isPublishedEmailEnabled();
         this.studentDeadlines = feedbackSession.getStudentDeadlines();
+        this.instructorDeadlines = feedbackSession.getInstructorDeadlines();
     }
 
     /**
@@ -152,7 +155,8 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 createdTime, deletedTime, startTime, endTime, sessionVisibleFromTime, resultsVisibleFromTime,
                 timeZone, getGracePeriodMinutes(),
                 sentOpeningSoonEmail, sentOpenEmail, sentClosingEmail, sentClosedEmail, sentPublishedEmail,
-                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled, studentDeadlines);
+                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled, studentDeadlines,
+                instructorDeadlines);
     }
 
     @Override
@@ -218,6 +222,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
         addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("student deadlines map", studentDeadlines),
+                errors);
+
+        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("instructor deadlines map", instructorDeadlines),
                 errors);
 
         return errors;
@@ -403,6 +410,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
                + ", studentDeadlines=" + studentDeadlines
+               + ", instructorDeadlines=" + instructorDeadlines
                + "]";
     }
 
@@ -595,6 +603,14 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.studentDeadlines = studentDeadlines;
     }
 
+    public Map<String, Instant> getInstructorDeadlines() {
+        return instructorDeadlines;
+    }
+
+    public void setInstructorDeadlines(Map<String, Instant> instructorDeadlines) {
+        this.instructorDeadlines = instructorDeadlines;
+    }
+
     /**
      * Updates with {@link UpdateOptions}.
      */
@@ -614,6 +630,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         updateOptions.isClosingEmailEnabledOption.ifPresent(s -> isClosingEmailEnabled = s);
         updateOptions.isPublishedEmailEnabledOption.ifPresent(s -> isPublishedEmailEnabled = s);
         updateOptions.studentDeadlinesOption.ifPresent(s -> studentDeadlines = s);
+        updateOptions.instructorDeadlinesOption.ifPresent(s -> instructorDeadlines = s);
     }
 
     /**
@@ -681,6 +698,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         private UpdateOption<Boolean> isClosingEmailEnabledOption = UpdateOption.empty();
         private UpdateOption<Boolean> isPublishedEmailEnabledOption = UpdateOption.empty();
         private UpdateOption<Map<String, Instant>> studentDeadlinesOption = UpdateOption.empty();
+        private UpdateOption<Map<String, Instant>> instructorDeadlinesOption = UpdateOption.empty();
 
         private UpdateOptions(String feedbackSessionName, String courseId) {
             assert feedbackSessionName != null;
@@ -718,6 +736,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                     + ", isClosingEmailEnabled = " + isClosingEmailEnabledOption
                     + ", isPublishedEmailEnabled = " + isPublishedEmailEnabledOption
                     + ", studentDeadlines = " + studentDeadlinesOption
+                    + ", instructorDeadlines = " + instructorDeadlinesOption
                     + "]";
         }
 
@@ -849,6 +868,13 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
             assert studentDeadlines != null;
 
             updateOptions.studentDeadlinesOption = UpdateOption.of(studentDeadlines);
+            return thisBuilder;
+        }
+
+        public B withInstructorDeadlines(Map<String, Instant> instructorDeadlines) {
+            assert instructorDeadlines != null;
+
+            updateOptions.instructorDeadlinesOption = UpdateOption.of(instructorDeadlines);
             return thisBuilder;
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -225,12 +225,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
-        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("student deadlines map", studentDeadlines),
-                errors);
-
-        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("instructor deadlines map", instructorDeadlines),
-                errors);
-
         return errors;
     }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -327,6 +327,55 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     /**
+     * Checks if the feedback session is closed for an instructor.
+     * This occurs when the current time is after both the deadline and the grace period. The deadline depends on
+     * the last extended deadline, if it exists.
+     *
+     * @return Whether the feedback session is closed for an instructor.
+     */
+    public boolean isClosedForInstructor() {
+        if (extendedDeadlines.isEmpty()) {
+            return isClosed();
+        }
+        Instant lastExtendedDeadline = Collections.max(extendedDeadlines.values());
+        return Instant.now().isAfter(lastExtendedDeadline.plus(gracePeriod));
+    }
+
+    /**
+     * Checks if the feedback session is open for an instructor.
+     * This occurs when the current time is either the start time or later but before the deadline. The deadline depends
+     * on the last extended deadline, if it exists.
+     *
+     * @return Whether the feedback session is open for an instructor.
+     */
+    public boolean isOpenForInstructor() {
+        if (extendedDeadlines.isEmpty()) {
+            return isOpened();
+        }
+        Instant now = Instant.now();
+        Instant lastExtendedDeadline = Collections.max(extendedDeadlines.values());
+        return (now.isAfter(startTime) || now.equals(startTime)) && now.isBefore(lastExtendedDeadline);
+    }
+
+    /**
+     * Checks if the feedback session is closed but still accepts responses for an instructor.
+     * This occurs when the current time is either the deadline or later but within the grace period. The deadline
+     * depends on the last extended deadline, if it exists.
+     *
+     * @return Whether the feedback session is closed but still accepts responses for the given participant.
+     */
+    public boolean isInGracePeriodForInstructor() {
+        if (extendedDeadlines.isEmpty()) {
+            return isInGracePeriod();
+        }
+        Instant now = Instant.now();
+        Instant lastExtendedDeadline = Collections.max(extendedDeadlines.values());
+        Instant gracedEnd = lastExtendedDeadline.plus(gracePeriod);
+        return (now.isAfter(lastExtendedDeadline) || now.equals(lastExtendedDeadline))
+                && (now.isBefore(gracedEnd) || now.equals(gracedEnd));
+    }
+
+    /**
      * Returns {@code true} has not opened before and is waiting to open,
      * {@code false} if session has opened before.
      */

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -237,10 +237,12 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     /**
-     * Finds the point in time when the session is considered closed.
-     * This is not necessarily the end time of the feedback session.
-     *
-     * @return The point in time when the session is considered closed.
+     * Finds the point in time when the session is considered closed, excluding the grace period.
+     * <p>This varies depending on who is looking at the session:</p>
+     * <ul>
+     *     <li>For instructors looking at the session in full detail, this is when the end time is reached.</li>
+     *     <li>For participants, this is when the end time is reached, or their extension deadline, if it exists.</li>
+     * </ul>
      */
     public Instant getDeadline() {
         return endTime;
@@ -302,8 +304,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     /**
      * Checks if the feedback session is closed.
      * This occurs when the current time is after both the deadline and the grace period.
-     *
-     * @return Whether the feedback session is closed.
      */
     public boolean isClosed() {
         return Instant.now().isAfter(getDeadline().plus(gracePeriod));
@@ -312,8 +312,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     /**
      * Checks if the feedback session is open.
      * This occurs when the current time is either the start time or later but before the deadline.
-     *
-     * @return Whether the feedback session is open.
      */
     public boolean isOpened() {
         Instant now = Instant.now();
@@ -323,8 +321,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     /**
      * Checks if the feedback session is closed but still accepts responses.
      * This occurs when the current time is either the deadline or later but still within the grace period.
-     *
-     * @return Whether the feedback session is closed but still accepts responses.
      */
     public boolean isInGracePeriod() {
         Instant now = Instant.now();

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -2,9 +2,7 @@ package teammates.common.datatransfer.attributes;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
@@ -37,6 +35,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     private boolean isOpeningEmailEnabled;
     private boolean isClosingEmailEnabled;
     private boolean isPublishedEmailEnabled;
+    private Map<String, Instant> extendedDeadlines;
 
     private FeedbackSessionAttributes(String feedbackSessionName, String courseId) {
         this.feedbackSessionName = feedbackSessionName;
@@ -48,6 +47,8 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isOpeningEmailEnabled = true;
         this.isClosingEmailEnabled = true;
         this.isPublishedEmailEnabled = true;
+
+        this.extendedDeadlines = new HashMap<>();
 
         this.timeZone = Const.DEFAULT_TIME_ZONE;
         this.gracePeriod = Duration.ZERO;
@@ -81,6 +82,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         feedbackSessionAttributes.isOpeningEmailEnabled = fs.isOpeningEmailEnabled();
         feedbackSessionAttributes.isClosingEmailEnabled = fs.isClosingEmailEnabled();
         feedbackSessionAttributes.isPublishedEmailEnabled = fs.isPublishedEmailEnabled();
+        feedbackSessionAttributes.extendedDeadlines = fs.getExtendedDeadlines();
 
         return feedbackSessionAttributes;
     }
@@ -124,7 +126,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 createdTime, deletedTime, startTime, endTime, sessionVisibleFromTime, resultsVisibleFromTime,
                 timeZone, getGracePeriodMinutes(),
                 sentOpeningSoonEmail, sentOpenEmail, sentClosingEmail, sentClosedEmail, sentPublishedEmail,
-                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled);
+                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled, extendedDeadlines);
     }
 
     @Override
@@ -188,6 +190,9 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
+
+        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("extended deadlines map", extendedDeadlines),
+                errors);
 
         return errors;
     }
@@ -344,6 +349,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                + ", isOpeningEmailEnabled=" + isOpeningEmailEnabled
                + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
+               + ", extendedDeadlines=" + extendedDeadlines
                + "]";
     }
 
@@ -528,6 +534,14 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
     }
 
+    public Map<String, Instant> getExtendedDeadlines() {
+        return extendedDeadlines;
+    }
+
+    public void setExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
+        this.extendedDeadlines = extendedDeadlines;
+    }
+
     /**
      * Updates with {@link UpdateOptions}.
      */
@@ -546,6 +560,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         updateOptions.sentPublishedEmailOption.ifPresent(s -> sentPublishedEmail = s);
         updateOptions.isClosingEmailEnabledOption.ifPresent(s -> isClosingEmailEnabled = s);
         updateOptions.isPublishedEmailEnabledOption.ifPresent(s -> isPublishedEmailEnabled = s);
+        updateOptions.extendedDeadlinesOption.ifPresent(s -> extendedDeadlines = s);
     }
 
     /**
@@ -612,6 +627,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         private UpdateOption<Boolean> sentPublishedEmailOption = UpdateOption.empty();
         private UpdateOption<Boolean> isClosingEmailEnabledOption = UpdateOption.empty();
         private UpdateOption<Boolean> isPublishedEmailEnabledOption = UpdateOption.empty();
+        private UpdateOption<Map<String, Instant>> extendedDeadlinesOption = UpdateOption.empty();
 
         private UpdateOptions(String feedbackSessionName, String courseId) {
             assert feedbackSessionName != null;
@@ -648,6 +664,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                     + ", sentPublishedEmail = " + sentPublishedEmailOption
                     + ", isClosingEmailEnabled = " + isClosingEmailEnabledOption
                     + ", isPublishedEmailEnabled = " + isPublishedEmailEnabledOption
+                    + ", extendedDeadlines = " + extendedDeadlinesOption
                     + "]";
         }
 
@@ -772,6 +789,13 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
         public B withIsPublishedEmailEnabled(boolean isPublishedEmailEnabled) {
             updateOptions.isPublishedEmailEnabledOption = UpdateOption.of(isPublishedEmailEnabled);
+            return thisBuilder;
+        }
+
+        public B withExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
+            assert extendedDeadlines != null;
+
+            updateOptions.extendedDeadlinesOption = UpdateOption.of(extendedDeadlines);
             return thisBuilder;
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -41,7 +41,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     private boolean isOpeningEmailEnabled;
     private boolean isClosingEmailEnabled;
     private boolean isPublishedEmailEnabled;
-    private Map<String, Instant> extendedDeadlines;
+    private Map<String, Instant> studentDeadlines;
 
     private FeedbackSessionAttributes(String feedbackSessionName, String courseId) {
         this.feedbackSessionName = feedbackSessionName;
@@ -54,7 +54,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isClosingEmailEnabled = true;
         this.isPublishedEmailEnabled = true;
 
-        this.extendedDeadlines = new HashMap<>();
+        this.studentDeadlines = new HashMap<>();
 
         this.timeZone = Const.DEFAULT_TIME_ZONE;
         this.gracePeriod = Duration.ZERO;
@@ -84,7 +84,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isOpeningEmailEnabled = feedbackSession.isOpeningEmailEnabled();
         this.isClosingEmailEnabled = feedbackSession.isClosingEmailEnabled();
         this.isPublishedEmailEnabled = feedbackSession.isPublishedEmailEnabled();
-        this.extendedDeadlines = feedbackSession.getExtendedDeadlines();
+        this.studentDeadlines = feedbackSession.getStudentDeadlines();
     }
 
     /**
@@ -152,7 +152,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 createdTime, deletedTime, startTime, endTime, sessionVisibleFromTime, resultsVisibleFromTime,
                 timeZone, getGracePeriodMinutes(),
                 sentOpeningSoonEmail, sentOpenEmail, sentClosingEmail, sentClosedEmail, sentPublishedEmail,
-                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled, extendedDeadlines);
+                isOpeningEmailEnabled, isClosingEmailEnabled, isPublishedEmailEnabled, studentDeadlines);
     }
 
     @Override
@@ -217,14 +217,14 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
-        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("extended deadlines map", extendedDeadlines),
+        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("student deadlines map", studentDeadlines),
                 errors);
 
         return errors;
     }
 
-    public Map<String, Instant> getFilteredExtendedDeadlines() {
-        return extendedDeadlines;
+    public Map<String, Instant> getFilteredStudentDeadlines() {
+        return studentDeadlines;
     }
 
     public Instant getDeadline() {
@@ -402,7 +402,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                + ", isOpeningEmailEnabled=" + isOpeningEmailEnabled
                + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
-               + ", extendedDeadlines=" + extendedDeadlines
+               + ", studentDeadlines=" + studentDeadlines
                + "]";
     }
 
@@ -587,12 +587,12 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
     }
 
-    public Map<String, Instant> getExtendedDeadlines() {
-        return extendedDeadlines;
+    public Map<String, Instant> getStudentDeadlines() {
+        return studentDeadlines;
     }
 
-    public void setExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
-        this.extendedDeadlines = extendedDeadlines;
+    public void setStudentDeadlines(Map<String, Instant> studentDeadlines) {
+        this.studentDeadlines = studentDeadlines;
     }
 
     /**
@@ -613,7 +613,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         updateOptions.sentPublishedEmailOption.ifPresent(s -> sentPublishedEmail = s);
         updateOptions.isClosingEmailEnabledOption.ifPresent(s -> isClosingEmailEnabled = s);
         updateOptions.isPublishedEmailEnabledOption.ifPresent(s -> isPublishedEmailEnabled = s);
-        updateOptions.extendedDeadlinesOption.ifPresent(s -> extendedDeadlines = s);
+        updateOptions.studentDeadlinesOption.ifPresent(s -> studentDeadlines = s);
     }
 
     /**
@@ -680,7 +680,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         private UpdateOption<Boolean> sentPublishedEmailOption = UpdateOption.empty();
         private UpdateOption<Boolean> isClosingEmailEnabledOption = UpdateOption.empty();
         private UpdateOption<Boolean> isPublishedEmailEnabledOption = UpdateOption.empty();
-        private UpdateOption<Map<String, Instant>> extendedDeadlinesOption = UpdateOption.empty();
+        private UpdateOption<Map<String, Instant>> studentDeadlinesOption = UpdateOption.empty();
 
         private UpdateOptions(String feedbackSessionName, String courseId) {
             assert feedbackSessionName != null;
@@ -717,7 +717,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                     + ", sentPublishedEmail = " + sentPublishedEmailOption
                     + ", isClosingEmailEnabled = " + isClosingEmailEnabledOption
                     + ", isPublishedEmailEnabled = " + isPublishedEmailEnabledOption
-                    + ", extendedDeadlines = " + extendedDeadlinesOption
+                    + ", studentDeadlines = " + studentDeadlinesOption
                     + "]";
         }
 
@@ -845,10 +845,10 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
             return thisBuilder;
         }
 
-        public B withExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
-            assert extendedDeadlines != null;
+        public B withStudentDeadlines(Map<String, Instant> studentDeadlines) {
+            assert studentDeadlines != null;
 
-            updateOptions.extendedDeadlinesOption = UpdateOption.of(extendedDeadlines);
+            updateOptions.studentDeadlinesOption = UpdateOption.of(studentDeadlines);
             return thisBuilder;
         }
 
@@ -868,8 +868,8 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         }
 
         @Override
-        public Map<String, Instant> getFilteredExtendedDeadlines() {
-            return getExtendedDeadlines()
+        public Map<String, Instant> getFilteredStudentDeadlines() {
+            return getStudentDeadlines()
                     .entrySet()
                     .stream()
                     .filter(entry -> entry.getKey().equals(participantEmailAddress))
@@ -878,10 +878,10 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
         @Override
         public Instant getDeadline() {
-            if (!getExtendedDeadlines().containsKey(participantEmailAddress)) {
+            if (!getStudentDeadlines().containsKey(participantEmailAddress)) {
                 return super.getDeadline();
             }
-            return getExtendedDeadlines().get(participantEmailAddress);
+            return getStudentDeadlines().get(participantEmailAddress);
         }
     }
 
@@ -893,10 +893,10 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
         @Override
         public Instant getDeadline() {
-            if (getExtendedDeadlines().isEmpty()) {
+            if (getStudentDeadlines().isEmpty()) {
                 return super.getDeadline();
             }
-            return Collections.max(getExtendedDeadlines().values());
+            return Collections.max(getStudentDeadlines().values());
         }
     }
 }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
@@ -226,14 +225,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
         return errors;
-    }
-
-    public Map<String, Instant> getFilteredStudentDeadlines() {
-        return studentDeadlines;
-    }
-
-    public Map<String, Instant> getFilteredInstructorDeadlines() {
-        return instructorDeadlines;
     }
 
     /**
@@ -896,30 +887,12 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         }
 
         abstract Map<String, Instant> getDeadlines();
-
-        Map<String, Instant> getFilteredDeadlines() {
-            return getDeadlines()
-                    .entrySet()
-                    .stream()
-                    .filter(entry -> entry.getKey().equals(emailAddress))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
     }
 
     private static class FeedbackSessionAttributesForStudent extends FeedbackSessionAttributesForParticipant {
 
         private FeedbackSessionAttributesForStudent(FeedbackSession feedbackSession, String studentEmailAddress) {
             super(feedbackSession, studentEmailAddress);
-        }
-
-        @Override
-        public Map<String, Instant> getFilteredStudentDeadlines() {
-            return getFilteredDeadlines();
-        }
-
-        @Override
-        public Map<String, Instant> getFilteredInstructorDeadlines() {
-            return new HashMap<>();
         }
 
         @Override
@@ -932,16 +905,6 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
         private FeedbackSessionAttributesForInstructor(FeedbackSession feedbackSession, String instructorEmailAddress) {
             super(feedbackSession, instructorEmailAddress);
-        }
-
-        @Override
-        public Map<String, Instant> getFilteredStudentDeadlines() {
-            return new HashMap<>();
-        }
-
-        @Override
-        public Map<String, Instant> getFilteredInstructorDeadlines() {
-            return getFilteredDeadlines();
         }
 
         @Override

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -234,6 +234,10 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         return studentDeadlines;
     }
 
+    public Map<String, Instant> getFilteredInstructorDeadlines() {
+        return instructorDeadlines;
+    }
+
     public Instant getDeadline() {
         return endTime;
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -85,8 +85,12 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         this.isOpeningEmailEnabled = feedbackSession.isOpeningEmailEnabled();
         this.isClosingEmailEnabled = feedbackSession.isClosingEmailEnabled();
         this.isPublishedEmailEnabled = feedbackSession.isPublishedEmailEnabled();
-        this.studentDeadlines = feedbackSession.getStudentDeadlines();
-        this.instructorDeadlines = feedbackSession.getInstructorDeadlines();
+        if (feedbackSession.getStudentDeadlines() != null) {
+            this.studentDeadlines = feedbackSession.getStudentDeadlines();
+        }
+        if (feedbackSession.getInstructorDeadlines() != null) {
+            this.instructorDeadlines = feedbackSession.getInstructorDeadlines();
+        }
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -116,21 +116,21 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     /**
      * Creates a copy of this object for the given student.
      *
-     * @param studentEmailAddress The email address of the given student.
+     * @param studentEmail The email address of the given student.
      * @return The copy of this object for the given student.
      */
-    public FeedbackSessionAttributes getCopyForStudent(String studentEmailAddress) {
-        return new FeedbackSessionAttributesForStudent(toEntity(), studentEmailAddress);
+    public FeedbackSessionAttributes getCopyForStudent(String studentEmail) {
+        return new FeedbackSessionAttributesForStudent(toEntity(), studentEmail);
     }
 
     /**
      * Creates a copy of this object for the given instructor.
      *
-     * @param instructorEmailAddress The email address of the given instructor.
+     * @param instructorEmail The email address of the given instructor.
      * @return The copy of this object for the given instructor.
      */
-    public FeedbackSessionAttributes getCopyForInstructor(String instructorEmailAddress) {
-        return new FeedbackSessionAttributesForInstructor(toEntity(), instructorEmailAddress);
+    public FeedbackSessionAttributes getCopyForInstructor(String instructorEmail) {
+        return new FeedbackSessionAttributesForInstructor(toEntity(), instructorEmail);
     }
 
     public String getCourseId() {
@@ -870,20 +870,20 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     private abstract static class FeedbackSessionAttributesForParticipant extends FeedbackSessionAttributes {
 
-        private String emailAddress;
+        private String email;
 
-        private FeedbackSessionAttributesForParticipant(FeedbackSession feedbackSession, String emailAddress) {
+        private FeedbackSessionAttributesForParticipant(FeedbackSession feedbackSession, String email) {
             super(feedbackSession);
 
-            this.emailAddress = emailAddress;
+            this.email = email;
         }
 
         @Override
         public Instant getDeadline() {
-            if (!getDeadlines().containsKey(emailAddress)) {
+            if (!getDeadlines().containsKey(email)) {
                 return getEndTime();
             }
-            return getDeadlines().get(emailAddress);
+            return getDeadlines().get(email);
         }
 
         abstract Map<String, Instant> getDeadlines();
@@ -891,8 +891,8 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     private static class FeedbackSessionAttributesForStudent extends FeedbackSessionAttributesForParticipant {
 
-        private FeedbackSessionAttributesForStudent(FeedbackSession feedbackSession, String studentEmailAddress) {
-            super(feedbackSession, studentEmailAddress);
+        private FeedbackSessionAttributesForStudent(FeedbackSession feedbackSession, String studentEmail) {
+            super(feedbackSession, studentEmail);
         }
 
         @Override
@@ -903,8 +903,8 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     private static class FeedbackSessionAttributesForInstructor extends FeedbackSessionAttributesForParticipant {
 
-        private FeedbackSessionAttributesForInstructor(FeedbackSession feedbackSession, String instructorEmailAddress) {
-            super(feedbackSession, instructorEmailAddress);
+        private FeedbackSessionAttributesForInstructor(FeedbackSession feedbackSession, String instructorEmail) {
+            super(feedbackSession, instructorEmail);
         }
 
         @Override

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.googlecode.objectify.Key;
@@ -269,7 +270,11 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, Feedba
                 && this.<Boolean>hasSameValue(
                         feedbackSession.isClosingEmailEnabled(), newAttributes.isClosingEmailEnabled())
                 && this.<Boolean>hasSameValue(
-                        feedbackSession.isPublishedEmailEnabled(), newAttributes.isPublishedEmailEnabled());
+                        feedbackSession.isPublishedEmailEnabled(), newAttributes.isPublishedEmailEnabled())
+                && this.<Map<String, Instant>>hasSameValue(
+                        feedbackSession.getStudentDeadlines(), newAttributes.getStudentDeadlines())
+                && this.<Map<String, Instant>>hasSameValue(
+                        feedbackSession.getInstructorDeadlines(), newAttributes.getInstructorDeadlines());
         if (hasSameAttributes) {
             log.info(String.format(
                     OPTIMIZED_SAVING_POLICY_APPLIED, FeedbackSession.class.getSimpleName(), updateOptions));
@@ -290,6 +295,8 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, Feedba
         feedbackSession.setSentPublishedEmail(newAttributes.isSentPublishedEmail());
         feedbackSession.setSendClosingEmail(newAttributes.isClosingEmailEnabled());
         feedbackSession.setSendPublishedEmail(newAttributes.isPublishedEmailEnabled());
+        feedbackSession.setStudentDeadlines(newAttributes.getStudentDeadlines());
+        feedbackSession.setInstructorDeadlines(newAttributes.getInstructorDeadlines());
 
         saveEntity(feedbackSession);
 

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -1,10 +1,12 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
+import java.util.Map;
 
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Serialize;
 import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
 
@@ -74,6 +76,9 @@ public class FeedbackSession extends BaseEntity {
 
     private boolean isPublishedEmailEnabled;
 
+    @Serialize
+    private Map<String, Instant> extendedDeadlines;
+
     @SuppressWarnings("unused")
     private FeedbackSession() {
         // required by Objectify
@@ -84,7 +89,7 @@ public class FeedbackSession extends BaseEntity {
             Instant sessionVisibleFromTime, Instant resultsVisibleFromTime, String timeZone, long gracePeriod,
             boolean sentOpeningSoonEmail, boolean sentOpenEmail, boolean sentClosingEmail,
             boolean sentClosedEmail, boolean sentPublishedEmail, boolean isOpeningEmailEnabled,
-            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled) {
+            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled, Map<String, Instant> extendedDeadlines) {
         this.feedbackSessionName = feedbackSessionName;
         this.courseId = courseId;
         this.creatorEmail = creatorEmail;
@@ -105,6 +110,7 @@ public class FeedbackSession extends BaseEntity {
         this.isOpeningEmailEnabled = isOpeningEmailEnabled;
         this.isClosingEmailEnabled = isClosingEmailEnabled;
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
+        this.extendedDeadlines = extendedDeadlines;
         this.feedbackSessionId = generateId(this.feedbackSessionName, this.courseId);
     }
 
@@ -274,6 +280,14 @@ public class FeedbackSession extends BaseEntity {
 
     public void setSendPublishedEmail(boolean isPublishedEmailEnabled) {
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
+    }
+
+    public Map<String, Instant> getExtendedDeadlines() {
+        return extendedDeadlines;
+    }
+
+    public void setExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
+        this.extendedDeadlines = extendedDeadlines;
     }
 
     @Override

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -79,6 +79,9 @@ public class FeedbackSession extends BaseEntity {
     @Serialize
     private Map<String, Instant> studentDeadlines;
 
+    @Serialize
+    private Map<String, Instant> instructorDeadlines;
+
     @SuppressWarnings("unused")
     private FeedbackSession() {
         // required by Objectify
@@ -89,7 +92,8 @@ public class FeedbackSession extends BaseEntity {
             Instant sessionVisibleFromTime, Instant resultsVisibleFromTime, String timeZone, long gracePeriod,
             boolean sentOpeningSoonEmail, boolean sentOpenEmail, boolean sentClosingEmail,
             boolean sentClosedEmail, boolean sentPublishedEmail, boolean isOpeningEmailEnabled,
-            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled, Map<String, Instant> studentDeadlines) {
+            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled, Map<String, Instant> studentDeadlines,
+            Map<String, Instant> instructorDeadlines) {
         this.feedbackSessionName = feedbackSessionName;
         this.courseId = courseId;
         this.creatorEmail = creatorEmail;
@@ -111,6 +115,7 @@ public class FeedbackSession extends BaseEntity {
         this.isClosingEmailEnabled = isClosingEmailEnabled;
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
         this.studentDeadlines = studentDeadlines;
+        this.instructorDeadlines = instructorDeadlines;
         this.feedbackSessionId = generateId(this.feedbackSessionName, this.courseId);
     }
 
@@ -290,6 +295,14 @@ public class FeedbackSession extends BaseEntity {
         this.studentDeadlines = studentDeadlines;
     }
 
+    public Map<String, Instant> getInstructorDeadlines() {
+        return instructorDeadlines;
+    }
+
+    public void setInstructorDeadlines(Map<String, Instant> instructorDeadlines) {
+        this.instructorDeadlines = instructorDeadlines;
+    }
+
     @Override
     public String toString() {
         return "FeedbackSession [feedbackSessionName=" + feedbackSessionName
@@ -309,6 +322,7 @@ public class FeedbackSession extends BaseEntity {
                 + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                 + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
                 + ", studentDeadlines=" + studentDeadlines
+                + ", instructorDeadlines=" + instructorDeadlines
                 + "]";
     }
 

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -77,7 +77,7 @@ public class FeedbackSession extends BaseEntity {
     private boolean isPublishedEmailEnabled;
 
     @Serialize
-    private Map<String, Instant> extendedDeadlines;
+    private Map<String, Instant> studentDeadlines;
 
     @SuppressWarnings("unused")
     private FeedbackSession() {
@@ -89,7 +89,7 @@ public class FeedbackSession extends BaseEntity {
             Instant sessionVisibleFromTime, Instant resultsVisibleFromTime, String timeZone, long gracePeriod,
             boolean sentOpeningSoonEmail, boolean sentOpenEmail, boolean sentClosingEmail,
             boolean sentClosedEmail, boolean sentPublishedEmail, boolean isOpeningEmailEnabled,
-            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled, Map<String, Instant> extendedDeadlines) {
+            boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled, Map<String, Instant> studentDeadlines) {
         this.feedbackSessionName = feedbackSessionName;
         this.courseId = courseId;
         this.creatorEmail = creatorEmail;
@@ -110,7 +110,7 @@ public class FeedbackSession extends BaseEntity {
         this.isOpeningEmailEnabled = isOpeningEmailEnabled;
         this.isClosingEmailEnabled = isClosingEmailEnabled;
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
-        this.extendedDeadlines = extendedDeadlines;
+        this.studentDeadlines = studentDeadlines;
         this.feedbackSessionId = generateId(this.feedbackSessionName, this.courseId);
     }
 
@@ -282,12 +282,12 @@ public class FeedbackSession extends BaseEntity {
         this.isPublishedEmailEnabled = isPublishedEmailEnabled;
     }
 
-    public Map<String, Instant> getExtendedDeadlines() {
-        return extendedDeadlines;
+    public Map<String, Instant> getStudentDeadlines() {
+        return studentDeadlines;
     }
 
-    public void setExtendedDeadlines(Map<String, Instant> extendedDeadlines) {
-        this.extendedDeadlines = extendedDeadlines;
+    public void setStudentDeadlines(Map<String, Instant> studentDeadlines) {
+        this.studentDeadlines = studentDeadlines;
     }
 
     @Override
@@ -308,6 +308,7 @@ public class FeedbackSession extends BaseEntity {
                 + ", isOpeningEmailEnabled=" + isOpeningEmailEnabled
                 + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                 + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
+                + ", studentDeadlines=" + studentDeadlines
                 + "]";
     }
 

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -90,13 +90,13 @@ public class FeedbackSessionData extends ApiOutput {
         if (feedbackSessionAttributes.isVisible() && !feedbackSessionAttributes.isOpened()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN;
         }
-        if (feedbackSessionAttributes.isOpenForInstructor()) {
+        if (feedbackSessionAttributes.isOpened()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.OPEN;
         }
-        if (feedbackSessionAttributes.isInGracePeriodForInstructor()) {
+        if (feedbackSessionAttributes.isInGracePeriod()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.GRACE_PERIOD;
         }
-        if (feedbackSessionAttributes.isClosedForInstructor()) {
+        if (feedbackSessionAttributes.isClosed()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.CLOSED;
         }
 
@@ -117,35 +117,12 @@ public class FeedbackSessionData extends ApiOutput {
         }
 
         this.extendedDeadlines = new HashMap<>();
-        feedbackSessionAttributes.getExtendedDeadlines()
-                .forEach((email, extendedDeadlineInstant) -> {
+        feedbackSessionAttributes.getFilteredExtendedDeadlines().forEach((email, extendedDeadlineInstant) -> {
             long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
                     extendedDeadlineInstant, timeZone, true)
                     .toEpochMilli();
             this.extendedDeadlines.put(email, extendedDeadline);
         });
-    }
-
-    public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes, String participantEmailAddress) {
-        this(feedbackSessionAttributes);
-
-        if (feedbackSessionAttributes.isOpenForParticipant(participantEmailAddress)) {
-            this.submissionStatus = FeedbackSessionSubmissionStatus.OPEN;
-        }
-        if (feedbackSessionAttributes.isInGracePeriodForParticipant(participantEmailAddress)) {
-            this.submissionStatus = FeedbackSessionSubmissionStatus.GRACE_PERIOD;
-        }
-        if (feedbackSessionAttributes.isClosedForParticipant(participantEmailAddress)) {
-            this.submissionStatus = FeedbackSessionSubmissionStatus.CLOSED;
-        }
-
-        this.extendedDeadlines = new HashMap<>();
-        Map<String, Instant> extendedDeadlineInstants = feedbackSessionAttributes.getExtendedDeadlines();
-        if (extendedDeadlineInstants.containsKey(participantEmailAddress)) {
-            long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-                    extendedDeadlineInstants.get(participantEmailAddress), timeZone, true).toEpochMilli();
-            this.extendedDeadlines.put(participantEmailAddress, extendedDeadline);
-        }
     }
 
     public String getCourseId() {

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -49,6 +49,7 @@ public class FeedbackSessionData extends ApiOutput {
     private InstructorPermissionSet privileges;
 
     private Map<String, Long> studentDeadlines;
+    private Map<String, Long> instructorDeadlines;
 
     public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes) {
         String timeZone = feedbackSessionAttributes.getTimeZone();
@@ -122,6 +123,14 @@ public class FeedbackSessionData extends ApiOutput {
                     studentDeadlineInstant, timeZone, true)
                     .toEpochMilli();
             this.studentDeadlines.put(email, studentDeadline);
+        });
+
+        this.instructorDeadlines = new HashMap<>();
+        feedbackSessionAttributes.getFilteredInstructorDeadlines().forEach((email, instructorDeadlineInstant) -> {
+            long instructorDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                    instructorDeadlineInstant, timeZone, true)
+                    .toEpochMilli();
+            this.instructorDeadlines.put(email, instructorDeadline);
         });
     }
 
@@ -197,6 +206,10 @@ public class FeedbackSessionData extends ApiOutput {
         return studentDeadlines;
     }
 
+    public Map<String, Long> getInstructorDeadlines() {
+        return instructorDeadlines;
+    }
+
     public void setSessionVisibleFromTimestamp(Long sessionVisibleFromTimestamp) {
         this.sessionVisibleFromTimestamp = sessionVisibleFromTimestamp;
     }
@@ -259,6 +272,10 @@ public class FeedbackSessionData extends ApiOutput {
 
     public void setStudentDeadlines(Map<String, Long> studentDeadlines) {
         this.studentDeadlines = studentDeadlines;
+    }
+
+    public void setInstructorDeadlines(Map<String, Long> instructorDeadlines) {
+        this.instructorDeadlines = instructorDeadlines;
     }
 
     /**

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -90,14 +90,14 @@ public class FeedbackSessionData extends ApiOutput {
         if (feedbackSessionAttributes.isVisible() && !feedbackSessionAttributes.isOpened()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN;
         }
-        if (feedbackSessionAttributes.isOpened()) {
+        if (feedbackSessionAttributes.isOpenForInstructor()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.OPEN;
         }
-        if (feedbackSessionAttributes.isClosed()) {
-            this.submissionStatus = FeedbackSessionSubmissionStatus.CLOSED;
-        }
-        if (feedbackSessionAttributes.isInGracePeriod()) {
+        if (feedbackSessionAttributes.isInGracePeriodForInstructor()) {
             this.submissionStatus = FeedbackSessionSubmissionStatus.GRACE_PERIOD;
+        }
+        if (feedbackSessionAttributes.isClosedForInstructor()) {
+            this.submissionStatus = FeedbackSessionSubmissionStatus.CLOSED;
         }
 
         if (feedbackSessionAttributes.isPublished()) {

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -1,6 +1,8 @@
 package teammates.ui.output;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -45,6 +47,8 @@ public class FeedbackSessionData extends ApiOutput {
     private final Long deletedAtTimestamp;
     @Nullable
     private InstructorPermissionSet privileges;
+
+    private Map<String, Long> extendedDeadlines;
 
     public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes) {
         String timeZone = feedbackSessionAttributes.getTimeZone();
@@ -111,6 +115,15 @@ public class FeedbackSessionData extends ApiOutput {
         } else {
             this.deletedAtTimestamp = feedbackSessionAttributes.getDeletedTime().toEpochMilli();
         }
+
+        this.extendedDeadlines = new HashMap<>();
+        feedbackSessionAttributes.getExtendedDeadlines()
+                .forEach((email, extendedDeadlineInstant) -> {
+            long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                    extendedDeadlineInstant, timeZone, true)
+                    .toEpochMilli();
+            this.extendedDeadlines.put(email, extendedDeadline);
+        });
     }
 
     public String getCourseId() {
@@ -181,6 +194,10 @@ public class FeedbackSessionData extends ApiOutput {
         return isPublishedEmailEnabled;
     }
 
+    public Map<String, Long> getExtendedDeadlines() {
+        return extendedDeadlines;
+    }
+
     public void setSessionVisibleFromTimestamp(Long sessionVisibleFromTimestamp) {
         this.sessionVisibleFromTimestamp = sessionVisibleFromTimestamp;
     }
@@ -239,6 +256,10 @@ public class FeedbackSessionData extends ApiOutput {
 
     public void setPrivileges(InstructorPermissionSet privileges) {
         this.privileges = privileges;
+    }
+
+    public void setExtendedDeadlines(Map<String, Long> extendedDeadlines) {
+        this.extendedDeadlines = extendedDeadlines;
     }
 
     /**

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -279,24 +279,10 @@ public class FeedbackSessionData extends ApiOutput {
         this.instructorDeadlines = instructorDeadlines;
     }
 
-    private void hideInformationForParticipant() {
-        setClosingEmailEnabled(null);
-        setPublishedEmailEnabled(null);
-        setGracePeriod(null);
-        setCreatedAtTimestamp(0);
-    }
-
-    private void hideInformationForParticipantSubmission() {
-        hideInformationForParticipant();
-        setSessionVisibleFromTimestamp(null);
-        setResultVisibleFromTimestamp(null);
-        setSessionVisibleSetting(null);
-        setCustomSessionVisibleTimestamp(null);
-        setResponseVisibleSetting(null);
-        setCustomResponseVisibleTimestamp(null);
-    }
-
-    private void filterDeadlinesForStudent(String studentEmailAddress) {
+    /**
+     * Filter out all the deadlines that are not for the given student.
+     */
+    public void filterDeadlinesForStudent(String studentEmailAddress) {
         setStudentDeadlines(studentDeadlines.entrySet()
                 .stream()
                 .filter(entry -> entry.getKey().equals(studentEmailAddress))
@@ -304,7 +290,10 @@ public class FeedbackSessionData extends ApiOutput {
         setInstructorDeadlines(new HashMap<>());
     }
 
-    private void filterDeadlinesForInstructor(String instructorEmailAddress) {
+    /**
+     * Filter out all the deadlines that are not for the given instructor.
+     */
+    public void filterDeadlinesForInstructor(String instructorEmailAddress) {
         setStudentDeadlines(new HashMap<>());
         setInstructorDeadlines(instructorDeadlines.entrySet()
                 .stream()
@@ -315,24 +304,23 @@ public class FeedbackSessionData extends ApiOutput {
     /**
      * Hides some attributes to student.
      */
-    public void hideInformationForStudent(String studentEmailAddress) {
-        hideInformationForParticipantSubmission();
-        filterDeadlinesForStudent(studentEmailAddress);
+    public void hideInformationForStudent() {
+        hideInformationForInstructor();
+        setSessionVisibleFromTimestamp(null);
+        setResultVisibleFromTimestamp(null);
+        setSessionVisibleSetting(null);
+        setCustomSessionVisibleTimestamp(null);
+        setResponseVisibleSetting(null);
+        setCustomResponseVisibleTimestamp(null);
     }
 
     /**
-     * Hides some information for an instructor viewing the submission.
+     * Hides some attributes to instructor without appropriate privilege.
      */
-    public void hideInformationForInstructorSubmission(String instructorEmailAddress) {
-        hideInformationForParticipantSubmission();
-        filterDeadlinesForInstructor(instructorEmailAddress);
-    }
-
-    /**
-     * Hides some information for an instructor viewing the result.
-     */
-    public void hideInformationForInstructorResult(String instructorEmailAddress) {
-        hideInformationForParticipant();
-        filterDeadlinesForInstructor(instructorEmailAddress);
+    public void hideInformationForInstructor() {
+        setClosingEmailEnabled(null);
+        setPublishedEmailEnabled(null);
+        setGracePeriod(null);
+        setCreatedAtTimestamp(0);
     }
 }

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -48,7 +48,7 @@ public class FeedbackSessionData extends ApiOutput {
     @Nullable
     private InstructorPermissionSet privileges;
 
-    private Map<String, Long> extendedDeadlines;
+    private Map<String, Long> studentDeadlines;
 
     public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes) {
         String timeZone = feedbackSessionAttributes.getTimeZone();
@@ -116,12 +116,12 @@ public class FeedbackSessionData extends ApiOutput {
             this.deletedAtTimestamp = feedbackSessionAttributes.getDeletedTime().toEpochMilli();
         }
 
-        this.extendedDeadlines = new HashMap<>();
-        feedbackSessionAttributes.getFilteredExtendedDeadlines().forEach((email, extendedDeadlineInstant) -> {
-            long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-                    extendedDeadlineInstant, timeZone, true)
+        this.studentDeadlines = new HashMap<>();
+        feedbackSessionAttributes.getFilteredStudentDeadlines().forEach((email, studentDeadlineInstant) -> {
+            long studentDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                    studentDeadlineInstant, timeZone, true)
                     .toEpochMilli();
-            this.extendedDeadlines.put(email, extendedDeadline);
+            this.studentDeadlines.put(email, studentDeadline);
         });
     }
 
@@ -193,8 +193,8 @@ public class FeedbackSessionData extends ApiOutput {
         return isPublishedEmailEnabled;
     }
 
-    public Map<String, Long> getExtendedDeadlines() {
-        return extendedDeadlines;
+    public Map<String, Long> getStudentDeadlines() {
+        return studentDeadlines;
     }
 
     public void setSessionVisibleFromTimestamp(Long sessionVisibleFromTimestamp) {
@@ -257,8 +257,8 @@ public class FeedbackSessionData extends ApiOutput {
         this.privileges = privileges;
     }
 
-    public void setExtendedDeadlines(Map<String, Long> extendedDeadlines) {
-        this.extendedDeadlines = extendedDeadlines;
+    public void setStudentDeadlines(Map<String, Long> studentDeadlines) {
+        this.studentDeadlines = studentDeadlines;
     }
 
     /**

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -126,6 +126,28 @@ public class FeedbackSessionData extends ApiOutput {
         });
     }
 
+    public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes, String participantEmailAddress) {
+        this(feedbackSessionAttributes);
+
+        if (feedbackSessionAttributes.isOpenForParticipant(participantEmailAddress)) {
+            this.submissionStatus = FeedbackSessionSubmissionStatus.OPEN;
+        }
+        if (feedbackSessionAttributes.isInGracePeriodForParticipant(participantEmailAddress)) {
+            this.submissionStatus = FeedbackSessionSubmissionStatus.GRACE_PERIOD;
+        }
+        if (feedbackSessionAttributes.isClosedForParticipant(participantEmailAddress)) {
+            this.submissionStatus = FeedbackSessionSubmissionStatus.CLOSED;
+        }
+
+        this.extendedDeadlines = new HashMap<>();
+        Map<String, Instant> extendedDeadlineInstants = feedbackSessionAttributes.getExtendedDeadlines();
+        if (extendedDeadlineInstants.containsKey(participantEmailAddress)) {
+            long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                    extendedDeadlineInstants.get(participantEmailAddress), timeZone, true).toEpochMilli();
+            this.extendedDeadlines.put(participantEmailAddress, extendedDeadline);
+        }
+    }
+
     public String getCourseId() {
         return courseId;
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -58,18 +58,22 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         case STUDENT_RESULT:
             StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
             String studentEmailAddress = studentAttributes.getEmail();
-            response = new FeedbackSessionData(feedbackSession, studentEmailAddress);
+            feedbackSession = feedbackSession.getCopyForParticipant(studentEmailAddress);
+            response = new FeedbackSessionData(feedbackSession);
             response.hideInformationForStudent();
             break;
         case INSTRUCTOR_SUBMISSION:
+            feedbackSession = feedbackSession.getCopyForInstructor();
             response = new FeedbackSessionData(feedbackSession);
             response.hideInformationForStudent();
             break;
         case INSTRUCTOR_RESULT:
+            feedbackSession = feedbackSession.getCopyForInstructor();
             response = new FeedbackSessionData(feedbackSession);
             response.hideInformationForInstructor();
             break;
         case FULL_DETAIL:
+            feedbackSession = feedbackSession.getCopyForInstructor();
             response = new FeedbackSessionData(feedbackSession);
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -79,7 +79,7 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         case STUDENT_RESULT:
             StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
             String studentEmail = studentAttributes.getEmail();
-            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForStudent(studentEmail);
+            feedbackSessionAttributes = feedbackSessionAttributes.sanitizeForStudent(studentEmail);
             response = new FeedbackSessionData(feedbackSessionAttributes);
             response.filterDeadlinesForStudent(studentEmail);
             break;
@@ -87,7 +87,7 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         case INSTRUCTOR_RESULT:
             InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
             String instructorEmail = instructorAttributes.getEmail();
-            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForInstructor(instructorEmail);
+            feedbackSessionAttributes = feedbackSessionAttributes.sanitizeForInstructor(instructorEmail);
             response = new FeedbackSessionData(feedbackSessionAttributes);
             response.filterDeadlinesForInstructor(instructorEmail);
             break;

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -52,9 +52,7 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
 
         switch (intent) {
         case STUDENT_SUBMISSION:
-            // fall-through
         case STUDENT_RESULT:
-            // fall-through
         case INSTRUCTOR_SUBMISSION:
             response.hideInformationForStudent();
             break;
@@ -78,22 +76,20 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         FeedbackSessionData response;
         switch (intent) {
         case STUDENT_SUBMISSION:
-            // fall-through
         case STUDENT_RESULT:
             StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
-            String studentEmailAddress = studentAttributes.getEmail();
-            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForStudent(studentEmailAddress);
+            String studentEmail = studentAttributes.getEmail();
+            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForStudent(studentEmail);
             response = new FeedbackSessionData(feedbackSessionAttributes);
-            response.filterDeadlinesForStudent(studentEmailAddress);
+            response.filterDeadlinesForStudent(studentEmail);
             break;
         case INSTRUCTOR_SUBMISSION:
-            // fall-through
         case INSTRUCTOR_RESULT:
             InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
-            String instructorEmailAddress = instructorAttributes.getEmail();
-            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForInstructor(instructorEmailAddress);
+            String instructorEmail = instructorAttributes.getEmail();
+            feedbackSessionAttributes = feedbackSessionAttributes.getCopyForInstructor(instructorEmail);
             response = new FeedbackSessionData(feedbackSessionAttributes);
-            response.filterDeadlinesForInstructor(instructorEmailAddress);
+            response.filterDeadlinesForInstructor(instructorEmail);
             break;
         case FULL_DETAIL:
             response = new FeedbackSessionData(feedbackSessionAttributes);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -51,19 +51,26 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
         FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
-        FeedbackSessionData response = new FeedbackSessionData(feedbackSession);
 
+        FeedbackSessionData response;
         switch (intent) {
         case STUDENT_SUBMISSION:
-        case INSTRUCTOR_SUBMISSION:
         case STUDENT_RESULT:
-            // hide some attributes for submission
+            StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
+            String studentEmailAddress = studentAttributes.getEmail();
+            response = new FeedbackSessionData(feedbackSession, studentEmailAddress);
+            response.hideInformationForStudent();
+            break;
+        case INSTRUCTOR_SUBMISSION:
+            response = new FeedbackSessionData(feedbackSession);
             response.hideInformationForStudent();
             break;
         case INSTRUCTOR_RESULT:
+            response = new FeedbackSessionData(feedbackSession);
             response.hideInformationForInstructor();
             break;
         case FULL_DETAIL:
+            response = new FeedbackSessionData(feedbackSession);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -13,7 +13,6 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
-import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.output.FeedbackSessionsData;
 
 /**
@@ -109,7 +108,9 @@ class GetFeedbackSessionsAction extends Action {
 
         FeedbackSessionsData responseData = new FeedbackSessionsData(feedbackSessionAttributes);
         if (entityType.equals(Const.EntityType.STUDENT)) {
-            responseData.getFeedbackSessions().forEach(FeedbackSessionData::hideInformationForStudent);
+            StudentAttributes studentAttributes = logic.getStudentsForGoogleId(userInfo.getId()).get(0);
+            responseData.getFeedbackSessions().forEach(feedbackSessionData -> feedbackSessionData
+                            .hideInformationForStudent(studentAttributes.getEmail()));
         } else if (entityType.equals(Const.EntityType.INSTRUCTOR)) {
             responseData.getFeedbackSessions().forEach(session -> {
                 InstructorAttributes instructor = courseIdToInstructor.get(session.getCourseId());

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -13,6 +13,7 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.output.FeedbackSessionsData;
 
 /**
@@ -108,9 +109,7 @@ class GetFeedbackSessionsAction extends Action {
 
         FeedbackSessionsData responseData = new FeedbackSessionsData(feedbackSessionAttributes);
         if (entityType.equals(Const.EntityType.STUDENT)) {
-            StudentAttributes studentAttributes = logic.getStudentsForGoogleId(userInfo.getId()).get(0);
-            responseData.getFeedbackSessions().forEach(feedbackSessionData -> feedbackSessionData
-                            .hideInformationForStudent(studentAttributes.getEmail()));
+            responseData.getFeedbackSessions().forEach(FeedbackSessionData::hideInformationForStudent);
         } else if (entityType.equals(Const.EntityType.INSTRUCTOR)) {
             responseData.getFeedbackSessions().forEach(session -> {
                 InstructorAttributes instructor = courseIdToInstructor.get(session.getCourseId());

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -135,7 +135,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "demo.course:Second Session": {
       "feedbackSessionName": "First team feedback session",
@@ -156,7 +157,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "demo.course:Third Session": {
       "feedbackSessionName": "Second team feedback session",
@@ -177,7 +179,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -136,7 +136,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "demo.course:Second Session": {
       "feedbackSessionName": "First team feedback session",
@@ -158,7 +159,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "demo.course:Third Session": {
       "feedbackSessionName": "Second team feedback session",
@@ -180,7 +182,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -136,7 +136,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "demo.course:Second Session": {
       "feedbackSessionName": "First team feedback session",
@@ -158,7 +158,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "demo.course:Third Session": {
       "feedbackSessionName": "Second team feedback session",
@@ -180,7 +180,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
@@ -3,6 +3,8 @@ package teammates.common.datatransfer.attributes;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -47,6 +49,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(fsa.isOpeningEmailEnabled());
         assertTrue(fsa.isClosingEmailEnabled());
         assertTrue(fsa.isPublishedEmailEnabled());
+
+        assertEquals(new HashMap<>(), fsa.getExtendedDeadlines());
     }
 
     @Test
@@ -108,6 +112,12 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                     .withGracePeriod(null)
                     .build();
         });
+
+        assertThrows(AssertionError.class, () -> {
+            FeedbackSessionAttributes.builder("session name", "course")
+                    .withExtendedDeadlines(null)
+                    .build();
+        });
     }
 
     @Test
@@ -119,7 +129,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                 Instant.now().minusSeconds(20), Instant.now().plusSeconds(20),
                 "UTC", 10,
                 false, false, false, false, false,
-                true, true, true);
+                true, true, true, new HashMap<>());
 
         FeedbackSessionAttributes feedbackSessionAttributes = FeedbackSessionAttributes.valueOf(feedbackSession);
 
@@ -141,6 +151,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isOpeningEmailEnabled(), feedbackSessionAttributes.isOpeningEmailEnabled());
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
+        assertEquals(feedbackSession.getExtendedDeadlines(), feedbackSessionAttributes.getExtendedDeadlines());
     }
 
     @Test
@@ -152,7 +163,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                 Instant.now().minusSeconds(20), Instant.now().plusSeconds(20),
                 "UTC", 10, false,
                 false, false, false, false,
-                true, true, true);
+                true, true, true, new HashMap<>());
         assertNull(feedbackSession.getInstructions());
 
         FeedbackSessionAttributes feedbackSessionAttributes = FeedbackSessionAttributes.valueOf(feedbackSession);
@@ -175,6 +186,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isOpeningEmailEnabled(), feedbackSessionAttributes.isOpeningEmailEnabled());
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
+        assertEquals(feedbackSession.getExtendedDeadlines(), feedbackSessionAttributes.getExtendedDeadlines());
     }
 
     @Test
@@ -217,6 +229,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertFalse(fsa.isSentClosedEmail());
         assertFalse(fsa.isSentPublishedEmail());
 
+        assertEquals(new HashMap<>(), fsa.getExtendedDeadlines());
+
     }
 
     @Test
@@ -257,6 +271,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(original.isSentOpeningSoonEmail(), copy.isSentOpeningSoonEmail());
         assertEquals(original.isSentOpenEmail(), copy.isSentOpenEmail());
         assertEquals(original.isSentPublishedEmail(), copy.isSentPublishedEmail());
+        assertEquals(original.getExtendedDeadlines(), copy.getExtendedDeadlines());
     }
 
     @Test
@@ -295,6 +310,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         Instant startTime = TimeHelper.getInstantDaysOffsetFromNow(-2);
         Instant endTime = TimeHelper.getInstantDaysOffsetFromNow(-1);
         Instant resultVisibleTime = TimeHelper.getInstantDaysOffsetFromNow(1);
+        Map<String, Instant> newExtendedDeadlines = new HashMap<>();
+        newExtendedDeadlines.put("student@school.edu", endTime.plusSeconds(3600L));
         FeedbackSessionAttributes.UpdateOptions updateOptions =
                 FeedbackSessionAttributes.updateOptionsBuilder("sessionName", "courseId")
                         .withInstructions("instruction 1")
@@ -311,6 +328,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                         .withSentPublishedEmail(true)
                         .withIsClosingEmailEnabled(true)
                         .withIsPublishedEmailEnabled(true)
+                        .withExtendedDeadlines(newExtendedDeadlines)
                         .build();
 
         assertEquals("sessionName", updateOptions.getFeedbackSessionName());
@@ -347,6 +365,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(feedbackSessionAttributes.isOpeningEmailEnabled());
         assertTrue(feedbackSessionAttributes.isClosingEmailEnabled());
         assertTrue(feedbackSessionAttributes.isPublishedEmailEnabled());
+        assertEquals(newExtendedDeadlines, feedbackSessionAttributes.getExtendedDeadlines());
 
         // build update option based on existing update option
         FeedbackSessionAttributes.UpdateOptions newUpdateOptions =
@@ -386,6 +405,9 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertThrows(AssertionError.class, () ->
                 FeedbackSessionAttributes.updateOptionsBuilder("session", "courseId")
                         .withGracePeriod(null));
+        assertThrows(AssertionError.class, () ->
+                FeedbackSessionAttributes.updateOptionsBuilder("session", "courseId")
+                        .withExtendedDeadlines(null));
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
@@ -171,7 +171,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                 Instant.now().minusSeconds(20), Instant.now().plusSeconds(20),
                 "UTC", 10, false,
                 false, false, false, false,
-                true, true, true, new HashMap<>(), new HashMap<>());
+                true, true, true, null, null);
         assertNull(feedbackSession.getInstructions());
 
         FeedbackSessionAttributes feedbackSessionAttributes = FeedbackSessionAttributes.valueOf(feedbackSession);
@@ -194,8 +194,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isOpeningEmailEnabled(), feedbackSessionAttributes.isOpeningEmailEnabled());
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
-        assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
-        assertEquals(feedbackSession.getInstructorDeadlines(), feedbackSessionAttributes.getInstructorDeadlines());
+        assertEquals(new HashMap<>(), feedbackSessionAttributes.getStudentDeadlines());
+        assertEquals(new HashMap<>(), feedbackSessionAttributes.getInstructorDeadlines());
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.common.util.TimeHelperExtension;
@@ -52,6 +53,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
 
         assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
         assertEquals(new HashMap<>(), fsa.getInstructorDeadlines());
+
+        assertEquals(fsa.getEndTime(), fsa.getDeadline());
     }
 
     @Test
@@ -160,6 +163,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
         assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
         assertEquals(feedbackSession.getInstructorDeadlines(), feedbackSessionAttributes.getInstructorDeadlines());
+
+        assertEquals(feedbackSession.getEndTime(), feedbackSessionAttributes.getDeadline());
     }
 
     @Test
@@ -196,6 +201,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
         assertEquals(new HashMap<>(), feedbackSessionAttributes.getStudentDeadlines());
         assertEquals(new HashMap<>(), feedbackSessionAttributes.getInstructorDeadlines());
+
+        assertEquals(feedbackSession.getEndTime(), feedbackSessionAttributes.getDeadline());
     }
 
     @Test
@@ -241,6 +248,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
         assertEquals(new HashMap<>(), fsa.getInstructorDeadlines());
 
+        assertEquals(endTime, fsa.getDeadline());
+
     }
 
     @Test
@@ -283,6 +292,48 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(original.isSentPublishedEmail(), copy.isSentPublishedEmail());
         assertEquals(original.getStudentDeadlines(), copy.getStudentDeadlines());
         assertEquals(original.getInstructorDeadlines(), copy.getInstructorDeadlines());
+
+        assertEquals(original.getEndTime(), copy.getDeadline());
+    }
+
+    @Test
+    public void testSanitizeForStudent() {
+        DataBundle typicalDataBundle = getTypicalDataBundle();
+        FeedbackSessionAttributes session1InCourse1 = typicalDataBundle.feedbackSessions
+                .get("session1InCourse1");
+
+        StudentAttributes student1InCourse1 = typicalDataBundle.students.get("student1InCourse1");
+        StudentAttributes student3InCourse1 = typicalDataBundle.students.get("student3InCourse1");
+
+        FeedbackSessionAttributes sanitizedSession1InCourse1 = session1InCourse1.sanitizeForStudent(
+                student1InCourse1.getEmail());
+        assertEquals(sanitizedSession1InCourse1.getEndTime(), sanitizedSession1InCourse1.getDeadline());
+
+        sanitizedSession1InCourse1 = session1InCourse1.sanitizeForStudent(student3InCourse1.getEmail());
+        assertEquals(sanitizedSession1InCourse1.getStudentDeadlines().get(student3InCourse1.getEmail()),
+                sanitizedSession1InCourse1.getDeadline());
+
+        assertEquals(session1InCourse1.getEndTime(), session1InCourse1.getDeadline());
+    }
+
+    @Test
+    public void testSanitizeForInstructor() {
+        DataBundle typicalDataBundle = getTypicalDataBundle();
+        FeedbackSessionAttributes session1InCourse1 = typicalDataBundle.feedbackSessions
+                .get("session1InCourse1");
+
+        InstructorAttributes helperOfCourse1 = typicalDataBundle.instructors.get("helperOfCourse1");
+        InstructorAttributes instructor1OfCourse1 = typicalDataBundle.instructors.get("instructor1OfCourse1");
+
+        FeedbackSessionAttributes sanitizedSession1InCourse1 = session1InCourse1.sanitizeForInstructor(
+                helperOfCourse1.getEmail());
+        assertEquals(sanitizedSession1InCourse1.getEndTime(), sanitizedSession1InCourse1.getDeadline());
+
+        sanitizedSession1InCourse1 = session1InCourse1.sanitizeForInstructor(instructor1OfCourse1.getEmail());
+        assertEquals(sanitizedSession1InCourse1.getInstructorDeadlines().get(instructor1OfCourse1.getEmail()),
+                sanitizedSession1InCourse1.getDeadline());
+
+        assertEquals(session1InCourse1.getEndTime(), session1InCourse1.getDeadline());
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
@@ -50,7 +50,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(fsa.isClosingEmailEnabled());
         assertTrue(fsa.isPublishedEmailEnabled());
 
-        assertEquals(new HashMap<>(), fsa.getExtendedDeadlines());
+        assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
 
         assertThrows(AssertionError.class, () -> {
             FeedbackSessionAttributes.builder("session name", "course")
-                    .withExtendedDeadlines(null)
+                    .withStudentDeadlines(null)
                     .build();
         });
     }
@@ -151,7 +151,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isOpeningEmailEnabled(), feedbackSessionAttributes.isOpeningEmailEnabled());
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
-        assertEquals(feedbackSession.getExtendedDeadlines(), feedbackSessionAttributes.getExtendedDeadlines());
+        assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
     }
 
     @Test
@@ -186,7 +186,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isOpeningEmailEnabled(), feedbackSessionAttributes.isOpeningEmailEnabled());
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
-        assertEquals(feedbackSession.getExtendedDeadlines(), feedbackSessionAttributes.getExtendedDeadlines());
+        assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
     }
 
     @Test
@@ -229,7 +229,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertFalse(fsa.isSentClosedEmail());
         assertFalse(fsa.isSentPublishedEmail());
 
-        assertEquals(new HashMap<>(), fsa.getExtendedDeadlines());
+        assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
 
     }
 
@@ -271,7 +271,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(original.isSentOpeningSoonEmail(), copy.isSentOpeningSoonEmail());
         assertEquals(original.isSentOpenEmail(), copy.isSentOpenEmail());
         assertEquals(original.isSentPublishedEmail(), copy.isSentPublishedEmail());
-        assertEquals(original.getExtendedDeadlines(), copy.getExtendedDeadlines());
+        assertEquals(original.getStudentDeadlines(), copy.getStudentDeadlines());
     }
 
     @Test
@@ -310,8 +310,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         Instant startTime = TimeHelper.getInstantDaysOffsetFromNow(-2);
         Instant endTime = TimeHelper.getInstantDaysOffsetFromNow(-1);
         Instant resultVisibleTime = TimeHelper.getInstantDaysOffsetFromNow(1);
-        Map<String, Instant> newExtendedDeadlines = new HashMap<>();
-        newExtendedDeadlines.put("student@school.edu", endTime.plusSeconds(3600L));
+        Map<String, Instant> newStudentDeadlines = new HashMap<>();
+        newStudentDeadlines.put("student@school.edu", endTime.plusSeconds(3600L));
         FeedbackSessionAttributes.UpdateOptions updateOptions =
                 FeedbackSessionAttributes.updateOptionsBuilder("sessionName", "courseId")
                         .withInstructions("instruction 1")
@@ -328,7 +328,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                         .withSentPublishedEmail(true)
                         .withIsClosingEmailEnabled(true)
                         .withIsPublishedEmailEnabled(true)
-                        .withExtendedDeadlines(newExtendedDeadlines)
+                        .withStudentDeadlines(newStudentDeadlines)
                         .build();
 
         assertEquals("sessionName", updateOptions.getFeedbackSessionName());
@@ -365,7 +365,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(feedbackSessionAttributes.isOpeningEmailEnabled());
         assertTrue(feedbackSessionAttributes.isClosingEmailEnabled());
         assertTrue(feedbackSessionAttributes.isPublishedEmailEnabled());
-        assertEquals(newExtendedDeadlines, feedbackSessionAttributes.getExtendedDeadlines());
+        assertEquals(newStudentDeadlines, feedbackSessionAttributes.getStudentDeadlines());
 
         // build update option based on existing update option
         FeedbackSessionAttributes.UpdateOptions newUpdateOptions =
@@ -407,7 +407,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                         .withGracePeriod(null));
         assertThrows(AssertionError.class, () ->
                 FeedbackSessionAttributes.updateOptionsBuilder("session", "courseId")
-                        .withExtendedDeadlines(null));
+                        .withStudentDeadlines(null));
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributesTest.java
@@ -51,6 +51,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(fsa.isPublishedEmailEnabled());
 
         assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
+        assertEquals(new HashMap<>(), fsa.getInstructorDeadlines());
     }
 
     @Test
@@ -118,6 +119,12 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                     .withStudentDeadlines(null)
                     .build();
         });
+
+        assertThrows(AssertionError.class, () -> {
+            FeedbackSessionAttributes.builder("session name", "course")
+                    .withInstructorDeadlines(null)
+                    .build();
+        });
     }
 
     @Test
@@ -129,7 +136,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                 Instant.now().minusSeconds(20), Instant.now().plusSeconds(20),
                 "UTC", 10,
                 false, false, false, false, false,
-                true, true, true, new HashMap<>());
+                true, true, true, new HashMap<>(), new HashMap<>());
 
         FeedbackSessionAttributes feedbackSessionAttributes = FeedbackSessionAttributes.valueOf(feedbackSession);
 
@@ -152,6 +159,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
         assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
+        assertEquals(feedbackSession.getInstructorDeadlines(), feedbackSessionAttributes.getInstructorDeadlines());
     }
 
     @Test
@@ -163,7 +171,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                 Instant.now().minusSeconds(20), Instant.now().plusSeconds(20),
                 "UTC", 10, false,
                 false, false, false, false,
-                true, true, true, new HashMap<>());
+                true, true, true, new HashMap<>(), new HashMap<>());
         assertNull(feedbackSession.getInstructions());
 
         FeedbackSessionAttributes feedbackSessionAttributes = FeedbackSessionAttributes.valueOf(feedbackSession);
@@ -187,6 +195,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(feedbackSession.isClosingEmailEnabled(), feedbackSessionAttributes.isClosingEmailEnabled());
         assertEquals(feedbackSession.isPublishedEmailEnabled(), feedbackSessionAttributes.isPublishedEmailEnabled());
         assertEquals(feedbackSession.getStudentDeadlines(), feedbackSessionAttributes.getStudentDeadlines());
+        assertEquals(feedbackSession.getInstructorDeadlines(), feedbackSessionAttributes.getInstructorDeadlines());
     }
 
     @Test
@@ -230,6 +239,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertFalse(fsa.isSentPublishedEmail());
 
         assertEquals(new HashMap<>(), fsa.getStudentDeadlines());
+        assertEquals(new HashMap<>(), fsa.getInstructorDeadlines());
 
     }
 
@@ -272,6 +282,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertEquals(original.isSentOpenEmail(), copy.isSentOpenEmail());
         assertEquals(original.isSentPublishedEmail(), copy.isSentPublishedEmail());
         assertEquals(original.getStudentDeadlines(), copy.getStudentDeadlines());
+        assertEquals(original.getInstructorDeadlines(), copy.getInstructorDeadlines());
     }
 
     @Test
@@ -312,6 +323,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         Instant resultVisibleTime = TimeHelper.getInstantDaysOffsetFromNow(1);
         Map<String, Instant> newStudentDeadlines = new HashMap<>();
         newStudentDeadlines.put("student@school.edu", endTime.plusSeconds(3600L));
+        Map<String, Instant> newInstructorDeadlines = new HashMap<>();
+        newInstructorDeadlines.put("instructor@university.edu", endTime.plusSeconds(7200L));
         FeedbackSessionAttributes.UpdateOptions updateOptions =
                 FeedbackSessionAttributes.updateOptionsBuilder("sessionName", "courseId")
                         .withInstructions("instruction 1")
@@ -329,6 +342,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
                         .withIsClosingEmailEnabled(true)
                         .withIsPublishedEmailEnabled(true)
                         .withStudentDeadlines(newStudentDeadlines)
+                        .withInstructorDeadlines(newInstructorDeadlines)
                         .build();
 
         assertEquals("sessionName", updateOptions.getFeedbackSessionName());
@@ -366,6 +380,7 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertTrue(feedbackSessionAttributes.isClosingEmailEnabled());
         assertTrue(feedbackSessionAttributes.isPublishedEmailEnabled());
         assertEquals(newStudentDeadlines, feedbackSessionAttributes.getStudentDeadlines());
+        assertEquals(newInstructorDeadlines, feedbackSessionAttributes.getInstructorDeadlines());
 
         // build update option based on existing update option
         FeedbackSessionAttributes.UpdateOptions newUpdateOptions =
@@ -408,6 +423,9 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
         assertThrows(AssertionError.class, () ->
                 FeedbackSessionAttributes.updateOptionsBuilder("session", "courseId")
                         .withStudentDeadlines(null));
+        assertThrows(AssertionError.class, () ->
+                FeedbackSessionAttributes.updateOptionsBuilder("session", "courseId")
+                        .withInstructorDeadlines(null));
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
@@ -6,7 +6,9 @@ import static teammates.common.util.FieldValidator.TIME_FRAME_ERROR_MESSAGE;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.testng.annotations.AfterMethod;
@@ -451,6 +453,8 @@ public class FeedbackSessionsDbTest extends BaseTestCaseWithLocalDatabaseAccess 
                         .withSentPublishedEmail(fs.isSentPublishedEmail())
                         .withIsClosingEmailEnabled(fs.isClosingEmailEnabled())
                         .withIsPublishedEmailEnabled(fs.isPublishedEmailEnabled())
+                        .withStudentDeadlines(fs.getStudentDeadlines())
+                        .withInstructorDeadlines(fs.getInstructorDeadlines())
                         .build());
 
         assertEquals(JsonUtils.toJson(fs), JsonUtils.toJson(updatedFs));
@@ -661,6 +665,30 @@ public class FeedbackSessionsDbTest extends BaseTestCaseWithLocalDatabaseAccess 
         actualFs = fsDb.getFeedbackSession(typicalFs.getCourseId(), typicalFs.getFeedbackSessionName());
         assertFalse(updatedFs.isPublishedEmailEnabled());
         assertFalse(actualFs.isPublishedEmailEnabled());
+
+        assertEquals(new HashMap<>(), actualFs.getStudentDeadlines());
+        Map<String, Instant> newStudentDeadlines = new HashMap<>();
+        newStudentDeadlines.put("student@school.edu", Instant.now());
+        updatedFs = fsDb.updateFeedbackSession(
+                FeedbackSessionAttributes
+                        .updateOptionsBuilder(typicalFs.getFeedbackSessionName(), typicalFs.getCourseId())
+                        .withStudentDeadlines(newStudentDeadlines)
+                        .build());
+        actualFs = fsDb.getFeedbackSession(typicalFs.getCourseId(), typicalFs.getFeedbackSessionName());
+        assertEquals(newStudentDeadlines, updatedFs.getStudentDeadlines());
+        assertEquals(newStudentDeadlines, actualFs.getStudentDeadlines());
+
+        assertEquals(new HashMap<>(), actualFs.getInstructorDeadlines());
+        Map<String, Instant> newInstructorDeadlines = new HashMap<>();
+        newInstructorDeadlines.put("instructor@school.edu", Instant.now());
+        updatedFs = fsDb.updateFeedbackSession(
+                FeedbackSessionAttributes
+                        .updateOptionsBuilder(typicalFs.getFeedbackSessionName(), typicalFs.getCourseId())
+                        .withInstructorDeadlines(newInstructorDeadlines)
+                        .build());
+        actualFs = fsDb.getFeedbackSession(typicalFs.getCourseId(), typicalFs.getFeedbackSessionName());
+        assertEquals(newInstructorDeadlines, updatedFs.getInstructorDeadlines());
+        assertEquals(newInstructorDeadlines, actualFs.getInstructorDeadlines());
     }
 
     private FeedbackSessionAttributes getNewFeedbackSession() {

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
 
@@ -1179,12 +1180,11 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
     private void assertEqualDeadlines(Map<String, Instant> expectedDeadlineInstants, Map<String, Long> actualDeadlines,
             String timeZone) {
-        Map<String, Long> expectedDeadlines = new HashMap<>();
-        expectedDeadlineInstants.forEach((emailAddress, deadlineInstant) -> {
-            Long deadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(deadlineInstant, timeZone, true)
-                    .toEpochMilli();
-            expectedDeadlines.put(emailAddress, deadline);
-        });
+        Map<String, Long> expectedDeadlines = expectedDeadlineInstants.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry ->
+                        TimeHelper.getMidnightAdjustedInstantBasedOnZone(entry.getValue(), timeZone, true)
+                                .toEpochMilli()));
         assertEquals(expectedDeadlines, actualDeadlines);
     }
 

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
@@ -14,6 +14,10 @@ import teammates.ui.output.ResponseVisibleSetting;
 import teammates.ui.output.SessionVisibleSetting;
 import teammates.ui.request.Intent;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * SUT: {@link GetFeedbackSessionAction}.
  */
@@ -91,6 +95,9 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(feedbackSessionAttributes.getCreatedTime().toEpochMilli(), response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
+
+        assertEqualExtendedDeadlines(feedbackSessionAttributes.getExtendedDeadlines(), response.getExtendedDeadlines(),
+                timeZone);
     }
 
     @Override
@@ -241,5 +248,18 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
                 Const.ParamsNames.PREVIEWAS, previewPerson,
                 Const.ParamsNames.REGKEY, regKey,
         };
+    }
+
+    private void assertEqualExtendedDeadlines(Map<String, Instant> expectedExtendedDeadlineInstants,
+                                              Map<String, Long> actualExtendedDeadlines, String timeZone) {
+        Map<String, Long> expectedExtendedDeadlines = new HashMap<>();
+        expectedExtendedDeadlineInstants
+                .forEach((participantEmailAddress, extendedDeadlineInstant) -> {
+                    Long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                                    extendedDeadlineInstant, timeZone, true)
+                            .toEpochMilli();
+                    expectedExtendedDeadlines.put(participantEmailAddress, extendedDeadline);
+                });
+        assertEquals(expectedExtendedDeadlines, actualExtendedDeadlines);
     }
 }

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
@@ -97,7 +97,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(feedbackSessionAttributes.getCreatedTime().toEpochMilli(), response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertEqualExtendedDeadlines(feedbackSessionAttributes.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(feedbackSessionAttributes.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         logoutUser();
@@ -111,9 +111,9 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
-        Map<String, Long> relativeExtendedDeadlines = new HashMap<>();
+        Map<String, Long> relativeStudentDeadlines = new HashMap<>();
         FeedbackSessionAttributes relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(60 * 60,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         String[] params = new String[] {
@@ -164,12 +164,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(relativeFeedbackSession.getCreatedTime().toEpochMilli(), response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get full detail; no extensions; after end time but within grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -178,12 +178,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get full detail; no extensions; after end time and beyond grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -192,15 +192,15 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get full detail; some extensions; after end time but before last extended deadline");
 
-        relativeExtendedDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
+        relativeStudentDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -209,14 +209,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get full detail; some extensions; after last extended deadline but within grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -225,14 +225,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get full detail; some extensions; after last extended deadline and beyond grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -241,7 +241,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         logoutUser();
@@ -255,9 +255,9 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
-        Map<String, Long> relativeExtendedDeadlines = new HashMap<>();
+        Map<String, Long> relativeStudentDeadlines = new HashMap<>();
         FeedbackSessionAttributes relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(60 * 60,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         String[] params = new String[] {
@@ -300,12 +300,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(0, response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get submission by instructor; no extensions; after end time but within grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -314,12 +314,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get submission by instructor; no extensions; after end time and beyond grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -328,15 +328,15 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get submission by instructor; some extensions; after end time but before last extended deadline");
 
-        relativeExtendedDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
+        relativeStudentDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -345,14 +345,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get submission by instructor; some extensions; after last extended deadline but within grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -361,14 +361,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get submission by instructor; some extensions; after last extended deadline and beyond grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -377,7 +377,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         logoutUser();
@@ -391,9 +391,9 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
-        Map<String, Long> relativeExtendedDeadlines = new HashMap<>();
+        Map<String, Long> relativeStudentDeadlines = new HashMap<>();
         FeedbackSessionAttributes relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(60 * 60,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         String[] params = new String[] {
@@ -444,12 +444,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(0, response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get result by instructor; no extensions; after end time but within grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -458,12 +458,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get result by instructor; no extensions; after end time and beyond grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -472,15 +472,15 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get result by instructor; some extensions; after end time but before last extended deadline");
 
-        relativeExtendedDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
+        relativeStudentDeadlines.put("student1InCourse1@gmail.tmt", -60L * 60 * 23);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -489,14 +489,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get result by instructor; some extensions; after last extended deadline but within grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -505,14 +505,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         ______TS("get result by instructor; some extensions; after last extended deadline and beyond grace period");
 
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", -60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 24,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -521,7 +521,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertEqualExtendedDeadlines(relativeFeedbackSession.getExtendedDeadlines(), response.getExtendedDeadlines(),
+        assertEqualStudentDeadlines(relativeFeedbackSession.getStudentDeadlines(), response.getStudentDeadlines(),
                 timeZone);
 
         logoutUser();
@@ -535,10 +535,10 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
         loginAsStudent(student1InCourse1.getGoogleId());
 
-        Map<String, Long> relativeExtendedDeadlines = new HashMap<>();
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60 * 24);
+        Map<String, Long> relativeStudentDeadlines = new HashMap<>();
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60 * 24);
         FeedbackSessionAttributes relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(60 * 60,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         String[] params = new String[] {
@@ -581,11 +581,11 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(0, response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get submission by student with no extension; after end time but within grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -594,11 +594,11 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get submission by student with no extension; after end time and beyond grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -607,12 +607,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get submission by student with extension; after end time but before extended deadline");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), 60L * 60);
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), 60L * 60);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -621,13 +621,13 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         ______TS("get submission by student with extension; after extended deadline but within grace period");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), -60L);
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), -60L);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -636,14 +636,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         ______TS("get submission by student with extension; after extended deadline and beyond grace period");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), -60L * 60);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), -60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 2,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -652,8 +652,8 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         logoutUser();
     }
@@ -666,10 +666,10 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
         loginAsStudent(student1InCourse1.getGoogleId());
 
-        Map<String, Long> relativeExtendedDeadlines = new HashMap<>();
-        relativeExtendedDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60 * 24);
+        Map<String, Long> relativeStudentDeadlines = new HashMap<>();
+        relativeStudentDeadlines.put("student2InCourse1@gmail.tmt", 60L * 60 * 24);
         FeedbackSessionAttributes relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(60 * 60,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         String[] params = new String[] {
@@ -712,11 +712,11 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         assertEquals(0, response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get result by student with no extension; after end time but within grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -725,11 +725,11 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get result by student with no extension; after end time and beyond grace period");
 
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -738,12 +738,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().isEmpty());
+        assertTrue(response.getStudentDeadlines().isEmpty());
 
         ______TS("get result by student with extension; after end time but before extended deadline");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), 60L * 60);
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), 60L * 60);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -752,13 +752,13 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         ______TS("get result by student with extension; after extended deadline but within grace period");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), -60L);
-        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeExtendedDeadlines);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), -60L);
+        relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60, relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -767,14 +767,14 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         ______TS("get result by student with extension; after extended deadline and beyond grace period");
 
-        relativeExtendedDeadlines.put(student1InCourse1.getEmail(), -60L * 60);
+        relativeStudentDeadlines.put(student1InCourse1.getEmail(), -60L * 60);
         relativeFeedbackSession = generateRelativeFeedbackSessionInTypicalCourse1(-60 * 60 * 2,
-                relativeExtendedDeadlines);
+                relativeStudentDeadlines);
         typicalBundle.feedbackSessions.put("relativeFeedbackSession", relativeFeedbackSession);
         removeAndRestoreDataBundle(typicalBundle);
         a = getAction(params);
@@ -783,8 +783,8 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
         assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
 
-        assertTrue(response.getExtendedDeadlines().containsKey(student1InCourse1.getEmail()));
-        assertEquals(1, response.getExtendedDeadlines().size());
+        assertTrue(response.getStudentDeadlines().containsKey(student1InCourse1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
 
         logoutUser();
     }
@@ -939,26 +939,26 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         };
     }
 
-    private void assertEqualExtendedDeadlines(Map<String, Instant> expectedExtendedDeadlineInstants,
-                                              Map<String, Long> actualExtendedDeadlines, String timeZone) {
-        Map<String, Long> expectedExtendedDeadlines = new HashMap<>();
-        expectedExtendedDeadlineInstants
-                .forEach((participantEmailAddress, extendedDeadlineInstant) -> {
-                    Long extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-                                    extendedDeadlineInstant, timeZone, true)
+    private void assertEqualStudentDeadlines(Map<String, Instant> expectedStudentDeadlineInstants,
+                                             Map<String, Long> actualStudentDeadlines, String timeZone) {
+        Map<String, Long> expectedStudentDeadlines = new HashMap<>();
+        expectedStudentDeadlineInstants
+                .forEach((participantEmailAddress, studentDeadlineInstant) -> {
+                    Long studentDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                                    studentDeadlineInstant, timeZone, true)
                             .toEpochMilli();
-                    expectedExtendedDeadlines.put(participantEmailAddress, extendedDeadline);
+                    expectedStudentDeadlines.put(participantEmailAddress, studentDeadline);
                 });
-        assertEquals(expectedExtendedDeadlines, actualExtendedDeadlines);
+        assertEquals(expectedStudentDeadlines, actualStudentDeadlines);
     }
 
     private FeedbackSessionAttributes generateRelativeFeedbackSessionInTypicalCourse1(long secondsUntilEndTime,
-            Map<String, Long> relativeExtendedDeadlines) {
+            Map<String, Long> relativeStudentDeadlines) {
         Instant now = Instant.now();
         Instant startTime = now.minusSeconds(60 * 60 * 24);
-        Map<String, Instant> extendedDeadlines = new HashMap<>();
-        relativeExtendedDeadlines.forEach((participantEmailAddress, relativeExtendedDeadline) -> {
-            extendedDeadlines.put(participantEmailAddress, now.plusSeconds(relativeExtendedDeadline));
+        Map<String, Instant> studentDeadlines = new HashMap<>();
+        relativeStudentDeadlines.forEach((participantEmailAddress, relativeStudentDeadline) -> {
+            studentDeadlines.put(participantEmailAddress, now.plusSeconds(relativeStudentDeadline));
         });
         return FeedbackSessionAttributes
                 .builder("relativeFeedbackSession", "idOfTypicalCourse1")
@@ -968,7 +968,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
                 .withStartTime(startTime)
                 .withEndTime(now.plusSeconds(secondsUntilEndTime))
                 .withGracePeriod(Duration.ofMinutes(15))
-                .withExtendedDeadlines(extendedDeadlines)
+                .withStudentDeadlines(studentDeadlines)
                 .build();
     }
 }

--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -429,7 +429,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -451,7 +452,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -473,7 +475,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -495,7 +498,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -517,7 +521,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -539,7 +544,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -561,7 +567,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -583,7 +590,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -606,7 +614,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -628,7 +637,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse4": {
       "feedbackSessionName": "Second feedback session",
@@ -650,7 +660,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InTestingNoEmailsSentCourse": {
       "feedbackSessionName": "Feedback session with no emails sent",
@@ -672,7 +683,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -694,7 +706,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -428,7 +428,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -449,7 +450,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -470,7 +472,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -491,7 +494,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -512,7 +516,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -533,7 +538,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -554,7 +560,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -575,7 +582,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -597,7 +605,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -618,7 +627,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse4": {
       "feedbackSessionName": "Second feedback session",
@@ -639,7 +649,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InTestingNoEmailsSentCourse": {
       "feedbackSessionName": "Feedback session with no emails sent",
@@ -660,7 +671,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -681,7 +693,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -429,7 +429,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -451,7 +451,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -473,7 +473,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -495,7 +495,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -517,7 +517,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -539,7 +539,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -561,7 +561,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -583,7 +583,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -606,7 +606,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -628,7 +628,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse4": {
       "feedbackSessionName": "Second feedback session",
@@ -650,7 +650,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InTestingNoEmailsSentCourse": {
       "feedbackSessionName": "Feedback session with no emails sent",
@@ -672,7 +672,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -694,7 +694,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -429,8 +429,15 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
-      "instructorDeadlines": {}
+      "studentDeadlines": {
+        "student1InCourse1@gmail.tmt": "2027-04-30T23:00:00Z",
+        "student4InCourse1@gmail.tmt": "2027-04-30T23:00:00Z",
+        "student5InCourse1@gmail.tmt": "2027-04-30T23:00:00Z"
+      },
+      "instructorDeadlines": {
+        "instructor1@course1.tmt": "2027-04-30T23:00:00Z",
+        "instructor2@course1.tmt": "2027-04-30T23:00:00Z"
+      }
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",

--- a/src/test/resources/data/FeedbackContributionQuestionTest.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTest.json
@@ -747,7 +747,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -769,7 +769,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -791,7 +791,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -813,7 +813,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -835,7 +835,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -857,7 +857,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -879,7 +879,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -901,7 +901,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -923,7 +923,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -945,7 +945,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -968,7 +968,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -991,7 +991,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1013,7 +1013,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackContributionQuestionTest.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTest.json
@@ -746,7 +746,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -767,7 +768,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -788,7 +790,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -809,7 +812,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -830,7 +834,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -851,7 +856,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -872,7 +878,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -893,7 +900,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -914,7 +922,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -935,7 +944,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -957,7 +967,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -979,7 +990,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1000,7 +1012,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackContributionQuestionTest.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTest.json
@@ -747,7 +747,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -769,7 +770,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -791,7 +793,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -813,7 +816,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -835,7 +839,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -857,7 +862,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -879,7 +885,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -901,7 +908,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -923,7 +931,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -945,7 +954,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -968,7 +978,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -991,7 +1002,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1013,7 +1025,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
+++ b/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
@@ -224,7 +224,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
+++ b/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
@@ -225,7 +225,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
+++ b/src/test/resources/data/FeedbackResponseCommentCRUDTest.json
@@ -225,7 +225,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
+++ b/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
@@ -391,7 +391,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "msqSession": {
       "feedbackSessionName": "MSQ Session",
@@ -412,7 +413,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "numscaleSession": {
       "feedbackSessionName": "NUMSCALE Session",
@@ -433,7 +435,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "constSumSession": {
       "feedbackSessionName": "CONSTSUM Session",
@@ -454,7 +457,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "contribSession": {
       "feedbackSessionName": "CONTRIB Session",
@@ -475,7 +479,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "rubricSession": {
       "feedbackSessionName": "RUBRIC Session",
@@ -496,7 +501,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "unregisteredStudentSession": {
       "feedbackSessionName": "Unregistered Student Session",
@@ -517,7 +523,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "contribSessionStudentAnonymised": {
       "feedbackSessionName": "CONTRIB Session Student Anonymised",
@@ -538,7 +545,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "contribSessionInstructorSectionRestricted": {
       "feedbackSessionName": "CONTRIB Session Section Restricted",
@@ -559,7 +567,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "contribSession2": {
       "feedbackSessionName": "CONTRIB Session 2",
@@ -580,7 +589,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "rankSession": {
       "feedbackSessionName": "RANK Session",
@@ -601,7 +611,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
+++ b/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
@@ -392,7 +392,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "msqSession": {
       "feedbackSessionName": "MSQ Session",
@@ -414,7 +415,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "numscaleSession": {
       "feedbackSessionName": "NUMSCALE Session",
@@ -436,7 +438,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "constSumSession": {
       "feedbackSessionName": "CONSTSUM Session",
@@ -458,7 +461,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "contribSession": {
       "feedbackSessionName": "CONTRIB Session",
@@ -480,7 +484,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "rubricSession": {
       "feedbackSessionName": "RUBRIC Session",
@@ -502,7 +507,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "unregisteredStudentSession": {
       "feedbackSessionName": "Unregistered Student Session",
@@ -524,7 +530,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "contribSessionStudentAnonymised": {
       "feedbackSessionName": "CONTRIB Session Student Anonymised",
@@ -546,7 +553,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "contribSessionInstructorSectionRestricted": {
       "feedbackSessionName": "CONTRIB Session Section Restricted",
@@ -568,7 +576,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "contribSession2": {
       "feedbackSessionName": "CONTRIB Session 2",
@@ -590,7 +599,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "rankSession": {
       "feedbackSessionName": "RANK Session",
@@ -612,7 +622,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
+++ b/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
@@ -392,7 +392,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "msqSession": {
       "feedbackSessionName": "MSQ Session",
@@ -414,7 +414,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "numscaleSession": {
       "feedbackSessionName": "NUMSCALE Session",
@@ -436,7 +436,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "constSumSession": {
       "feedbackSessionName": "CONSTSUM Session",
@@ -458,7 +458,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "contribSession": {
       "feedbackSessionName": "CONTRIB Session",
@@ -480,7 +480,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "rubricSession": {
       "feedbackSessionName": "RUBRIC Session",
@@ -502,7 +502,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "unregisteredStudentSession": {
       "feedbackSessionName": "Unregistered Student Session",
@@ -524,7 +524,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "contribSessionStudentAnonymised": {
       "feedbackSessionName": "CONTRIB Session Student Anonymised",
@@ -546,7 +546,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "contribSessionInstructorSectionRestricted": {
       "feedbackSessionName": "CONTRIB Session Section Restricted",
@@ -568,7 +568,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "contribSession2": {
       "feedbackSessionName": "CONTRIB Session 2",
@@ -590,7 +590,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "rankSession": {
       "feedbackSessionName": "RANK Session",
@@ -612,7 +612,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -85,7 +85,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -85,7 +85,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -84,7 +84,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsTest.json
@@ -253,7 +253,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsTest.json
@@ -253,7 +253,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsTest.json
@@ -252,7 +252,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionsLogicTest.json
+++ b/src/test/resources/data/FeedbackSessionsLogicTest.json
@@ -609,7 +609,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -631,7 +632,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -653,7 +655,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -675,7 +678,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -697,7 +701,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -719,7 +724,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -741,7 +747,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -763,7 +770,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -786,7 +794,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -808,7 +817,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionsLogicTest.json
+++ b/src/test/resources/data/FeedbackSessionsLogicTest.json
@@ -608,7 +608,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -629,7 +630,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -650,7 +652,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -671,7 +674,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -692,7 +696,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -713,7 +718,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -734,7 +740,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -755,7 +762,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -777,7 +785,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -798,7 +807,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionsLogicTest.json
+++ b/src/test/resources/data/FeedbackSessionsLogicTest.json
@@ -609,7 +609,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -631,7 +631,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -653,7 +653,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -675,7 +675,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -697,7 +697,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -719,7 +719,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -741,7 +741,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -763,7 +763,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -786,7 +786,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -808,7 +808,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
+++ b/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
@@ -727,7 +727,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -748,7 +749,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -769,7 +771,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -790,7 +793,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -811,7 +815,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -832,7 +837,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -853,7 +859,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -874,7 +881,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -895,7 +903,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -916,7 +925,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -938,7 +948,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -960,7 +971,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -981,7 +993,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
+++ b/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
@@ -728,7 +728,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -750,7 +750,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -772,7 +772,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -794,7 +794,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -816,7 +816,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -838,7 +838,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -860,7 +860,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -882,7 +882,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -904,7 +904,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -926,7 +926,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -949,7 +949,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -972,7 +972,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -994,7 +994,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
+++ b/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
@@ -728,7 +728,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -750,7 +751,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -772,7 +774,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -794,7 +797,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -816,7 +820,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -838,7 +843,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -860,7 +866,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -882,7 +889,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -904,7 +912,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -926,7 +935,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -949,7 +959,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -972,7 +983,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -994,7 +1006,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/SpecialCharacterTest.json
+++ b/src/test/resources/data/SpecialCharacterTest.json
@@ -161,7 +161,8 @@
       "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/SpecialCharacterTest.json
+++ b/src/test/resources/data/SpecialCharacterTest.json
@@ -162,7 +162,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/SpecialCharacterTest.json
+++ b/src/test/resources/data/SpecialCharacterTest.json
@@ -162,7 +162,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -783,7 +783,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -805,7 +806,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -827,7 +829,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -849,7 +852,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -871,7 +875,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -893,7 +898,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -915,7 +921,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -937,7 +944,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -959,7 +967,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -981,7 +990,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -1004,7 +1014,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -1027,7 +1038,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1049,7 +1061,8 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {}
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -783,7 +783,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -805,7 +805,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -827,7 +827,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -849,7 +849,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -871,7 +871,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -893,7 +893,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -915,7 +915,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -937,7 +937,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -959,7 +959,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -981,7 +981,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -1004,7 +1004,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -1027,7 +1027,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1049,7 +1049,7 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "extendedDeadlines": {}
+      "studentDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -783,8 +783,15 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
-      "instructorDeadlines": {}
+      "studentDeadlines": {
+        "student3InCourse1@gmail.tmt": "2027-04-30T23:00:00Z",
+        "student4InCourse1@gmail.tmt": "2027-04-30T23:00:00Z",
+        "student5InCourse1@gmail.tmt": "2027-04-30T23:00:00Z"
+      },
+      "instructorDeadlines": {
+        "instructor1@course1.tmt": "2027-04-30T23:00:00Z",
+        "instructor2@course1.tmt": "2027-04-30T23:00:00Z"
+      }
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -806,7 +813,9 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
+      "studentDeadlines": {
+        "student4InCourse1@gmail.tmt": "2026-04-28T23:00:00Z"
+      },
       "instructorDeadlines": {}
     },
     "gracePeriodSession": {

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -782,7 +782,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -803,7 +804,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
@@ -824,7 +826,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "closedSession": {
       "feedbackSessionName": "Closed Session",
@@ -845,7 +848,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "empty.session": {
       "feedbackSessionName": "Empty session",
@@ -866,7 +870,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "awaiting.session": {
       "feedbackSessionName": "non visible session",
@@ -887,7 +892,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "archiveCourse.session1": {
       "feedbackSessionName": "session without student questions",
@@ -908,7 +914,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
@@ -929,7 +936,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse2": {
       "feedbackSessionName": "Not answerable feedback session",
@@ -950,7 +958,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse3": {
       "feedbackSessionName": "First feedback session",
@@ -971,7 +980,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session2InCourse3": {
       "feedbackSessionName": "Second feedback session",
@@ -993,7 +1003,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InCourse4": {
       "feedbackSessionName": "First feedback session",
@@ -1015,7 +1026,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     },
     "session1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1036,7 +1048,8 @@
       "sentPublishedEmail": false,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "extendedDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
@@ -108,6 +108,7 @@ describe('CopyCourseModalComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
+      extendedDeadlines: {},
     };
     component.selectedFeedbackSessions.add(testFeedbackSession);
     fixture.detectChanges();

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
@@ -108,7 +108,7 @@ describe('CopyCourseModalComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     };
     component.selectedFeedbackSessions.add(testFeedbackSession);
     fixture.detectChanges();

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.spec.ts
@@ -109,6 +109,7 @@ describe('CopyCourseModalComponent', () => {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
       studentDeadlines: {},
+      instructorDeadlines: {},
     };
     component.selectedFeedbackSessions.add(testFeedbackSession);
     fixture.detectChanges();

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -59,7 +59,7 @@ describe('CopySessionModalComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const courseSessionIn: Course = {

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -59,6 +59,7 @@ describe('CopySessionModalComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
+    extendedDeadlines: {},
   };
 
   const courseSessionIn: Course = {

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -60,6 +60,7 @@ describe('CopySessionModalComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const courseSessionIn: Course = {

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -43,7 +43,7 @@ export class QuestionResponsePanelComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -43,6 +43,7 @@ export class QuestionResponsePanelComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -44,6 +44,7 @@ export class QuestionResponsePanelComponent {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -52,6 +52,7 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @Input() isGqr: boolean = true;

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -52,7 +52,7 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @Input() isGqr: boolean = true;

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -53,6 +53,7 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @Input() isGqr: boolean = true;

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -42,7 +42,7 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   hasRealResponses: boolean = false;

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -43,6 +43,7 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   hasRealResponses: boolean = false;

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -42,6 +42,7 @@ export class GroupedResponsesComponent extends InstructorResponsesViewBase imple
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   hasRealResponses: boolean = false;

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -48,7 +48,7 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @Input() isGrq: boolean = true;

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -48,6 +48,7 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @Input() isGrq: boolean = true;

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -49,6 +49,7 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @Input() isGrq: boolean = true;

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -48,6 +48,7 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
   @Input() isDisplayOnly: boolean = false;
   @Input() statistics: string = '';

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -49,6 +49,7 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
   @Input() isDisplayOnly: boolean = false;
   @Input() statistics: string = '';

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -48,7 +48,7 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
   @Input() isDisplayOnly: boolean = false;
   @Input() statistics: string = '';

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -56,7 +56,7 @@ describe('SessionsTableComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const feedbackSession2: FeedbackSession = {
@@ -74,7 +74,7 @@ describe('SessionsTableComponent', () => {
     isClosingEmailEnabled: false,
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 1554967204,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const instructorCanEverything: InstructorPermissionSet = {

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -56,6 +56,7 @@ describe('SessionsTableComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
+    extendedDeadlines: {},
   };
 
   const feedbackSession2: FeedbackSession = {
@@ -73,6 +74,7 @@ describe('SessionsTableComponent', () => {
     isClosingEmailEnabled: false,
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 1554967204,
+    extendedDeadlines: {},
   };
 
   const instructorCanEverything: InstructorPermissionSet = {

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -57,6 +57,7 @@ describe('SessionsTableComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 1554967204,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const feedbackSession2: FeedbackSession = {
@@ -75,6 +76,7 @@ describe('SessionsTableComponent', () => {
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 1554967204,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const instructorCanEverything: InstructorPermissionSet = {

--- a/src/web/app/components/view-results-panel/view-results-panel.component.ts
+++ b/src/web/app/components/view-results-panel/view-results-panel.component.ts
@@ -49,6 +49,7 @@ export class ViewResultsPanelComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/components/view-results-panel/view-results-panel.component.ts
+++ b/src/web/app/components/view-results-panel/view-results-panel.component.ts
@@ -49,7 +49,7 @@ export class ViewResultsPanelComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/components/view-results-panel/view-results-panel.component.ts
+++ b/src/web/app/components/view-results-panel/view-results-panel.component.ts
@@ -50,6 +50,7 @@ export class ViewResultsPanelComponent {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -531,6 +531,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
+  extendedDeadlines: {},
 };
 /**
  * Structure for example of distrution point option question detail

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -531,7 +531,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
-  extendedDeadlines: {},
+  studentDeadlines: {},
 };
 /**
  * Structure for example of distrution point option question detail

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -532,6 +532,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
   studentDeadlines: {},
+  instructorDeadlines: {},
 };
 /**
  * Structure for example of distrution point option question detail

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
@@ -195,7 +195,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
-  extendedDeadlines: {},
+  studentDeadlines: {},
 };
 
 /**

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
@@ -196,6 +196,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
   studentDeadlines: {},
+  instructorDeadlines: {},
 };
 
 /**

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
@@ -195,6 +195,7 @@ export const EXAMPLE_FEEDBACK_SESSION: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
+  extendedDeadlines: {},
 };
 
 /**

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
@@ -117,7 +117,7 @@ describe('InstructorAuditLogsPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
   const testLogs1: FeedbackSessionLog = {
     feedbackSessionData: testFeedbackSession,

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
@@ -118,6 +118,7 @@ describe('InstructorAuditLogsPageComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
   const testLogs1: FeedbackSessionLog = {
     feedbackSessionData: testFeedbackSession,

--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
@@ -117,6 +117,7 @@ describe('InstructorAuditLogsPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
   const testLogs1: FeedbackSessionLog = {
     feedbackSessionData: testFeedbackSession,

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
@@ -141,7 +141,7 @@ describe('AddCourseFormComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     };
 
     jest.spyOn(feedbackSessionsService, 'getFeedbackSessionsForInstructor')

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
@@ -142,6 +142,7 @@ describe('AddCourseFormComponent', () => {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
       studentDeadlines: {},
+      instructorDeadlines: {},
     };
 
     jest.spyOn(feedbackSessionsService, 'getFeedbackSessionsForInstructor')

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
@@ -141,6 +141,7 @@ describe('AddCourseFormComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
+      extendedDeadlines: {},
     };
 
     jest.spyOn(feedbackSessionsService, 'getFeedbackSessionsForInstructor')

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -68,6 +68,7 @@ const testFeedbackSession1: FeedbackSession = {
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
   studentDeadlines: {},
+  instructorDeadlines: {},
 };
 
 const testFeedbackSession2: FeedbackSession = {
@@ -86,6 +87,7 @@ const testFeedbackSession2: FeedbackSession = {
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
   studentDeadlines: {},
+  instructorDeadlines: {},
 };
 
 const activeCourseTabModels: CourseTabModel[] = [

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -67,6 +67,7 @@ const testFeedbackSession1: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
+  extendedDeadlines: {},
 };
 
 const testFeedbackSession2: FeedbackSession = {
@@ -84,6 +85,7 @@ const testFeedbackSession2: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
+  extendedDeadlines: {},
 };
 
 const activeCourseTabModels: CourseTabModel[] = [

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -67,7 +67,7 @@ const testFeedbackSession1: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
-  extendedDeadlines: {},
+  studentDeadlines: {},
 };
 
 const testFeedbackSession2: FeedbackSession = {
@@ -85,7 +85,7 @@ const testFeedbackSession2: FeedbackSession = {
   isClosingEmailEnabled: true,
   isPublishedEmailEnabled: true,
   createdAtTimestamp: 0,
-  extendedDeadlines: {},
+  studentDeadlines: {},
 };
 
 const activeCourseTabModels: CourseTabModel[] = [

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -82,7 +82,7 @@ describe('InstructorSessionEditPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const testFeedbackQuestion1: FeedbackQuestion = {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -83,6 +83,7 @@ describe('InstructorSessionEditPageComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const testFeedbackQuestion1: FeedbackQuestion = {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -82,6 +82,7 @@ describe('InstructorSessionEditPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   const testFeedbackQuestion1: FeedbackQuestion = {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -55,6 +55,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
   isTabExpanded: boolean = false;
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -54,7 +54,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
   isTabExpanded: boolean = false;
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -54,6 +54,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
   isTabExpanded: boolean = false;
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -131,7 +131,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @ViewChild(InstructorSessionNoResponsePanelComponent) noResponsePanel?:

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -132,6 +132,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @ViewChild(InstructorSessionNoResponsePanelComponent) noResponsePanel?:

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -131,6 +131,7 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @ViewChild(InstructorSessionNoResponsePanelComponent) noResponsePanel?:

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -38,6 +38,7 @@ export abstract class InstructorSessionResultView {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
   @Input() instructorCommentTableModel: Record<string, CommentTableModel> = {};
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -37,6 +37,7 @@ export abstract class InstructorSessionResultView {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
   @Input() instructorCommentTableModel: Record<string, CommentTableModel> = {};
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -37,7 +37,7 @@ export abstract class InstructorSessionResultView {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
   @Input() instructorCommentTableModel: Record<string, CommentTableModel> = {};
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
@@ -32,7 +32,7 @@ export class ResponseModerationButtonComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
@@ -32,6 +32,7 @@ export class ResponseModerationButtonComponent {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
@@ -33,6 +33,7 @@ export class ResponseModerationButtonComponent {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   @Input()

--- a/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
@@ -77,6 +77,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   const testFeedbackSessionNotPublished: FeedbackSession = {
@@ -94,6 +95,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   const testStudent: Student = {

--- a/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
@@ -77,7 +77,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const testFeedbackSessionNotPublished: FeedbackSession = {
@@ -95,7 +95,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const testStudent: Student = {

--- a/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-track-view-page/instructor-track-view-page.component.spec.ts
@@ -78,6 +78,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const testFeedbackSessionNotPublished: FeedbackSession = {
@@ -96,6 +97,7 @@ describe('InstructorTrackViewPageComponent', () => {
     isPublishedEmailEnabled: false,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const testStudent: Student = {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -54,6 +54,7 @@ describe('SessionResultPageComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const testInfo: AuthInfo = {
@@ -313,6 +314,7 @@ describe('SessionResultPageComponent', () => {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 1555231400,
       studentDeadlines: {},
+      instructorDeadlines: {},
     };
     component.questions = [];
     fixture.detectChanges();

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -53,6 +53,7 @@ describe('SessionResultPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   const testInfo: AuthInfo = {
@@ -311,6 +312,7 @@ describe('SessionResultPageComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 1555231400,
+      extendedDeadlines: {},
     };
     component.questions = [];
     fixture.detectChanges();

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -53,7 +53,7 @@ describe('SessionResultPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const testInfo: AuthInfo = {
@@ -312,7 +312,7 @@ describe('SessionResultPageComponent', () => {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 1555231400,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     };
     component.questions = [];
     fixture.detectChanges();

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -54,7 +54,7 @@ export class SessionResultPageComponent implements OnInit {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
   questions: QuestionOutput[] = [];
   formattedSessionOpeningTime: string = '';

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -54,6 +54,7 @@ export class SessionResultPageComponent implements OnInit {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
   questions: QuestionOutput[] = [];
   formattedSessionOpeningTime: string = '';

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -55,6 +55,7 @@ export class SessionResultPageComponent implements OnInit {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
   questions: QuestionOutput[] = [];
   formattedSessionOpeningTime: string = '';

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -105,7 +105,7 @@ describe('SessionSubmissionPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   const testComment: FeedbackResponseComment = {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -106,6 +106,7 @@ describe('SessionSubmissionPageComponent', () => {
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   const testComment: FeedbackResponseComment = {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -105,6 +105,7 @@ describe('SessionSubmissionPageComponent', () => {
     isClosingEmailEnabled: true,
     isPublishedEmailEnabled: true,
     createdAtTimestamp: 0,
+    extendedDeadlines: {},
   };
 
   const testComment: FeedbackResponseComment = {

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -218,6 +218,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
+      extendedDeadlines: {},
     },
     {
       feedbackSessionName: 'Orientation Session',
@@ -234,6 +235,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
+      extendedDeadlines: {},
     },
     {
       feedbackSessionName: 'Welcome Tea Session',
@@ -250,6 +252,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
+      extendedDeadlines: {},
     },
   ],
 };
@@ -310,6 +313,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
+          extendedDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -326,6 +330,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
+          extendedDeadlines: {},
         },
       ],
     };
@@ -366,6 +371,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
+          extendedDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -382,6 +388,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
+          extendedDeadlines: {},
         },
       ],
     };

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -218,7 +218,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     },
     {
       feedbackSessionName: 'Orientation Session',
@@ -235,7 +235,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     },
     {
       feedbackSessionName: 'Welcome Tea Session',
@@ -252,7 +252,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isClosingEmailEnabled: true,
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     },
   ],
 };
@@ -313,7 +313,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
-          extendedDeadlines: {},
+          studentDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -330,7 +330,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
-          extendedDeadlines: {},
+          studentDeadlines: {},
         },
       ],
     };
@@ -371,7 +371,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
-          extendedDeadlines: {},
+          studentDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -388,7 +388,7 @@ describe('StudentHomePageComponent', () => {
           isClosingEmailEnabled: true,
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
-          extendedDeadlines: {},
+          studentDeadlines: {},
         },
       ],
     };

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -219,6 +219,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
       studentDeadlines: {},
+      instructorDeadlines: {},
     },
     {
       feedbackSessionName: 'Orientation Session',
@@ -236,6 +237,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
       studentDeadlines: {},
+      instructorDeadlines: {},
     },
     {
       feedbackSessionName: 'Welcome Tea Session',
@@ -253,6 +255,7 @@ const studentFeedbackSessions: FeedbackSessions = {
       isPublishedEmailEnabled: true,
       createdAtTimestamp: 0,
       studentDeadlines: {},
+      instructorDeadlines: {},
     },
   ],
 };
@@ -314,6 +317,7 @@ describe('StudentHomePageComponent', () => {
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
           studentDeadlines: {},
+          instructorDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -331,6 +335,7 @@ describe('StudentHomePageComponent', () => {
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
           studentDeadlines: {},
+          instructorDeadlines: {},
         },
       ],
     };
@@ -372,6 +377,7 @@ describe('StudentHomePageComponent', () => {
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
           studentDeadlines: {},
+          instructorDeadlines: {},
         },
         {
           feedbackSessionName: 'Second Session',
@@ -389,6 +395,7 @@ describe('StudentHomePageComponent', () => {
           isPublishedEmailEnabled: true,
           createdAtTimestamp: 0,
           studentDeadlines: {},
+          instructorDeadlines: {},
         },
       ],
     };

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -34,7 +34,7 @@ describe('FeedbackSessionsService', () => {
     responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
     isClosingEmailEnabled: false,
     isPublishedEmailEnabled: false,
-    extendedDeadlines: {},
+    studentDeadlines: {},
   };
 
   beforeEach(() => {
@@ -69,7 +69,7 @@ describe('FeedbackSessionsService', () => {
         isClosingEmailEnabled: false,
         isPublishedEmailEnabled: false,
         createdAtTimestamp: 0,
-        extendedDeadlines: {},
+        studentDeadlines: {},
       },
       responseRate: '',
       isLoadingResponseRate: false,

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -34,6 +34,7 @@ describe('FeedbackSessionsService', () => {
     responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
     isClosingEmailEnabled: false,
     isPublishedEmailEnabled: false,
+    extendedDeadlines: {},
   };
 
   beforeEach(() => {
@@ -68,6 +69,7 @@ describe('FeedbackSessionsService', () => {
         isClosingEmailEnabled: false,
         isPublishedEmailEnabled: false,
         createdAtTimestamp: 0,
+        extendedDeadlines: {},
       },
       responseRate: '',
       isLoadingResponseRate: false,

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -35,6 +35,7 @@ describe('FeedbackSessionsService', () => {
     isClosingEmailEnabled: false,
     isPublishedEmailEnabled: false,
     studentDeadlines: {},
+    instructorDeadlines: {},
   };
 
   beforeEach(() => {
@@ -70,6 +71,7 @@ describe('FeedbackSessionsService', () => {
         isPublishedEmailEnabled: false,
         createdAtTimestamp: 0,
         studentDeadlines: {},
+        instructorDeadlines: {},
       },
       responseRate: '',
       isLoadingResponseRate: false,

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -70,6 +70,7 @@ describe('SearchService', () => {
       responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
+      extendedDeadlines: {},
     },
     {
       courseId: 'dog.gma-demo',
@@ -86,6 +87,7 @@ describe('SearchService', () => {
       responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
+      extendedDeadlines: {},
     },
   ];
 

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -71,6 +71,7 @@ describe('SearchService', () => {
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
       studentDeadlines: {},
+      instructorDeadlines: {},
     },
     {
       courseId: 'dog.gma-demo',
@@ -88,6 +89,7 @@ describe('SearchService', () => {
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
       studentDeadlines: {},
+      instructorDeadlines: {},
     },
   ];
 

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -70,7 +70,7 @@ describe('SearchService', () => {
       responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     },
     {
       courseId: 'dog.gma-demo',
@@ -87,7 +87,7 @@ describe('SearchService', () => {
       responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
       isClosingEmailEnabled: false,
       isPublishedEmailEnabled: false,
-      extendedDeadlines: {},
+      studentDeadlines: {},
     },
   ];
 


### PR DESCRIPTION
Part of #11571

**PR Checklist**

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Maps were added to the `FeedbackSession` entity, the `FeedbackSessionAttributes`, and `FeedbackSessionData`. These maps are a mapping from the email addresses of participants (students or instructors) with deadline extensions to the extension date/times.

These maps are passed back to the front-end during GET requests. However, the maps are filtered for participants to include only their extended deadline, if it exists.

Checks for whether a feedback session is open, in its grace period, or closed depend on the deadline, which is no longer fixed but depends on whether this is in the context of a participant or an instructor trying to get a session in full detail. This is handled by sanitizing the `FeedbackSessionAttributes` object for participants, or leaving it as it is for instructors viewing the session in full detail. This involves changing the deadline returned by `getDeadline`, which is done by changing the `Supplier<Instant>` used to produce the deadline within that method.