### PR TITLE
[#11585] Remove unnecessary data read

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -141,6 +141,22 @@ public final class FeedbackQuestionsLogic {
     }
 
     /**
+     * Checks if there are any questions for the given session that instructors can view/submit.
+     */
+    public boolean hasFeedbackQuestionsForInstructors(
+            String feedbackSessionName, String courseId, String userEmail) {
+        boolean hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
+                feedbackSessionName, courseId, FeedbackParticipantType.INSTRUCTORS);
+
+        if (userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
+            hasQuestions = hasQuestions || fqDb.hasFeedbackQuestionsForGiverType(
+                    feedbackSessionName, courseId, FeedbackParticipantType.SELF);
+        }
+
+        return hasQuestions;
+    }
+
+    /**
      * Gets a {@code List} of all questions for the given session that instructors can view/submit.
      */
     public List<FeedbackQuestionAttributes> getFeedbackQuestionsForInstructors(
@@ -178,6 +194,15 @@ public final class FeedbackQuestionsLogic {
         }
 
         return questions;
+    }
+
+    /**
+     * Checks if there are any questions for the given session that students can view/submit.
+     */
+    public boolean hasFeedbackQuestionsForStudents(
+            String feedbackSessionName, String courseId) {
+        return fqDb.hasFeedbackQuestionsForGiverType(feedbackSessionName, courseId, FeedbackParticipantType.STUDENTS)
+                || fqDb.hasFeedbackQuestionsForGiverType(feedbackSessionName, courseId, FeedbackParticipantType.TEAMS);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -147,9 +147,11 @@ public final class FeedbackQuestionsLogic {
             String feedbackSessionName, String courseId, String userEmail) {
         boolean hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                 feedbackSessionName, courseId, FeedbackParticipantType.INSTRUCTORS);
+        if (hasQuestions) {
+            return true;
+        }
 
-        if (!hasQuestions
-                && userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
+        if (userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
             hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                     feedbackSessionName, courseId, FeedbackParticipantType.SELF);
         }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -148,8 +148,8 @@ public final class FeedbackQuestionsLogic {
         boolean hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                 feedbackSessionName, courseId, FeedbackParticipantType.INSTRUCTORS);
 
-        if (!hasQuestions &&
-                userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
+        if (!hasQuestions
+                && userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
             hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                     feedbackSessionName, courseId, FeedbackParticipantType.SELF);
         }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -148,8 +148,9 @@ public final class FeedbackQuestionsLogic {
         boolean hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                 feedbackSessionName, courseId, FeedbackParticipantType.INSTRUCTORS);
 
-        if (userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
-            hasQuestions = hasQuestions || fqDb.hasFeedbackQuestionsForGiverType(
+        if (!hasQuestions &&
+                userEmail != null && fsLogic.isCreatorOfSession(feedbackSessionName, courseId, userEmail)) {
+            hasQuestions = fqDb.hasFeedbackQuestionsForGiverType(
                     feedbackSessionName, courseId, FeedbackParticipantType.SELF);
         }
 

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -558,11 +558,13 @@ public final class FeedbackSessionsLogic {
      * Returns true if there are any questions for the specified user type (students/instructors) to answer.
      */
     public boolean isFeedbackSessionForUserTypeToAnswer(FeedbackSessionAttributes session, boolean isInstructor) {
-        List<FeedbackQuestionAttributes> questionsToAnswer = isInstructor
-                ? fqLogic.getFeedbackQuestionsForInstructors(session.getFeedbackSessionName(), session.getCourseId(), null)
-                : fqLogic.getFeedbackQuestionsForStudents(session.getFeedbackSessionName(), session.getCourseId());
+        if (!session.isVisible()) {
+            return false;
+        }
 
-        return session.isVisible() && !questionsToAnswer.isEmpty();
+        return isInstructor
+                ? fqLogic.hasFeedbackQuestionsForInstructors(session.getFeedbackSessionName(), session.getCourseId(), null)
+                : fqLogic.hasFeedbackQuestionsForStudents(session.getFeedbackSessionName(), session.getCourseId());
     }
 
 }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -208,6 +208,9 @@ public final class FeedbackSessionsLogic {
      */
     public boolean isCreatorOfSession(String feedbackSessionName, String courseId, String userEmail) {
         FeedbackSessionAttributes fs = getFeedbackSession(feedbackSessionName, courseId);
+        if (fs == null) {
+            return false;
+        }
         return fs.getCreatorEmail().equals(userEmail);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -419,6 +419,7 @@ public final class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, Feed
                 .filterKey(Key.create(FeedbackResponse.class,
                         FeedbackResponse.generateId(entityToCreate.getFeedbackQuestionId(),
                                 entityToCreate.getGiver(), entityToCreate.getRecipient())))
+                .keys()
                 .list()
                 .isEmpty();
     }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -416,6 +416,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, Feedba
         return !load()
                 .filterKey(Key.create(FeedbackSession.class,
                         FeedbackSession.generateId(entityToCreate.getFeedbackSessionName(), entityToCreate.getCourseId())))
+                .keys()
                 .list()
                 .isEmpty();
     }

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -368,6 +368,7 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
         return !load()
                 .filterKey(Key.create(CourseStudent.class,
                         CourseStudent.generateId(entityToCreate.getEmail(), entityToCreate.getCourse())))
+                .keys()
                 .list()
                 .isEmpty();
     }

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -77,7 +77,9 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
 
     @Test
     public void allTests() throws Exception {
+        testHasFeedbackQuestionsForInstructor();
         testGetFeedbackQuestionsForInstructor();
+        testHasFeedbackQuestionsForStudents();
         testGetFeedbackQuestionsForStudents();
         testAddQuestion();
     }
@@ -905,6 +907,16 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         assertTrue(completeGiverRecipientMap.get("Team 1.2").contains("Team 1.1</td></div>'\""));
     }
 
+    private void testHasFeedbackQuestionsForInstructor() {
+        ______TS("Valid course valid instructor should have questions");
+        assertTrue(fqLogic.hasFeedbackQuestionsForInstructors(
+                "First feedback session", "idOfTypicalCourse1", "instructor1@course1.tmt"));
+
+        ______TS("Invalid course should not have questions");
+        assertFalse(fqLogic.hasFeedbackQuestionsForInstructors(
+                "Zeroth feedback session", "idOfTypicalCourse1", "nonexistent@course1.tmt"));
+    }
+
     private void testGetFeedbackQuestionsForInstructor() {
         List<FeedbackQuestionAttributes> expectedQuestions;
         List<FeedbackQuestionAttributes> actualQuestions;
@@ -962,6 +974,17 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
 
         assertEquals(actualQuestions, expectedQuestions);
     }
+
+    private void testHasFeedbackQuestionsForStudents() {
+        ______TS("Valid course should have questions");
+        assertTrue(fqLogic.hasFeedbackQuestionsForStudents(
+                "First feedback session", "idOfTypicalCourse1"));
+
+        ______TS("Invalid course should not have questions");
+        assertFalse(fqLogic.hasFeedbackQuestionsForStudents(
+                "Zeroth feedback session", "idOfTypicalCourse1"));
+    }
+
 
     private void testGetFeedbackQuestionsForStudents() {
         List<FeedbackQuestionAttributes> expectedQuestions;

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -985,7 +985,6 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
                 "Zeroth feedback session", "idOfTypicalCourse1"));
     }
 
