### PR TITLE
[#11572] Notification Feature - Remove notif banner sticky behaviour

### DIFF
--- a/src/web/app/components/notification-banner/notification-banner.component.scss
+++ b/src/web/app/components/notification-banner/notification-banner.component.scss
@@ -1,26 +1,9 @@
 .banner {
-  position: sticky;
-  top: 70px;
-  margin: 0 5rem;
   padding: 1.875rem 1.875rem 1.25rem;
-  z-index: 900;
   word-break: break-word;
 }
 
 .banner-text {
   max-height: 80px;
   overflow-y: auto;
-}
-
-@media (max-width: 1024px) {
-  .banner {
-    margin: 0 1.25rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .banner {
-    top: 50px;
-    margin: 0;
-  }
 }

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -42,12 +42,12 @@
     </ul>
   </div>
 </nav>
-<tm-notification-banner *ngIf="isStudent || isInstructor"
-                        [url]="getUrl()"
-                        [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
 <tm-loader-bar></tm-loader-bar>
 <tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
 <div id="main-content" class="container main-content">
+  <tm-notification-banner *ngIf="isStudent || isInstructor"
+                          [url]="getUrl()"
+                          [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
   <div *tmIsLoading="isFetchingAuthDetails">
     <div *ngIf="isUnsupportedBrowser && !isUsingIe">
       <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
Part of #11572 

Removes sticky behaviour of notification banner due to a bug in Safari 14 that causes `position: sticky` to not work properly.
