### PR TITLE
[#11572] Notification feature - Add tests PUT and DELETE route

### DIFF
--- a/src/main/java/teammates/ui/webapi/DeleteNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteNotificationAction.java
@@ -11,6 +11,6 @@ public class DeleteNotificationAction extends AdminOnlyAction {
     public JsonResult execute() {
         String notificationId = getNonNullRequestParamValue(Const.ParamsNames.NOTIFICATION_ID);
         logic.deleteNotification(notificationId);
-        return new JsonResult("Notification has been deleted");
+        return new JsonResult("Notification has been deleted.");
     }
 }

--- a/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import org.testng.annotations.Test;
+
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.attributes.NotificationAttributes;
@@ -25,6 +27,7 @@ public class CreateNotificationActionTest extends BaseActionTest<CreateNotificat
         return POST;
     }
 
+    @Test
     @Override
     protected void testExecute() throws Exception {
         long startTime = testNotificationAttribute.getStartTime().toEpochMilli();
@@ -49,7 +52,7 @@ public class CreateNotificationActionTest extends BaseActionTest<CreateNotificat
         assertEquals(createdNotification.getStyle(), res.getStyle());
         assertEquals(createdNotification.getTargetUser(), res.getTargetUser());
         assertEquals(createdNotification.getTitle(), res.getTitle());
-        assertEquals(createdNotification.getTitle(), res.getMessage());
+        assertEquals(createdNotification.getMessage(), res.getMessage());
 
         // check DB correctly processed request
         assertEquals(startTime, createdNotification.getStartTime().toEpochMilli());
@@ -57,7 +60,7 @@ public class CreateNotificationActionTest extends BaseActionTest<CreateNotificat
         assertEquals(style, createdNotification.getStyle());
         assertEquals(targetUser, createdNotification.getTargetUser());
         assertEquals(title, createdNotification.getTitle());
-        assertEquals(message, createdNotification.getTitle());
+        assertEquals(message, createdNotification.getMessage());
 
         ______TS("Parameters cannot be null");
         req = getTypicalCreateRequest();
@@ -94,9 +97,10 @@ public class CreateNotificationActionTest extends BaseActionTest<CreateNotificat
         ______TS("Invalid parameter should throw an error");
         req = getTypicalCreateRequest();
         req.setTitle(invalidTitle);
-        verifyHttpParameterFailure(req);
+        verifyHttpRequestBodyFailure(req);
     }
 
+    @Test
     @Override
     protected void testAccessControl() throws Exception {
         verifyOnlyAdminCanAccess();

--- a/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import org.testng.annotations.Test;
+
 import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.util.Const;
 import teammates.ui.output.MessageOutput;
@@ -21,6 +23,7 @@ public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificat
         return DELETE;
     }
 
+    @Test
     @Override
     protected void testExecute() throws Exception {
         loginAsAdmin();
@@ -58,6 +61,7 @@ public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificat
         assertEquals("Notification has been deleted.", msg.getMessage());
     }
 
+    @Test
     @Override
     protected void testAccessControl() throws Exception {
         verifyOnlyAdminCanAccess();

--- a/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
@@ -23,8 +23,7 @@ public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificat
     @Test
     @Override
     protected void testExecute() throws Exception {
-        final String TEST_NOTIFICATION = "notification1";
-        NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
+        NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get("notification1");
 
         loginAsAdmin();
 
@@ -46,7 +45,7 @@ public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificat
                 Const.ParamsNames.NOTIFICATION_ID, invalidNotificationId,
         };
 
-        NotificationAttributes nonExistentNotification = typicalBundle.notifications.get(TEST_NOTIFICATION);
+        NotificationAttributes nonExistentNotification = typicalBundle.notifications.get("notification1");
         nonExistentNotification.setNotificationId(invalidNotificationId);
 
         verifyAbsentInDatabase(nonExistentNotification);
@@ -64,8 +63,7 @@ public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificat
         verifyHttpParameterFailure(requestParams);
 
         ______TS("Not enough request parameters should throw an error");
-        requestParams = new String[] {};
-        verifyHttpParameterFailure(requestParams);
+        verifyHttpParameterFailure();
 
     }
 

