### PR TITLE
[#11572] Add get notification route and helper functions for testing

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -18,6 +18,7 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.common.exception.HttpRequestFailedException;
@@ -311,6 +312,15 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
     @Override
     protected AccountRequestAttributes getAccountRequest(AccountRequestAttributes accountRequest) {
         return BACKDOOR.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+    }
+
+    NotificationAttributes getNotification(String notificationId) {
+        return BACKDOOR.getNotification(notificationId);
+    }
+
+    @Override
+    protected NotificationAttributes getNotification(NotificationAttributes notification) {
+        return getNotification(notification.getNotificationId());
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/attributes/NotificationAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/NotificationAttributes.java
@@ -83,6 +83,10 @@ public class NotificationAttributes extends EntityAttributes<Notification> {
         return notificationId;
     }
 
+    public void setNotificationId(String notificationId) {
+        this.notificationId = notificationId;
+    }
+
     public Instant getStartTime() {
         return startTime;
     }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -322,6 +322,7 @@ public final class Const {
         public static final String STUDENT = URI_PREFIX + "/student";
         public static final String STUDENT_KEY = URI_PREFIX + "/student/key";
         public static final String NOTIFICATION = URI_PREFIX + "/notification";
+        public static final String NOTIFICATIONS = URI_PREFIX + "/notifications";
         public static final String SESSIONS_ONGOING = URI_PREFIX + "/sessions/ongoing";
         public static final String SESSION = URI_PREFIX + "/session";
         public static final String SESSION_PUBLISH = URI_PREFIX + "/session/publish";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -92,6 +92,18 @@ public class Logic {
         return notificationsLogic.getAllNotifications();
     }
 
+    /**
+     * Gets a notification by ID.
+     *
+     * <p>Preconditions:</p>
+     * * All parameters are non-null.
+     *
+     * @return Null if no match found.
+     */
+    public NotificationAttributes getNotification(String id) {
+        return notificationsLogic.getNotification(id);
+    }
+
     public NotificationAttributes createNotification(NotificationAttributes notification) throws
             InvalidParametersException, EntityAlreadyExistsException {
         return notificationsLogic.createNotification(notification);

--- a/src/main/java/teammates/ui/constants/ResourceEndpoints.java
+++ b/src/main/java/teammates/ui/constants/ResourceEndpoints.java
@@ -46,6 +46,7 @@ public enum ResourceEndpoints {
     RESPONSES(ResourceURIs.RESPONSES),
     HAS_RESPONSES(ResourceURIs.HAS_RESPONSES),
     NOTIFICATION(ResourceURIs.NOTIFICATION),
+    NOTIFICATIONS(ResourceURIs.NOTIFICATIONS),
     JOIN(ResourceURIs.JOIN),
     JOIN_REMIND(ResourceURIs.JOIN_REMIND),
     TIMEZONE(ResourceURIs.TIMEZONE),

--- a/src/main/java/teammates/ui/output/NotificationData.java
+++ b/src/main/java/teammates/ui/output/NotificationData.java
@@ -23,7 +23,7 @@ public class NotificationData extends ApiOutput {
     public NotificationData(NotificationAttributes notificationAttributes) {
         this.notificationId = notificationAttributes.getNotificationId();
         this.startTimestamp = notificationAttributes.getStartTime().toEpochMilli();
-        this.endTimestamp = notificationAttributes.getStartTime().toEpochMilli();
+        this.endTimestamp = notificationAttributes.getEndTime().toEpochMilli();
         this.createdAt = notificationAttributes.getCreatedAt().toEpochMilli();
         this.updatedAt = notificationAttributes.getUpdatedAt().toEpochMilli();
         this.notificationType = notificationAttributes.getType();

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -80,6 +80,7 @@ public final class ActionFactory {
         map(ResourceURIs.STUDENT, PUT, UpdateStudentAction.class);
 
         // NOTIFICATION APIs
+        map(ResourceURIs.NOTIFICATION, GET, GetNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, POST, CreateNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, DELETE, DeleteNotificationAction.class);
 

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -84,6 +84,7 @@ public final class ActionFactory {
         map(ResourceURIs.NOTIFICATION, POST, CreateNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, DELETE, DeleteNotificationAction.class);
 
+        // NOTIFICATIONS APIs
         map(ResourceURIs.NOTIFICATIONS, GET, GetNotificationsAction.class);
 
         //SEARCH APIs

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -80,9 +80,10 @@ public final class ActionFactory {
         map(ResourceURIs.STUDENT, PUT, UpdateStudentAction.class);
 
         // NOTIFICATION APIs
-        map(ResourceURIs.NOTIFICATION, GET, GetNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, POST, CreateNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, DELETE, DeleteNotificationAction.class);
+
+        map(ResourceURIs.NOTIFICATIONS, GET, GetNotificationsAction.class);
 
         //SEARCH APIs
         map(ResourceURIs.SEARCH_INSTRUCTORS, GET, SearchInstructorsAction.class);

--- a/src/main/java/teammates/ui/webapi/GetNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationAction.java
@@ -1,0 +1,29 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.Const;
+import teammates.ui.output.NotificationData;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+
+/**
+ * Action: Gets a notification by ID.
+ */
+public class GetNotificationAction extends AdminOnlyAction {
+
+    @Override
+    public JsonResult execute() throws InvalidHttpRequestBodyException {
+        String notificationId = getRequestParamValue(Const.ParamsNames.NOTIFICATION_ID);
+
+        if (notificationId == null) {
+            throw new InvalidHttpParameterException("Notification ID cannot be null");
+        }
+
+        NotificationAttributes notification = logic.getNotification(notificationId);
+
+        if (notification == null) {
+            throw new EntityNotFoundException("Notification does not exist.");
+        }
+
+        return new JsonResult(new NotificationData(notification));
+    }
+}

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -12,7 +12,7 @@ import teammates.ui.output.NotificationsData;
 /**
  * Action: Get a list of notifications.
  */
-public class GetNotificationAction extends Action {
+public class GetNotificationsAction extends Action {
 
     private static final String INVALID_TARGET_USER = "Target user can only be STUDENT or INSTRUCTOR.";
     private static final String UNAUTHORIZED_ACCESS = "You are not allowed to view this resource!";

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -39,6 +39,7 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
@@ -58,6 +59,7 @@ import teammates.ui.output.FeedbackVisibilityType;
 import teammates.ui.output.InstructorData;
 import teammates.ui.output.InstructorsData;
 import teammates.ui.output.MessageOutput;
+import teammates.ui.output.NotificationData;
 import teammates.ui.output.NumberOfEntitiesToGiveFeedbackToSetting;
 import teammates.ui.output.ResponseVisibleSetting;
 import teammates.ui.output.SessionVisibleSetting;
@@ -772,6 +774,37 @@ public abstract class AbstractBackDoor {
         params.put(Const.ParamsNames.INSTRUCTOR_EMAIL, email);
         params.put(Const.ParamsNames.INSTRUCTOR_INSTITUTION, institute);
         executeDeleteRequest(Const.ResourceURIs.ACCOUNT_REQUEST, params);
+    }
+
+    /**
+     * Gets notification data from the database.
+     */
+    public NotificationData getNotificationData(String notificationId) {
+        Map<String, String> params = new HashMap<>();
+        params.put(Const.ParamsNames.NOTIFICATION_ID, notificationId);
+        ResponseBodyAndCode response = executeGetRequest(Const.ResourceURIs.NOTIFICATION, params);
+        if (response.responseCode == HttpStatus.SC_NOT_FOUND) {
+            return null;
+        }
+        return JsonUtils.fromJson(response.responseBody, NotificationData.class);
+    }
+
+    /**
+     * Gets a notification from the database.
+     */
+    public NotificationAttributes getNotification(String notificationId) {
+        NotificationData notificationData = getNotificationData(notificationId);
+        if (notificationData == null) {
+            return null;
+        }
+        return NotificationAttributes.builder(notificationData.getNotificationId())
+                .withStartTime(Instant.ofEpochMilli(notificationData.getStartTimestamp()))
+                .withEndTime(Instant.ofEpochMilli(notificationData.getEndTimestamp()))
+                .withType(notificationData.getNotificationType())
+                .withTargetUser(notificationData.getTargetUser())
+                .withTitle(notificationData.getTitle())
+                .withMessage(notificationData.getMessage())
+                .build();
     }
 
     private static final class ResponseBodyAndCode {

--- a/src/test/java/teammates/test/BaseTestCaseWithDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithDatabaseAccess.java
@@ -10,6 +10,7 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.common.util.JsonUtils;
@@ -156,6 +157,12 @@ public abstract class BaseTestCaseWithDatabaseAccess extends BaseTestCase {
             AccountRequestAttributes actualAccountRequest = (AccountRequestAttributes) actual;
             assertEquals(JsonUtils.toJson(expectedAccountRequest), JsonUtils.toJson(actualAccountRequest));
 
+        } else if (expected instanceof NotificationAttributes) {
+            NotificationAttributes expectedNotification = (NotificationAttributes) expected;
+            NotificationAttributes actualNotification = (NotificationAttributes) actual;
+            equalizeIrrelevantData(expectedNotification, actualNotification);
+            assertEquals(JsonUtils.toJson(expectedNotification), JsonUtils.toJson(actualNotification));
+
         } else {
             throw new RuntimeException("Unknown entity type!");
         }
@@ -216,6 +223,15 @@ public abstract class BaseTestCaseWithDatabaseAccess extends BaseTestCase {
         }
     }
 
+    private void equalizeIrrelevantData(NotificationAttributes expected, NotificationAttributes actual) {
+        // Ignore time field as it is stamped at the time of creation in testing
+        expected.setCreatedAt(actual.getCreatedAt());
+        expected.setUpdatedAt(actual.getUpdatedAt());
+
+        // Ignore ID field as it is unique - UUID
+        expected.setNotificationId(actual.getNotificationId());
+    }
+
     protected abstract StudentProfileAttributes getStudentProfile(StudentProfileAttributes studentProfileAttributes);
 
     protected abstract CourseAttributes getCourse(CourseAttributes course);
@@ -233,6 +249,8 @@ public abstract class BaseTestCaseWithDatabaseAccess extends BaseTestCase {
     protected abstract StudentAttributes getStudent(StudentAttributes student);
 
     protected abstract AccountRequestAttributes getAccountRequest(AccountRequestAttributes accountRequest);
+
+    protected abstract NotificationAttributes getNotification(NotificationAttributes notification);
 
     protected void removeAndRestoreDataBundle(DataBundle testData) {
         int retryLimit = OPERATION_RETRY_COUNT;

--- a/src/test/java/teammates/test/BaseTestCaseWithDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithDatabaseAccess.java
@@ -79,6 +79,9 @@ public abstract class BaseTestCaseWithDatabaseAccess extends BaseTestCase {
         } else if (expected instanceof AccountRequestAttributes) {
             return getAccountRequest((AccountRequestAttributes) expected);
 
+        } else if (expected instanceof NotificationAttributes) {
+            return getNotification((NotificationAttributes) expected);
+
         } else {
             throw new RuntimeException("Unknown entity type!");
         }

--- a/src/test/java/teammates/test/BaseTestCaseWithLocalDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithLocalDatabaseAccess.java
@@ -21,6 +21,7 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.logic.api.LogicExtension;
@@ -140,6 +141,11 @@ public abstract class BaseTestCaseWithLocalDatabaseAccess extends BaseTestCaseWi
     @Override
     protected AccountRequestAttributes getAccountRequest(AccountRequestAttributes accountRequest) {
         return logic.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+    }
+
+    @Override
+    protected NotificationAttributes getNotification(NotificationAttributes notification) {
+        return logic.getNotification(notification.getNotificationId());
     }
 
     protected void removeAndRestoreTypicalDataBundle() {

--- a/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
@@ -134,8 +134,8 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 AccountRequestSearchIndexingWorkerAction.class,
                 SearchAccountRequestsAction.class,
                 CreateNotificationAction.class,
-                GetNotificationAction.class,
-                DeleteNotificationAction.class
+                DeleteNotificationAction.class,
+                GetNotificationsAction.class
         );
         List<String> expectedActionClassesNames = expectedActionClasses.stream()
                 .map(Class::getSimpleName)

--- a/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
@@ -133,6 +133,7 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 StudentSearchIndexingWorkerAction.class,
                 AccountRequestSearchIndexingWorkerAction.class,
                 SearchAccountRequestsAction.class,
+                GetNotificationAction.class,
                 CreateNotificationAction.class,
                 DeleteNotificationAction.class,
                 GetNotificationsAction.class

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -13,15 +13,15 @@ import teammates.ui.output.NotificationData;
 import teammates.ui.output.NotificationsData;
 
 /**
- * SUT: {@link GetNotificationAction}.
+ * SUT: {@link GetNotificationsAction}.
  */
-public class GetNotificationActionTest extends BaseActionTest<GetNotificationAction> {
+public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsAction> {
 
     // TODO: add tests for isfetchingall
 
     @Override
     String getActionUri() {
-        return Const.ResourceURIs.NOTIFICATION;
+        return Const.ResourceURIs.NOTIFICATIONS;
     }
 
     @Override
@@ -101,7 +101,7 @@ public class GetNotificationActionTest extends BaseActionTest<GetNotificationAct
                 Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
         };
 
-        GetNotificationAction action = getAction(requestParams);
+        GetNotificationsAction action = getAction(requestParams);
         JsonResult jsonResult = getJsonResult(action);
 
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
@@ -125,7 +125,7 @@ public class GetNotificationActionTest extends BaseActionTest<GetNotificationAct
                 Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
         };
 
-        GetNotificationAction action = getAction(requestParams);
+        GetNotificationsAction action = getAction(requestParams);
         JsonResult jsonResult = getJsonResult(action);
 
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
@@ -144,7 +144,7 @@ public class GetNotificationActionTest extends BaseActionTest<GetNotificationAct
         ______TS("Request without user type for non admin");
         InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor.getGoogleId());
-        GetNotificationAction action = getAction(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true));
+        GetNotificationsAction action = getAction(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true));
         assertThrows(AssertionError.class, action::execute);
     }
 

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -26,7 +26,7 @@ export class NotificationService {
    * Retrieve all notifications by calling API.
    */
   getNotifications(): Observable<Notifications> {
-    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATION);
+    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS);
   }
 
   /**


### PR DESCRIPTION
Part of #11572

**Outline of Solution**
- Moved GET route for `Notification` to `Notifications` (`GetNotificationAction` renamed to `GetNotificationsAction`)
- `Notification` GET route is now used to get a single notification based on ID (Uses the new `GetNotificationAction` class)
- Add methods required in `BaseTestCaseWithDatabaseAccess` to allow methods like `verifyAbsentInDatabase` to be used by notifications. (Needed for testing notification logic layer and E2E tests)