### PR TITLE
[#11697] Remove projection query without index

### DIFF
--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -155,7 +155,6 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
 
         return load()
                 .filter("courseId =", courseId)
-                .project("email")
                 .list()
                 .stream()
                 .map(Instructor::getEmail)


### PR DESCRIPTION
Fixes #11697 

We should not add an index to Instructor just for this small impact change.
Revert to entity query for instructor email instead.