--- a/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteNotificationActionTest.java
@@ -1,0 +1,65 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.Const;
+import teammates.ui.output.MessageOutput;
+
+/**
+ * SUT: {@link DeleteNotificationAction}.
+ */
+public class DeleteNotificationActionTest extends BaseActionTest<DeleteNotificationAction> {
+    private static final String TEST_NOTIFICATION = "notification1";
+    private final NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.NOTIFICATION;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return DELETE;
+    }
+
+    @Override
+    protected void testExecute() throws Exception {
+        loginAsAdmin();
+
+        ______TS("Typical Case: Delete notification successfully");
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_ID, testNotificationAttribute.getNotificationId(),
+        };
+
+        DeleteNotificationAction action = getAction(requestParams);
+        JsonResult response = getJsonResult(action);
+        MessageOutput msg = (MessageOutput) response.getOutput();
+        assertEquals("Notification has been deleted.", msg.getMessage());
+
+        verifyAbsentInDatabase(testNotificationAttribute);
+
+        ______TS("Notification ID cannot be null");
+        requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_ID, null,
+        };
+
+        verifyHttpParameterFailure(requestParams);
+
+        ______TS("Deleting non-existent notification");
+        // Deleting a non-existent notificiation will not throw an error and fail silently
+        requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_ID, "non-existent notification",
+        };
+
+        verifyAbsentInDatabase(testNotificationAttribute);
+
+        action = getAction(requestParams);
+        response = getJsonResult(action);
+        msg = (MessageOutput) response.getOutput();
+        assertEquals("Notification has been deleted.", msg.getMessage());
+    }
+
+    @Override
+    protected void testAccessControl() throws Exception {
+        verifyOnlyAdminCanAccess();
+    }
+}

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -92,6 +92,14 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         ex = verifyHttpRequestBodyFailure(req, requestParams);
         assertEquals("End timestamp should be greater than zero", ex.getMessage());
 
+        ______TS("Start timestamp should not be after end timestamp");
+        req = getTypicalUpdateRequest();
+        req.setEndTimestamp(req.getStartTimestamp() - 100);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("The time when the notification will expire for this notification "
+                + "cannot be earlier than the time when the notification will be visible.",
+                ex.getMessage());
+
         ______TS("Invalid parameter should throw an error");
         req = getTypicalUpdateRequest();
         req.setTitle(invalidTitle);
@@ -105,9 +113,8 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         verifyEntityNotFound(req, requestParams);
 
         ______TS("Not enough request parameters should throw an error");
-        requestParams = new String[] {};
         req = getTypicalUpdateRequest();
