### PR TITLE
[#11572] Notification feature - Fix permission problem for instructors

### DIFF
--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -35,8 +35,8 @@ public class GetNotificationsAction extends Action {
             throw new InvalidHttpParameterException(targetUserErrorMessage);
         }
         NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-        if (targetUser == NotificationTargetUser.INSTRUCTOR && userInfo.isStudent
-                || targetUser == NotificationTargetUser.STUDENT && userInfo.isInstructor) {
+        if (targetUser == NotificationTargetUser.INSTRUCTOR && !userInfo.isInstructor
+                || targetUser == NotificationTargetUser.STUDENT && !userInfo.isStudent) {
             throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
         }
     }

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -1,5 +1,5 @@
-<div class="row mb-3" *tmIsLoading="isLoadingNotifications">
-  <div class="col-12" *ngIf="notificationTabs.length > 0">
+<div class="row mb-3" *ngIf="notificationTabs.length > 0">
+  <div class="col-12">
     <div class="float-right">
       <strong class="d-inline"> Sort By: </strong>
       <div class="btn-group" data-toggle="buttons">

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -42,7 +42,7 @@
     </ul>
   </div>
 </nav>
-<tm-notification-banner *ngIf="(notificationTargetUser !== NotificationTargetUser.GENERAL) && (isStudent || isInstructor)"
+<tm-notification-banner *ngIf="isStudent || isInstructor"
                         [url]="getUrl()"
                         [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
 <tm-loader-bar></tm-loader-bar>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -42,7 +42,9 @@
     </ul>
   </div>
 </nav>
-<tm-notification-banner *ngIf="notificationTargetUser !== NotificationTargetUser.GENERAL" [url]="getUrl()" [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
+<tm-notification-banner *ngIf="(notificationTargetUser !== NotificationTargetUser.GENERAL) && (isStudent || isInstructor)"
+                        [url]="getUrl()"
+                        [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
 <tm-loader-bar></tm-loader-bar>
 <tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
 <div id="main-content" class="container main-content">


### PR DESCRIPTION
Part of #11572

This fixes the problem that a non-admin instructor has no permission to fetch any notification.

Also, it prevents a user that is neither student nor instructor (e.g. someone logs in with an email address not registered for any courses) to load the notification banner component. It removes banner for this situation:

![image](https://user-images.githubusercontent.com/10681776/163530551-d6c1818e-6a86-4d92-99cc-b1e574cc39d4.png)

Also, this removes duplicated loading spinner at the notification page for both students and instructors.
