### PR TITLE
[#11572] Notification feature - Fix edit button and move style demo to the side

### DIFF
--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
@@ -149,26 +149,30 @@ export class AdminNotificationsPageComponent implements OnInit {
 
   /**
    * Loads notification data into the edit form for updating actions.
+   * Will do checks to skip or show warnings if necessary.
    */
   loadNotificationEditFormHandler(notification: Notification): void {
-    if (this.notificationEditFormModel.notificationId === notification.notificationId) {
-      // Not to do anything if the notification is already loaded
-      return;
-    }
     if (this.isNotificationEditFormExpanded) {
-      // Warns user that the existing edits will be cleared
-      this.simpleModalService.openConfirmationModal(
-        'Discard unsaved edit?',
-        SimpleModalType.WARNING,
-        'Warning: If you choose to edit another notification, any unsaved changes will be lost.',
-      ).result.then(() => {
-        this.loadNotificationEditForm(notification);
-      });
+      if (this.notificationEditFormModel.notificationId !== notification.notificationId) {
+        // Warns user that the existing edits will be cleared
+        this.simpleModalService.openConfirmationModal(
+          'Discard unsaved edit?',
+          SimpleModalType.WARNING,
+          'Warning: If you choose to edit another notification, any unsaved changes will be lost.',
+        ).result.then(() => {
+          this.loadNotificationEditForm(notification);
+        });
+      }
+      // Not to do anything if the notification is already loaded
     } else {
+      // Loads notification data into the edit form without doing any check if the form was closed originally
       this.loadNotificationEditForm(notification);
     }
   }
 
+  /**
+   * The actual function to load data into edit form.
+   */
   loadNotificationEditForm(notification: Notification): void {
     const startTime = moment(notification.startTimestamp);
     const endTime = moment(notification.endTimestamp);
@@ -241,7 +245,6 @@ export class AdminNotificationsPageComponent implements OnInit {
           notification,
         });
 
-        this.isNotificationEditFormExpanded = false;
         this.initNotificationEditFormModel();
       },
       (resp: ErrorMessageOutput) => {
@@ -284,7 +287,6 @@ export class AdminNotificationsPageComponent implements OnInit {
           }
         });
 
-        this.isNotificationEditFormExpanded = false;
         this.initNotificationEditFormModel();
       },
       (resp: ErrorMessageOutput) => {

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
@@ -28,8 +28,11 @@
             </div>
             <div class="col-md-auto text-md-left">
               <select id="notification-style" class="form-control" [ngModel]="model.style" (ngModelChange)="triggerModelChange('style', $event)">
-                <option *ngFor="let style of NotificationStyle | keyvalue" [ngClass]="style.key | notificationStyleClass" [ngValue]="style.value">{{ style.key | notificationStyleDescription }}</option>
+                <option *ngFor="let style of NotificationStyle | keyvalue" [ngValue]="style.value">{{ style.key | notificationStyleDescription }}</option>
               </select>
+            </div>
+            <div class="col-md-auto text-md-middle d-flex" [ngClass]="model.style | notificationStyleClass">
+              <span class="align-self-center">Style Demonstration</span>
             </div>
           </div>
           <br/>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
@@ -65,9 +65,6 @@ export class NotificationEditFormComponent implements OnInit {
   @Output()
   cancelEditingNotificationEvent = new EventEmitter<void>();
 
-  @Output()
-  deleteExistingNotificationEvent = new EventEmitter<void>();
-
   constructor(
     private timezoneService: TimezoneService,
     private simpleModalService: SimpleModalService,
@@ -109,19 +106,6 @@ export class NotificationEditFormComponent implements OnInit {
         SimpleModalType.WARNING, 'Warning: Any unsaved changes will be lost.').result.then(() => {
           this.cancelEditingNotificationEvent.emit();
         });
-  }
-
-  /**
-   * Handles delete current feedback session button click event.
-   */
-  deleteHandler(): void {
-    this.simpleModalService.openConfirmationModal(
-        `Delete the notification <strong>${this.model.title}</strong>?`,
-        SimpleModalType.WARNING,
-        'This action is not reversible and the delete will be permanent.',
-    ).result.then(() => {
-      this.deleteExistingNotificationEvent.emit();
-    });
   }
 
 }


### PR DESCRIPTION
Part of #11572

This PR contains the following fixes:
- Fix the issue that edit button cannot open edit form (way to replicate: edit notif 1 -> edit notif 2 without saving 1 -> save notif 2 without changing message field -> click "edit" button for notif 2 again)
- Move style demo to the side of the selector
- Remove redundant code

The style demo looks like this now and it should work for all OS and browser:

![image](https://user-images.githubusercontent.com/10681776/161371896-a1c6cb05-b6ce-4a63-aae1-de517210d8cf.png)

Thanks @moziliar for pointing out the bugs.