-        verifyHttpParameterFailure(req, requestParams);
+        verifyHttpParameterFailure(req);
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -30,8 +30,7 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
     @Test
     @Override
     protected void testExecute() throws Exception {
-        final String TEST_NOTIFICATION = "notification1";
-        NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
+        NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get("notification1");
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_ID, testNotificationAttribute.getNotificationId(),

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -17,9 +17,6 @@ import teammates.ui.request.NotificationUpdateRequest;
  * SUT: {@link UpdateNotificationAction}.
  */
 public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificationAction> {
-    private static final String TEST_NOTIFICATION = "notification1";
-    private final NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
-
     @Override
     String getActionUri() {
         return Const.ResourceURIs.NOTIFICATION;
@@ -33,6 +30,9 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
     @Test
     @Override
     protected void testExecute() throws Exception {
+        final String TEST_NOTIFICATION = "notification1";
+        NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
+
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_ID, testNotificationAttribute.getNotificationId(),
         };
@@ -53,8 +53,9 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
 
         NotificationAttributes updatedNotification = logic.getNotification(res.getNotificationId());
 
-        assertEquals(res.getStartTimestamp(), updatedNotification.getStartTime().toEpochMilli());
-        assertEquals(res.getEndTimestamp(), updatedNotification.getEndTime().toEpochMilli());
+        // Verify that correctly updated in the DB
+        assertEquals(req.getStartTimestamp(), updatedNotification.getStartTime().toEpochMilli());
+        assertEquals(req.getEndTimestamp(), updatedNotification.getEndTime().toEpochMilli());
         assertEquals(style, updatedNotification.getStyle());
         assertEquals(targetUser, updatedNotification.getTargetUser());
         assertEquals(title, updatedNotification.getTitle());
@@ -103,6 +104,11 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         };
         req = getTypicalUpdateRequest();
         verifyEntityNotFound(req, requestParams);
+
+        ______TS("Not enough request parameters should throw an error");
+        requestParams = new String[] {};
+        req = getTypicalUpdateRequest();
+        verifyHttpParameterFailure(req, requestParams);
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -1,0 +1,124 @@
+package teammates.ui.webapi;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import teammates.common.datatransfer.NotificationStyle;
+import teammates.common.datatransfer.NotificationTargetUser;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.Const;
+import teammates.ui.output.NotificationData;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.request.NotificationUpdateRequest;
+
+/**
+ * SUT: {@link UpdateNotificationAction}.
+ */
+public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificationAction> {
+    private static final String TEST_NOTIFICATION = "notification1";
+    private final NotificationAttributes testNotificationAttribute = typicalBundle.notifications.get(TEST_NOTIFICATION);
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.NOTIFICATION;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return PUT;
+    }
+
+    @Override
+    protected void testExecute() throws Exception {
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_ID, testNotificationAttribute.getNotificationId(),
+        };
+        NotificationUpdateRequest req = getTypicalUpdateRequest();
+        long startTime = req.getStartTimestamp();
+        long endTime = req.getEndTimestamp();
+        NotificationStyle style = req.getStyle();
+        NotificationTargetUser targetUser = req.getTargetUser();
+        String title = req.getTitle();
+        String message = req.getMessage();
+        String invalidTitle = "";
+        String invalidNotificationId = "InvalidNotificationId";
+
+        loginAsAdmin();
+
+        ______TS("Typical Case: Update notification successfully");
+        req = getTypicalUpdateRequest();
+        UpdateNotificationAction action = getAction(req, requestParams);
+        NotificationData res = (NotificationData) action.execute().getOutput();
+
+        NotificationAttributes updatedNotification = logic.getNotification(res.getNotificationId());
+
+        assertEquals(startTime, updatedNotification.getStartTime().toEpochMilli());
+        assertEquals(endTime, updatedNotification.getEndTime().toEpochMilli());
+        assertEquals(style, updatedNotification.getStyle());
+        assertEquals(targetUser, updatedNotification.getTargetUser());
+        assertEquals(title, updatedNotification.getTitle());
+        assertEquals(message, updatedNotification.getTitle());
+
+        ______TS("Parameters cannot be null");
+        req = getTypicalUpdateRequest();
+        req.setStyle(null);
+        InvalidHttpRequestBodyException ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("Notification style cannot be null", ex.getMessage());
+
+        req = getTypicalUpdateRequest();
+        req.setTargetUser(null);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("Notification target user cannot be null", ex.getMessage());
+
+        req = getTypicalUpdateRequest();
+        req.setTitle(null);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("Notification title cannot be null", ex.getMessage());
+
+        req = getTypicalUpdateRequest();
+        req.setMessage(null);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("Notification message cannot be null", ex.getMessage());
+
+        ______TS("Timestamps should be greater than 0");
+        req = getTypicalUpdateRequest();
+        req.setStartTimestamp(-1);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("Start timestamp should be greater than zero", ex.getMessage());
+
+        req = getTypicalUpdateRequest();
+        req.setEndTimestamp(-1);
+        ex = verifyHttpRequestBodyFailure(req, requestParams);
+        assertEquals("End timestamp should be greater than zero", ex.getMessage());
+
+        ______TS("Invalid parameter should throw an error");
+        req = getTypicalUpdateRequest();
+        req.setTitle(invalidTitle);
+        verifyHttpParameterFailure(req, requestParams);
+
+        ______TS("Non-existent notification should throw an error");
+        requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_ID, invalidNotificationId,
+        };
+        req = getTypicalUpdateRequest();
+        verifyHttpParameterFailure(req, requestParams);
+    }
+
+    @Override
+    protected void testAccessControl() throws Exception {
+        verifyOnlyAdminCanAccess();
+    }
+
+    private NotificationUpdateRequest getTypicalUpdateRequest() {
+        NotificationUpdateRequest req = new NotificationUpdateRequest();
+
+        req.setStartTimestamp(Instant.now().toEpochMilli());
+        req.setEndTimestamp(Instant.now().plus(5, ChronoUnit.MONTHS).toEpochMilli());
+        req.setStyle(NotificationStyle.INFO);
+        req.setTargetUser(NotificationTargetUser.GENERAL);
+        req.setTitle("New notification title");
+        req.setMessage("New notification message");
+
+        return req;
+    }
+}

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -3,6 +3,8 @@ package teammates.ui.webapi;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import org.testng.annotations.Test;
+
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.attributes.NotificationAttributes;
@@ -28,14 +30,13 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         return PUT;
     }
 
