### PR TITLE
[#11571] Selective Deadline Extensions - Integrate the backend

### DIFF
--- a/src/main/appengine/queue.yaml
+++ b/src/main/appengine/queue.yaml
@@ -64,3 +64,7 @@ queue:
   bucket_size: 10
   retry_parameters:
     min_backoff_seconds: 1
+- name: deadline-extensions-queue
+  mode: push
+  rate: 1/s
+  bucket_size: 5

--- a/src/main/appengine/queue.yaml
+++ b/src/main/appengine/queue.yaml
@@ -68,3 +68,6 @@ queue:
   mode: push
   rate: 1/s
   bucket_size: 5
+  retry_parameters:
+    task_retry_limit: 3
+    min_backoff_seconds: 5

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -379,6 +379,7 @@ public final class Const {
     public static class TaskQueue {
         public static final String URI_PREFIX = "/worker";
 
+        public static final String DEADLINE_EXTENSIONS_QUEUE_NAME = "deadline-extensions-queue";
         public static final String DEADLINE_EXTENSIONS_WORKER_URL = URI_PREFIX + "/deadlineExtensions";
 
         public static final String FEEDBACK_SESSION_PUBLISHED_EMAIL_QUEUE_NAME =

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -249,7 +249,7 @@ public class TaskQueuer {
     /**
      * Schedules to create, update, and delete (C_UD) deadline extension entities, and possibly notify users of them.
      */
-    public void scheduleDeadlineExtensionsCudAndPossiblyNotify(String courseId, String feedbackSessionName,
+    public void scheduleChangesToDeadlineExtensions(String courseId, String feedbackSessionName,
             boolean notifyAboutDeadlines, Map<String, Instant> oldStudentDeadlines,
             Map<String, Instant> newStudentDeadlines, Map<String, Instant> oldInstructorDeadlines,
             Map<String, Instant> newInstructorDeadlines) {

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -1,5 +1,6 @@
 package teammates.logic.api;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import teammates.common.util.TaskWrapper;
 import teammates.logic.core.GoogleCloudTasksService;
 import teammates.logic.core.LocalTaskQueueService;
 import teammates.logic.core.TaskQueueService;
+import teammates.ui.request.DeadlineExtensionsRequest;
 import teammates.ui.request.FeedbackSessionRemindRequest;
 import teammates.ui.request.SendEmailRequest;
 
@@ -242,6 +244,21 @@ public class TaskQueuer {
 
         addTask(TaskQueue.SEARCH_INDEXING_QUEUE_NAME, TaskQueue.STUDENT_SEARCH_INDEXING_WORKER_URL,
                 paramMap, null);
+    }
+
+    /**
+     * Schedules to create, update, and delete (C_UD) deadline extension entities, and possibly notify users of them.
+     */
+    public void scheduleDeadlineExtensionsCudAndPossiblyNotify(String courseId, String feedbackSessionName,
+            boolean notifyAboutDeadlines, Map<String, Instant> oldStudentDeadlines,
+            Map<String, Instant> newStudentDeadlines, Map<String, Instant> oldInstructorDeadlines,
+            Map<String, Instant> newInstructorDeadlines) {
+        DeadlineExtensionsRequest deadlineExtensionsRequest = new DeadlineExtensionsRequest(courseId,
+                feedbackSessionName, notifyAboutDeadlines, oldStudentDeadlines, newStudentDeadlines,
+                oldInstructorDeadlines, newInstructorDeadlines);
+
+        addTask(TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, TaskQueue.DEADLINE_EXTENSIONS_WORKER_URL, new HashMap<>(),
+                deadlineExtensionsRequest);
     }
 
     private void scheduleEmailForSending(EmailWrapper email, long emailDelayTimer) {

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -44,8 +44,6 @@ class UpdateFeedbackSessionAction extends Action {
     public JsonResult execute() throws InvalidHttpRequestBodyException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        // TODO: Use the value here.
-        getBooleanRequestParamValue(Const.ParamsNames.NOTIFY_ABOUT_DEADLINES);
 
         FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
 
@@ -71,6 +69,8 @@ class UpdateFeedbackSessionAction extends Action {
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
         }
+
+        boolean notifyAboutDeadlines = getBooleanRequestParamValue(Const.ParamsNames.NOTIFY_ABOUT_DEADLINES);
 
         String timeZone = feedbackSession.getTimeZone();
         Instant startTime = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
@@ -103,6 +103,12 @@ class UpdateFeedbackSessionAction extends Action {
                             .withStudentDeadlines(studentDeadlines)
                             .withInstructorDeadlines(instructorDeadlines)
                             .build());
+
+            if (!studentDeadlines.equals(oldStudentDeadlines) || !instructorDeadlines.equals(oldInstructorDeadlines)) {
+                taskQueuer.scheduleDeadlineExtensionsCudAndPossiblyNotify(courseId, feedbackSessionName,
+                        notifyAboutDeadlines, oldStudentDeadlines, studentDeadlines, oldInstructorDeadlines,
+                        instructorDeadlines);
+            }
 
             return new JsonResult(new FeedbackSessionData(updateFeedbackSession));
         } catch (InvalidParametersException ipe) {

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -105,7 +105,7 @@ class UpdateFeedbackSessionAction extends Action {
                             .build());
 
             if (!studentDeadlines.equals(oldStudentDeadlines) || !instructorDeadlines.equals(oldInstructorDeadlines)) {
-                taskQueuer.scheduleDeadlineExtensionsCudAndPossiblyNotify(courseId, feedbackSessionName,
+                taskQueuer.scheduleChangesToDeadlineExtensions(courseId, feedbackSessionName,
                         notifyAboutDeadlines, oldStudentDeadlines, studentDeadlines, oldInstructorDeadlines,
                         instructorDeadlines);
             }

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -123,6 +123,9 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
         Map<String, Long> expectedInstructorDeadlines = convertDeadlinesToLong(session.getInstructorDeadlines());
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        // The typical feedback session update request does not change any selective deadlines.
+        verifyNoTasksAdded();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -145,6 +145,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
+        verifyNoTasksAdded();
+
         ______TS("create new deadline extension for student");
 
         assertNull(expectedStudentDeadlines.get(studentAEmailAddress));
@@ -160,6 +162,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         expectedStudentDeadlines.put(studentAEmailAddress, endTimePlus1Day);
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
 
         ______TS("update deadline extension for student");
 
@@ -177,6 +181,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         expectedStudentDeadlines.put(studentAEmailAddress, endTimePlus2Days);
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
 
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
+
         ______TS("delete deadline extension for student");
 
         assertNotNull(expectedStudentDeadlines.get(studentAEmailAddress));
@@ -191,6 +197,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         // The deadline for course 1 student 1 was deleted; the map no longer contains a deadline for them.
         expectedStudentDeadlines.remove(studentAEmailAddress);
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
 
         ______TS("C_UD on extensions for different students within the same request");
 
@@ -220,6 +228,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         expectedStudentDeadlines.remove(studentCEmailAddress);
         assertEquals(expectedStudentDeadlines, response.getStudentDeadlines());
 
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
+
         ______TS("change deadline extension for non-existent student; should throw EntityNotFoundException");
 
         updateRequest = getTypicalFeedbackSessionUpdateRequest();
@@ -228,6 +238,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setStudentDeadlines(newStudentDeadlines);
 
         verifyEntityNotFound(updateRequest, param);
+
+        verifyNoTasksAdded();
 
         ______TS("change deadline extension for student to the same time as the end time; "
                 + "should throw InvalidHttpRequestBodyException");
@@ -240,6 +252,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         verifyHttpRequestBodyFailure(updateRequest, param);
 
+        verifyNoTasksAdded();
+
         ______TS("change deadline extension for student to before end time; "
                 + "should throw InvalidHttpRequestBodyException");
 
@@ -250,6 +264,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setStudentDeadlines(newStudentDeadlines);
 
         verifyHttpRequestBodyFailure(updateRequest, param);
+
+        verifyNoTasksAdded();
 
         logoutUser();
     }
@@ -274,6 +290,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
+        verifyNoTasksAdded();
+
         ______TS("create new deadline extension for instructor");
 
         assertNull(expectedInstructorDeadlines.get(instructorAEmailAddress));
@@ -289,6 +307,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         expectedInstructorDeadlines.put(instructorAEmailAddress, endTimePlus1Day);
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
 
         ______TS("update deadline extension for instructor");
 
@@ -306,6 +326,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         expectedInstructorDeadlines.put(instructorAEmailAddress, endTimePlus2Days);
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
 
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
+
         ______TS("delete deadline extension for instructor");
 
         assertNotNull(expectedInstructorDeadlines.get(instructorAEmailAddress));
@@ -320,6 +342,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         // The deadline for course 1 helper instructor was deleted; the map no longer contains a deadline for them.
         expectedInstructorDeadlines.remove(instructorAEmailAddress);
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
 
         ______TS("C_UD on extensions for different instructors within the same request");
 
@@ -349,6 +373,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         expectedInstructorDeadlines.remove(instructorCEmailAddress);
         assertEquals(expectedInstructorDeadlines, response.getInstructorDeadlines());
 
+        verifySpecifiedTasksAdded(Const.TaskQueue.DEADLINE_EXTENSIONS_QUEUE_NAME, 1);
+
         ______TS("change deadline extension for non-existent instructor; "
                 + "should throw EntityNotFoundException");
 
@@ -358,6 +384,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setInstructorDeadlines(newInstructorDeadlines);
 
         verifyEntityNotFound(updateRequest, param);
+
+        verifyNoTasksAdded();
 
         ______TS("change deadline extension for instructor to the same time as the end time; "
                 + "should throw InvalidHttpRequestBodyException");
@@ -370,6 +398,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
         verifyHttpRequestBodyFailure(updateRequest, param);
 
+        verifyNoTasksAdded();
+
         ______TS("change deadline extension for instructor to before end time; "
                 + "should throw InvalidHttpRequestBodyException");
 
@@ -380,6 +410,8 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         updateRequest.setInstructorDeadlines(newInstructorDeadlines);
 
         verifyHttpRequestBodyFailure(updateRequest, param);
+
+        verifyNoTasksAdded();
 
         logoutUser();
     }


### PR DESCRIPTION
Part of #11571

<!-- **PR Checklist** -->

<!-- Remove this portion after you have made the checks. -->

<!-- Ensure that you have: -->
<!-- - [ ] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr -->
<!--   - [ ] Added the issue number to the "Fixes" keyword above -->
<!--   - [ ] Titled the PR as specified in the abovementioned document -->
<!-- - [ ] Made your changes on a branch other than `master` and `release` -->
<!-- - [ ] Gone through all the changes in this PR and ensured that: -->
<!--   - [ ] They addressed one (and only one) issue -->
<!--   - [ ] No unintended changes were made -->
<!-- - [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint` -->
<!-- - [ ] Added/updated tests, if changes in functionality were involved -->
<!-- - [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable -->

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

A queue is created to allow the enqueueing of `DeadlineExtensionsWorkerAction` tasks. A task is enqueued in each `UpdateFeedbackSessionAction` when there are changes to the deadline maps. This task then creates, updates, or deletes the deadline extension entities if necessary, and notifies users of such changes if specified. Thus, the backend is integrated.