### PR TITLE
[#11673] Add ESLint rule for member delimiter style

### DIFF
--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -23,8 +23,8 @@ export interface SortableTableCellData {
   displayValue?: string; // Raw string to be display in the cell
   style?: string; // Optional value used to set style of data
   customComponent?: {
-    component: Type<any>;
-    componentData: Record<string, any>; // @Input values for component
+    component: Type<any>,
+    componentData: Record<string, any>, // @Input values for component
   };
 }
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -306,10 +306,10 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
    * Gets the {@code sessionEditFormModel} with {@link FeedbackSession} entity.
    */
   getSessionEditFormModel(feedbackSession: FeedbackSession, isEditable: boolean = false): SessionEditFormModel {
-    const submissionStart: { date: DateFormat; time: TimeFormat } =
+    const submissionStart: { date: DateFormat, time: TimeFormat } =
         this.getDateTimeAtTimezone(feedbackSession.submissionStartTimestamp, feedbackSession.timeZone, true);
 
-    const submissionEnd: { date: DateFormat; time: TimeFormat } =
+    const submissionEnd: { date: DateFormat, time: TimeFormat } =
         this.getDateTimeAtTimezone(feedbackSession.submissionEndTimestamp, feedbackSession.timeZone, true);
 
     const model: SessionEditFormModel = {
@@ -351,14 +351,14 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
     };
 
     if (feedbackSession.customSessionVisibleTimestamp) {
-      const customSessionVisible: { date: DateFormat; time: TimeFormat } =
+      const customSessionVisible: { date: DateFormat, time: TimeFormat } =
           this.getDateTimeAtTimezone(feedbackSession.customSessionVisibleTimestamp, feedbackSession.timeZone, true);
       model.customSessionVisibleTime = customSessionVisible.time;
       model.customSessionVisibleDate = customSessionVisible.date;
     }
 
     if (feedbackSession.customResponseVisibleTimestamp) {
-      const customResponseVisible: { date: DateFormat; time: TimeFormat } =
+      const customResponseVisible: { date: DateFormat, time: TimeFormat } =
           this.getDateTimeAtTimezone(feedbackSession.customResponseVisibleTimestamp, feedbackSession.timeZone, true);
       model.customResponseVisibleTime = customResponseVisible.time;
       model.customResponseVisibleDate = customResponseVisible.date;
@@ -371,7 +371,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
    * Get the local date and time of timezone from timestamp.
    */
   private getDateTimeAtTimezone(timestamp: number, timeZone: string, resolveMidnightTo2359: boolean):
-      { date: DateFormat; time: TimeFormat } {
+      { date: DateFormat, time: TimeFormat } {
     let momentInstance: moment.Moment = this.timezoneService.getMomentInstance(timestamp, timeZone);
     if (resolveMidnightTo2359 && momentInstance.hour() === 0 && momentInstance.minute() === 0) {
       momentInstance = momentInstance.subtract(1, 'minute');

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -363,7 +363,7 @@ export class FeedbackSessionsService {
   getFeedbackSessionResults(queryParams: {
     courseId: string,
     feedbackSessionName: string,
-    intent: Intent
+    intent: Intent,
     questionId?: string,
     groupBySection?: string,
     key?: string,

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -27,7 +27,8 @@ export class LogService {
     courseId: string,
     feedbackSessionName: string,
     studentEmail: string,
-    logType: FeedbackSessionLogType }): Observable<string> {
+    logType: FeedbackSessionLogType,
+  }): Observable<string> {
     const paramMap: Record<string, string> = {
       courseid: queryParams.courseId,
       fsname: queryParams.feedbackSessionName,

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -496,9 +496,9 @@ export interface StudentAccountSearchResult extends InstructorAccountSearchResul
  */
 export interface FeedbackSessionsGroup {
   [name: string]: {
-    startTime: string;
-    endTime: string;
-    feedbackSessionUrl: string;
+    startTime: string,
+    endTime: string,
+    feedbackSessionUrl: string,
   };
 }
 

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -90,6 +90,19 @@ overrides:
     #   - PropertyDeclaration
     "@typescript-eslint/lines-between-class-members":
     - off
+    "@typescript-eslint/member-delimiter-style":
+    - error
+    - multiline:
+        delimiter: comma
+        requireLast: true
+      singleline:
+        delimiter: comma
+        requireLast: false
+      overrides:
+        interface:
+          multiline:
+            delimiter: semi
+            requireLast: true
     "deprecation/deprecation":
     - error
     arrow-body-style:


### PR DESCRIPTION
Fixes #11673 

**Outline of Solution**

Config:
```yaml
"@typescript-eslint/member-delimiter-style":
  - error
  - multiline:
      delimiter: "comma"
      requireLast: true
    singleline:
      delimiter: "comma"
      requireLast: false
    overrides:
      interface:
        multiline:
          delimiter: "semi"
          requireLast: true
```

Doubts:
I picked `false` for single line `requireLast` delimiter option (trailing comma) because it required the least changes to existing files. I'm not too sure what the convention is and if we should be standardizing and changing this to true instead.