### PR TITLE
[#11585] Add key only queries to data count and existential checks

### DIFF
--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -401,7 +401,7 @@ public final class StudentsLogic {
         }
 
         frLogic.deleteFeedbackResponsesInvolvedEntityOfCourseCascade(courseId, studentEmail);
-        if (studentsDb.getStudentsForTeam(student.getTeam(), student.getCourse()).size() == 1) {
+        if (studentsDb.getStudentCountForTeam(student.getTeam(), student.getCourse()) == 1) {
             // the student is the only student in the team, delete responses related to the team
             frLogic.deleteFeedbackResponsesInvolvedEntityOfCourseCascade(student.getCourse(), student.getTeam());
         }

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -119,7 +119,7 @@ public final class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, Feed
 
         return !load()
                 .filter("feedbackQuestionId =", feedbackQuestionId)
-                .limit(1)
+                .keys()
                 .list()
                 .isEmpty();
     }
@@ -313,7 +313,7 @@ public final class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, Feed
      */
     public boolean hasFeedbackResponseEntitiesForCourse(String courseId) {
         assert courseId != null;
-        return !load().filter("courseId =", courseId).limit(1).list().isEmpty();
+        return !load().filter("courseId =", courseId).keys().list().isEmpty();
     }
 
     private FeedbackResponse getFeedbackResponseEntity(String feedbackResponseId) {

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -196,6 +196,16 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
     }
 
     /**
+     * Gets count of students of a team of a course.
+     */
+    public int getStudentCountForTeam(String teamName, String courseId) {
+        assert teamName != null;
+        assert courseId != null;
+
+        return getCourseStudentCountForTeam(teamName, courseId);
+    }
+
+    /**
      * Gets all unregistered students of a course.
      */
     public List<StudentAttributes> getUnregisteredStudentsForCourse(String courseId) {
@@ -349,6 +359,13 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
                 .filter("teamName =", teamName)
                 .filter("courseId =", courseId)
                 .list();
+    }
+
+    private int getCourseStudentCountForTeam(String teamName, String courseId) {
+        return load()
+                .filter("teamName =", teamName)
+                .filter("courseId =", courseId)
+                .count();
     }
 
     private List<CourseStudent> getCourseStudentEntitiesForSection(String sectionName, String courseId) {


### PR DESCRIPTION
Fixes #11585 

Update the rest of the unnecessary data read to only using key-only queries.