-
     private void testGetFeedbackQuestionsForStudents() {
         List<FeedbackQuestionAttributes> expectedQuestions;
         List<FeedbackQuestionAttributes> actualQuestions;

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -908,11 +908,15 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
     }
 
     private void testHasFeedbackQuestionsForInstructor() {
-        ______TS("Valid course valid instructor should have questions");
+        ______TS("Valid session valid instructor should have questions");
         assertTrue(fqLogic.hasFeedbackQuestionsForInstructors(
                 "First feedback session", "idOfTypicalCourse1", "instructor1@course1.tmt"));
 
-        ______TS("Invalid course should not have questions");
+        ______TS("Valid session without questions for instructor should return false");
+        assertFalse(fqLogic.hasFeedbackQuestionsForInstructors(
+                "session without instructor questions", "idOfTestingSanitizationCourse", "instructor1@course1.tmt"));
+
+        ______TS("Invalid session should not have questions");
         assertFalse(fqLogic.hasFeedbackQuestionsForInstructors(
                 "Zeroth feedback session", "idOfTypicalCourse1", "nonexistent@course1.tmt"));
     }
@@ -976,11 +980,15 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
     }
 
     private void testHasFeedbackQuestionsForStudents() {
-        ______TS("Valid course should have questions");
+        ______TS("Valid session should have questions");
         assertTrue(fqLogic.hasFeedbackQuestionsForStudents(
                 "First feedback session", "idOfTypicalCourse1"));
 
-        ______TS("Invalid course should not have questions");
+        ______TS("Valid session without questions for students should return false");
+        assertFalse(fqLogic.hasFeedbackQuestionsForStudents(
+                "session without student questions", "idOfArchivedCourse"));
+
+        ______TS("Invalid session should not have questions");
         assertFalse(fqLogic.hasFeedbackQuestionsForStudents(
                 "Zeroth feedback session", "idOfTypicalCourse1"));
     }

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -151,6 +151,8 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         testCreateAndDeleteFeedbackSession();
 
