### PR TITLE
[#11572] Add notification banner E2E test (General E2E test case)

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/NotificationBannerE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationBannerE2ETest.java
@@ -1,0 +1,81 @@
+package teammates.e2e.cases;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.AccountAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.pageobjects.PageWithNotificationBanner;
+
+/**
+ * SUT: Pages that can display notification banners.
+ * Used in this test and arbitrarily chosen {@link Const.WebPageURIs#STUDENT_HOME_PAGE},
+ * {@link Const.WebPageURIs#STUDENT_PROFILE_PAGE}, {@link Const.WebPageURIs#STUDENT_NOTIFICATIONS_PAGE}
+ */
+public class NotificationBannerE2ETest extends BaseE2ETestCase {
+    @Override
+    protected void prepareTestData() {
+        testData = loadDataBundle("/NotificationBannerE2ETest.json");
+        removeAndRestoreDataBundle(testData);
+    }
+
+    @Test
+    @Override
+    protected void testAll() {
+        AccountAttributes account = testData.accounts.get("NotifBanner.student");
+        NotificationAttributes notification = testData.notifications.get("notification1");
+        AppUrl studentHomePageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
+        PageWithNotificationBanner page = loginToPage(studentHomePageUrl, PageWithNotificationBanner.class,
+                account.getGoogleId());
+
+        ______TS("verify that active notifications with correct information are shown");
+        page.verifyNotificationBannerIsVisible(notification);
+
+        ______TS("close notification");
+        // After user closes a notification banner, it should not appear till user refreshes page
+        page.clickCloseNotificationBannerButton();
+        page.verifyNotificationBannerIsNotVisible();
+        page.clickHelpPageNavLink();
+        page.verifyNotificationBannerIsNotVisible();
+        page.reloadPage();
+        page.verifyNotificationBannerIsVisible(notification);
+
+        ______TS("navigating to notifications page closes notification banner");
+        page.clickHomePageNavLink();
+        page.reloadPage();
+        page.verifyNotificationBannerIsVisible(notification);
+
+        // After user visits notification page, it should not appear till user refreshes page
+        page.clickNotificationPageNavLink();
+        page.verifyNotificationBannerIsNotVisible();
+        page.clickHomePageNavLink();
+        page.verifyNotificationBannerIsNotVisible();
+        page.reloadPage();
+        page.verifyNotificationBannerIsVisible(notification);
+
+        ______TS("mark notification as read");
+        page.clickHomePageNavLink();
+        page.reloadPage();
+        page.verifyNotificationBannerIsVisible(notification);
+        page.clickMarkAsReadButton();
+        page.verifyStatusMessage("Notification marked as read.");
+        page.verifyNotificationBannerIsNotVisible();
+
+        Map<String, Instant> readNotifications = new HashMap<>();
+        readNotifications.put(notification.getNotificationId(), notification.getEndTime());
+
+        account.setReadNotifications(readNotifications);
+        verifyPresentInDatabase(account);
+
+        ______TS("delete test notifications from database");
+        for (NotificationAttributes n : testData.notifications.values()) {
+            BACKDOOR.deleteNotification(n.getNotificationId());
+            verifyAbsentInDatabase(n);
+        }
+    }
+}

--- a/src/e2e/java/teammates/e2e/pageobjects/PageWithNotificationBanner.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/PageWithNotificationBanner.java
@@ -1,0 +1,85 @@
+package teammates.e2e.pageobjects;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+
+/**
+ * Page Object Model for page that can display notification banners.
+ */
+public class PageWithNotificationBanner extends AppPage {
+    @FindBy(tagName = "tm-notification-banner")
+    private WebElement bannerContainer;
+
+    @FindBy(id = "btn-close-notif")
+    private WebElement closeNotifButton;
+
+    @FindBy(id = "btn-mark-as-read")
+    private WebElement markNotifAsReadButton;
+
+    public PageWithNotificationBanner(Browser browser) {
+        super(browser);
+    }
+
+    @Override
+    protected boolean containsExpectedPageContents() {
+        // Notification Banner can appear on any page except for the past notification page
+        String pageTitle = getPageTitle();
+        return !"Instructor Notifications".equals(pageTitle) || !"Student Notifications".equals(pageTitle);
+    }
+
+    public void verifyNotificationBannerIsNotVisible() {
+        List<WebElement> bannerContent = bannerContainer.findElements(By.id("banner-contents"));
+        assertEquals(0, bannerContent.size());
+    }
+
+    public void verifyNotificationBannerIsVisible(NotificationAttributes notification) {
+        List<WebElement> bannerContent = bannerContainer.findElements(By.id("banner-contents"));
+        String title = bannerContainer.findElement(By.tagName("h5")).getText();
+        String message = bannerContainer.findElement(By.className("banner-text")).getText();
+
+        assertEquals(1, bannerContent.size());
+        assertEquals(notification.getTitle(), title);
+        assertEquals(removeParagraphTag(notification.getMessage()), message);
+    }
+
+    public String removeParagraphTag(String message) {
+        return message.replace("<p>", "").replace("</p>", "");
+    }
+
+    public void clickCloseNotificationBannerButton() {
+        waitForElementToBeClickable(closeNotifButton);
+        click(closeNotifButton);
+        waitUntilAnimationFinish();
+    }
+
+    public void clickMarkAsReadButton() {
+        waitForElementToBeClickable(markNotifAsReadButton);
+        click(markNotifAsReadButton);
+        waitUntilAnimationFinish();
+    }
+
+    public void clickHomePageNavLink() {
+        waitForPageToLoad();
+        click(By.linkText("Home"));
+        waitUntilAnimationFinish();
+    }
+
+    public void clickNotificationPageNavLink() {
+        waitForPageToLoad();
+        click(By.linkText("Notifications"));
+        waitUntilAnimationFinish();
+    }
+
+    public void clickHelpPageNavLink() {
+        waitForPageToLoad();
+        click(By.linkText("Help"));
+        waitUntilAnimationFinish();
+    }
+}

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -210,7 +210,7 @@ public class TestDataValidityTest extends BaseTestCase {
                 .replace("Confirmation", "Conf")
                 .replace("Profile", "Prof")
                 .replace("Reminders", "Rem")
-                .replace("Notifications", "Notifs");
+                .replace("Notification", "Notif");
 
         // Shorten question types
         shortenedTestPage = shortenedTestPage

--- a/src/e2e/resources/data/NotificationBannerE2ETest.json
+++ b/src/e2e/resources/data/NotificationBannerE2ETest.json
@@ -1,0 +1,86 @@
+{
+  "accounts": {
+    "NotifBanner.instructor": {
+      "googleId": "tm.e2e.NotifBanner.instructor",
+      "name": "Teammates Test Instructor",
+      "email": "NotifBanner.instructor@gmail.tmt",
+      "readNotifications": {}
+    },
+    "NotifBanner.student": {
+      "googleId": "tm.e2e.NotifBanner.student",
+      "name": "Teammates Test Student",
+      "email": "NotifBanner.student@gmail.tmt",
+      "readNotifications": {}
+    }
+  },
+  "courses": {
+    "typicalCourse1": {
+      "id": "tm.e2e.NotifBanner.course1",
+      "name": "Typical Course 1",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg"
+    }
+  },
+  "instructors": {
+    "teammates.test.CS2104": {
+      "googleId": "tm.e2e.NotifBanner.instructor",
+      "courseId": "tm.e2e.NotifBanner.CS2104",
+      "name": "Teammates Test Instructor",
+      "email": "NotifBanner.instructor@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    }
+  },
+  "students": {
+    "SNotifications.student": {
+      "googleId": "tm.e2e.NotifBanner.student",
+      "email": "NotifBanner.student@gmail.tmt",
+      "course": "tm.e2e.NotifBanner.course1",
+      "name": "Amy Betsy</option></td></div>'\"",
+      "comments": "This student's name is Amy Betsy</option></td></div>'\"",
+      "team": "Team 1</td></div>'\"",
+      "section": "None"
+    }
+  },
+  "notifications": {
+    "notification1": {
+      "notificationId": "notification1",
+      "startTime": "2011-01-01T00:00:00Z",
+      "endTime": "2099-01-01T00:00:00Z",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "updatedAt": "2011-01-01T00:00:00Z",
+      "style": "DANGER",
+      "targetUser": "GENERAL",
+      "title": "A deprecation note",
+      "message": "<p>Deprecation happens in three minutes</p>",
+      "shown": false
+    },
+    "notification2": {
+      "notificationId": "notification2",
+      "startTime": "2011-01-01T00:00:00Z",
+      "endTime": "2099-01-01T00:00:00Z",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "updatedAt": "2011-01-01T00:00:00Z",
+      "style": "INFO",
+      "targetUser": "STUDENT",
+      "title": "New Update",
+      "message": "<p>Information on new update</p>",
+      "shown": false
+    }
+  }
+}

--- a/src/e2e/resources/testng-e2e.xml
+++ b/src/e2e/resources/testng-e2e.xml
@@ -41,6 +41,7 @@
             <class name="teammates.e2e.cases.InstructorSearchPageE2ETest" />
             <class name="teammates.e2e.cases.InstructorStudentListPageE2ETest" />
             <class name="teammates.e2e.cases.InstructorStudentRecordsPageE2ETest" />
+            <class name="teammates.e2e.cases.NotificationBannerE2ETest" />
             <class name="teammates.e2e.cases.StudentCourseDetailsPageE2ETest" />
             <class name="teammates.e2e.cases.StudentCourseJoinConfirmationPageE2ETest" />
             <class name="teammates.e2e.cases.StudentHomePageE2ETest" />

--- a/src/web/app/components/notification-banner/notification-banner.component.html
+++ b/src/web/app/components/notification-banner/notification-banner.component.html
@@ -1,4 +1,4 @@
-<div class="banner" [ngClass]="notifications[0].style | notificationStyleClass" *ngIf="isShown && notifications.length > 0" @collapseAnim>
+<div id="banner-contents" class="banner" [ngClass]="notifications[0].style | notificationStyleClass" *ngIf="isShown && notifications.length > 0" @collapseAnim>
   <button id="btn-close-notif" type="button" class="close" aria-label="Close" (click)="closeNotification()">
     <span aria-hidden="true">&times;</span>
   </button>


### PR DESCRIPTION
Part of #11572

**Outline of Solution**
Added E2E tests that test the notification banner functionality.

Since the notification banner can be found on a few pages, I had to use a general page object called `PageWithNotificationBanner` object. I have tested the banner using a student account (chosen instead of instructor for no particular reason) across 3 pages, home page, notification page and help page since these pages are shared with the instructor and is sufficient to test the notification banner functionality.