### PR TITLE
[#11571] Selective Deadline Extensions - C_UD selective deadlines

### DIFF
--- a/src/main/appengine/index.yaml
+++ b/src/main/appengine/index.yaml
@@ -1,6 +1,18 @@
 # Reference: https://cloud.google.com/appengine/docs/standard/java11/configuring-datastore-indexes-with-index-yaml
 
 indexes:
+- kind: CourseStudent
+  properties:
+  - direction: asc
+    name: courseId
+  - direction: asc
+    name: email
+- kind: Instructor
+  properties:
+  - direction: asc
+    name: courseId
+  - direction: asc
+    name: email
 - kind: Instructor
   properties:
   - direction: asc

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -230,6 +230,12 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
+        addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                endTime, studentDeadlines), errors);
+
+        addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                endTime, instructorDeadlines), errors);
+
         return errors;
     }
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -157,7 +157,7 @@ public final class Const {
 
         public static final String TIMEZONE = "timezone";
 
-        public static final String MUST_NOTIFY_ABOUT_DEADLINES = "notifydeadlines";
+        public static final String NOTIFY_ABOUT_DEADLINES = "notifydeadlines";
 
         public static final String QUERY_LOGS_STARTTIME = "starttime";
         public static final String QUERY_LOGS_ENDTIME = "endtime";

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -157,6 +157,8 @@ public final class Const {
 
         public static final String TIMEZONE = "timezone";
 
+        public static final String MUST_NOTIFY_ABOUT_DEADLINES = "notifydeadlines";
+
         public static final String QUERY_LOGS_STARTTIME = "starttime";
         public static final String QUERY_LOGS_ENDTIME = "endtime";
         public static final String QUERY_LOGS_SEVERITY = "severity";

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -92,6 +93,8 @@ public final class FieldValidator {
     public static final String GIVER_TYPE_NAME = "feedback giver";
     public static final String RECIPIENT_TYPE_NAME = "feedback recipient";
     public static final String VIEWER_TYPE_NAME = "feedback viewer";
+
+    public static final String EXTENDED_DEADLINES_FIELD_NAME = "extended deadlines";
 
     ////////////////////
     // ERROR MESSAGES //
@@ -576,6 +579,22 @@ public final class FieldValidator {
             Instant visibilityStart, Instant resultsPublish) {
         return getInvalidityInfoForFirstTimeIsBeforeSecondTime(visibilityStart, resultsPublish,
                 SESSION_VISIBLE_TIME_FIELD_NAME, RESULTS_VISIBLE_TIME_FIELD_NAME);
+    }
+
+    /**
+     * Checks if the session end time is before all extended deadlines.
+     * @return Error string if any deadline in {@code deadlines} is before {@code sessionEnd}
+     *         Empty string if any deadline in {@code deadlines} is after {@code sessionEnd}
+     */
+    public static String getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+            Instant sessionEnd, Map<String, Instant> deadlines) {
+        return deadlines.entrySet()
+                .stream()
+                .map(entry -> getInvalidityInfoForFirstTimeIsBeforeSecondTime(sessionEnd, entry.getValue(),
+                        SESSION_END_TIME_FIELD_NAME, EXTENDED_DEADLINES_FIELD_NAME))
+                .filter(invalidityInfo -> !invalidityInfo.isEmpty())
+                .findFirst()
+                .orElse("");
     }
 
     private static String getInvalidityInfoForFirstTimeIsBeforeSecondTime(

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -586,8 +586,7 @@ public final class FieldValidator {
 
     /**
      * Checks if the session end time is before all extended deadlines.
-     * @return Error string if any deadline in {@code deadlines} is before {@code sessionEnd}
-     *         Empty string if any deadline in {@code deadlines} is after {@code sessionEnd}
+     * @return Error string if any deadline in {@code deadlines} is before {@code sessionEnd}, an empty one otherwise.
      */
     public static String getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
             Instant sessionEnd, Map<String, Instant> deadlines) {

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -602,27 +602,27 @@ public final class FieldValidator {
     private static String getInvalidityInfoForFirstTimeIsBeforeSecondTime(
             Instant earlierTime, Instant laterTime, String earlierTimeFieldName, String laterTimeFieldName) {
         return getInvalidityInfoForFirstTimeComparedToSecondTime(earlierTime, laterTime, earlierTimeFieldName,
-                laterTimeFieldName, (firstTime, secondTime) -> secondTime.isBefore(firstTime),
+                laterTimeFieldName,
+                (firstTime, secondTime) -> firstTime.isBefore(secondTime) || firstTime.equals(secondTime),
                 TIME_BEFORE_ERROR_MESSAGE);
     }
 
     private static String getInvalidityInfoForFirstTimeIsStrictlyBeforeSecondTime(
             Instant earlierTime, Instant laterTime, String earlierTimeFieldName, String laterTimeFieldName) {
         return getInvalidityInfoForFirstTimeComparedToSecondTime(earlierTime, laterTime, earlierTimeFieldName,
-                laterTimeFieldName,
-                (firstTime, secondTime) -> secondTime.isBefore(firstTime) || secondTime.equals(firstTime),
+                laterTimeFieldName, Instant::isBefore,
                 TIME_BEFORE_OR_EQUAL_ERROR_MESSAGE);
     }
 
     private static String getInvalidityInfoForFirstTimeComparedToSecondTime(Instant earlierTime, Instant laterTime,
-            String earlierTimeFieldName, String laterTimeFieldName, BiPredicate<Instant, Instant> invalidityChecker,
+            String earlierTimeFieldName, String laterTimeFieldName, BiPredicate<Instant, Instant> validityChecker,
             String invalidityInfoTemplate) {
         assert earlierTime != null;
         assert laterTime != null;
         if (TimeHelper.isSpecialTime(earlierTime) || TimeHelper.isSpecialTime(laterTime)) {
             return "";
         }
-        if (invalidityChecker.test(earlierTime, laterTime)) {
+        if (!validityChecker.test(earlierTime, laterTime)) {
             return String.format(invalidityInfoTemplate, laterTimeFieldName, earlierTimeFieldName);
         }
         return "";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1,6 +1,7 @@
 package teammates.logic.api;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,6 +113,14 @@ public class Logic {
         assert googleId != null;
 
         accountsLogic.deleteAccountCascade(googleId);
+    }
+
+    public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
+            throws EntityDoesNotExistException {
+        assert courseId != null;
+        assert instructorEmailAddresses != null;
+
+        instructorsLogic.verifyAllInstructorsExistInCourse(courseId, instructorEmailAddresses);
     }
 
     /**
@@ -1372,6 +1381,14 @@ public class Logic {
      */
     public void putDocuments(DataBundle dataBundle) throws SearchServiceException {
         dataBundleLogic.putDocuments(dataBundle);
+    }
+
+    public void verifyAllStudentsExistInCourse(String courseId, Collection<String> studentEmailAddresses)
+            throws EntityDoesNotExistException {
+        assert courseId != null;
+        assert studentEmailAddresses != null;
+
+        studentsLogic.verifyAllStudentsExistInCourse(courseId, studentEmailAddresses);
     }
 
     public boolean isStudentsInSameTeam(String courseId, String student1Email, String student2Email) {

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -115,6 +115,14 @@ public class Logic {
         accountsLogic.deleteAccountCascade(googleId);
     }
 
+    /**
+     * Verifies that all the given instructors exist in the given course.
+     *
+     * <p>Preconditions:</p>
+     * * All parameters are non-null.
+     *
+     * @throws EntityDoesNotExistException If some instructor does not exist in the course.
+     */
     public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
             throws EntityDoesNotExistException {
         assert courseId != null;
@@ -1383,6 +1391,14 @@ public class Logic {
         dataBundleLogic.putDocuments(dataBundle);
     }
 
+    /**
+     * Verifies that all the given students exist in the given course.
+     *
+     * <p>Preconditions:</p>
+     * * All parameters are non-null.
+     *
+     * @throws EntityDoesNotExistException If some student does not exist in the course.
+     */
     public void verifyAllStudentsExistInCourse(String courseId, Collection<String> studentEmailAddresses)
             throws EntityDoesNotExistException {
         assert courseId != null;

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -101,8 +101,8 @@ public final class InstructorsLogic {
     public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
             throws EntityDoesNotExistException {
         boolean hasOnlyExistingInstructors = instructorEmailAddresses.stream()
-                .allMatch(studentEmailAddress ->
-                        instructorsDb.hasExistingInstructorInCourse(courseId, studentEmailAddress));
+                .allMatch(instructorEmailAddress ->
+                        instructorsDb.hasExistingInstructorInCourse(courseId, instructorEmailAddress));
         if (!hasOnlyExistingInstructors) {
             throw new EntityDoesNotExistException("There are instructors that do not exist in the course.");
         }

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
@@ -92,6 +93,19 @@ public final class InstructorsLogic {
                         .withIsArchived(archiveStatus)
                         .build()
         );
+    }
+
+    /**
+     * Checks if all the given instructors exist in the given course.
+     */
+    public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
+            throws EntityDoesNotExistException {
+        boolean hasOnlyExistingInstructors = instructorEmailAddresses.stream()
+                .allMatch(studentEmailAddress ->
+                        instructorsDb.hasExistingInstructorInCourse(courseId, studentEmailAddress));
+        if (!hasOnlyExistingInstructors) {
+            throw new EntityDoesNotExistException("There are instructors that do not exist in the course.");
+        }
     }
 
     /**

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -100,9 +100,8 @@ public final class InstructorsLogic {
      */
     public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
             throws EntityDoesNotExistException {
-        boolean hasOnlyExistingInstructors = instructorEmailAddresses.stream()
-                .allMatch(instructorEmailAddress ->
-                        instructorsDb.hasExistingInstructorInCourse(courseId, instructorEmailAddress));
+        boolean hasOnlyExistingInstructors = instructorsDb
+                .hasExistingInstructorsInCourse(courseId, instructorEmailAddresses);
         if (!hasOnlyExistingInstructors) {
             throw new EntityDoesNotExistException("There are instructors that do not exist in the course.");
         }

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -97,6 +97,8 @@ public final class InstructorsLogic {
 
     /**
      * Checks if all the given instructors exist in the given course.
+     *
+     * @throws EntityDoesNotExistException If some instructor does not exist in the course.
      */
     public void verifyAllInstructorsExistInCourse(String courseId, Collection<String> instructorEmailAddresses)
             throws EntityDoesNotExistException {

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -153,8 +153,7 @@ public final class StudentsLogic {
      */
     public void verifyAllStudentsExistInCourse(String courseId, Collection<String> studentEmailAddresses)
             throws EntityDoesNotExistException {
-        boolean hasOnlyExistingStudents = studentEmailAddresses.stream()
-                .allMatch(studentEmailAddress -> studentsDb.hasExistingStudentInCourse(courseId, studentEmailAddress));
+        boolean hasOnlyExistingStudents = studentsDb.hasExistingStudentsInCourse(courseId, studentEmailAddresses);
         if (!hasOnlyExistingStudents) {
             throw new EntityDoesNotExistException("There are students that do not exist in the course.");
         }

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.StringJoiner;
 
@@ -145,6 +146,18 @@ public final class StudentsLogic {
     public List<StudentAttributes> searchStudentsInWholeSystem(String queryString)
             throws SearchServiceException {
         return studentsDb.searchStudentsInWholeSystem(queryString);
+    }
+
+    /**
+     * Checks if all the given students exist in the given course.
+     */
+    public void verifyAllStudentsExistInCourse(String courseId, Collection<String> studentEmailAddresses)
+            throws EntityDoesNotExistException {
+        boolean hasOnlyExistingStudents = studentEmailAddresses.stream()
+                .allMatch(studentEmailAddress -> studentsDb.hasExistingStudentInCourse(courseId, studentEmailAddress));
+        if (!hasOnlyExistingStudents) {
+            throw new EntityDoesNotExistException("There are students that do not exist in the course.");
+        }
     }
 
     /**

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -150,6 +150,8 @@ public final class StudentsLogic {
 
     /**
      * Checks if all the given students exist in the given course.
+     *
+     * @throws EntityDoesNotExistException If some student does not exist in the course.
      */
     public void verifyAllStudentsExistInCourse(String courseId, Collection<String> studentEmailAddresses)
             throws EntityDoesNotExistException {

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -97,6 +97,13 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     /**
+     * Checks if the given instructor exists in the given course.
+     */
+    public boolean hasExistingInstructorInCourse(String courseId, String instructorEmailAddress) {
+        return hasExistingEntities(InstructorAttributes.builder(courseId, instructorEmailAddress).build());
+    }
+
+    /**
      * Gets an instructor by unique constraint courseId-email.
      */
     public InstructorAttributes getInstructorForEmail(String courseId, String email) {

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -3,8 +3,10 @@ package teammates.storage.api;
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.googlecode.objectify.Key;
@@ -97,10 +99,24 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     /**
-     * Checks if the given instructor exists in the given course.
+     * Checks if the given instructors exist in the given course.
      */
-    public boolean hasExistingInstructorInCourse(String courseId, String instructorEmailAddress) {
-        return hasExistingEntities(InstructorAttributes.builder(courseId, instructorEmailAddress).build());
+    public boolean hasExistingInstructorsInCourse(String courseId, Collection<String> instructorEmailAddresses) {
+        if (instructorEmailAddresses.isEmpty()) {
+            return true;
+        }
+        Set<String> existingInstructorEmailAddressesInCourse = load().filter("courseId =", courseId)
+                .project("email")
+                .list()
+                .stream()
+                .map(Instructor::getEmail)
+                .collect(Collectors.toSet());
+        for (String instructorEmailAddress : instructorEmailAddresses) {
+            if (!existingInstructorEmailAddressesInCourse.contains(instructorEmailAddress)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -105,18 +105,13 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
         if (instructorEmailAddresses.isEmpty()) {
             return true;
         }
-        Set<String> existingInstructorEmailAddressesInCourse = load().filter("courseId =", courseId)
+        Set<String> existingInstructorEmailAddresses = load().filter("courseId =", courseId)
                 .project("email")
                 .list()
                 .stream()
                 .map(Instructor::getEmail)
                 .collect(Collectors.toSet());
-        for (String instructorEmailAddress : instructorEmailAddresses) {
-            if (!existingInstructorEmailAddressesInCourse.contains(instructorEmailAddress)) {
-                return false;
-            }
-        }
-        return true;
+        return existingInstructorEmailAddresses.containsAll(instructorEmailAddresses);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -114,6 +114,13 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
     }
 
     /**
+     * Checks if the given student exists in the given course.
+     */
+    public boolean hasExistingStudentInCourse(String courseId, String studentEmailAddress) {
+        return hasExistingEntities(StudentAttributes.builder(courseId, studentEmailAddress).build());
+    }
+
+    /**
      * Gets a student by unique ID courseId-email.
      */
     public StudentAttributes getStudentForEmail(String courseId, String email) {

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -3,8 +3,10 @@ package teammates.storage.api;
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.googlecode.objectify.Key;
@@ -114,10 +116,24 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
     }
 
     /**
-     * Checks if the given student exists in the given course.
+     * Checks if the given students exist in the given course.
      */
-    public boolean hasExistingStudentInCourse(String courseId, String studentEmailAddress) {
-        return hasExistingEntities(StudentAttributes.builder(courseId, studentEmailAddress).build());
+    public boolean hasExistingStudentsInCourse(String courseId, Collection<String> studentEmailAddresses) {
+        if (studentEmailAddresses.isEmpty()) {
+            return true;
+        }
+        Set<String> existingStudentEmailAddressesInCourse = load().filter("courseId =", courseId)
+                .project("email")
+                .list()
+                .stream()
+                .map(CourseStudent::getEmail)
+                .collect(Collectors.toSet());
+        for (String studentEmailAddress : studentEmailAddresses) {
+            if (!existingStudentEmailAddressesInCourse.contains(studentEmailAddress)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -122,18 +122,13 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
         if (studentEmailAddresses.isEmpty()) {
             return true;
         }
-        Set<String> existingStudentEmailAddressesInCourse = load().filter("courseId =", courseId)
+        Set<String> existingStudentEmailAddresses = load().filter("courseId =", courseId)
                 .project("email")
                 .list()
                 .stream()
                 .map(CourseStudent::getEmail)
                 .collect(Collectors.toSet());
-        for (String studentEmailAddress : studentEmailAddresses) {
-            if (!existingStudentEmailAddressesInCourse.contains(studentEmailAddress)) {
-                return false;
-            }
-        }
-        return true;
+        return existingStudentEmailAddresses.containsAll(studentEmailAddresses);
     }
 
     /**

--- a/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
@@ -1,8 +1,44 @@
 package teammates.ui.request;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The update request of a feedback session.
  */
 public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
 
+    private Map<String, Long> studentDeadlines;
+    private Map<String, Long> instructorDeadlines;
+
+    /**
+     * Gets the deadlines for students.
+     */
+    public Map<String, Instant> getStudentDeadlines() {
+        Map<String, Instant> studentDeadlineInstants = new HashMap<>();
+        studentDeadlines.forEach((emailAddress, deadline) -> {
+            studentDeadlineInstants.put(emailAddress, Instant.ofEpochMilli(deadline));
+        });
+        return studentDeadlineInstants;
+    }
+
+    /**
+     * Gets the deadlines for instructors.
+     */
+    public Map<String, Instant> getInstructorDeadlines() {
+        Map<String, Instant> instructorDeadlineInstants = new HashMap<>();
+        instructorDeadlines.forEach((emailAddress, deadline) -> {
+            instructorDeadlineInstants.put(emailAddress, Instant.ofEpochMilli(deadline));
+        });
+        return instructorDeadlineInstants;
+    }
+
+    public void setStudentDeadlines(Map<String, Long> studentDeadlines) {
+        this.studentDeadlines = studentDeadlines;
+    }
+
+    public void setInstructorDeadlines(Map<String, Long> instructorDeadlines) {
+        this.instructorDeadlines = instructorDeadlines;
+    }
 }

--- a/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
@@ -1,8 +1,8 @@
 package teammates.ui.request;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * The update request of a feedback session.
@@ -18,22 +18,18 @@ public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
      * Gets the deadlines for students.
      */
     public Map<String, Instant> getStudentDeadlines() {
-        Map<String, Instant> studentDeadlineInstants = new HashMap<>();
-        studentDeadlines.forEach((emailAddress, deadline) -> {
-            studentDeadlineInstants.put(emailAddress, Instant.ofEpochMilli(deadline));
-        });
-        return studentDeadlineInstants;
+        return studentDeadlines.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Instant.ofEpochMilli(entry.getValue())));
     }
 
     /**
      * Gets the deadlines for instructors.
      */
     public Map<String, Instant> getInstructorDeadlines() {
-        Map<String, Instant> instructorDeadlineInstants = new HashMap<>();
-        instructorDeadlines.forEach((emailAddress, deadline) -> {
-            instructorDeadlineInstants.put(emailAddress, Instant.ofEpochMilli(deadline));
-        });
-        return instructorDeadlineInstants;
+        return instructorDeadlines.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Instant.ofEpochMilli(entry.getValue())));
     }
 
     public boolean isGoingToNotifyAboutDeadlines() {

--- a/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
@@ -12,8 +12,6 @@ public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
     private Map<String, Long> studentDeadlines;
     private Map<String, Long> instructorDeadlines;
 
-    private boolean isGoingToNotifyAboutDeadlines;
-
     /**
      * Gets the deadlines for students.
      */
@@ -32,19 +30,11 @@ public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> Instant.ofEpochMilli(entry.getValue())));
     }
 
-    public boolean isGoingToNotifyAboutDeadlines() {
-        return isGoingToNotifyAboutDeadlines;
-    }
-
     public void setStudentDeadlines(Map<String, Long> studentDeadlines) {
         this.studentDeadlines = studentDeadlines;
     }
 
     public void setInstructorDeadlines(Map<String, Long> instructorDeadlines) {
         this.instructorDeadlines = instructorDeadlines;
-    }
-
-    public void setGoingToNotifyAboutDeadlines(boolean isGoingToNotifyAboutDeadlines) {
-        this.isGoingToNotifyAboutDeadlines = isGoingToNotifyAboutDeadlines;
     }
 }

--- a/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionUpdateRequest.java
@@ -12,6 +12,8 @@ public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
     private Map<String, Long> studentDeadlines;
     private Map<String, Long> instructorDeadlines;
 
+    private boolean isGoingToNotifyAboutDeadlines;
+
     /**
      * Gets the deadlines for students.
      */
@@ -34,11 +36,19 @@ public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
         return instructorDeadlineInstants;
     }
 
+    public boolean isGoingToNotifyAboutDeadlines() {
+        return isGoingToNotifyAboutDeadlines;
+    }
+
     public void setStudentDeadlines(Map<String, Long> studentDeadlines) {
         this.studentDeadlines = studentDeadlines;
     }
 
     public void setInstructorDeadlines(Map<String, Long> instructorDeadlines) {
         this.instructorDeadlines = instructorDeadlines;
+    }
+
+    public void setGoingToNotifyAboutDeadlines(boolean isGoingToNotifyAboutDeadlines) {
+        this.isGoingToNotifyAboutDeadlines = isGoingToNotifyAboutDeadlines;
     }
 }

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -57,6 +57,7 @@ class UpdateFeedbackSessionAction extends Action {
         Map<String, Instant> studentDeadlines = updateRequest.getStudentDeadlines();
         Map<String, Instant> instructorDeadlines = updateRequest.getInstructorDeadlines();
         try {
+            // These ensure the existence checks are only done whenever necessary in order to reduce data reads.
             boolean hasExtraStudents = !oldStudentDeadlines.keySet()
                     .containsAll(studentDeadlines.keySet());
             boolean hasExtraInstructors = !oldInstructorDeadlines.keySet()

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -57,6 +57,8 @@ class UpdateFeedbackSessionAction extends Action {
         }
 
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        // TODO: Use the value here.
+        getBooleanRequestParamValue(Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES);
 
         FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
 

--- a/src/test/java/teammates/common/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/common/util/FieldValidatorTest.java
@@ -603,10 +603,19 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForTimeForSessionEndAndExtendedDeadlines_invalid_returnErrorString() {
+        ______TS("extended deadline earlier than the end time");
         Instant sessionEnd = TimeHelperExtension.getInstantHoursOffsetFromNow(1);
         Map<String, Instant> extendedDeadlines = new HashMap<>();
         extendedDeadlines.put("participant@email.com", TimeHelperExtension.getInstantHoursOffsetFromNow(-1));
-        assertEquals("The extended deadlines for this feedback session cannot be earlier than the end time.",
+        assertEquals("The extended deadlines for this feedback session cannot be earlier than or at the same time as "
+                        + "the end time.",
+                FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                        sessionEnd, extendedDeadlines));
+
+        ______TS("extended deadline earlier than the end time");
+        extendedDeadlines.put("participant@email.com", sessionEnd);
+        assertEquals("The extended deadlines for this feedback session cannot be earlier than or at the same time as "
+                        + "the end time.",
                 FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
                         sessionEnd, extendedDeadlines));
     }

--- a/src/test/java/teammates/common/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/common/util/FieldValidatorTest.java
@@ -1,6 +1,8 @@
 package teammates.common.util;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -587,6 +589,26 @@ public class FieldValidatorTest extends BaseTestCase {
                          + "earlier than the time when the session will be visible.",
                      FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                          visibilityStart, resultsPublish));
+    }
+
+    @Test
+    public void testGetInvalidityInfoForTimeForSessionEndAndExtendedDeadlines_valid_returnEmptyString() {
+        Instant sessionEnd = TimeHelperExtension.getInstantHoursOffsetFromNow(-1);
+        Map<String, Instant> extendedDeadlines = new HashMap<>();
+        extendedDeadlines.put("participant@email.com", TimeHelperExtension.getInstantHoursOffsetFromNow(1));
+        assertEquals("",
+                FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                        sessionEnd, extendedDeadlines));
+    }
+
+    @Test
+    public void testGetInvalidityInfoForTimeForSessionEndAndExtendedDeadlines_invalid_returnErrorString() {
+        Instant sessionEnd = TimeHelperExtension.getInstantHoursOffsetFromNow(1);
+        Map<String, Instant> extendedDeadlines = new HashMap<>();
+        extendedDeadlines.put("participant@email.com", TimeHelperExtension.getInstantHoursOffsetFromNow(-1));
+        assertEquals("The extended deadlines for this feedback session cannot be earlier than the end time.",
+                FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                        sessionEnd, extendedDeadlines));
     }
 
     @Test

--- a/src/test/java/teammates/common/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/common/util/FieldValidatorTest.java
@@ -612,7 +612,7 @@ public class FieldValidatorTest extends BaseTestCase {
                 FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
                         sessionEnd, extendedDeadlines));
 
-        ______TS("extended deadline earlier than the end time");
+        ______TS("extended deadline at the same time as the end time");
         extendedDeadlines.put("participant@email.com", sessionEnd);
         assertEquals("The extended deadlines for this feedback session cannot be earlier than or at the same time as "
                         + "the end time.",

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +117,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
         InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
         String courseId = instructor.getCourseId();
 
-        List<String> instructorEmailAddresses = new ArrayList<>();
+        Collection<String> instructorEmailAddresses = new ArrayList<>();
         instructorEmailAddresses.add(instructor.getEmail());
 
         ______TS("existing instructor");

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -47,7 +47,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
     @Test
     public void testAll() throws Exception {
-        testVerifyAllStudentsExistInCourse();
+        testVerifyAllInstructorsExistInCourse();
         testGetInstructorForEmail();
         testGetInstructorForGoogleId();
         testGetInstructorsForGoogleId();
@@ -111,7 +111,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
         assertThrows(AssertionError.class, () -> instructorsLogic.createInstructor(null));
     }
 
-    private void testVerifyAllStudentsExistInCourse() throws Exception {
+    private void testVerifyAllInstructorsExistInCourse() throws Exception {
 
         InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
         String courseId = instructor.getCourseId();

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -47,6 +47,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
     @Test
     public void testAll() throws Exception {
+        testVerifyAllStudentsExistInCourse();
         testGetInstructorForEmail();
         testGetInstructorForGoogleId();
         testGetInstructorsForGoogleId();
@@ -108,6 +109,37 @@ public class InstructorsLogicTest extends BaseLogicTest {
         ______TS("failure: null parameters");
 
         assertThrows(AssertionError.class, () -> instructorsLogic.createInstructor(null));
+    }
+
+    private void testVerifyAllStudentsExistInCourse() throws Exception {
+
+        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
+        String courseId = instructor.getCourseId();
+
+        List<String> instructorEmailAddresses = new ArrayList<>();
+        instructorEmailAddresses.add(instructor.getEmail());
+
+        ______TS("existing instructor");
+
+        // should not throw an exception
+        instructorsLogic.verifyAllInstructorsExistInCourse(courseId, instructorEmailAddresses);
+
+        ______TS("existing instructor in non-existent course");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                instructorsLogic.verifyAllInstructorsExistInCourse("non-existent-course", instructorEmailAddresses));
+
+        ______TS("non-existent instructor in existing course");
+
+        instructorEmailAddresses.add("non-existent.instructor@email.com");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                instructorsLogic.verifyAllInstructorsExistInCourse(courseId, instructorEmailAddresses));
+
+        ______TS("non-existent instructor in non-existent course");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                instructorsLogic.verifyAllInstructorsExistInCourse("non-existent-course", instructorEmailAddresses));
     }
 
     private void testGetInstructorForEmail() {

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -120,24 +120,24 @@ public class InstructorsLogicTest extends BaseLogicTest {
         Collection<String> instructorEmailAddresses = new ArrayList<>();
         instructorEmailAddresses.add(instructor.getEmail());
 
-        ______TS("existing instructor");
+        ______TS("existing instructor email address in existing course");
 
         // should not throw an exception
         instructorsLogic.verifyAllInstructorsExistInCourse(courseId, instructorEmailAddresses);
 
-        ______TS("existing instructor in non-existent course");
+        ______TS("existing instructor email address in non-existent course");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 instructorsLogic.verifyAllInstructorsExistInCourse("non-existent-course", instructorEmailAddresses));
 
-        ______TS("non-existent instructor in existing course");
+        ______TS("non-existent instructor email address in existing course");
 
         instructorEmailAddresses.add("non-existent.instructor@email.com");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 instructorsLogic.verifyAllInstructorsExistInCourse(courseId, instructorEmailAddresses));
 
-        ______TS("non-existent instructor in non-existent course");
+        ______TS("non-existent instructor email address in non-existent course");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 instructorsLogic.verifyAllInstructorsExistInCourse("non-existent-course", instructorEmailAddresses));

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -52,6 +52,7 @@ public class StudentsLogicTest extends BaseLogicTest {
         testGetStudentsForGoogleId();
         testGetStudentForCourseIdAndGoogleId();
         testGetStudentsForCourse();
+        testVerifyAllStudentsExistInCourse();
         testIsStudentInAnyCourse();
         testIsStudentInTeam();
         testIsStudentsInSameTeam();
@@ -438,6 +439,37 @@ public class StudentsLogicTest extends BaseLogicTest {
         studentList = studentsLogic.getStudentsForCourse("non-existent");
         assertEquals(0, studentList.size());
 
+    }
+
+    private void testVerifyAllStudentsExistInCourse() throws Exception {
+
+        StudentAttributes student = dataBundle.students.get("student1InCourse1");
+        String courseId = student.getCourse();
+
+        List<String> studentEmailAddresses = new ArrayList<>();
+        studentEmailAddresses.add(student.getEmail());
+
+        ______TS("existing student");
+
+        // should not throw an exception
+        studentsLogic.verifyAllStudentsExistInCourse(courseId, studentEmailAddresses);
+
+        ______TS("existing student in non-existent course");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                studentsLogic.verifyAllStudentsExistInCourse("non-existent-course", studentEmailAddresses));
+
+        ______TS("non-existent student in existing course");
+
+        studentEmailAddresses.add("non-existent.student@email.com");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                studentsLogic.verifyAllStudentsExistInCourse(courseId, studentEmailAddresses));
+
+        ______TS("non-existent student in non-existent course");
+
+        assertThrows(EntityDoesNotExistException.class, () ->
+                studentsLogic.verifyAllStudentsExistInCourse("non-existent-course", studentEmailAddresses));
     }
 
     private void testIsStudentInAnyCourse() {

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
@@ -446,7 +447,7 @@ public class StudentsLogicTest extends BaseLogicTest {
         StudentAttributes student = dataBundle.students.get("student1InCourse1");
         String courseId = student.getCourse();
 
-        List<String> studentEmailAddresses = new ArrayList<>();
+        Collection<String> studentEmailAddresses = new ArrayList<>();
         studentEmailAddresses.add(student.getEmail());
 
         ______TS("existing student");

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -450,24 +450,24 @@ public class StudentsLogicTest extends BaseLogicTest {
         Collection<String> studentEmailAddresses = new ArrayList<>();
         studentEmailAddresses.add(student.getEmail());
 
-        ______TS("existing student");
+        ______TS("existing student email address in existing course");
 
         // should not throw an exception
         studentsLogic.verifyAllStudentsExistInCourse(courseId, studentEmailAddresses);
 
-        ______TS("existing student in non-existent course");
+        ______TS("existing student email address in non-existent course");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 studentsLogic.verifyAllStudentsExistInCourse("non-existent-course", studentEmailAddresses));
 
-        ______TS("non-existent student in existing course");
+        ______TS("non-existent student email address in existing course");
 
         studentEmailAddresses.add("non-existent.student@email.com");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 studentsLogic.verifyAllStudentsExistInCourse(courseId, studentEmailAddresses));
 
-        ______TS("non-existent student in non-existent course");
+        ______TS("non-existent student email address in non-existent course");
 
         assertThrows(EntityDoesNotExistException.class, () ->
                 studentsLogic.verifyAllStudentsExistInCourse("non-existent-course", studentEmailAddresses));

--- a/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
@@ -2,7 +2,7 @@ package teammates.storage.api;
 
 import static teammates.common.util.FieldValidator.SESSION_END_TIME_FIELD_NAME;
 import static teammates.common.util.FieldValidator.SESSION_START_TIME_FIELD_NAME;
-import static teammates.common.util.FieldValidator.TIME_FRAME_ERROR_MESSAGE;
+import static teammates.common.util.FieldValidator.TIME_BEFORE_ERROR_MESSAGE;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -483,7 +483,7 @@ public class FeedbackSessionsDbTest extends BaseTestCaseWithLocalDatabaseAccess 
                                 .withResultsVisibleFromTime(invalidFs.getResultsVisibleFromTime())
                                 .build()));
         assertEquals(
-                String.format(TIME_FRAME_ERROR_MESSAGE, SESSION_END_TIME_FIELD_NAME, SESSION_START_TIME_FIELD_NAME),
+                String.format(TIME_BEFORE_ERROR_MESSAGE, SESSION_END_TIME_FIELD_NAME, SESSION_START_TIME_FIELD_NAME),
                 ipe.getLocalizedMessage());
 
         ______TS("feedback session does not exist");

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -108,6 +108,30 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
+    public void testHasExistingStudentInCourse() {
+
+        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
+
+        ______TS("existing instructor");
+
+        assertTrue(instructorsDb.hasExistingInstructorInCourse(instructor.getCourseId(), instructor.getEmail()));
+
+        ______TS("non-existent instructor in existing course");
+
+        assertFalse(instructorsDb
+                .hasExistingInstructorInCourse(instructor.getCourseId(), "non-existent.instructor@email.com"));
+
+        ______TS("existing instructor in non-existent course");
+
+        assertFalse(instructorsDb.hasExistingInstructorInCourse("non-existent-course", instructor.getEmail()));
+
+        ______TS("non-existent instructor in non-existent course");
+
+        assertFalse(instructorsDb
+                .hasExistingInstructorInCourse("non-existent-course", "non-existent.instructor@email.com"));
+    }
+
+    @Test
     public void testGetInstructorForEmail() {
 
         InstructorAttributes i = dataBundle.instructors.get("instructor1OfCourse1");

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -108,7 +108,7 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
-    public void testHasExistingStudentInCourse() {
+    public void testHasExistingInstructorInCourse() {
 
         InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
 

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -1,6 +1,7 @@
 package teammates.storage.api;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
@@ -108,27 +109,29 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
-    public void testHasExistingInstructorInCourse() {
+    public void testHasExistingInstructorsInCourse() {
 
         InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
+        Collection<String> instructorEmailAddresses = new ArrayList<>();
+        instructorEmailAddresses.add(instructor.getEmail());
 
-        ______TS("existing instructor");
+        ______TS("all existing instructors");
 
-        assertTrue(instructorsDb.hasExistingInstructorInCourse(instructor.getCourseId(), instructor.getEmail()));
+        assertTrue(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
 
-        ______TS("non-existent instructor in existing course");
+        ______TS("all existing instructors in non-existent course");
 
-        assertFalse(instructorsDb
-                .hasExistingInstructorInCourse(instructor.getCourseId(), "non-existent.instructor@email.com"));
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
 
-        ______TS("existing instructor in non-existent course");
+        ______TS("some non-existent instructor in existing course");
 
-        assertFalse(instructorsDb.hasExistingInstructorInCourse("non-existent-course", instructor.getEmail()));
+        instructorEmailAddresses.add("non-existent.instructor@email.com");
 
-        ______TS("non-existent instructor in non-existent course");
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
 
-        assertFalse(instructorsDb
-                .hasExistingInstructorInCourse("non-existent-course", "non-existent.instructor@email.com"));
+        ______TS("some non-existent instructor in non-existent course");
+
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -115,21 +115,21 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
         Collection<String> instructorEmailAddresses = new ArrayList<>();
         instructorEmailAddresses.add(instructor.getEmail());
 
-        ______TS("all existing instructors");
+        ______TS("all existing instructor email addresses");
 
         assertTrue(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
 
-        ______TS("all existing instructors in non-existent course");
+        ______TS("all existing instructor email addresses in non-existent course");
 
         assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
 
-        ______TS("some non-existent instructor in existing course");
+        ______TS("some non-existent instructor email address in existing course");
 
         instructorEmailAddresses.add("non-existent.instructor@email.com");
 
         assertFalse(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
 
-        ______TS("some non-existent instructor in non-existent course");
+        ______TS("some non-existent instructor email address in non-existent course");
 
         assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
     }

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -111,27 +111,35 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     @Test
     public void testHasExistingInstructorsInCourse() {
 
-        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
+        InstructorAttributes instructor1 = dataBundle.instructors.get("instructor1OfCourse1");
+        InstructorAttributes instructor2 = dataBundle.instructors.get("instructor2OfCourse1");
+        String courseId = instructor1.getCourseId();
+        assertEquals(courseId, instructor2.getCourseId());
+        String nonExistentCourseId = "non-existent-course";
+
         Collection<String> instructorEmailAddresses = new ArrayList<>();
-        instructorEmailAddresses.add(instructor.getEmail());
+        instructorEmailAddresses.add(instructor1.getEmail());
 
         ______TS("all existing instructor email addresses");
 
-        assertTrue(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
+        assertTrue(instructorsDb.hasExistingInstructorsInCourse(courseId, instructorEmailAddresses));
+
+        instructorEmailAddresses.add(instructor2.getEmail());
+        assertTrue(instructorsDb.hasExistingInstructorsInCourse(courseId, instructorEmailAddresses));
 
         ______TS("all existing instructor email addresses in non-existent course");
 
-        assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse(nonExistentCourseId, instructorEmailAddresses));
 
         ______TS("some non-existent instructor email address in existing course");
 
         instructorEmailAddresses.add("non-existent.instructor@email.com");
 
-        assertFalse(instructorsDb.hasExistingInstructorsInCourse(instructor.getCourseId(), instructorEmailAddresses));
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse(courseId, instructorEmailAddresses));
 
         ______TS("some non-existent instructor email address in non-existent course");
 
-        assertFalse(instructorsDb.hasExistingInstructorsInCourse("non-existent-course", instructorEmailAddresses));
+        assertFalse(instructorsDb.hasExistingInstructorsInCourse(nonExistentCourseId, instructorEmailAddresses));
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/StudentsDbTest.java
+++ b/src/test/java/teammates/storage/api/StudentsDbTest.java
@@ -3,6 +3,9 @@ package teammates.storage.api;
 import static teammates.common.util.FieldValidator.COURSE_ID_ERROR_MESSAGE;
 import static teammates.common.util.FieldValidator.REASON_INCORRECT_FORMAT;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
@@ -104,25 +107,29 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
-    public void testHasExistingStudentInCourse() throws Exception {
+    public void testHasExistingStudentsInCourse() throws Exception {
 
         StudentAttributes student = createNewStudent();
+        Collection<String> studentEmailAddresses = new ArrayList<>();
+        studentEmailAddresses.add(student.getEmail());
 
-        ______TS("existing student");
+        ______TS("all existing students");
 
-        assertTrue(studentsDb.hasExistingStudentInCourse(student.getCourse(), student.getEmail()));
+        assertTrue(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
 
-        ______TS("non-existent student in existing course");
+        ______TS("all existing students in non-existent course");
 
-        assertFalse(studentsDb.hasExistingStudentInCourse(student.getCourse(), "non-existent.student@email.com"));
+        assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
 
-        ______TS("existing student in non-existent course");
+        ______TS("some non-existent student in existing course");
 
-        assertFalse(studentsDb.hasExistingStudentInCourse("non-existent-course", student.getEmail()));
+        studentEmailAddresses.add("non-existent.student@email.com");
 
-        ______TS("non-existent student in non-existent course");
+        assertFalse(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
 
-        assertFalse(studentsDb.hasExistingStudentInCourse("non-existent-course", "non-existent.student@email.com"));
+        ______TS("some non-existent student in non-existent course");
+
+        assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/StudentsDbTest.java
+++ b/src/test/java/teammates/storage/api/StudentsDbTest.java
@@ -104,6 +104,28 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
+    public void testHasExistingStudentInCourse() throws Exception {
+
+        StudentAttributes student = createNewStudent();
+
+        ______TS("existing student");
+
+        assertTrue(studentsDb.hasExistingStudentInCourse(student.getCourse(), student.getEmail()));
+
+        ______TS("non-existent student in existing course");
+
+        assertFalse(studentsDb.hasExistingStudentInCourse(student.getCourse(), "non-existent.student@email.com"));
+
+        ______TS("existing student in non-existent course");
+
+        assertFalse(studentsDb.hasExistingStudentInCourse("non-existent-course", student.getEmail()));
+
+        ______TS("non-existent student in non-existent course");
+
+        assertFalse(studentsDb.hasExistingStudentInCourse("non-existent-course", "non-existent.student@email.com"));
+    }
+
+    @Test
     public void testGetStudent() throws Exception {
 
         StudentAttributes s = createNewStudent();

--- a/src/test/java/teammates/storage/api/StudentsDbTest.java
+++ b/src/test/java/teammates/storage/api/StudentsDbTest.java
@@ -113,21 +113,21 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
         Collection<String> studentEmailAddresses = new ArrayList<>();
         studentEmailAddresses.add(student.getEmail());
 
-        ______TS("all existing students");
+        ______TS("all existing student email addresses");
 
         assertTrue(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
 
-        ______TS("all existing students in non-existent course");
+        ______TS("all existing student email addresses in non-existent course");
 
         assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
 
-        ______TS("some non-existent student in existing course");
+        ______TS("some non-existent student email address in existing course");
 
         studentEmailAddresses.add("non-existent.student@email.com");
 
         assertFalse(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
 
-        ______TS("some non-existent student in non-existent course");
+        ______TS("some non-existent student email address in non-existent course");
 
         assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
     }

--- a/src/test/java/teammates/storage/api/StudentsDbTest.java
+++ b/src/test/java/teammates/storage/api/StudentsDbTest.java
@@ -109,27 +109,35 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     @Test
     public void testHasExistingStudentsInCourse() throws Exception {
 
-        StudentAttributes student = createNewStudent();
+        StudentAttributes student1 = createNewStudent("student1@uni.edu");
+        StudentAttributes student2 = createNewStudent("student2@uni.edu");
+        String courseId = student1.getCourse();
+        assertEquals(courseId, student2.getCourse());
+        String nonExistentCourseId = "non-existent-course";
+
         Collection<String> studentEmailAddresses = new ArrayList<>();
-        studentEmailAddresses.add(student.getEmail());
+        studentEmailAddresses.add(student1.getEmail());
 
         ______TS("all existing student email addresses");
 
-        assertTrue(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
+        assertTrue(studentsDb.hasExistingStudentsInCourse(courseId, studentEmailAddresses));
+
+        studentEmailAddresses.add(student2.getEmail());
+        assertTrue(studentsDb.hasExistingStudentsInCourse(courseId, studentEmailAddresses));
 
         ______TS("all existing student email addresses in non-existent course");
 
-        assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
+        assertFalse(studentsDb.hasExistingStudentsInCourse(nonExistentCourseId, studentEmailAddresses));
 
         ______TS("some non-existent student email address in existing course");
 
         studentEmailAddresses.add("non-existent.student@email.com");
 
-        assertFalse(studentsDb.hasExistingStudentsInCourse(student.getCourse(), studentEmailAddresses));
+        assertFalse(studentsDb.hasExistingStudentsInCourse(courseId, studentEmailAddresses));
 
         ______TS("some non-existent student email address in non-existent course");
 
-        assertFalse(studentsDb.hasExistingStudentsInCourse("non-existent-course", studentEmailAddresses));
+        assertFalse(studentsDb.hasExistingStudentsInCourse(nonExistentCourseId, studentEmailAddresses));
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -1,5 +1,9 @@
 package teammates.ui.webapi;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -37,9 +41,11 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         ______TS("Not enough parameters");
 
-        verifyHttpParameterFailure();
-        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, session.getCourseId());
-        verifyHttpParameterFailure(Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName());
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+
+        verifyHttpParameterFailure(updateRequest);
+        verifyHttpParameterFailure(updateRequest, Const.ParamsNames.COURSE_ID, session.getCourseId());
+        verifyHttpParameterFailure(updateRequest, Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName());
 
         ______TS("success: Typical case");
 
@@ -47,7 +53,6 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
 
         UpdateFeedbackSessionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
@@ -94,6 +99,216 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         assertNotNull(response.getCreatedAtTimestamp());
         assertNull(response.getDeletedAtTimestamp());
+
+        Map<String, Long> expectedStudentDeadlines = new HashMap<>();
+        expectedStudentDeadlines.put("student3InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student4InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student5InCourse1@gmail.tmt", 1809126000000L);
+        assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+        Map<String, Long> expectedInstructorDeadlines = new HashMap<>();
+        expectedInstructorDeadlines.put("instructor1@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("instructor2@course1.tmt", 1809126000000L);
+        assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+    }
+
+    @Test
+    public void testExecute_changeDeadlineForStudents_shouldChangeDeadlinesCorrectlyWhenAppropriate() {
+        InstructorAttributes instructor1ofCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+        FeedbackSessionAttributes session = typicalBundle.feedbackSessions.get("session1InCourse1");
+
+        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+
+        String[] param = new String[] {
+                Const.ParamsNames.COURSE_ID, session.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+        };
+
+        ______TS("create new deadline extension for student");
+
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        Map<String, Long> newStudentDeadlines = updateRequest.getStudentDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newStudentDeadlines.put("student1InCourse1@gmail.tmt", 1809126000000L);
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        UpdateFeedbackSessionAction a = getAction(updateRequest, param);
+        JsonResult r = getJsonResult(a);
+        FeedbackSessionData response = (FeedbackSessionData) r.getOutput();
+
+        Map<String, Long> expectedStudentDeadlines = new HashMap<>();
+        expectedStudentDeadlines.put("student1InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student3InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student4InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student5InCourse1@gmail.tmt", 1809126000000L);
+        assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
+        ______TS("update deadline extension for student");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newStudentDeadlines = updateRequest.getStudentDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newStudentDeadlines.put("student1InCourse1@gmail.tmt", 1809212400000L);
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        expectedStudentDeadlines = new HashMap<>();
+        expectedStudentDeadlines.put("student1InCourse1@gmail.tmt", 1809212400000L);
+        expectedStudentDeadlines.put("student3InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student4InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student5InCourse1@gmail.tmt", 1809126000000L);
+        assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
+        ______TS("delete deadline extension for student");
+
+        // the typical update request does not contain the course 1 student 1's email
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        expectedStudentDeadlines = new HashMap<>();
+        expectedStudentDeadlines.put("student3InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student4InCourse1@gmail.tmt", 1809126000000L);
+        expectedStudentDeadlines.put("student5InCourse1@gmail.tmt", 1809126000000L);
+        assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
+        ______TS("change deadline extension for non-existent student; should throw EntityNotFoundException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newStudentDeadlines = updateRequest.getStudentDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newStudentDeadlines.put("nonExistentStudent@gmail.tmt", 1809126000000L);
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        a = getAction(updateRequest, param);
+        final UpdateFeedbackSessionAction a1 = a;
+        assertThrows(EntityNotFoundException.class, a1::execute);
+
+        ______TS("change deadline extension for student to before end time; "
+                + "should throw InvalidHttpRequestBodyException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newStudentDeadlines = updateRequest.getStudentDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newStudentDeadlines.put("student1InCourse1@gmail.tmt", 1546003050999L);
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        a = getAction(updateRequest, param);
+        final UpdateFeedbackSessionAction a2 = a;
+        assertThrows(InvalidHttpRequestBodyException.class, a2::execute);
+
+        logoutUser();
+    }
+
+    @Test
+    public void testExecute_changeDeadlineForInstructors_shouldChangeDeadlinesCorrectlyWhenAppropriate() {
+        InstructorAttributes instructor1ofCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+        FeedbackSessionAttributes session = typicalBundle.feedbackSessions.get("session1InCourse1");
+
+        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+
+        String[] param = new String[] {
+                Const.ParamsNames.COURSE_ID, session.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+        };
+
+        ______TS("create new deadline extension for instructor");
+
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        Map<String, Long> newInstructorDeadlines = updateRequest.getInstructorDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newInstructorDeadlines.put("helper@course1.tmt", 1809126000000L);
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        UpdateFeedbackSessionAction a = getAction(updateRequest, param);
+        JsonResult r = getJsonResult(a);
+        FeedbackSessionData response = (FeedbackSessionData) r.getOutput();
+
+        Map<String, Long> expectedInstructorDeadlines = new HashMap<>();
+        expectedInstructorDeadlines.put("instructor1@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("instructor2@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("helper@course1.tmt", 1809126000000L);
+        assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        ______TS("update deadline extension for instructor");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newInstructorDeadlines = updateRequest.getInstructorDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newInstructorDeadlines.put("helper@course1.tmt", 1809298800000L);
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        expectedInstructorDeadlines = new HashMap<>();
+        expectedInstructorDeadlines.put("instructor1@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("instructor2@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("helper@course1.tmt", 1809298800000L);
+        assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        ______TS("delete deadline extension for instructor");
+
+        // the typical update request does not contain the course 1 helper instructor's email
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        expectedInstructorDeadlines = new HashMap<>();
+        expectedInstructorDeadlines.put("instructor1@course1.tmt", 1809126000000L);
+        expectedInstructorDeadlines.put("instructor2@course1.tmt", 1809126000000L);
+        assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        ______TS("change deadline extension for non-existent instructor; "
+                + "should throw EntityNotFoundException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newInstructorDeadlines = updateRequest.getInstructorDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newInstructorDeadlines.put("nonExistentInstructor@gmail.tmt", 1809126000000L);
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        a = getAction(updateRequest, param);
+        final UpdateFeedbackSessionAction a1 = a;
+        assertThrows(EntityNotFoundException.class, a1::execute);
+
+        ______TS("change deadline extension for instructor to before end time; "
+                + "should throw InvalidHttpRequestBodyException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newInstructorDeadlines = updateRequest.getInstructorDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newInstructorDeadlines.put("helper@course1.tmt", 1546003050999L);
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        a = getAction(updateRequest, param);
+        final UpdateFeedbackSessionAction a2 = a;
+        assertThrows(InvalidHttpRequestBodyException.class, a2::execute);
+
+        logoutUser();
     }
 
     @Test
@@ -221,6 +436,16 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         updateRequest.setClosingEmailEnabled(false);
         updateRequest.setPublishedEmailEnabled(false);
+
+        Map<String, Long> studentDeadlines = new HashMap<>();
+        studentDeadlines.put("student3InCourse1@gmail.tmt", 1809126000000L);
+        studentDeadlines.put("student4InCourse1@gmail.tmt", 1809126000000L);
+        studentDeadlines.put("student5InCourse1@gmail.tmt", 1809126000000L);
+        updateRequest.setStudentDeadlines(studentDeadlines);
+        Map<String, Long> instructorDeadlines = new HashMap<>();
+        instructorDeadlines.put("instructor1@course1.tmt", 1809126000000L);
+        instructorDeadlines.put("instructor2@course1.tmt", 1809126000000L);
+        updateRequest.setInstructorDeadlines(instructorDeadlines);
 
         return updateRequest;
     }

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -191,8 +191,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setStudentDeadlines(newStudentDeadlines);
 
         a = getAction(updateRequest, param);
-        final UpdateFeedbackSessionAction a1 = a;
-        assertThrows(EntityNotFoundException.class, a1::execute);
+        assertThrows(EntityNotFoundException.class, a::execute);
 
         ______TS("change deadline extension for student to before end time; "
                 + "should throw InvalidHttpRequestBodyException");
@@ -206,8 +205,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setStudentDeadlines(newStudentDeadlines);
 
         a = getAction(updateRequest, param);
-        final UpdateFeedbackSessionAction a2 = a;
-        assertThrows(InvalidHttpRequestBodyException.class, a2::execute);
+        assertThrows(InvalidHttpRequestBodyException.class, a::execute);
 
         logoutUser();
     }
@@ -290,8 +288,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setInstructorDeadlines(newInstructorDeadlines);
 
         a = getAction(updateRequest, param);
-        final UpdateFeedbackSessionAction a1 = a;
-        assertThrows(EntityNotFoundException.class, a1::execute);
+        assertThrows(EntityNotFoundException.class, a::execute);
 
         ______TS("change deadline extension for instructor to before end time; "
                 + "should throw InvalidHttpRequestBodyException");
@@ -305,8 +302,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setInstructorDeadlines(newInstructorDeadlines);
 
         a = getAction(updateRequest, param);
-        final UpdateFeedbackSessionAction a2 = a;
-        assertThrows(InvalidHttpRequestBodyException.class, a2::execute);
+        assertThrows(InvalidHttpRequestBodyException.class, a::execute);
 
         logoutUser();
     }

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -193,6 +193,20 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         a = getAction(updateRequest, param);
         assertThrows(EntityNotFoundException.class, a::execute);
 
+        ______TS("change deadline extension for student to the same time as the end time; "
+                + "should throw InvalidHttpRequestBodyException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newStudentDeadlines = updateRequest.getStudentDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newStudentDeadlines.put("student1InCourse1@gmail.tmt", 1546003051000L);
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        a = getAction(updateRequest, param);
+        assertThrows(InvalidHttpRequestBodyException.class, a::execute);
+
         ______TS("change deadline extension for student to before end time; "
                 + "should throw InvalidHttpRequestBodyException");
 
@@ -289,6 +303,20 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         a = getAction(updateRequest, param);
         assertThrows(EntityNotFoundException.class, a::execute);
+
+        ______TS("change deadline extension for instructor to the same time as the end time; "
+                + "should throw InvalidHttpRequestBodyException");
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newInstructorDeadlines = updateRequest.getInstructorDeadlines()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toEpochMilli()));
+        newInstructorDeadlines.put("helper@course1.tmt", 1546003051000L);
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        a = getAction(updateRequest, param);
+        assertThrows(InvalidHttpRequestBodyException.class, a::execute);
 
         ______TS("change deadline extension for instructor to before end time; "
                 + "should throw InvalidHttpRequestBodyException");

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -127,6 +127,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         ______TS("create new deadline extension for student");
 
+        assertNull(expectedStudentDeadlines.get("student1InCourse1@gmail.tmt"));
+
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
         Map<String, Long> newStudentDeadlines = convertDeadlinesToLong(updateRequest.getStudentDeadlines());
         newStudentDeadlines.put("student1InCourse1@gmail.tmt", endTimePlus1Day);
@@ -141,6 +143,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         ______TS("update deadline extension for student");
 
+        assertNotEquals(endTimePlus2Days, expectedStudentDeadlines.get("student1InCourse1@gmail.tmt"));
+
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
         newStudentDeadlines = convertDeadlinesToLong(updateRequest.getStudentDeadlines());
         newStudentDeadlines.put("student1InCourse1@gmail.tmt", endTimePlus2Days);
@@ -154,6 +158,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
 
         ______TS("delete deadline extension for student");
+
+        assertNotNull(expectedStudentDeadlines.get("student1InCourse1@gmail.tmt"));
 
         // The typical update request does not contain the course 1 student 1's email.
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
@@ -248,6 +254,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         ______TS("create new deadline extension for instructor");
 
+        assertNull(expectedInstructorDeadlines.get("helper@course1.tmt"));
+
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
         Map<String, Long> newInstructorDeadlines = convertDeadlinesToLong(updateRequest.getInstructorDeadlines());
         newInstructorDeadlines.put("helper@course1.tmt", endTimePlus1Day);
@@ -262,6 +270,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         ______TS("update deadline extension for instructor");
 
+        assertNotEquals(endTimePlus2Days, expectedInstructorDeadlines.get("helper@course1.tmt"));
+
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
         newInstructorDeadlines = convertDeadlinesToLong(updateRequest.getInstructorDeadlines());
         newInstructorDeadlines.put("helper@course1.tmt", endTimePlus2Days);
@@ -275,6 +285,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
 
         ______TS("delete deadline extension for instructor");
+
+        assertNotNull(expectedInstructorDeadlines.get("helper@course1.tmt"));
 
         // The typical update request does not contain the course 1 helper instructor's email.
         updateRequest = getTypicalFeedbackSessionUpdateRequest();

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -166,6 +166,31 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         expectedStudentDeadlines.remove("student1InCourse1@gmail.tmt");
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
 
+        ______TS("C_UD deadline extensions for students simultaneously");
+
+        assertNull(expectedStudentDeadlines.get("student1InCourse1@gmail.tmt"));
+        assertNotEquals(endTimePlus2Days, expectedStudentDeadlines.get("student3InCourse1@gmail.tmt"));
+        assertNotNull(expectedStudentDeadlines.get("student4InCourse1@gmail.tmt"));
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newStudentDeadlines = convertDeadlinesToLong(updateRequest.getStudentDeadlines());
+        newStudentDeadlines.put("student1InCourse1@gmail.tmt", endTimePlus1Day);
+        newStudentDeadlines.put("student3InCourse1@gmail.tmt", endTimePlus2Days);
+        newStudentDeadlines.remove("student4InCourse1@gmail.tmt");
+        updateRequest.setStudentDeadlines(newStudentDeadlines);
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        // Create deadline.
+        expectedStudentDeadlines.put("student1InCourse1@gmail.tmt", endTimePlus1Day);
+        // Update deadline.
+        expectedStudentDeadlines.put("student3InCourse1@gmail.tmt", endTimePlus2Days);
+        // Delete deadline.
+        expectedStudentDeadlines.remove("student4InCourse1@gmail.tmt");
+        assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
         ______TS("change deadline extension for non-existent student; should throw EntityNotFoundException");
 
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
@@ -260,6 +285,31 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         // The deadline for course 1 helper instructor was deleted; the map no longer contains a deadline for them.
         expectedInstructorDeadlines.remove("helper@course1.tmt");
+        assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        ______TS("C_UD deadline extensions for instructors simultaneously");
+
+        assertNull(expectedInstructorDeadlines.get("helper@course1.tmt"));
+        assertNotEquals(endTimePlus2Days, expectedInstructorDeadlines.get("instructor1@course1.tmt"));
+        assertNotNull(expectedInstructorDeadlines.get("instructor2@course1.tmt"));
+
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        newInstructorDeadlines = convertDeadlinesToLong(updateRequest.getInstructorDeadlines());
+        newInstructorDeadlines.put("helper@course1.tmt", endTimePlus1Day);
+        newInstructorDeadlines.put("instructor1@course1.tmt", endTimePlus2Days);
+        newInstructorDeadlines.remove("instructor2@course1.tmt");
+        updateRequest.setInstructorDeadlines(newInstructorDeadlines);
+
+        a = getAction(updateRequest, param);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        // Create deadline.
+        expectedInstructorDeadlines.put("helper@course1.tmt", endTimePlus1Day);
+        // Update deadline.
+        expectedInstructorDeadlines.put("instructor1@course1.tmt", endTimePlus2Days);
+        // Delete deadline.
+        expectedInstructorDeadlines.remove("instructor2@course1.tmt");
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
 
         ______TS("change deadline extension for non-existent instructor; "

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -45,6 +45,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         verifyHttpRequestBodyFailure(null, param);
@@ -54,8 +55,15 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
 
         verifyHttpParameterFailure(updateRequest);
-        verifyHttpParameterFailure(updateRequest, Const.ParamsNames.COURSE_ID, session.getCourseId());
-        verifyHttpParameterFailure(updateRequest, Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName());
+        verifyHttpParameterFailure(updateRequest,
+                Const.ParamsNames.COURSE_ID, session.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName());
+        verifyHttpParameterFailure(updateRequest,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false));
+        verifyHttpParameterFailure(updateRequest,
+                Const.ParamsNames.COURSE_ID, session.getCourseId(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false));
 
         ______TS("success: Typical case");
 
@@ -127,6 +135,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         ______TS("create new deadline extension for student");
@@ -254,6 +263,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         ______TS("create new deadline extension for instructor");
@@ -376,6 +386,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
         updateRequest.setCustomSessionVisibleTimestamp(
@@ -405,6 +416,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
         updateRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
@@ -427,6 +439,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
         updateRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
@@ -449,6 +462,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
         param = addUserIdToParams(instructor1ofCourse1.getGoogleId(), param);
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
@@ -468,6 +482,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] param = new String[] {
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
         updateRequest.setInstructions(null);
@@ -519,6 +534,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, fs.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, "abcSession",
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
@@ -529,6 +545,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, fs.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, fs.getFeedbackSessionName(),
+                Const.ParamsNames.MUST_NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         verifyInaccessibleWithoutModifySessionPrivilege(submissionParams);

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -40,6 +40,15 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         loginAsInstructor(instructor1ofCourse1.getGoogleId());
 
+        ______TS("Missing request body");
+
+        String[] param = new String[] {
+                Const.ParamsNames.COURSE_ID, session.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
+        };
+
+        verifyHttpRequestBodyFailure(null, param);
+
         ______TS("Not enough parameters");
 
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
@@ -49,11 +58,6 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         verifyHttpParameterFailure(updateRequest, Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName());
 
         ______TS("success: Typical case");
-
-        String[] param = new String[] {
-                Const.ParamsNames.COURSE_ID, session.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
-        };
 
         UpdateFeedbackSessionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -433,6 +433,9 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
 
       isClosingEmailEnabled: this.sessionEditFormModel.isClosingEmailEnabled,
       isPublishedEmailEnabled: this.sessionEditFormModel.isPublishedEmailEnabled,
+
+      studentDeadlines: {},
+      instructorDeadlines: {},
     }).pipe(finalize(() => {
       this.sessionEditFormModel.isSaving = false;
     })).subscribe((feedbackSession: FeedbackSession) => {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -436,8 +436,6 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
 
       studentDeadlines: {},
       instructorDeadlines: {},
-
-      isGoingToNotifyAboutDeadlines: false,
     }).pipe(finalize(() => {
       this.sessionEditFormModel.isSaving = false;
     })).subscribe((feedbackSession: FeedbackSession) => {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -436,6 +436,8 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
 
       studentDeadlines: {},
       instructorDeadlines: {},
+
+      isGoingToNotifyAboutDeadlines: false,
     }).pipe(finalize(() => {
       this.sessionEditFormModel.isSaving = false;
     })).subscribe((feedbackSession: FeedbackSession) => {

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -105,7 +105,11 @@ export class FeedbackSessionsService {
    */
   updateFeedbackSession(courseId: string, feedbackSessionName: string, request: FeedbackSessionUpdateRequest):
       Observable<FeedbackSession> {
-    const paramMap: Record<string, string> = { courseid: courseId, fsname: feedbackSessionName };
+    const paramMap: Record<string, string> = {
+      courseid: courseId,
+      fsname: feedbackSessionName,
+      notifydeadlines: 'false',
+    };
     return this.httpRequestService.put(ResourceEndpoints.SESSION, paramMap, request);
   }
 


### PR DESCRIPTION
Part of #11571

<!-- **PR Checklist** -->

<!-- Remove this portion after you have made the checks. -->

<!-- Ensure that you have: -->
<!-- - [x] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr -->
<!--   - [x] Added the issue number to the "Fixes" keyword above -->
<!--   - [x] Titled the PR as specified in the abovementioned document -->
<!-- - [x] Made your changes on a branch other than `master` and `release` -->
<!-- - [x] Gone through all the changes in this PR and ensured that: -->
<!--   - [x] They addressed one (and only one) issue -->
<!--   - [x] No unintended changes were made -->
<!-- - [x] Run and passed static analysis: `./gradlew lint` and `npm run lint` -->
<!-- - [x] Added/updated tests, if changes in functionality were involved -->
<!-- - [x] Added/updated documentation to public APIs (classes, methods, variables), if applicable -->

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

The deadline maps are added to `FeedbackSessionUpdateRequest`. This allows deadlines to be created, updated, or deleted, by adding, modifying, or removing the deadline respectively from the corresponding deadline map(s) in the new updated feedback session sent as a request. This is done by allowing updates to the deadline maps in the feedback session through changes in `UpdateFeedbackSessionAction`.

The emails in the deadline maps are all checked for their existence in the database if there are any extra emails (when a new deadline is created; not when updated or deleted). An error is thrown if this is not the case. A single projection query over all emails in a course for either students or instructors is used to reduce database reads.

The deadlines are also checked for whether they are all after the end time. An error is thrown if this is not the case.

Note:
- Integration of this with the deadline entities and the emails will be done in a separate PR.