### PR TITLE
[#11572] Notification feature - Admin page update (edit) feature

### DIFF
--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
@@ -11,10 +11,9 @@
 
 <div class="margin-top-30px" *ngIf="isNotificationEditFormExpanded && !isNotificationLoading" @collapseAnim>
   <tm-notification-edit-form [formMode]="currentNotificationEditFormMode" [(model)]="notificationEditFormModel"
-                        (addNewNotificationEvent)="addNewNotificationHandler()"
-                        (editExistingNotificationEvent)="editExistingNotificationHandler()"
-                        (cancelEditingNotificationEvent)="initNotificationEditFormModel()"
-  ></tm-notification-edit-form>
+                             (addNewNotificationEvent)="addNewNotificationHandler()"
+                             (editExistingNotificationEvent)="editExistingNotificationHandler()"
+                             (cancelEditingNotificationEvent)="initNotificationEditFormModel()"></tm-notification-edit-form>
 </div>
 
 <tm-loading-retry [shouldShowRetry]="hasNotificationLoadingFailed" [message]="'Failed to load data'"

--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
@@ -12,6 +12,7 @@
 <div class="margin-top-30px" *ngIf="isNotificationEditFormExpanded && !isNotificationLoading" @collapseAnim>
   <tm-notification-edit-form [formMode]="currentNotificationEditFormMode" [(model)]="notificationEditFormModel"
                         (addNewNotificationEvent)="addNewNotificationHandler()"
+                        (editExistingNotificationEvent)="editExistingNotificationHandler()"
                         (cancelEditingNotificationEvent)="initNotificationEditFormModel()"
   ></tm-notification-edit-form>
 </div>

--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.html
@@ -3,14 +3,16 @@
 
 <div>
   <button id="btn-add-notification" class="btn btn-success" (click)="isNotificationEditFormExpanded = true"
-          [disabled]="isNotificationEditFormExpanded || isNotificationLoading"><i class="fas fa-plus"></i> Add New Notification
+          [disabled]="isNotificationEditFormExpanded || isNotificationLoading">
+          <span *ngIf="currentNotificationEditFormMode === NotificationEditFormMode.ADD else editbtn"><i class="fas fa-plus"></i> Add New Notification</span>
+          <ng-template #editbtn><i class="fas fa-cog"></i> Edit Existing Notification</ng-template>
   </button>
 </div>
 
 <div class="margin-top-30px" *ngIf="isNotificationEditFormExpanded && !isNotificationLoading" @collapseAnim>
-  <tm-notification-edit-form [formMode]="NotificationEditFormMode.ADD" [(model)]="notificationEditFormModel"
+  <tm-notification-edit-form [formMode]="currentNotificationEditFormMode" [(model)]="notificationEditFormModel"
                         (addNewNotificationEvent)="addNewNotificationHandler()"
-                        (closeEditFormEvent)="isNotificationEditFormExpanded = false"
+                        (cancelEditingNotificationEvent)="initNotificationEditFormModel()"
   ></tm-notification-edit-form>
 </div>
 
@@ -27,6 +29,7 @@
                               [notificationsTableRowModelsSortBy]="notificationsTableRowModelsSortBy"
                               [notificationsTableRowModelsSortOrder]="notificationsTableRowModelsSortOrder"
                               (deleteNotificationEvent)="deleteNotificationHandler($event)"
+                              (loadNotificationEditFormEvent)="loadNotificationEditFormHandler($event)"
                               (sortNotificationsTableRowModelsEvent)="sortNotificationsTableRowModelsHandler($event)"></tm-notifications-table>
     </div>
   </div>

--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
@@ -171,7 +171,7 @@ export class AdminNotificationsPageComponent implements OnInit {
 
   loadNotificationEditForm(notification: Notification): void {
     const startTime = moment(notification.startTimestamp);
-    const endTime = moment(notification.startTimestamp);
+    const endTime = moment(notification.endTimestamp);
     this.notificationEditFormModel = {
       notificationId: notification.notificationId,
       shown: notification.shown,

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form-model.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form-model.ts
@@ -37,6 +37,5 @@ export interface NotificationEditFormModel {
   message: string;
 
   isSaving: boolean;
-  isEditable: boolean;
   isDeleting: boolean;
 }

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
@@ -1,19 +1,10 @@
 <div class="card card-plain">
-    <div class="close-header" *ngIf="formMode === NotificationEditFormMode.ADD">
-      <button type="button" class="close" aria-label="Close" (click)="closeEditFormHandler()">
+    <div class="close-header">
+      <button type="button" class="close" aria-label="Close" (click)="cancelHandler()">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
     <div class="card-body">
-      <div class="row" *ngIf="formMode === NotificationEditFormMode.EDIT">
-        <div class="col-12 text-center text-md-right notification-form-buttons">
-          <button id="btn-fs-edit" type="button" class="btn btn-primary" (click)="triggerModelChange('isEditable', true)" *ngIf="formMode === NotificationEditFormMode.EDIT && !model.isEditable && !model.isSaving"><i class="fas fa-pencil-alt"></i> Edit</button>
-          <button id="btn-fs-save" type="button" class="btn btn-primary" (click)="submitFormHandler()" [disabled]="model.isSaving" *ngIf="model.isEditable || model.isSaving"><tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading> <i class="fas fa-check"></i> Save</button>
-          <button type="button" class="btn btn-primary" ngbTooltip="Discard changes to the notification" (click)="cancelHandler()" *ngIf="model.isEditable" [disabled]="model.isSaving"><i class="fas fa-ban"></i> Cancel</button>
-          <button id="btn-fs-delete" type="button" class="btn btn-primary" ngbTooltip="Delete the notification" (click)="deleteHandler()" [disabled]="model.isSaving"><tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete</button>
-        </div>
-      </div>
-
       <div class="card border-primary margin-top-20px">
         <div class="card-body">
 
@@ -60,7 +51,7 @@
               <span class="ngb-tooltip-class" ngbTooltip="Message body of the notification.">Message content</span>
             </div>
             <div class="col-md-10 text-md-left">
-              <tm-rich-text-editor id="message" [richText]="model.message" (richTextChange)="triggerModelChange('message', $event)" [isDisabled]="!model.isEditable"></tm-rich-text-editor>
+              <tm-rich-text-editor id="message" [richText]="model.message" (richTextChange)="triggerModelChange('message', $event)"></tm-rich-text-editor>
             </div>
           </div>
           <br/>
@@ -99,11 +90,11 @@
               </div>
               <div class="row text-center align-items-center">
                 <div id="notification-start-date" class="col-md-7 col-xs-center">
-                  <tm-datepicker [disabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('startDate', $event)"
+                  <tm-datepicker (dateChangeCallback)="triggerModelChange('startDate', $event)"
                                  [date]="model.startDate"></tm-datepicker>
                 </div>
                 <div class="col-md-5">
-                  <tm-timepicker id="notification-start-time" [time]="model.startTime" (timeChange)="triggerModelChange('startTime', $event)" [isDisabled]="!model.isEditable"></tm-timepicker>
+                  <tm-timepicker id="notification-start-time" [time]="model.startTime" (timeChange)="triggerModelChange('startTime', $event)"></tm-timepicker>
                 </div>
               </div>
             </div>
@@ -117,11 +108,11 @@
               </div>
               <div class="row align-items-center">
                 <div id="notification-end-date" class="col-md-7 col-xs-center">
-                  <tm-datepicker [disabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('endDate', $event)"
+                  <tm-datepicker (dateChangeCallback)="triggerModelChange('endDate', $event)"
                                  [minDate]="model.startDate" [date]="model.endDate"></tm-datepicker>
                 </div>
                 <div class="col-md-5">
-                  <tm-timepicker id="notification-end-time" [time]="model.endTime" (timeChange)="triggerModelChange('endTime', $event)" [isDisabled]="!model.isEditable"></tm-timepicker>
+                  <tm-timepicker id="notification-end-time" [time]="model.endTime" (timeChange)="triggerModelChange('endTime', $event)"></tm-timepicker>
                 </div>
               </div>
             </div>
@@ -137,7 +128,7 @@
             </button>
           </div>
           <div *ngIf="formMode === NotificationEditFormMode.EDIT">
-            <button type="button" class="btn btn-success" [disabled]="model.isSaving || !model.isEditable" *ngIf="formMode === NotificationEditFormMode.EDIT" (click)="submitFormHandler()">
+            <button type="button" class="btn btn-success" [disabled]="model.isSaving" *ngIf="formMode === NotificationEditFormMode.EDIT" (click)="submitFormHandler()">
               <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>Save Changes
             </button>
           </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.scss
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.scss
@@ -19,7 +19,7 @@
   margin-top: 20px;
 }
 
-.session-form-buttons > button {
+.notification-form-buttons > button {
   margin-left: var(--btn-margin);
 }
 

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.scss
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.scss
@@ -19,10 +19,6 @@
   margin-top: 20px;
 }
 
-.notification-form-buttons > button {
-  margin-left: var(--btn-margin);
-}
-
 .align-row {
   display: flex;
   flex-direction: row;

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
@@ -43,7 +43,6 @@ export class NotificationEditFormComponent implements OnInit {
     message: '',
 
     isSaving: false,
-    isEditable: true,
     isDeleting: false,
   };
 
@@ -68,9 +67,6 @@ export class NotificationEditFormComponent implements OnInit {
 
   @Output()
   deleteExistingNotificationEvent = new EventEmitter<void>();
-
-  @Output()
-  closeEditFormEvent = new EventEmitter<void>();
 
   constructor(
     private timezoneService: TimezoneService,
@@ -112,7 +108,7 @@ export class NotificationEditFormComponent implements OnInit {
     this.simpleModalService.openConfirmationModal('Discard unsaved edit?',
         SimpleModalType.WARNING, 'Warning: Any unsaved changes will be lost.').result.then(() => {
           this.cancelEditingNotificationEvent.emit();
-        }, () => {});
+        });
   }
 
   /**
@@ -125,14 +121,7 @@ export class NotificationEditFormComponent implements OnInit {
         'This action is not reversible and the delete will be permanent.',
     ).result.then(() => {
       this.deleteExistingNotificationEvent.emit();
-    }, () => {});
-  }
-
-  /**
-   * Handles closing of the edit form.
-   */
-  closeEditFormHandler(): void {
-    this.closeEditFormEvent.emit();
+    });
   }
 
 }

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table-model.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table-model.ts
@@ -4,8 +4,8 @@ import { Notification } from '../../../../types/api-output';
  * The model for a row in the notifications table.
  */
 export interface NotificationsTableRowModel {
-  isHighlighted: boolean,
-  notification: Notification,
+  isHighlighted: boolean;
+  notification: Notification;
 }
 
 /**

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
@@ -64,8 +64,7 @@
         <td class="text-break"><span class="ngb-tooltip-class" ngbTooltip="{{ notificationsTableRowModel.notification.createdAt | formatDateDetail: guessTimezone }}">{{ notificationsTableRowModel.notification.createdAt | formatDateBrief: guessTimezone }}</span></td>
         <td class="actions-cell">
           <div class="d-flex">
-            <!-- TODO: Implement edit -->
-            <button type="button" class="btn btn-light btn-sm">
+            <button type="button" class="btn btn-light btn-sm" (click)="loadNotificationEditForm(notificationsTableRowModel.notification)">
               Edit
             </button>
             <button type="button" class="btn btn-danger btn-sm" (click)="deleteNotification(notificationsTableRowModel.notification.notificationId, notificationsTableRowModel.notification.title)">

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { SimpleModalService } from '../../../../services/simple-modal.service';
 import { TimezoneService } from '../../../../services/timezone.service';
+import { Notification } from '../../../../types/api-output';
 import { SortBy, SortOrder } from '../../../../types/sort-properties';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { NotificationsTableHeaderColorScheme, NotificationsTableRowModel } from './notifications-table-model';
@@ -35,6 +36,8 @@ export class NotificationsTableComponent implements OnInit {
   @Output()
   deleteNotificationEvent: EventEmitter<String> = new EventEmitter();
 
+  loadNotificationEditFormEvent: EventEmitter<Notification> = new EventEmitter();
+
   constructor(private simpleModalService: SimpleModalService, private timezoneService: TimezoneService) { }
 
   ngOnInit(): void {
@@ -58,5 +61,12 @@ export class NotificationsTableComponent implements OnInit {
       `Do you want to delete this notification (titled "${title}") permanently? This action will not be reversible.`,
     );
     modalRef.result.then(() => this.deleteNotificationEvent.emit(notificationId));
+  }
+
+  /**
+   * Loads the notification edit form.
+   */
+  loadNotificationEditForm(notification: Notification): void {
+    this.loadNotificationEditFormEvent.emit(notification);
   }
 }

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
@@ -36,6 +36,7 @@ export class NotificationsTableComponent implements OnInit {
   @Output()
   deleteNotificationEvent: EventEmitter<String> = new EventEmitter();
 
+  @Output()
   loadNotificationEditFormEvent: EventEmitter<Notification> = new EventEmitter();
 
   constructor(private simpleModalService: SimpleModalService, private timezoneService: TimezoneService) { }

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -32,7 +32,7 @@ export class NotificationService {
   /**
    * Updates a notification by calling API.
    */
-   updateNotification(request: NotificationUpdateRequest, notificationId: string): Observable<Notification> {
+  updateNotification(request: NotificationUpdateRequest, notificationId: string): Observable<Notification> {
     const paramsMap: { [key: string]: string } = {
       notificationid: notificationId,
     };


### PR DESCRIPTION
Part of #11572

This PR consists of code for the pages enabling the admin to update a notification. Since notification is rather simple and there is nothing linked to it to be edited together unlike feedback sessions, the same edit form (the one for creating notifications) will be reused.

Other improvements related to this is also included, including the removal of redundant code such as `isEditable` 

This PR is ready for review.

- [X] Frontend page for updating notification
- [X] Frontend logic to PUT data to server
- [X] Final check after PUT route backend API (#11665) has been merged
