### PR TITLE
[#11571] Cascade user updates/deletes to deadline maps

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -649,7 +649,8 @@ public final class FeedbackSessionsLogic {
             try {
                 fsDb.updateFeedbackSession(updateOptions);
             } catch (InvalidParametersException | EntityDoesNotExistException e) {
-                assert false : "Updating deadlines in feedback sessions for a user should not cause: " + e.getMessage();
+                // Both Exceptions should not be thrown.
+                log.severe("Unexpected error", e);
             }
         });
     }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
@@ -617,25 +617,21 @@ public final class FeedbackSessionsLogic {
         if (oldEmailAddress.equals(newEmailAddress)) {
             return;
         }
-        updateFeedbackSessionsDeadlinesForUser(courseId, oldEmailAddress, deadlinesGetter, deadlines -> {
-            deadlines.put(newEmailAddress, deadlines.remove(oldEmailAddress));
-            return deadlines;
-        }, withDeadlinesBuilder);
+        updateFeedbackSessionsDeadlinesForUser(courseId, oldEmailAddress, deadlinesGetter,
+                deadlines -> deadlines.put(newEmailAddress, deadlines.remove(oldEmailAddress)), withDeadlinesBuilder);
     }
 
     private void deleteFeedbackSessionsDeadlinesForUser(String courseId, String emailAddress,
             Function<FeedbackSessionAttributes, Map<String, Instant>> deadlinesGetter,
             BiFunction<FeedbackSessionAttributes.UpdateOptions.Builder, Map<String, Instant>,
                     FeedbackSessionAttributes.UpdateOptions.Builder> withDeadlinesBuilder) {
-        updateFeedbackSessionsDeadlinesForUser(courseId, emailAddress, deadlinesGetter, deadlines -> {
-            deadlines.remove(emailAddress);
-            return deadlines;
-        }, withDeadlinesBuilder);
+        updateFeedbackSessionsDeadlinesForUser(courseId, emailAddress, deadlinesGetter,
+                deadlines -> deadlines.remove(emailAddress), withDeadlinesBuilder);
     }
 
     private void updateFeedbackSessionsDeadlinesForUser(String courseId, String emailAddress,
             Function<FeedbackSessionAttributes, Map<String, Instant>> deadlinesGetter,
-            UnaryOperator<Map<String, Instant>> deadlinesUpdater,
+            Consumer<Map<String, Instant>> deadlinesUpdater,
             BiFunction<FeedbackSessionAttributes.UpdateOptions.Builder, Map<String, Instant>,
                     FeedbackSessionAttributes.UpdateOptions.Builder> withDeadlinesBuilder) {
         List<FeedbackSessionAttributes> feedbackSessions = fsDb.getFeedbackSessionsForCourse(courseId);
@@ -644,7 +640,7 @@ public final class FeedbackSessionsLogic {
             if (!deadlines.containsKey(emailAddress)) {
                 return;
             }
-            deadlines = deadlinesUpdater.apply(deadlines);
+            deadlinesUpdater.accept(deadlines);
             FeedbackSessionAttributes.UpdateOptions.Builder updateOptionsBuilder = FeedbackSessionAttributes
                     .updateOptionsBuilder(feedbackSession.getFeedbackSessionName(), feedbackSession.getCourseId());
             FeedbackSessionAttributes.UpdateOptions updateOptions = withDeadlinesBuilder.apply(updateOptionsBuilder,

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -35,6 +35,7 @@ public final class InstructorsLogic {
     private FeedbackResponsesLogic frLogic;
     private FeedbackResponseCommentsLogic frcLogic;
     private FeedbackQuestionsLogic fqLogic;
+    private FeedbackSessionsLogic fsLogic;
     private DeadlineExtensionsLogic deLogic;
 
     private InstructorsLogic() {
@@ -49,6 +50,7 @@ public final class InstructorsLogic {
         fqLogic = FeedbackQuestionsLogic.inst();
         frLogic = FeedbackResponsesLogic.inst();
         frcLogic = FeedbackResponseCommentsLogic.inst();
+        fsLogic = FeedbackSessionsLogic.inst();
         deLogic = DeadlineExtensionsLogic.inst();
     }
 
@@ -252,6 +254,8 @@ public final class InstructorsLogic {
             frcLogic.updateFeedbackResponseCommentsEmails(
                     updatedInstructor.getCourseId(), originalInstructor.getEmail(), updatedInstructor.getEmail());
             // cascade deadline extensions
+            fsLogic.updateFeedbackSessionsInstructorDeadlinesWithNewEmail(updatedInstructor.getCourseId(),
+                    originalInstructor.getEmail(), updatedInstructor.getEmail());
             deLogic.updateDeadlineExtensionsWithNewEmail(updatedInstructor.getCourseId(),
                     originalInstructor.getEmail(), updatedInstructor.getEmail(), true);
         }
@@ -307,6 +311,7 @@ public final class InstructorsLogic {
 
         frLogic.deleteFeedbackResponsesInvolvedEntityOfCourseCascade(courseId, email);
         instructorsDb.deleteInstructor(courseId, email);
+        fsLogic.deleteFeedbackSessionsDeadlinesForInstructor(courseId, email);
         deLogic.deleteDeadlineExtensions(courseId, email, true);
     }
 

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -39,6 +39,7 @@ public final class StudentsLogic {
     private final StudentsDb studentsDb = StudentsDb.inst();
 
     private FeedbackResponsesLogic frLogic;
+    private FeedbackSessionsLogic fsLogic;
     private DeadlineExtensionsLogic deLogic;
 
     private StudentsLogic() {
@@ -51,6 +52,7 @@ public final class StudentsLogic {
 
     void initLogicDependencies() {
         frLogic = FeedbackResponsesLogic.inst();
+        fsLogic = FeedbackSessionsLogic.inst();
         deLogic = DeadlineExtensionsLogic.inst();
     }
 
@@ -225,6 +227,8 @@ public final class StudentsLogic {
         if (!originalStudent.getEmail().equals(updatedStudent.getEmail())) {
             frLogic.updateFeedbackResponsesForChangingEmail(
                     updatedStudent.getCourse(), originalStudent.getEmail(), updatedStudent.getEmail());
+            fsLogic.updateFeedbackSessionsStudentDeadlinesWithNewEmail(originalStudent.getCourse(),
+                    originalStudent.getEmail(), updatedStudent.getEmail());
             deLogic.updateDeadlineExtensionsWithNewEmail(
                     originalStudent.getCourse(), originalStudent.getEmail(), updatedStudent.getEmail(), false);
         }
@@ -425,6 +429,7 @@ public final class StudentsLogic {
             frLogic.deleteFeedbackResponsesInvolvedEntityOfCourseCascade(student.getCourse(), student.getTeam());
         }
         studentsDb.deleteStudent(courseId, studentEmail);
+        fsLogic.deleteFeedbackSessionsDeadlinesForStudent(courseId, studentEmail);
         deLogic.deleteDeadlineExtensions(courseId, studentEmail, false);
     }
 

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -713,16 +713,16 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("Update email; transfers deadlines to new email.");
 
-        Map<Instant, Long> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(oldEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(oldEmailAddress))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        assertEquals(2L, oldDeadlineCounts.values()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
+        assertEquals(2, oldDeadlineCounts.values()
                 .stream()
-                .reduce(0L, Long::sum)
-                .longValue());
+                .reduce(0, Integer::sum)
+                .intValue());
 
         fsLogic.updateFeedbackSessionsInstructorDeadlinesWithNewEmail(courseId, oldEmailAddress, newEmailAddress);
 
@@ -730,12 +730,12 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .stream()
                 .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
                         .containsKey(oldEmailAddress)));
-        Map<Instant, Long> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(newEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(newEmailAddress))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
@@ -748,16 +748,16 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("Update email; transfers deadlines to new email.");
 
-        Map<Instant, Long> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(oldEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(oldEmailAddress))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        assertEquals(2L, oldDeadlineCounts.values()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
+        assertEquals(2, oldDeadlineCounts.values()
                 .stream()
-                .reduce(0L, Long::sum)
-                .longValue());
+                .reduce(0, Integer::sum)
+                .intValue());
 
         fsLogic.updateFeedbackSessionsStudentDeadlinesWithNewEmail(courseId, oldEmailAddress, newEmailAddress);
 
@@ -765,12 +765,12 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .stream()
                 .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
                         .containsKey(oldEmailAddress)));
-        Map<Instant, Long> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(newEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(newEmailAddress))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -4,10 +4,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
@@ -711,23 +711,18 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         String oldEmailAddress = instructorToBeUpdated.getEmail();
         String newEmailAddress = "new@email.tmt";
 
-        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        ______TS("Update email; transfers deadlines to new email.");
+
+        Map<Instant, Long> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(oldEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(oldEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
-        assertEquals(2, oldDeadlineCounts.values()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        assertEquals(2L, oldDeadlineCounts.values()
                 .stream()
-                .reduce(0, Integer::sum)
-                .intValue());
+                .reduce(0L, Long::sum)
+                .longValue());
 
         fsLogic.updateFeedbackSessionsInstructorDeadlinesWithNewEmail(courseId, oldEmailAddress, newEmailAddress);
 
@@ -735,19 +730,12 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .stream()
                 .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
                         .containsKey(oldEmailAddress)));
-        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Long> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(newEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(newEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
@@ -758,23 +746,18 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         String oldEmailAddress = student4InCourse1.getEmail();
         String newEmailAddress = "new@email.tmt";
 
-        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        ______TS("Update email; transfers deadlines to new email.");
+
+        Map<Instant, Long> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(oldEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(oldEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
-        assertEquals(2, oldDeadlineCounts.values()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        assertEquals(2L, oldDeadlineCounts.values()
                 .stream()
-                .reduce(0, Integer::sum)
-                .intValue());
+                .reduce(0L, Long::sum)
+                .longValue());
 
         fsLogic.updateFeedbackSessionsStudentDeadlinesWithNewEmail(courseId, oldEmailAddress, newEmailAddress);
 
@@ -782,19 +765,12 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .stream()
                 .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
                         .containsKey(oldEmailAddress)));
-        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+        Map<Instant, Long> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
                 .stream()
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(newEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(newEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
@@ -806,6 +782,8 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         String courseId = instructor1OfCourse1.getCourseId();
         String emailAddress = instructor1OfCourse1.getEmail();
 
+        ______TS("Delete user; deadlines associated with the email are removed.");
+
         // The instructor should have selective deadlines.
         Set<FeedbackSessionAttributes> oldSessionsWithInstructor1Deadlines = fsLogic
                 .getFeedbackSessionsForCourse(courseId)
@@ -813,10 +791,10 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
                         .containsKey(emailAddress))
                 .collect(Collectors.toSet());
-        assertEquals(2, oldSessionsWithInstructor1Deadlines.size());
         Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithInstructor1Deadlines
                 .stream()
                 .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getInstructorDeadlines().size()));
+        assertEquals(2, oldSessionsWithInstructor1Deadlines.size());
 
         fsLogic.deleteFeedbackSessionsDeadlinesForInstructor(courseId, emailAddress);
 
@@ -847,6 +825,8 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         String courseId = student4InCourse1.getCourse();
         String emailAddress = student4InCourse1.getEmail();
 
+        ______TS("Delete user; deadlines associated with the email are removed.");
+
         // The student should have selective deadlines.
         Set<FeedbackSessionAttributes> oldSessionsWithStudent4Deadlines = fsLogic
                 .getFeedbackSessionsForCourse(courseId)
@@ -854,10 +834,10 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
                         .containsKey(emailAddress))
                 .collect(Collectors.toSet());
-        assertEquals(2, oldSessionsWithStudent4Deadlines.size());
         Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithStudent4Deadlines
                 .stream()
                 .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getStudentDeadlines().size()));
+        assertEquals(2, oldSessionsWithStudent4Deadlines.size());
 
         fsLogic.deleteFeedbackSessionsDeadlinesForStudent(courseId, emailAddress);
 

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -1,10 +1,13 @@
 package teammates.logic.core;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -13,6 +16,7 @@ import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -33,6 +37,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
     private final CoursesLogic coursesLogic = CoursesLogic.inst();
     private final FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
     private final FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
+    private final FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
 
     @Override
     protected void prepareTestData() {
@@ -318,6 +323,58 @@ public class InstructorsLogicTest extends BaseLogicTest {
     }
 
     @Test
+    public void testUpdateInstructorByGoogleIdCascade_shouldCascadeUpdateToFeedbackSessions() throws Exception {
+        InstructorAttributes instructorToBeUpdated = dataBundle.instructors.get("instructor1OfCourse1");
+        String courseId = instructorToBeUpdated.getCourseId();
+        String oldEmailAddress = instructorToBeUpdated.getEmail();
+        String newEmailAddress = "new@email.tmt";
+
+        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .map(FeedbackSessionAttributes::getInstructorDeadlines)
+                .filter(instructorDeadlines -> instructorDeadlines.containsKey(oldEmailAddress))
+                .map(instructorDeadlines -> instructorDeadlines.get(oldEmailAddress))
+                .reduce(new HashMap<>(), (counts, deadline) -> {
+                    int count = counts.getOrDefault(deadline, 0);
+                    counts.put(deadline, count + 1);
+                    return counts;
+                }, (curr, next) -> {
+                    curr.putAll(next);
+                    return curr;
+                });
+        assertEquals(2, oldDeadlineCounts.values()
+                .stream()
+                .reduce(0, Integer::sum)
+                .intValue());
+
+        instructorsLogic.updateInstructorByGoogleIdCascade(
+                InstructorAttributes
+                        .updateOptionsWithGoogleIdBuilder(
+                                courseId, instructorToBeUpdated.getGoogleId())
+                        .withEmail(newEmailAddress)
+                        .build());
+
+        assertTrue(fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
+                        .containsKey(oldEmailAddress)));
+        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .map(FeedbackSessionAttributes::getInstructorDeadlines)
+                .filter(instructorDeadlines -> instructorDeadlines.containsKey(newEmailAddress))
+                .map(instructorDeadlines -> instructorDeadlines.get(newEmailAddress))
+                .reduce(new HashMap<>(), (counts, deadline) -> {
+                    int count = counts.getOrDefault(deadline, 0);
+                    counts.put(deadline, count + 1);
+                    return counts;
+                }, (curr, next) -> {
+                    curr.putAll(next);
+                    return curr;
+                });
+        assertEquals(oldDeadlineCounts, newDeadlineCounts);
+    }
+
+    @Test
     public void testUpdateInstructorByGoogleIdCascade_shouldDoCascadeUpdateToCommentsAndResponses() throws Exception {
         InstructorAttributes instructorToBeUpdated = dataBundle.instructors.get("instructor1OfCourse1");
 
@@ -522,12 +579,42 @@ public class InstructorsLogicTest extends BaseLogicTest {
         assertFalse(frLogic.getFeedbackResponsesFromGiverForCourse(courseId, email).isEmpty());
         assertFalse(frLogic.getFeedbackResponsesForReceiverForCourse(courseId, email).isEmpty());
 
+        // The instructor should have selective deadlines.
+        Set<FeedbackSessionAttributes> oldSessionsWithInstructor1Deadlines = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
+                        .containsKey(email))
+                .collect(Collectors.toSet());
+        assertEquals(2, oldSessionsWithInstructor1Deadlines.size());
+        Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithInstructor1Deadlines
+                .stream()
+                .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getInstructorDeadlines().size()));
+
         instructorsLogic.deleteInstructorCascade(courseId, email);
 
         verifyAbsentInDatabase(instructorDeleted);
         // there should be no response of the instructor
         assertTrue(frLogic.getFeedbackResponsesFromGiverForCourse(courseId, email).isEmpty());
         assertTrue(frLogic.getFeedbackResponsesForReceiverForCourse(courseId, email).isEmpty());
+
+        // The instructor should have no more selective deadlines.
+        Set<FeedbackSessionAttributes> newSessionsWithInstructor1Deadlines = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
+                        .containsKey(email))
+                .collect(Collectors.toSet());
+        assertTrue(newSessionsWithInstructor1Deadlines.isEmpty());
+        Map<FeedbackSessionAttributes, Integer> expectedSessionsDeadlineCounts = oldSessionsDeadlineCounts.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue() - 1));
+        Map<FeedbackSessionAttributes, Integer> newSessionsDeadlineCounts = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(oldSessionsWithInstructor1Deadlines::contains)
+                .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getInstructorDeadlines().size()));
+        assertEquals(expectedSessionsDeadlineCounts, newSessionsDeadlineCounts);
 
         ______TS("failure: null parameter");
 

