### PR TITLE
[#11715] Selective Deadline Extension - Error in getting deadline extension entities possibly needing closing email 

### DIFF
--- a/src/main/appengine/index.yaml
+++ b/src/main/appengine/index.yaml
@@ -84,6 +84,6 @@ indexes:
 - kind: DeadlineExtension
   properties:
   - direction: asc
-    name: endTime
-  - direction: asc
     name: sentClosingEmail
+  - direction: asc
+    name: endTime


### PR DESCRIPTION
Fixes #11715 

**Outline of Solution**

Swapped ordering of properties as properties used in equality filters should come before those used in inequality filters.

See https://github.com/TEAMMATES/teammates/issues/11715#issuecomment-1094072639 and https://cloud.google.com/appengine/docs/standard/java-gen2/configuring-datastore-indexes-with-index-yaml#index_definitions.
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
