### PR TITLE
[#11571] Add selective deadlines into access control checks

### DIFF
--- a/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
@@ -54,6 +54,7 @@ class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             if (studentAttributes == null) {
                 throw new EntityNotFoundException("Student does not exist.");
             }
+            session = session.sanitizeForStudent(studentAttributes.getEmail());
 
             gateKeeper.verifyAnswerableForStudent(question);
             verifySessionOpenExceptForModeration(session);
@@ -70,6 +71,7 @@ class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             if (instructorAsFeedbackParticipant == null) {
                 throw new EntityNotFoundException("Instructor does not exist.");
             }
+            session = session.sanitizeForInstructor(instructorAsFeedbackParticipant.getEmail());
 
             gateKeeper.verifyAnswerableForInstructor(question);
             verifySessionOpenExceptForModeration(session);

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -38,11 +38,12 @@ class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             StudentAttributes student = getStudentOfCourseFromRequest(courseId);
 
             gateKeeper.verifyAnswerableForStudent(question);
-            verifySessionOpenExceptForModeration(session);
             verifyInstructorCanSeeQuestionIfInModeration(question);
             verifyNotPreview();
 
             checkAccessControlForStudentFeedbackSubmission(student, session);
+            session = session.sanitizeForStudent(student.getEmail());
+            verifySessionOpenExceptForModeration(session);
             gateKeeper.verifyOwnership(frc,
                     question.getGiverType() == FeedbackParticipantType.TEAMS
                             ? student.getTeam() : student.getEmail());
@@ -51,11 +52,12 @@ class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             InstructorAttributes instructorAsFeedbackParticipant = getInstructorOfCourseFromRequest(courseId);
 
             gateKeeper.verifyAnswerableForInstructor(question);
-            verifySessionOpenExceptForModeration(session);
             verifyInstructorCanSeeQuestionIfInModeration(question);
             verifyNotPreview();
 
             checkAccessControlForInstructorFeedbackSubmission(instructorAsFeedbackParticipant, session);
+            session = session.sanitizeForInstructor(instructorAsFeedbackParticipant.getEmail());
+            verifySessionOpenExceptForModeration(session);
             gateKeeper.verifyOwnership(frc, instructorAsFeedbackParticipant.getEmail());
             break;
         case INSTRUCTOR_RESULT:

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -50,7 +50,6 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
                 getNonNullFeedbackSession(feedbackQuestion.getFeedbackSessionName(), feedbackQuestion.getCourseId());
 
         verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
-        verifySessionOpenExceptForModeration(feedbackSession);
         verifyNotPreview();
 
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
@@ -58,11 +57,15 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         case STUDENT_SUBMISSION:
             gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
             StudentAttributes studentAttributes = getStudentOfCourseFromRequest(feedbackQuestion.getCourseId());
+            feedbackSession = feedbackSession.sanitizeForStudent(studentAttributes.getEmail());
+            verifySessionOpenExceptForModeration(feedbackSession);
             checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
             gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
             InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(feedbackQuestion.getCourseId());
+            feedbackSession = feedbackSession.sanitizeForInstructor(instructorAttributes.getEmail());
+            verifySessionOpenExceptForModeration(feedbackSession);
             checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSession);
             break;
         case INSTRUCTOR_RESULT:

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -53,6 +53,7 @@ class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             if (student == null) {
                 throw new EntityNotFoundException("Student does not exist.");
             }
+            session = session.sanitizeForStudent(student.getEmail());
 
             gateKeeper.verifyAnswerableForStudent(question);
             verifySessionOpenExceptForModeration(session);
