### PR TITLE
[#11572] Notification Feature - Add Mark As Read to Past Notification Page

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -109,7 +109,7 @@ public class Logic {
      * <p>Preconditions:</p>
      * * All parameters are non-null. {@code endTime} must be after current moment.
      */
-    public AccountAttributes updateReadNotifications(String googleId, String notificationId, Instant endTime)
+    public List<String> updateReadNotifications(String googleId, String notificationId, Instant endTime)
             throws InvalidParametersException, EntityDoesNotExistException {
         assert googleId != null;
         return accountsLogic.updateReadNotifications(googleId, notificationId, endTime);

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -266,7 +266,7 @@ public final class AccountsLogic {
      * @throws InvalidParametersException if the notification has expired.
      * @throws EntityDoesNotExistException if account or notification does not exist.
      */
-    public AccountAttributes updateReadNotifications(String googleId, String notificationId, Instant endTime)
+    public List<String> updateReadNotifications(String googleId, String notificationId, Instant endTime)
             throws InvalidParametersException, EntityDoesNotExistException {
         AccountAttributes a = accountsDb.getAccount(googleId);
 
@@ -290,9 +290,10 @@ public final class AccountsLogic {
 
         updatedReadNotifications.put(notificationId, endTime);
 
-        return accountsDb.updateAccount(
+        AccountAttributes accountAttributes = accountsDb.updateAccount(
                 AccountAttributes.updateOptionsBuilder(googleId)
                         .withReadNotifications(updatedReadNotifications)
                         .build());
+        return new ArrayList<>(accountAttributes.getReadNotifications().keySet());
     }
 }

--- a/src/main/java/teammates/ui/output/ReadNotificationsData.java
+++ b/src/main/java/teammates/ui/output/ReadNotificationsData.java
@@ -1,0 +1,29 @@
+package teammates.ui.output;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import teammates.common.datatransfer.attributes.AccountAttributes;
+
+/**
+ * Output format of read notifications.
+ */
+public class ReadNotificationsData extends ApiOutput {
+
+    private final Map<String, Long> readNotifications;
+
+    public ReadNotificationsData(AccountAttributes accountInfo) {
+        this.readNotifications = accountInfo.getReadNotifications()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey(),
+                        e -> e.getValue().toEpochMilli()
+                ));
+    }
+
+    public Map<String, Long> getReadNotifications() {
+        return this.readNotifications;
+    }
+
+}

--- a/src/main/java/teammates/ui/output/ReadNotificationsData.java
+++ b/src/main/java/teammates/ui/output/ReadNotificationsData.java
@@ -1,28 +1,19 @@
 package teammates.ui.output;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import teammates.common.datatransfer.attributes.AccountAttributes;
+import java.util.List;
 
 /**
  * Output format of read notifications.
  */
 public class ReadNotificationsData extends ApiOutput {
 
-    private final Map<String, Long> readNotifications;
+    private final List<String> readNotifications;
 
-    public ReadNotificationsData(AccountAttributes accountInfo) {
-        this.readNotifications = accountInfo.getReadNotifications()
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        e -> e.getKey(),
-                        e -> e.getValue().toEpochMilli()
-                ));
+    public ReadNotificationsData(List<String> notificationIds) {
+        this.readNotifications = notificationIds;
     }
 
-    public Map<String, Long> getReadNotifications() {
+    public List<String> getReadNotifications() {
         return this.readNotifications;
     }
 

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -86,6 +86,7 @@ public final class ActionFactory {
         map(ResourceURIs.NOTIFICATION, PUT, UpdateNotificationAction.class);
         map(ResourceURIs.NOTIFICATION, DELETE, DeleteNotificationAction.class);
         map(ResourceURIs.NOTIFICATION_READ, POST, MarkNotificationAsReadAction.class);
+        map(ResourceURIs.NOTIFICATION_READ, GET, GetReadNotificationsAction.class);
 
         // NOTIFICATIONS APIs
         map(ResourceURIs.NOTIFICATIONS, GET, GetNotificationsAction.class);

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -1,6 +1,7 @@
 package teammates.ui.webapi;
 
-import teammates.common.datatransfer.attributes.AccountAttributes;
+import java.util.List;
+
 import teammates.ui.output.ReadNotificationsData;
 
 /**
@@ -19,9 +20,9 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     public ActionResult execute() {
-        AccountAttributes accountAttributes =
-                logic.getAccount(userInfo.getId());
-        ReadNotificationsData output = new ReadNotificationsData(accountAttributes);
+        List<String> readNotifications =
+                logic.getReadNotificationsId(userInfo.getId());
+        ReadNotificationsData output = new ReadNotificationsData(readNotifications);
         return new JsonResult(output);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -5,7 +5,7 @@ import java.util.List;
 import teammates.ui.output.ReadNotificationsData;
 
 /**
- * Action: Gets read notifications in account entity.
+ * Action: Gets read notifications from account entity.
  */
 public class GetReadNotificationsAction extends Action {
     @Override

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -15,7 +15,7 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        // Any user can create a read status for notification.
+        // Any user can get the read notifications for their account.
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -1,0 +1,27 @@
+package teammates.ui.webapi;
+
+import teammates.common.datatransfer.attributes.AccountAttributes;
+import teammates.ui.output.ReadNotificationsData;
+
+/**
+ * Action: Gets read notifications in account entity.
+ */
+public class GetReadNotificationsAction extends Action {
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    void checkSpecificAccessControl() throws UnauthorizedAccessException {
+        // Any user can create a read status for notification.
+    }
+
+    @Override
+    public ActionResult execute() {
+        AccountAttributes accountAttributes =
+                logic.getAccount(userInfo.getId());
+        ReadNotificationsData output = new ReadNotificationsData(accountAttributes);
+        return new JsonResult(output);
+    }
+}

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -1,11 +1,11 @@
 package teammates.ui.webapi;
 
 import java.time.Instant;
+import java.util.List;
 
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.ui.output.AccountData;
+import teammates.ui.output.ReadNotificationsData;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
@@ -32,9 +32,9 @@ public class MarkNotificationAsReadAction extends Action {
         Instant endTime = Instant.ofEpochMilli(readNotificationCreateRequest.getEndTimestamp());
 
         try {
-            AccountAttributes accountAttributes =
+            List<String> readNotifications =
                     logic.updateReadNotifications(userInfo.getId(), notificationId, endTime);
-            AccountData output = new AccountData(accountAttributes);
+            ReadNotificationsData output = new ReadNotificationsData(readNotifications);
             return new JsonResult(output);
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);

--- a/src/test/java/teammates/logic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicTest.java
@@ -435,16 +435,19 @@ public class AccountsLogicTest extends BaseLogicTest {
 
         ______TS("success: mark notification as read and remove expired ones from read status");
 
-        AccountAttributes accountAttributes = accountsLogic.updateReadNotifications(
+        List<String> readNotificationIds = accountsLogic.updateReadNotifications(
                 instructor2OfCourse1.getGoogleId(),
                 notificationAttributes.getNotificationId(),
                 notificationAttributes.getEndTime());
-        Map<String, Instant> updatedReadNotifications = accountAttributes.getReadNotifications();
 
-        assertNotNull(updatedReadNotifications.get("notification4"));
-        assertEquals(notificationAttributes.getEndTime(), updatedReadNotifications.get("notification4"));
+        assertTrue(readNotificationIds.contains("notification4"));
 
-        for (Map.Entry<String, Instant> notification : updatedReadNotifications.entrySet()) {
+        AccountAttributes accountAttributes = accountsLogic.getAccount(instructor2OfCourse1.getGoogleId());
+        Map<String, Instant> readNotifications = accountAttributes.getReadNotifications();
+
+        assertEquals(notificationAttributes.getEndTime(), readNotifications.get("notification4"));
+
+        for (Map.Entry<String, Instant> notification : readNotifications.entrySet()) {
             assertTrue(notification.getValue().isAfter(Instant.now()));
         }
 

--- a/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
@@ -141,7 +141,8 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 UpdateNotificationAction.class,
                 DeleteNotificationAction.class,
                 GetNotificationsAction.class,
-                MarkNotificationAsReadAction.class
+                MarkNotificationAsReadAction.class,
+                GetReadNotificationsAction.class
         );
         List<String> expectedActionClassesNames = expectedActionClasses.stream()
                 .map(Class::getSimpleName)

--- a/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
@@ -1,6 +1,6 @@
 package teammates.ui.webapi;
 
-import java.util.Map;
+import java.util.List;
 
 import org.testng.annotations.Test;
 
@@ -33,9 +33,11 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
 
         ReadNotificationsData output = (ReadNotificationsData) jsonResult.getOutput();
 
-        Map<String, Long> readNotificationsData = output.getReadNotifications();
-        assertNotNull(readNotificationsData.get("notification1"));
-        assertNotNull(readNotificationsData.get("notification3"));
+        List<String> readNotificationsData = output.getReadNotifications();
+
+        assertTrue(readNotificationsData.contains("notification1"));
+        assertTrue(readNotificationsData.contains("notification3"));
+        assertEquals(2, readNotificationsData.size());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
@@ -1,0 +1,46 @@
+package teammates.ui.webapi;
+
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.ui.output.ReadNotificationsData;
+
+/**
+ * SUT: {@link GetReadNotificationsAction}.
+ */
+public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotificationsAction> {
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.NOTIFICATION_READ;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() {
+        ______TS("Typical success case: User request to fetch read notifications");
+        InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        loginAsInstructor(instructor.getGoogleId());
+        GetReadNotificationsAction action = getAction();
+        JsonResult jsonResult = getJsonResult(action);
+
+        ReadNotificationsData output = (ReadNotificationsData) jsonResult.getOutput();
+
+        Map<String, Long> readNotificationsData = output.getReadNotifications();
+        assertNotNull(readNotificationsData.get("notification1"));
+        assertNotNull(readNotificationsData.get("notification3"));
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() {
+        verifyAnyLoggedInUserCanAccess();
+    }
+}

--- a/src/test/java/teammates/ui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/ui/webapi/MarkNotificationAsReadActionTest.java
@@ -1,13 +1,13 @@
 package teammates.ui.webapi;
 
-import java.util.Map;
+import java.util.List;
 
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.util.Const;
-import teammates.ui.output.AccountData;
+import teammates.ui.output.ReadNotificationsData;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
 /**
@@ -38,9 +38,9 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
                 notification.getNotificationId(), notification.getEndTime().toEpochMilli());
         MarkNotificationAsReadAction action = getAction(reqBody);
         JsonResult actionOutput = getJsonResult(action);
-        AccountData response = (AccountData) actionOutput.getOutput();
-        Map<String, Long> readNotifications = response.getReadNotifications();
-        assertTrue(readNotifications.containsKey(notification.getNotificationId()));
+        ReadNotificationsData response = (ReadNotificationsData) actionOutput.getOutput();
+        List<String> readNotifications = response.getReadNotifications();
+        assertTrue(readNotifications.contains(notification.getNotificationId()));
 
         ______TS("Invalid case: mark non-existent notification as read");
         reqBody = new MarkNotificationAsReadRequest("invalid id", notification.getEndTime().toEpochMilli());

--- a/src/web/app/components/notification-banner/notification-banner.component.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.ts
@@ -35,6 +35,7 @@ export class NotificationBannerComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(): void {
+    // Hide the notification banner if the user is on user notifications page
     if (this.url.includes('notifications')) {
       this.closeNotification();
     }

--- a/src/web/app/components/notification-banner/notification-banner.component.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { NotificationService } from '../../../services/notification.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { Notification, Notifications, NotificationTargetUser } from '../../../types/api-output';
@@ -14,7 +14,10 @@ import { collapseAnim } from '../teammates-common/collapse-anim';
   styleUrls: ['./notification-banner.component.scss'],
   animations: [collapseAnim],
 })
-export class NotificationBannerComponent implements OnInit {
+export class NotificationBannerComponent implements OnInit, OnChanges {
+
+  @Input()
+  url: string = '';
 
   @Input()
   notificationTargetUser: NotificationTargetUser = NotificationTargetUser.GENERAL;
@@ -28,6 +31,12 @@ export class NotificationBannerComponent implements OnInit {
   ngOnInit(): void {
     if (this.notificationTargetUser !== NotificationTargetUser.GENERAL) {
       this.fetchNotifications();
+    }
+  }
+
+  ngOnChanges(): void {
+    if (this.url.includes('notifications')) {
+      this.closeNotification();
     }
   }
 

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -30,6 +30,11 @@
           <div class="card-body">
             <div [innerHtml]="notificationTab.notification.message"></div>
           </div>
+          <div class="d-flex flex-row ml-3 mb-3" *ngIf="!notificationTab.isRead">
+            <button id="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
+              Mark as Read
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -19,18 +19,18 @@
   <ng-container>
     <div class="notification-tabs" *ngFor="let notificationTab of notificationTabs">
       <div class="card">
-        <div class="card-header cursor-pointer" [ngClass]="notificationTab.notification.style | notificationStyleClass" (click)="toggleCard(notificationTab)">
+        <div class="card-header cursor-pointer mb-0" [ngClass]="notificationTab.notification.style | notificationStyleClass" (click)="toggleCard(notificationTab)">
           <strong class="text-break">{{notificationTab.notification.title}} [{{notificationTab.startDate}} - {{notificationTab.endDate}}]</strong>
           <div class="card-header-btn-toolbar">
             <tm-panel-chevron [isExpanded]="notificationTab.hasTabExpanded"></tm-panel-chevron>
           </div>
         </div>
 
-        <div *ngIf="notificationTab.hasTabExpanded" @collapseAnim>
-          <div class="card-body">
+        <div class="mb-0" *ngIf="notificationTab.hasTabExpanded" @collapseAnim>
+          <div [ngClass]="getBodyTextClass(notificationTab)">
             <div [innerHtml]="notificationTab.notification.message"></div>
           </div>
-          <div class="d-flex flex-row ml-3 mb-3" *ngIf="!notificationTab.isRead">
+          <div class="d-flex flex-row-reverse mr-4 mb-3" *ngIf="!notificationTab.isRead">
             <button id="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
               Mark as Read
             </button>

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -5,7 +5,6 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { TableComparatorService } from '../../../services/table-comparator.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
-  Account,
   Notification,
   Notifications,
   NotificationTargetUser,
@@ -109,8 +108,8 @@ export class UserNotificationsListComponent implements OnInit {
       endTimestamp: notification.endTimestamp,
     })
       .subscribe(
-        (account: Account) => {
-          this.readNotifications = new Set(Object.keys(account.readNotifications));
+        (readNotifications: ReadNotifications) => {
+          this.readNotifications = new Set(readNotifications.readNotifications);
           notificationTab.isRead = true;
           this.statusMessageService.showSuccessToast('Notification marked as read.');
           notificationTab.hasTabExpanded = false;

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -4,7 +4,13 @@ import { NotificationService } from '../../../services/notification.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { TableComparatorService } from '../../../services/table-comparator.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import { Notification, Notifications, NotificationTargetUser } from '../../../types/api-output';
+import {
+  Account,
+  Notification,
+  Notifications,
+  NotificationTargetUser,
+  ReadNotifications,
+} from '../../../types/api-output';
 import { SortBy, SortOrder } from '../../../types/sort-properties';
 import { ErrorMessageOutput } from '../../error-message-output';
 import { collapseAnim } from '../teammates-common/collapse-anim';
@@ -12,6 +18,7 @@ import { collapseAnim } from '../teammates-common/collapse-anim';
 interface NotificationTab {
   notification: Notification;
   hasTabExpanded: boolean;
+  isRead: boolean;
   startDate: string;
   endDate: string;
 }
@@ -36,6 +43,7 @@ export class UserNotificationsListComponent implements OnInit {
 
   notificationTabs: NotificationTab[] = [];
   notificationsSortBy: SortBy = SortBy.NONE;
+  readNotifications: Set<String> = new Set();
 
   isLoadingNotifications: boolean = false;
   hasLoadingFailed: boolean = false;
@@ -56,13 +64,24 @@ export class UserNotificationsListComponent implements OnInit {
   loadNotifications(): void {
     this.hasLoadingFailed = false;
     this.isLoadingNotifications = true;
+
+    this.notificationService.getReadNotifications()
+      .subscribe((readNotifications: ReadNotifications) => {
+        this.readNotifications = new Set(readNotifications.readNotifications);
+      }, (resp: ErrorMessageOutput) => {
+        this.hasLoadingFailed = true;
+        this.statusMessageService.showErrorToast(resp.error.message);
+      },
+    );
+
     this.notificationService.getAllNotificationsForTargetUser(this.userType)
       .pipe(finalize(() => { this.isLoadingNotifications = false; }))
       .subscribe((notifications: Notifications) => {
           notifications.notifications.forEach((notification: Notification) => {
             this.notificationTabs.push({
               notification,
-              hasTabExpanded: true,
+              hasTabExpanded: !this.readNotifications.has(notification.notificationId),
+              isRead: this.readNotifications.has(notification.notificationId),
               startDate: this.timezoneService.formatToString(
                 notification.startTimestamp, this.timezone, this.DATE_FORMAT,
               ),
@@ -81,6 +100,29 @@ export class UserNotificationsListComponent implements OnInit {
 
   toggleCard(notificationTab: NotificationTab): void {
     notificationTab.hasTabExpanded = !notificationTab.hasTabExpanded;
+  }
+
+  markNotificationAsRead(notificationTab: NotificationTab): void {
+    const notification: Notification = notificationTab.notification;
+    this.notificationService.markNotificationAsRead({
+      notificationId: notification.notificationId,
+      endTimestamp: notification.endTimestamp,
+    })
+      .subscribe(
+        (account: Account) => {
+          this.readNotifications = new Set(Object.keys(account.readNotifications));
+          notificationTab.isRead = true;
+          this.statusMessageService.showSuccessToast('Notification marked as read.');
+          notificationTab.hasTabExpanded = false;
+        },
+        (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      );
+  }
+
+  getButtonClass(notificationTab: NotificationTab): string {
+    return `btn btn-${notificationTab.notification.style.toLowerCase()}`;
   }
 
   /**

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -121,6 +121,10 @@ export class UserNotificationsListComponent implements OnInit {
       );
   }
 
+  getBodyTextClass(notificationTab: NotificationTab): string {
+    return notificationTab.isRead ? 'card-body' : 'card-body pb-0';
+  }
+
   getButtonClass(notificationTab: NotificationTab): string {
     return `btn btn-${notificationTab.notification.style.toLowerCase()}`;
   }

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -42,7 +42,7 @@
     </ul>
   </div>
 </nav>
-<tm-notification-banner *ngIf="notificationTargetUser !== NotificationTargetUser.GENERAL" [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
+<tm-notification-banner *ngIf="notificationTargetUser !== NotificationTargetUser.GENERAL" [url]="getUrl()" [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
 <tm-loader-bar></tm-loader-bar>
 <tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
 <div id="main-content" class="container main-content">

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -144,6 +144,13 @@ export class PageComponent {
       this.ngbModal.dismissAll();
     }
   }
+
+  /**
+   * Method to get the url of the current route.
+   */
+  getUrl(): string {
+    return this.router.url;
+  }
 }
 
 /**

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -93,6 +93,6 @@ export class NotificationService {
    * Retrieves read notifications for the user.
    */
   getReadNotifications(): Observable<ReadNotifications> {
-    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATION_READ, {});
+    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATION_READ);
   }
 }

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ResourceEndpoints } from '../types/api-const';
 import {
-  Account,
   MessageOutput,
   Notification,
   Notifications,
@@ -63,14 +62,14 @@ export class NotificationService {
   /**
    * Marks a notification as read.
    */
-  markNotificationAsRead(request: MarkNotificationAsReadRequest): Observable<Account> {
+  markNotificationAsRead(request: MarkNotificationAsReadRequest): Observable<ReadNotifications> {
     return this.httpRequestService.post(ResourceEndpoints.NOTIFICATION_READ, {}, request);
   }
 
   /**
    * Retrieves unread notifications for a specific target user type.
    */
-   getUnreadNotificationsForTargetUser(userType: NotificationTargetUser): Observable<Notifications> {
+  getUnreadNotificationsForTargetUser(userType: NotificationTargetUser): Observable<Notifications> {
     const paramMap: Record<string, string> = {
       usertype: userType,
       isfetchingall: 'false',

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -1,7 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ResourceEndpoints } from '../types/api-const';
-import { Account, MessageOutput, Notification, Notifications, NotificationTargetUser } from '../types/api-output';
+import {
+  Account,
+  MessageOutput,
+  Notification,
+  Notifications,
+  NotificationTargetUser,
+  ReadNotifications,
+} from '../types/api-output';
 import {
   MarkNotificationAsReadRequest,
   NotificationCreateRequest,
@@ -80,5 +87,12 @@ export class NotificationService {
       isfetchingall: 'true',
     };
     return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS, paramMap);
+  }
+
+  /**
+   * Retrieves read notifications for the user.
+   */
+  getReadNotifications(): Observable<ReadNotifications> {
+    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATION_READ, {});
   }
 }


### PR DESCRIPTION
Part of #11572 

This PR is based on changes in #11720 for styles.

**Outline of Solution**

* Add a GET API Route `GetReadNotificationsAction` to retrieve read notification ids for the user.
* Add relevant backend tests for `GetReadNotificationsAction`.
* Add mark as read button to past notification page, such that once a user marks a notification as read, the button will disappear and the tab will close (See the demo below).
* * Notification tab that has been marked as read will by default be closed.


https://user-images.githubusercontent.com/69516975/163303433-d3a8013c-4c0f-4b55-bfdc-001d4f5f19fc.mov




