### PR TITLE
[#11729] Update supported browsers list + add IE deprecation warning

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -47,16 +47,22 @@
 <tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
 <div id="main-content" class="container main-content">
   <div *tmIsLoading="isFetchingAuthDetails">
-    <div *ngIf="isUnsupportedBrowser">
+    <div *ngIf="isUnsupportedBrowser && !isUsingIe">
       <div class="alert alert-danger" role="alert">
         <i class="fas fa-exclamation-circle"></i>&nbsp;You are currently using {{ browser }}. This web browser is not officially supported by TEAMMATES.
         In case this web browser does not display the webpage correctly you may wish to view it in the following supported browsers:
         <ol>
-          <li>Microsoft Internet Explorer {{ minimumVersions['IE'] }}+</li>
           <li>Chrome {{ minimumVersions['Chrome'] }}+</li>
+          <li>Edge {{ minimumVersions['Edge'] }}+</li>
           <li>Firefox {{ minimumVersions['Firefox'] }}+</li>
           <li>Safari {{ minimumVersions['Safari'] }}+</li>
         </ol>
+      </div>
+    </div>
+    <div *ngIf="isUsingIe">
+      <div class="alert alert-danger" role="alert">
+        <i class="fas fa-exclamation-circle"></i>&nbsp;You are currently using Internet Explorer (IE). TEAMMATES support for IE is not guaranteed and will be dropped on 30 June 2022.
+        You are recommended to use an up-to-date browser such as Chrome, Firefox, Edge, or Safari.
       </div>
     </div>
     <div *ngIf="(isNetworkOnline$ | async) === false">

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -50,6 +50,7 @@ export class PageComponent {
 
   isCollapsed: boolean = true;
   isUnsupportedBrowser: boolean = false;
+  isUsingIe: boolean = false;
   isCookieDisabled: boolean = false;
   browser: string = '';
   isNetworkOnline$: Observable<boolean>;
@@ -66,7 +67,6 @@ export class PageComponent {
    */
   minimumVersions: Record<string, number> = {
     Chrome: 45,
-    IE: 11,
     Firefox: 40,
     Safari: 7,
     Edge: 44,
@@ -117,6 +117,9 @@ export class PageComponent {
     this.browser = `${browser.name} ${browser.version}`;
     this.isUnsupportedBrowser = !this.minimumVersions[browser.name]
         || this.minimumVersions[browser.name] > parseInt(browser.major, 10);
+    if (browser.name === 'IE') {
+      this.isUsingIe = true;
+    }
     this.isCookieDisabled = !navigator.cookieEnabled;
   }
 

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -66,10 +66,10 @@ export class PageComponent {
    * Bootstrap 4 browser support: https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/
    */
   minimumVersions: Record<string, number> = {
-    Chrome: 45,
-    Firefox: 40,
-    Safari: 7,
-    Edge: 44,
+    Chrome: 87,
+    Firefox: 86,
+    Safari: 13,
+    Edge: 88,
   };
 
   constructor(private router: Router, private route: ActivatedRoute, private title: Title,


### PR DESCRIPTION
Part of #11729 

**Outline of Solution**

It is noteworthy that all the non-IE browsers we officially support (Chrome, Edge, Firefox, Safari) are evergreen browsers, i.e. self-updating.

- Updated the supported browsers list. While [Bootstrap](https://getbootstrap.com/docs/4.6/getting-started/browsers-devices/) mentions explicit minimum versions for the browsers, [Angular](https://v12.angular.io/guide/browser-support) only mentions "latest" or "2 most recent" versions, thus the risk of having broken front-end is not small, but at the same time not large because the browsers are self-updating anyway.
  - As the middle ground, the minimum version numbers are updated based on [browser market share in the past one year](https://gs.statcounter.com/browser-version-market-share/desktop/worldwide/). The version number is the oldest version number that has >= 1% market share on any month based on Mar'21-Mar'22 statistics.
  - IE11 unfortunately does belong to the above category. Although the number has dropped below 1% for the past six months, it still warrants us to give this early warning.
- Added warning that IE support is not guaranteed and will be dropped:
  <img width="1246" alt="Screenshot 2022-04-14 at 12 59 04 AM" src="https://user-images.githubusercontent.com/7261051/163232128-1915db86-8e99-470a-b4a2-4f7759c06fba.png">