+        testIsFeedbackSessionForUserTypeToAnswer();
+
         testUpdateFeedbackSession();
         testPublishUnpublishFeedbackSession();
 
@@ -516,6 +518,26 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         session = dataBundle.feedbackSessions.get("empty.session");
         assertFalse(fsLogic.isFeedbackSessionViewableToUserType(session, false));
         assertFalse(fsLogic.isFeedbackSessionViewableToUserType(session, true));
+    }
+
+    private void testIsFeedbackSessionForUserTypeToAnswer() {
+        ______TS("Non-visible session should not be for any types of user to answer");
+        FeedbackSessionAttributes session = dataBundle.feedbackSessions.get("awaiting.session");
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
+
+        ______TS("Empty session should not be for any types of user to answer");
+        session = dataBundle.feedbackSessions.get("empty.session");
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
+
+        ______TS("Session without student question should not be for students to answer");
+        session = dataBundle.feedbackSessions.get("archiveCourse.session1");
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
+        assertTrue(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
+
+        session = dataBundle.feedbackSessions.get("session2InCourse1");
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
+        assertTrue(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
     }
 
     private void testUpdateFeedbackSession() throws Exception {

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -524,6 +524,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         ______TS("Non-visible session should not be for any types of user to answer");
         FeedbackSessionAttributes session = dataBundle.feedbackSessions.get("awaiting.session");
         assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
+        assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
 
         ______TS("Empty session should not be for any types of user to answer");
         session = dataBundle.feedbackSessions.get("empty.session");
@@ -535,6 +536,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));
         assertTrue(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
 
+        ______TS("Session without instructor question should not be for instructors to answer");
         session = dataBundle.feedbackSessions.get("session2InCourse1");
         assertFalse(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true));
         assertTrue(fsLogic.isFeedbackSessionForUserTypeToAnswer(session, false));

--- a/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
@@ -57,8 +57,8 @@ public class FeedbackSessionsDbTest extends BaseTestCaseWithLocalDatabaseAccess 
         Instant rangeStart = Instant.parse("2000-12-03T10:15:30.00Z");
         Instant rangeEnd = Instant.parse("2050-04-30T21:59:00Z");
         List<FeedbackSessionAttributes> actualAttributesList = fsDb.getAllOngoingSessions(rangeStart, rangeEnd);
-        assertEquals("should not return more than 13 sessions as there are only 13 distinct sessions in the range",
-                13, actualAttributesList.size());
+        assertEquals("should not return more than 14 sessions as there are only 14 distinct sessions in the range",
+                14, actualAttributesList.size());
     }
 
     @Test

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -903,9 +903,9 @@
       "gracePeriod": 5,
       "sentOpeningSoonEmail": true,
       "sentOpenEmail": true,
-      "sentClosingEmail": false,
-      "sentClosedEmail": false,
-      "sentPublishedEmail": false,
+      "sentClosingEmail": true,
+      "sentClosedEmail": true,
+      "sentPublishedEmail": true,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -910,6 +910,27 @@
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true
     },
+    "archiveCourse.session2": {
+      "feedbackSessionName": "session without instructor questions",
+      "courseId": "idOfArchivedCourse",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "createdTime": "2013-01-20T23:00:00Z",
+      "startTime": "2013-02-20T23:00:00Z",
+      "endTime": "2026-04-28T23:00:00Z",
+      "sessionVisibleFromTime": "2013-02-20T23:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T23:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpeningSoonEmail": true,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
     "session1InCourse2": {
       "feedbackSessionName": "Instructor feedback session",
       "courseId": "idOfTypicalCourse2",
@@ -1344,6 +1365,27 @@
       },
       "questionNumber": 1,
       "giverType": "INSTRUCTORS",
+      "recipientType": "STUDENTS",
+      "numberOfEntitiesToGiveFeedbackTo": 4,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "qn1InSession2InArchivedCourse": {
+      "feedbackSessionName": "session without instructor questions",
+      "courseId": "idOfArchivedCourse",
+      "questionDetails": {
+        "questionType": "TEXT",
+        "questionText": "Give feedback to each other"
+      },
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
       "recipientType": "STUDENTS",
       "numberOfEntitiesToGiveFeedbackTo": 4,
       "showResponsesTo": [


### PR DESCRIPTION
Fixes part of #11585

Fixes 
```
FeedbackResponsesDb.hasExistingEntities
FeedbackSessionsDb.hasExistingEntities
StudentsDb.hasExistingEntities
FeedbackSessionLogic.isFeedbackSessionForUserTypeToAnswer
```