### PR TITLE
[#11591] Use Firefox 96 in E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: '96.0.3'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Temporary fix for #11591 

**Outline of Solution**

- Use Firefox 96 for E2E tests while waiting for selenium dependency to be updated
- We can keep the issue open and rename it appropriately as a reminder to update the dependency and revert this PR.
