### PR TITLE
[#11572] Notification Feature - Add mark as read to notification GET API

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -98,6 +98,10 @@ public class Logic {
 
         return accountsLogic.getAccountsForEmail(email);
     }
+    
+    public List<String> getReadNotificationsId(String googleId) {
+        return accountsLogic.getReadNotificationsId(googleId);
+    }
 
     public String getCourseInstitute(String courseId) {
         return coursesLogic.getCourseInstitute(courseId);

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -98,7 +98,7 @@ public class Logic {
 
         return accountsLogic.getAccountsForEmail(email);
     }
-    
+
     public List<String> getReadNotificationsId(String googleId) {
         return accountsLogic.getReadNotificationsId(googleId);
     }

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -1,5 +1,6 @@
 package teammates.logic.core;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -60,6 +61,18 @@ public final class AccountsLogic {
      */
     public AccountAttributes getAccount(String googleId) {
         return accountsDb.getAccount(googleId);
+    }
+
+    /**
+     * Gets ids of read notifications in an account.
+     */
+    public List<String> getReadNotificationsId(String googleId) {
+        AccountAttributes a = accountsDb.getAccount(googleId);
+        List<String> readNotificationIds = new ArrayList<>();
+        if (a != null) {
+            readNotificationIds.addAll(a.getReadNotifications().keySet());
+        }
+        return readNotificationIds;
     }
 
     /**

--- a/src/main/java/teammates/ui/output/NotificationData.java
+++ b/src/main/java/teammates/ui/output/NotificationData.java
@@ -72,12 +72,4 @@ public class NotificationData extends ApiOutput {
     public boolean isShown() {
         return this.shown;
     }
-
-    public void setCreatedAt(long timestamp) {
-        this.createdAt = timestamp;
-    }
-
-    public void setTargetUser(NotificationTargetUser user) {
-        this.targetUser = user;
-    }
 }

--- a/src/main/java/teammates/ui/output/NotificationData.java
+++ b/src/main/java/teammates/ui/output/NotificationData.java
@@ -80,12 +80,4 @@ public class NotificationData extends ApiOutput {
     public void setTargetUser(NotificationTargetUser user) {
         this.targetUser = user;
     }
-
-    /**
-     * Hides some attributes to instructor and students without appropriate privilege.
-     */
-    public void hideInformationForNonAdmin() {
-        setCreatedAt(0);
-        setTargetUser(null);
-    }
 }

--- a/src/main/java/teammates/ui/output/NotificationData.java
+++ b/src/main/java/teammates/ui/output/NotificationData.java
@@ -73,10 +73,19 @@ public class NotificationData extends ApiOutput {
         return this.shown;
     }
 
+    public void setCreatedAt(long timestamp) {
+        this.createdAt = timestamp;
+    }
+
+    public void setTargetUser(NotificationTargetUser user) {
+        this.targetUser = user;
+    }
+
     /**
      * Hides some attributes to instructor and students without appropriate privilege.
      */
     public void hideInformationForNonAdmin() {
-        // TODO: hide information that might be admin-only: target users, isShown, (starttime and endtime)
+        setCreatedAt(0);
+        setTargetUser(null);
     }
 }

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -184,11 +184,11 @@ public abstract class Action {
      */
     boolean getBooleanRequestParamValue(String paramName) {
         String value = getNonNullRequestParamValue(paramName);
-        try {
+        if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
             return Boolean.parseBoolean(value);
-        } catch (IllegalArgumentException e) {
+        } else {
             throw new InvalidHttpParameterException(
-                    "Expected boolean value for " + paramName + " parameter, but found: [" + value + "]", e);
+                    "Expected boolean value for " + paramName + " parameter, but found: [" + value + "]");
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -43,9 +43,6 @@ public class GetNotificationsAction extends Action {
     @Override
     public JsonResult execute() {
         String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
-        boolean isFetchingAll = Boolean.parseBoolean(
-            getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL));
-
         List<NotificationAttributes> notificationAttributes;
         if (targetUserString == null && userInfo.isAdmin) {
             // retrieve all notifications
@@ -63,15 +60,15 @@ public class GetNotificationsAction extends Action {
                     logic.getActiveNotificationsByTargetUser(targetUser);
         }
 
+        boolean isFetchingAll = Boolean.parseBoolean(
+                getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL));
         if (!isFetchingAll) {
             // only unread notifications are returned
             List<String> readNotifications = logic.getReadNotificationsId(userInfo.getId());
-            if (readNotifications != null) {
-                notificationAttributes = notificationAttributes
-                        .stream()
-                        .filter(n -> !readNotifications.contains(n.getNotificationId()))
-                        .collect(Collectors.toList());
-            }
+            notificationAttributes = notificationAttributes
+                    .stream()
+                    .filter(n -> !readNotifications.contains(n.getNotificationId()))
+                    .collect(Collectors.toList());
         }
 
         NotificationsData responseData = new NotificationsData(notificationAttributes);

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -17,7 +17,6 @@ import teammates.ui.output.NotificationsData;
 public class GetNotificationsAction extends Action {
 
     private static final String INVALID_TARGET_USER = "Target user can only be STUDENT or INSTRUCTOR.";
-    private static final String INVALID_IS_FETCHING_ALL = "Isfetchingall should either be boolean or not specified.";
     private static final String UNAUTHORIZED_ACCESS = "You are not allowed to view this resource!";
 
     @Override
@@ -64,12 +63,10 @@ public class GetNotificationsAction extends Action {
                     logic.getActiveNotificationsByTargetUser(targetUser);
         }
 
-        String isFetchingAllString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL);
-        if (isFetchingAllString != null
-                && !isFetchingAllString.equals("true") && !isFetchingAllString.equals("false")) {
-            throw new InvalidHttpParameterException(INVALID_IS_FETCHING_ALL);
+        boolean isFetchingAll = false;
+        if (getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL) != null) {
+            isFetchingAll = getBooleanRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL);
         }
-        boolean isFetchingAll = Boolean.parseBoolean(isFetchingAllString);
 
         if (isFetchingAll) {
             return new JsonResult(new NotificationsData(notificationAttributes));

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -94,7 +94,6 @@ public class GetNotificationsAction extends Action {
                                 .withShown()
                                 .build();
                 logic.updateNotification(newNotification);
-                n.setShown();
             } catch (InvalidParametersException e) {
                 throw new InvalidHttpParameterException(e);
             } catch (EntityDoesNotExistException ednee) {

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -1,6 +1,5 @@
 package teammates.ui.webapi;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -201,7 +200,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         Set<String> readNotificationsId = typicalBundle.accounts.get("instructor1OfCourse1").getReadNotifications().keySet();
 
         String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString()
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
         };
 
         GetNotificationsAction action = getAction(requestParams);

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -4,7 +4,10 @@
       "googleId": "idOfInstructor1OfCourse1",
       "name": "Instructor 1 of Course 1",
       "email": "instr1@course1.tmt",
-      "readNotifications": {}
+      "readNotifications": {
+        "notification1": "2012-01-01T00:00:00Z",
+        "notification3": "2013-01-01T00:00:00Z"
+      }
     },
     "instructor2OfCourse1": {
       "googleId": "idOfInstructor2OfCourse1",


### PR DESCRIPTION
Part of #11572 

**Outline of Solution**
* Filter out unread notification list using notification ids stored in individual accounts.
* Add more tests for `isfetchingall` in test for `GetNotificationsAction`.
* Update `shown` feature of a notification when a non-admin user get notifications.
* Hide admin information(createdAt and target user) when non-admin get notifications.
