### PR TITLE
[#11571] Verify deadline extensions are valid before sending closing emails

### DIFF
--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -838,7 +838,9 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
+      "studentDeadlines": {
+        "student1InCourse1@gmail.tmt": "2026-04-28T23:00:00Z"
+      },
       "instructorDeadlines": {}
     },
     "closedSession": {
@@ -1766,6 +1768,16 @@
       "courseId": "idOfTypicalCourse1",
       "feedbackSessionName": "Second feedback session",
       "userEmail": "student4InCourse1@gmail.tmt",
+      "isInstructor": false,
+      "endTime": "2026-04-28T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2026-04-28T21:00:00Z",
+      "updatedAt": "2026-04-28T21:00:00Z"
+    },
+    "student1InCourse1GracePeriodSession": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "Grace Period Session",
+      "userEmail": "student1InCourse1@gmail.tmt",
       "isInstructor": false,
       "endTime": "2026-04-28T23:00:00Z",
       "sentClosingEmail": false,


### PR DESCRIPTION
Part of #11571

**Outline of Solution**

Since `DeadlineExtension` is not a source of truth for student deadlines, we cannot guarantee that the deadline is valid at the point where we need to send closing emails. For example, there might be eventual consistency issues (esp since we using an index) or the task queue worker used to DeadlineExtension entities might have failed to update/delete the entity.

Solution:
Check the validity of DeadlineExtensions before sending closing emails. In particular, check that the deadline exists in feedback session and is the correct time.