--- a/src/test/java/teammates/logic/core/InstructorsLogicTest.java
+++ b/src/test/java/teammates/logic/core/InstructorsLogicTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
@@ -334,14 +335,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(oldEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(oldEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(2, oldDeadlineCounts.values()
                 .stream()
                 .reduce(0, Integer::sum)
@@ -363,14 +357,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
                 .map(FeedbackSessionAttributes::getInstructorDeadlines)
                 .filter(instructorDeadlines -> instructorDeadlines.containsKey(newEmailAddress))
                 .map(instructorDeadlines -> instructorDeadlines.get(newEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
@@ -586,10 +573,10 @@ public class InstructorsLogicTest extends BaseLogicTest {
                 .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getInstructorDeadlines()
                         .containsKey(email))
                 .collect(Collectors.toSet());
-        assertEquals(2, oldSessionsWithInstructor1Deadlines.size());
         Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithInstructor1Deadlines
                 .stream()
                 .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getInstructorDeadlines().size()));
+        assertEquals(2, oldSessionsWithInstructor1Deadlines.size());
 
         instructorsLogic.deleteInstructorCascade(courseId, email);
 

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -1,9 +1,14 @@
 package teammates.logic.core;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
@@ -13,6 +18,7 @@ import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -32,6 +38,7 @@ public class StudentsLogicTest extends BaseLogicTest {
     private final CoursesLogic coursesLogic = CoursesLogic.inst();
     private final FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
     private final FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();
+    private final FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
 
     @Override
     protected void prepareTestData() {
@@ -222,6 +229,57 @@ public class StudentsLogicTest extends BaseLogicTest {
                 ));
         AssertHelper.assertContains(FieldValidator.REASON_INCORRECT_FORMAT, ipe.getMessage());
 
+    }
+
+    @Test
+    public void testUpdateStudentCascade_emailChanged_shouldUpdateStudentDeadlineMaps() throws Exception {
+        StudentAttributes student4InCourse1 = dataBundle.students.get("student4InCourse1");
+        String courseId = student4InCourse1.getCourse();
+        String oldEmailAddress = student4InCourse1.getEmail();
+        String newEmailAddress = "new@email.tmt";
+
+        Map<Instant, Integer> oldDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .map(FeedbackSessionAttributes::getStudentDeadlines)
+                .filter(studentDeadlines -> studentDeadlines.containsKey(oldEmailAddress))
+                .map(studentDeadlines -> studentDeadlines.get(oldEmailAddress))
+                .reduce(new HashMap<>(), (counts, deadline) -> {
+                    int count = counts.getOrDefault(deadline, 0);
+                    counts.put(deadline, count + 1);
+                    return counts;
+                }, (curr, next) -> {
+                    curr.putAll(next);
+                    return curr;
+                });
+        assertEquals(2, oldDeadlineCounts.values()
+                .stream()
+                .reduce(0, Integer::sum)
+                .intValue());
+
+        studentsLogic.updateStudentCascade(
+                StudentAttributes.updateOptionsBuilder(student4InCourse1.getCourse(), oldEmailAddress)
+                        .withNewEmail(newEmailAddress)
+                        .build()
+        );
+
+        assertTrue(fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .noneMatch(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
+                        .containsKey(oldEmailAddress)));
+        Map<Instant, Integer> newDeadlineCounts = fsLogic.getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .map(FeedbackSessionAttributes::getStudentDeadlines)
+                .filter(studentDeadlines -> studentDeadlines.containsKey(newEmailAddress))
+                .map(studentDeadlines -> studentDeadlines.get(newEmailAddress))
+                .reduce(new HashMap<>(), (counts, deadline) -> {
+                    int count = counts.getOrDefault(deadline, 0);
+                    counts.put(deadline, count + 1);
+                    return counts;
+                }, (curr, next) -> {
+                    curr.putAll(next);
+                    return curr;
+                });
+        assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
     @Test
@@ -567,6 +625,47 @@ public class StudentsLogicTest extends BaseLogicTest {
         assertFalse(
                 frLogic.getGiverSetThatAnswerFeedbackSession(fra.getCourseId(),
                         fra.getFeedbackSessionName()).contains(fra.getGiver()));
+    }
+
+    @Test
+    public void testDeleteStudentCascade_withSelectiveDeadlines_shouldDeleteDeadlines() {
+        StudentAttributes student4InCourse1 = dataBundle.students.get("student4InCourse1");
+        verifyPresentInDatabase(student4InCourse1);
+
+        String courseId = student4InCourse1.getCourse();
+        String emailAddress = student4InCourse1.getEmail();
+
+        // The student should have selective deadlines.
+        Set<FeedbackSessionAttributes> oldSessionsWithStudent4Deadlines = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
+                        .containsKey(emailAddress))
+                .collect(Collectors.toSet());
+        assertEquals(2, oldSessionsWithStudent4Deadlines.size());
+        Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithStudent4Deadlines
+                .stream()
+                .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getStudentDeadlines().size()));
+
+        studentsLogic.deleteStudentCascade(student4InCourse1.getCourse(), student4InCourse1.getEmail());
+
+        // The student should have no more selective deadlines.
+        Set<FeedbackSessionAttributes> newSessionsWithStudent4Deadlines = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
+                        .containsKey(emailAddress))
+                .collect(Collectors.toSet());
+        assertTrue(newSessionsWithStudent4Deadlines.isEmpty());
+        Map<FeedbackSessionAttributes, Integer> expectedSessionsDeadlineCounts = oldSessionsDeadlineCounts.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue() - 1));
+        Map<FeedbackSessionAttributes, Integer> newSessionsDeadlineCounts = fsLogic
+                .getFeedbackSessionsForCourse(courseId)
+                .stream()
+                .filter(oldSessionsWithStudent4Deadlines::contains)
+                .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getStudentDeadlines().size()));
+        assertEquals(expectedSessionsDeadlineCounts, newSessionsDeadlineCounts);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/StudentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/StudentsLogicTest.java
@@ -4,10 +4,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.AfterClass;
@@ -243,14 +243,7 @@ public class StudentsLogicTest extends BaseLogicTest {
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(oldEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(oldEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(2, oldDeadlineCounts.values()
                 .stream()
                 .reduce(0, Integer::sum)
@@ -271,14 +264,7 @@ public class StudentsLogicTest extends BaseLogicTest {
                 .map(FeedbackSessionAttributes::getStudentDeadlines)
                 .filter(studentDeadlines -> studentDeadlines.containsKey(newEmailAddress))
                 .map(studentDeadlines -> studentDeadlines.get(newEmailAddress))
-                .reduce(new HashMap<>(), (counts, deadline) -> {
-                    int count = counts.getOrDefault(deadline, 0);
-                    counts.put(deadline, count + 1);
-                    return counts;
-                }, (curr, next) -> {
-                    curr.putAll(next);
-                    return curr;
-                });
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(deadline -> 1)));
         assertEquals(oldDeadlineCounts, newDeadlineCounts);
     }
 
@@ -642,10 +628,10 @@ public class StudentsLogicTest extends BaseLogicTest {
                 .filter(feedbackSessionAttributes -> feedbackSessionAttributes.getStudentDeadlines()
                         .containsKey(emailAddress))
                 .collect(Collectors.toSet());
-        assertEquals(2, oldSessionsWithStudent4Deadlines.size());
         Map<FeedbackSessionAttributes, Integer> oldSessionsDeadlineCounts = oldSessionsWithStudent4Deadlines
                 .stream()
                 .collect(Collectors.toMap(fsa -> fsa, fsa -> fsa.getStudentDeadlines().size()));
+        assertEquals(2, oldSessionsWithStudent4Deadlines.size());
 
         studentsLogic.deleteStudentCascade(student4InCourse1.getCourse(), student4InCourse1.getEmail());
 

--- a/src/test/resources/data/FeedbackSessionsLogicTest.json
+++ b/src/test/resources/data/FeedbackSessionsLogicTest.json
@@ -609,8 +609,12 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
-      "instructorDeadlines": {}
+      "studentDeadlines": {
+        "student4InCourse1@gmail.tmt": "2037-04-30T23:00:00Z"
+      },
+      "instructorDeadlines": {
+        "instructor1@course1.tmt": "2037-04-30T23:00:00Z"
+      }
     },
     "session2InCourse1": {
       "feedbackSessionName": "Second feedback session",
@@ -632,8 +636,12 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "studentDeadlines": {},
-      "instructorDeadlines": {}
+      "studentDeadlines": {
+        "student4InCourse1@gmail.tmt": "2030-04-28T23:00:00Z"
+      },
+      "instructorDeadlines": {
+        "instructor1@course1.tmt": "2030-04-28T23:00:00Z"
+      }
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",

--- a/src/test/resources/data/FeedbackSessionsLogicTest.json
+++ b/src/test/resources/data/FeedbackSessionsLogicTest.json
@@ -1461,6 +1461,48 @@
       "commentText": "Instructor 1 comment to Team 2.1"
     }
   },
+  "deadlineExtensions": {
+    "student4InCourse1Session1": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "First feedback session",
+      "userEmail": "student4InCourse1@gmail.tmt",
+      "isInstructor": false,
+      "endTime": "2037-04-30T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2037-04-30T20:00:00Z",
+      "updatedAt": "2037-04-30T20:00:00Z"
+    },
+    "instructor1InCourse1Session1": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "First feedback session",
+      "userEmail": "instructor1@course1.tmt",
+      "isInstructor": true,
+      "endTime": "2037-04-30T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2037-04-30T20:00:00Z",
+      "updatedAt": "2037-04-30T20:00:00Z"
+    },
+    "student4InCourse1Session2": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "Second feedback session",
+      "userEmail": "student4InCourse1@gmail.tmt",
+      "isInstructor": false,
+      "endTime": "2030-04-28T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2030-04-28T20:00:00Z",
+      "updatedAt": "2030-04-28T20:00:00Z"
+    },
+    "instructor1InCourse1Session2": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "Second feedback session",
+      "userEmail": "instructor1@course1.tmt",
+      "isInstructor": true,
+      "endTime": "2030-04-28T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2030-04-28T20:00:00Z",
+      "updatedAt": "2030-04-28T20:00:00Z"
+    }
+  },
   "profiles": {
     "student1InCourse1": {
       "googleId": "student1InCourse1",

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -816,7 +816,9 @@
       "studentDeadlines": {
         "student4InCourse1@gmail.tmt": "2026-04-28T23:00:00Z"
       },
-      "instructorDeadlines": {}
+      "instructorDeadlines": {
+        "instructor1@course1.tmt": "2027-04-30T23:00:00Z"
+      }
     },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -1793,6 +1793,16 @@
       "sentClosingEmail": false,
       "createdAt": "2027-04-30T15:00:00Z",
       "updatedAt": "2027-04-30T15:00:00Z"
+    },
+    "instructor1InCourse1Session2": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "Second feedback session",
+      "userEmail": "instructor1@course1.tmt",
+      "isInstructor": true,
+      "endTime": "2027-04-30T23:00:00Z",
+      "sentClosingEmail": false,
+      "createdAt": "2027-04-30T15:00:00Z",
+      "updatedAt": "2027-04-30T15:00:00Z"
     }
   },
   "profiles": {


### PR DESCRIPTION
Part of #11571 

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

<!-- Ensure that you have: -->
<!-- - [x] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr -->
<!--   - [x] Added the issue number to the "Fixes" keyword above -->
<!--   - [x] Titled the PR as specified in the abovementioned document -->
<!-- - [x] Made your changes on a branch other than `master` and `release` -->
<!-- - [x] Gone through all the changes in this PR and ensured that: -->
<!--   - [x] They addressed one (and only one) issue -->
<!--   - [x] No unintended changes were made -->
<!-- - [x] Run and passed static analysis: `./gradlew lint` and `npm run lint` -->
<!-- - [x] Added/updated tests, if changes in functionality were involved -->
<!-- - [x] Added/updated documentation to public APIs (classes, methods, variables), if applicable -->

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Any user email address update or any user deletion is cascaded down to the deadline maps. This is implemented by finding all the feedback sessions in the course the user belongs to. For each feedback session, the email is updated or deleted accordingly in the respective deadline map if that map contains a selective deadline for that user.