@@ -69,6 +70,7 @@ class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionAction {
             if (instructorAsFeedbackParticipant == null) {
                 throw new EntityNotFoundException("Instructor does not exist.");
             }
+            session = session.sanitizeForInstructor(instructorAsFeedbackParticipant.getEmail());
 
             gateKeeper.verifyAnswerableForInstructor(question);
             verifySessionOpenExceptForModeration(session);

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -1,0 +1,127 @@
+package teammates.ui.webapi;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
+import teammates.ui.request.Intent;
+
+/**
+ * SUT: {@link SubmitFeedbackResponsesAction}.
+ */
+public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeedbackResponsesAction> {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.RESPONSES;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return PUT;
+    }
+
+    @Override
+    public void testExecute() {
+        // See each independent test case.
+    }
+
+    @Override
+    protected void testAccessControl() {
+        // See each independent test case.
+    }
+
+    @Test
+    public void testAccessControl_instructorSubmissionPastEndTime_shouldAllowIfBeforeDeadline() throws Exception {
+        int questionNumber = 4;
+        FeedbackSessionAttributes session1InCourse1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        String feedbackSessionName = session1InCourse1.getFeedbackSessionName();
+        String courseId = session1InCourse1.getCourseId();
+        InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+        FeedbackQuestionAttributes qn4InSession1InCourse1 = logic.getFeedbackQuestion(feedbackSessionName,
+                courseId, questionNumber);
+
+        Instant newEndTime = TimeHelper.getInstantDaysOffsetFromNow(-2);
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withInstructorDeadlines(Map.of())
+                .withEndTime(newEndTime)
+                .build());
+        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.FEEDBACK_QUESTION_ID, qn4InSession1InCourse1.getId(),
+                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
+        };
+
+        ______TS("No selective deadline; should fail.");
+
+        verifyCannotAccess(submissionParams);
+
+        ______TS("After selective deadline; should fail.");
+
+        Map<String, Instant> newInstructorDeadlines = Map.of(
+                instructor1OfCourse1.getEmail(), TimeHelper.getInstantDaysOffsetFromNow(-1));
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withInstructorDeadlines(newInstructorDeadlines)
+                .build());
+        verifyCannotAccess(submissionParams);
+
+        ______TS("Before selective deadline; should pass.");
+
+        newInstructorDeadlines = Map.of(
+                instructor1OfCourse1.getEmail(), TimeHelper.getInstantDaysOffsetFromNow(1));
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withInstructorDeadlines(newInstructorDeadlines)
+                .build());
+        verifyCanAccess(submissionParams);
+    }
+
+    @Test
+    public void testAccessControl_studentSubmissionPastEndTime_shouldAllowIfBeforeDeadline() throws Exception {
+        int questionNumber = 1;
+        FeedbackSessionAttributes session1InCourse1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        String feedbackSessionName = session1InCourse1.getFeedbackSessionName();
+        String courseId = session1InCourse1.getCourseId();
+        StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+        FeedbackQuestionAttributes qn1InSession1InCourse1 = logic.getFeedbackQuestion(feedbackSessionName,
+                courseId, questionNumber);
+
+        Instant newEndTime = TimeHelper.getInstantDaysOffsetFromNow(-2);
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withEndTime(newEndTime)
+                .build());
+        loginAsStudent(student1InCourse1.getGoogleId());
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.FEEDBACK_QUESTION_ID, qn1InSession1InCourse1.getId(),
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+        };
+
+        ______TS("No selective deadline; should fail.");
+
+        verifyCannotAccess(submissionParams);
+
+        ______TS("After selective deadline; should fail.");
+
+        Map<String, Instant> newStudentDeadlines = Map.of(
+                student1InCourse1.getEmail(), TimeHelper.getInstantDaysOffsetFromNow(-1));
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withStudentDeadlines(newStudentDeadlines)
+                .build());
+        verifyCannotAccess(submissionParams);
+
+        ______TS("Before selective deadline; should pass.");
+
+        newStudentDeadlines = Map.of(
+                student1InCourse1.getEmail(), TimeHelper.getInstantDaysOffsetFromNow(1));
+        logic.updateFeedbackSession(FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
+                .withStudentDeadlines(newStudentDeadlines)
+                .build());
+        verifyCanAccess(submissionParams);
+    }
+}


### PR DESCRIPTION
Part of #11571 

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

<!-- Ensure that you have: -->
<!-- - [x] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr -->
<!--   - [x] Added the issue number to the "Fixes" keyword above -->
<!--   - [x] Titled the PR as specified in the abovementioned document -->
<!-- - [x] Made your changes on a branch other than `master` and `release` -->
<!-- - [x] Gone through all the changes in this PR and ensured that: -->
<!--   - [x] They addressed one (and only one) issue -->
<!--   - [x] No unintended changes were made -->
<!-- - [x] Run and passed static analysis: `./gradlew lint` and `npm run lint` -->
<!-- - [x] Added/updated tests, if changes in functionality were involved -->
<!-- - [x] Added/updated documentation to public APIs (classes, methods, variables), if applicable -->

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

The feedback sessions were sanitized depending on what type of user was using the action. This meant that the correct deadline was used for the user regardless of whether it was the default session end time or their own selective deadline, if they had one. This allows the user to use actions such as submitting feedback responses when it is still open for them, even if it is already closed for others, if they have a selective deadline that is still in the future.