+    @Test
     @Override
     protected void testExecute() throws Exception {
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_ID, testNotificationAttribute.getNotificationId(),
         };
         NotificationUpdateRequest req = getTypicalUpdateRequest();
-        long startTime = req.getStartTimestamp();
-        long endTime = req.getEndTimestamp();
         NotificationStyle style = req.getStyle();
         NotificationTargetUser targetUser = req.getTargetUser();
         String title = req.getTitle();
@@ -52,12 +53,12 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
 
         NotificationAttributes updatedNotification = logic.getNotification(res.getNotificationId());
 
-        assertEquals(startTime, updatedNotification.getStartTime().toEpochMilli());
-        assertEquals(endTime, updatedNotification.getEndTime().toEpochMilli());
+        assertEquals(res.getStartTimestamp(), updatedNotification.getStartTime().toEpochMilli());
+        assertEquals(res.getEndTimestamp(), updatedNotification.getEndTime().toEpochMilli());
         assertEquals(style, updatedNotification.getStyle());
         assertEquals(targetUser, updatedNotification.getTargetUser());
         assertEquals(title, updatedNotification.getTitle());
-        assertEquals(message, updatedNotification.getTitle());
+        assertEquals(message, updatedNotification.getMessage());
 
         ______TS("Parameters cannot be null");
         req = getTypicalUpdateRequest();
@@ -94,16 +95,17 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         ______TS("Invalid parameter should throw an error");
         req = getTypicalUpdateRequest();
         req.setTitle(invalidTitle);
-        verifyHttpParameterFailure(req, requestParams);
+        verifyHttpRequestBodyFailure(req, requestParams);
 
         ______TS("Non-existent notification should throw an error");
         requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_ID, invalidNotificationId,
         };
         req = getTypicalUpdateRequest();
-        verifyHttpParameterFailure(req, requestParams);
+        verifyEntityNotFound(req, requestParams);
     }
 
+    @Test
     @Override
     protected void testAccessControl() throws Exception {
         verifyOnlyAdminCanAccess();
@@ -113,7 +115,7 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
         NotificationUpdateRequest req = new NotificationUpdateRequest();
 
         req.setStartTimestamp(Instant.now().toEpochMilli());
-        req.setEndTimestamp(Instant.now().plus(5, ChronoUnit.MONTHS).toEpochMilli());
+        req.setEndTimestamp(Instant.now().plus(5, ChronoUnit.DAYS).toEpochMilli());
         req.setStyle(NotificationStyle.INFO);
         req.setTargetUser(NotificationTargetUser.GENERAL);
         req.setTitle("New notification title");


### PR DESCRIPTION
Part of #11572

**Outline of Solution**
- Add tests for PUT and DELETE routes
- Add missing test annotation for `CreateNotificationAction` and fix test