### PR TITLE
[#11732] Broken PUML diagrams in developer guide

### DIFF
--- a/.github/workflows/dev-docs.yml
+++ b/.github/workflows/dev-docs.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+      - name: Install Graphviz
+        run: sudo apt install graphviz
       - run: npm ci
       - run: npm run build
       - name: Check build status

--- a/.github/workflows/dev-docs.yml
+++ b/.github/workflows/dev-docs.yml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
       - name: Install Graphviz
         run: sudo apt install graphviz
       - run: npm ci

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -13,6 +13,11 @@ All the commands in this document are assumed to be run from the `/docs` folder,
 1. Install `Node.js` (minimum version 12).
 1. Run `npm ci` to install the necessary tools to build documentation, including MarkBind.
 
+Install the following additional dependencies required by MarkBind to generate [PlantUML](https://plantuml.com/) diagrams locally:
+
+1. Install [Java](https://www.java.com/en/download/) 8 (or later).
+1. Install [Graphviz](https://www.graphviz.org/download/) v2.38 (or later).
+
 <box type="tip" light>
 
 You can also use a globally installed MarkBind if you have one. Make sure to use version `3.*.*`.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -15,7 +15,7 @@ All the commands in this document are assumed to be run from the `/docs` folder,
 
 Install the following additional dependencies required by MarkBind to generate [PlantUML](https://plantuml.com/) diagrams locally:
 
-1. Install [Java](https://www.java.com/en/download/) 8 (or later).
+1. Install Java 8 or later.
 1. Install [Graphviz](https://www.graphviz.org/download/) v2.38 (or later).
 
 <box type="tip" light>


### PR DESCRIPTION
Fixes #11732
Supersedes and hence closes ##11733

**Outline of Solution**
PlantUML diagrams are used in dev docs (Design), which MarkBind requires both Java and Graphviz to be installed, in order to generate these diagrams on build.

Let's add an installation step for Graphviz (Java is available by default since we use `ubuntu-lastest`) in CI such that the diagrams can be generated before deploying to gh-pages.
Let's also include such details in our dev docs (Documentation), to remind developers who intend to contribute to teammates' documentation to install the required dependencies.

The expected outcome of the dev docs page on "design" (that contains broken images) is available at this [link](https://tlylt.github.io/test-docs/design.html) for inspection.

**Others**
There are also some additional issues reported/found such as
- readme does not refer to the deployed dev docs
- pull request template does not refer to the deployed dev docs
- The issue bot does not refer to the deployed dev docs

Will make separate issues for these.