### PR TITLE
[#11710] Instructor Help Page: Outdated search bar documentation

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -110,9 +110,6 @@
     </p>
     <ol>
       <li>
-        Tick the option <b>Students</b> below the search box.
-      </li>
-      <li>
         Type your search terms into the search bar. You can search for a student record based on:
         <ul>
           <li>Section name</li>


### PR DESCRIPTION
Removed the following line from the Instuctors help section
        `Tick the option <b>Students</b> below the search box.`

This PR is ready for review.

Fixes #11710 