### PR TITLE
[#11585] fix unnecessary data read

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -122,6 +122,31 @@ public final class FeedbackQuestionsLogic {
         return questions;
     }
 
+    /**
+     * Gets the number of questions for student to answer from a map of giver type to question counts.
+     */
+    public long getFeedbackQuestionForStudentCountFrom(Map<FeedbackParticipantType, Long> giverTypeCounts) {
+        return giverTypeCounts.getOrDefault(FeedbackParticipantType.STUDENTS, 0L)
+                + giverTypeCounts.getOrDefault(FeedbackParticipantType.TEAMS, 0L);
+    }
+
+    /**
+     * Gets the number of questions for instructor to answer from a map of giver type to question counts.
+     */
+    public long getFeedbackQuestionForInstructorCountFrom(
+            Map<FeedbackParticipantType, Long> giverTypeCounts, boolean isCreator) {
+        return giverTypeCounts.getOrDefault(FeedbackParticipantType.INSTRUCTORS, 0L)
+                + (isCreator ? giverTypeCounts.getOrDefault(FeedbackParticipantType.SELF, 0L) : 0);
+    }
+
+    /**
+     * Gets a {@link Map} of FeedbackQuestion giver types to count in the given session.
+     */
+    public Map<FeedbackParticipantType, Long> getFeedbackQuestionGiverCountForSession(
+            String feedbackSessionName, String courseId) {
+        return fqDb.getFeedbackQuestionGiverTypeCountForSession(feedbackSessionName, courseId);
+    }
+
     // TODO can be removed once we are sure that question numbers will be consistent
     private boolean areQuestionNumbersConsistent(List<FeedbackQuestionAttributes> questions) {
         Set<Integer> questionNumbersInSession = new HashSet<>();

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -10,7 +10,6 @@ import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -493,7 +492,7 @@ public final class FeedbackSessionsLogic {
      */
     public int getExpectedTotalSubmission(FeedbackSessionAttributes fsa) {
         Integer numOfStudents = studentsLogic.getNumberOfStudentsForCourse(fsa.getCourseId());
-        List<InstructorAttributes> instructors = instructorsLogic.getInstructorsForCourse(fsa.getCourseId());
+        List<String> instructorEmails = instructorsLogic.getInstructorEmailsForCourse(fsa.getCourseId());
         List<FeedbackQuestionAttributes> questions =
                 fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
         List<FeedbackQuestionAttributes> studentQns = fqLogic.getFeedbackQuestionsForStudents(questions);
@@ -504,9 +503,9 @@ public final class FeedbackSessionsLogic {
             expectedTotal += numOfStudents;
         }
 
-        for (InstructorAttributes instructor : instructors) {
+        for (String instructorEmail : instructorEmails) {
             List<FeedbackQuestionAttributes> instructorQns =
-                    fqLogic.getFeedbackQuestionsForInstructors(questions, fsa.isCreator(instructor.getEmail()));
+                    fqLogic.getFeedbackQuestionsForInstructors(questions, fsa.isCreator(instructorEmail));
             if (!instructorQns.isEmpty()) {
                 expectedTotal += 1;
             }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -3,6 +3,7 @@ package teammates.logic.core;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
@@ -493,25 +494,21 @@ public final class FeedbackSessionsLogic {
     public int getExpectedTotalSubmission(FeedbackSessionAttributes fsa) {
         Integer numOfStudents = studentsLogic.getNumberOfStudentsForCourse(fsa.getCourseId());
         List<String> instructorEmails = instructorsLogic.getInstructorEmailsForCourse(fsa.getCourseId());
-        List<FeedbackQuestionAttributes> questions =
-                fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
-        List<FeedbackQuestionAttributes> studentQns = fqLogic.getFeedbackQuestionsForStudents(questions);
+        Map<FeedbackParticipantType, Long> giverTypeCounts = fqLogic.getFeedbackQuestionGiverCountForSession(
+                fsa.getFeedbackSessionName(), fsa.getCourseId());
 
-        int expectedTotal = 0;
-
-        if (!studentQns.isEmpty()) {
+        long expectedTotal = 0;
+        if (fqLogic.getFeedbackQuestionForStudentCountFrom(giverTypeCounts) > 0) {
             expectedTotal += numOfStudents;
         }
 
         for (String instructorEmail : instructorEmails) {
-            List<FeedbackQuestionAttributes> instructorQns =
-                    fqLogic.getFeedbackQuestionsForInstructors(questions, fsa.isCreator(instructorEmail));
-            if (!instructorQns.isEmpty()) {
+            if (fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, fsa.isCreator(instructorEmail)) > 0) {
                 expectedTotal += 1;
             }
         }
 
-        return expectedTotal;
+        return (int) expectedTotal;
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -492,7 +492,7 @@ public final class FeedbackSessionsLogic {
      * Gets the expected number of submissions for a feedback session.
      */
     public int getExpectedTotalSubmission(FeedbackSessionAttributes fsa) {
-        List<StudentAttributes> students = studentsLogic.getStudentsForCourse(fsa.getCourseId());
+        Integer numOfStudents = studentsLogic.getNumberOfStudentsForCourse(fsa.getCourseId());
         List<InstructorAttributes> instructors = instructorsLogic.getInstructorsForCourse(fsa.getCourseId());
         List<FeedbackQuestionAttributes> questions =
                 fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
@@ -501,7 +501,7 @@ public final class FeedbackSessionsLogic {
         int expectedTotal = 0;
 
         if (!studentQns.isEmpty()) {
-            expectedTotal += students.size();
+            expectedTotal += numOfStudents;
         }
 
         for (InstructorAttributes instructor : instructors) {

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
@@ -120,6 +121,16 @@ public final class InstructorsLogic {
      */
     public InstructorAttributes getInstructorForRegistrationKey(String registrationKey) {
         return instructorsDb.getInstructorForRegistrationKey(registrationKey);
+    }
+
+    /**
+     * Gets all instructors of a course.
+     */
+    public List<String> getInstructorEmailsForCourse(String courseId) {
+        List<String> instructorReturnList = instructorsDb.getInstructorEmailsForCourse(courseId);
+        instructorReturnList.sort(Comparator.naturalOrder());
+
+        return instructorReturnList;
     }
 
     /**

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -106,6 +106,13 @@ public final class StudentsLogic {
     }
 
     /**
+     * Gets the number of students of a course.
+     */
+    public Integer getNumberOfStudentsForCourse(String courseId) {
+        return studentsDb.getNumberOfStudentsForCourse(courseId);
+    }
+
+    /**
      * Gets all students of a section.
      */
     public List<StudentAttributes> getStudentsForSection(String sectionName, String courseId) {

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -3,6 +3,8 @@ package teammates.storage.api;
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
@@ -50,6 +52,23 @@ public final class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, Feed
         assert courseId != null;
 
         return makeAttributesOrNull(getFeedbackQuestionEntity(feedbackSessionName, courseId, questionNumber));
+    }
+
+    /**
+     * Gets feedback question count grouped by giver types of a session.
+     */
+    public Map<FeedbackParticipantType, Long> getFeedbackQuestionGiverTypeCountForSession(
+            String feedbackSessionName, String courseId) {
+        assert feedbackSessionName != null;
+        assert courseId != null;
+
+        return load()
+                .filter("feedbackSessionName =", feedbackSessionName)
+                .filter("courseId =", courseId)
+                .project("giverType")
+                .list()
+                .stream()
+                .collect(Collectors.groupingBy(FeedbackQuestion::getGiverType, Collectors.counting()));
     }
 
     /**

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -149,6 +149,21 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     /**
      * Gets all instructors of a course.
      */
+    public List<String> getInstructorEmailsForCourse(String courseId) {
+        assert courseId != null;
+
+        return load()
+                .filter("courseId =", courseId)
+                .project("email")
+                .list()
+                .stream()
+                .map(Instructor::getEmail)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets all instructors of a course.
+     */
     public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
         assert courseId != null;
 

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -176,6 +176,15 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
     }
 
     /**
+     * Gets all students of a course.
+     */
+    public int getNumberOfStudentsForCourse(String courseId) {
+        assert courseId != null;
+
+        return getCourseStudentsForCourseQuery(courseId).count();
+    }
+
+    /**
      * Gets all students of a section of a course.
      */
     public List<StudentAttributes> getStudentsForSection(String sectionName, String courseId) {

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -77,6 +77,7 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
 
     @Test
     public void allTests() throws Exception {
+        testGetFeedbackQuestionGiverCount();
         testHasFeedbackQuestionsForInstructor();
         testGetFeedbackQuestionsForInstructor();
         testHasFeedbackQuestionsForStudents();
@@ -905,6 +906,41 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         assertTrue(completeGiverRecipientMap.get("Team 1.1</td></div>'\"").contains("Team 1.2"));
         assertEquals(1, completeGiverRecipientMap.get("Team 1.2").size());
         assertTrue(completeGiverRecipientMap.get("Team 1.2").contains("Team 1.1</td></div>'\""));
+    }
+
+    private void testGetFeedbackQuestionGiverCount() {
+        ______TS("Valid session valid course should give correct counts counts");
+        Map<FeedbackParticipantType, Long> giverTypeCounts = fqLogic.getFeedbackQuestionGiverCountForSession(
+                "First feedback session", "idOfTypicalCourse1");
+        long studentTypeCount = giverTypeCounts.get(FeedbackParticipantType.STUDENTS);
+        long instructorTypeCount = giverTypeCounts.get(FeedbackParticipantType.INSTRUCTORS);
+        long selfTypeCount = giverTypeCounts.get(FeedbackParticipantType.SELF);
+        assertEquals(2L, studentTypeCount);
+        assertEquals(1L, instructorTypeCount);
+        assertEquals(2L, selfTypeCount);
+
+        assertEquals(studentTypeCount, fqLogic.getFeedbackQuestionForStudentCountFrom(giverTypeCounts));
+
+        assertEquals(instructorTypeCount,
+                fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, false));
+        assertEquals(instructorTypeCount + selfTypeCount,
+                fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, true));
+
+        ______TS("Invalid session valid course should give no count");
+        giverTypeCounts = fqLogic.getFeedbackQuestionGiverCountForSession("invalid session", "idOfTypicalCourse1");
+        assertEquals(0L, giverTypeCounts.size());
+
+        assertEquals(0L, fqLogic.getFeedbackQuestionForStudentCountFrom(giverTypeCounts));
+        assertEquals(0L, fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, false));
+        assertEquals(0L, fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, true));
+
+        ______TS("Invalid session invalid course should give no count");
+        giverTypeCounts = fqLogic.getFeedbackQuestionGiverCountForSession("invalid session", "invalid course");
+        assertEquals(0L, giverTypeCounts.size());
+
+        assertEquals(0L, fqLogic.getFeedbackQuestionForStudentCountFrom(giverTypeCounts));
+        assertEquals(0L, fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, false));
+        assertEquals(0L, fqLogic.getFeedbackQuestionForInstructorCountFrom(giverTypeCounts, true));
     }
 
     private void testHasFeedbackQuestionsForInstructor() {

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -51,6 +51,7 @@ public class StudentsLogicTest extends BaseLogicTest {
         testGetStudentForRegistrationKey();
         testGetStudentsForGoogleId();
         testGetStudentForCourseIdAndGoogleId();
+        testGetNumberOfStudentsForCourse();
         testGetStudentsForCourse();
         testIsStudentInAnyCourse();
         testIsStudentInTeam();
@@ -409,6 +410,31 @@ public class StudentsLogicTest extends BaseLogicTest {
 
         assertThrows(AssertionError.class,
                 () -> studentsLogic.getStudentForCourseIdAndGoogleId("valid.course", null));
+    }
+
+    private void testGetNumberOfStudentsForCourse() {
+
+        ______TS("course with multiple students");
+
+        CourseAttributes course1OfInstructor1 = dataBundle.courses.get("typicalCourse1");
+        int numOfStudents = studentsLogic.getNumberOfStudentsForCourse(course1OfInstructor1.getId());
+        assertEquals(5, numOfStudents);
+
+        ______TS("course with 0 students");
+
+        CourseAttributes course2OfInstructor1 = dataBundle.courses.get("courseNoEvals");
+        numOfStudents = studentsLogic.getNumberOfStudentsForCourse(course2OfInstructor1.getId());
+        assertEquals(0, numOfStudents);
+
+        ______TS("null parameter");
+
+        assertThrows(AssertionError.class, () -> studentsLogic.getNumberOfStudentsForCourse(null));
+
+        ______TS("non-existent course");
+
+        numOfStudents = studentsLogic.getNumberOfStudentsForCourse("non-existent");
+        assertEquals(0, numOfStudents);
+
     }
 
     private void testGetStudentsForCourse() {

--- a/src/test/java/teammates/storage/api/InstructorsDbTest.java
+++ b/src/test/java/teammates/storage/api/InstructorsDbTest.java
@@ -211,6 +211,31 @@ public class InstructorsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
     }
 
     @Test
+    public void testGetInstructorEmailsForCourse() {
+
+        ______TS("Success: get instructors of a specific course");
+
+        String courseId = "idOfTypicalCourse1";
+
+        List<String> emails = instructorsDb.getInstructorEmailsForCourse(courseId);
+        List<InstructorAttributes> instructors = instructorsDb.getInstructorsForCourse(courseId);
+        assertEquals(5, emails.size());
+        assertEquals(5, instructors.size());
+        for (var instructor : instructors) {
+            assertTrue(emails.contains(instructor.getEmail()));
+        }
+
+        ______TS("Failure: no instructors for a course");
+
+        emails = instructorsDb.getInstructorEmailsForCourse("non-exist-course");
+        assertEquals(0, emails.size());
+
+        ______TS("Failure: null parameters");
+
+        assertThrows(AssertionError.class, () -> instructorsDb.getInstructorEmailsForCourse(null));
+    }
+
+    @Test
     public void testGetInstructorsForCourse() {
 
         ______TS("Success: get instructors of a specific course");

--- a/src/test/java/teammates/storage/api/StudentsDbTest.java
+++ b/src/test/java/teammates/storage/api/StudentsDbTest.java
@@ -344,7 +344,7 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
                         .build());
 
         // should pass, others students remain
-        assertEquals(1, studentsDb.getStudentsForCourse(s.getCourse()).size());
+        assertEquals(1, studentsDb.getNumberOfStudentsForCourse(s.getCourse()));
 
         // delete all students in a course
 
@@ -361,16 +361,16 @@ public class StudentsDbTest extends BaseTestCaseWithLocalDatabaseAccess {
         assertNotNull(studentsDb.getStudentForEmail(anotherStudent.getCourse(), anotherStudent.getEmail()));
 
         // there are students in the course
-        assertFalse(studentsDb.getStudentsForCourse(s.getCourse()).isEmpty());
+        assertFalse(studentsDb.getNumberOfStudentsForCourse(s.getCourse()) == 0);
 
         studentsDb.deleteStudents(
                 AttributesDeletionQuery.builder()
                         .withCourseId(s.getCourse())
                         .build());
 
-        assertEquals(0, studentsDb.getStudentsForCourse(s.getCourse()).size());
+        assertEquals(0, studentsDb.getNumberOfStudentsForCourse(s.getCourse()));
         // other course should remain
-        assertEquals(1, studentsDb.getStudentsForCourse(anotherStudent.getCourse()).size());
+        assertEquals(1, studentsDb.getNumberOfStudentsForCourse(anotherStudent.getCourse()));
 
         // clean up
         studentsDb.deleteStudent(anotherStudent.getCourse(), anotherStudent.getEmail());


### PR DESCRIPTION
Fixes part of #11585

Add method to get student count in feedback session without data entity read.
Add method to get instructor emails in course with small operation (1 data read per query counted).

Add method to get aggregate count of feedback questions within a session and use appropriate filtering to get the number of expected submissions within a session. This is also small operation and will incur 1 data read per query.

`Instructor.email` and `FeedbackQuestion.questionType` are indexed by default.