### PR TITLE
[#11551] Fix incorrect loading message (rework)

### DIFF
--- a/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
@@ -175,123 +175,125 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <thead>
-              <tr>
-                <th>
-                  Session Name
-                </th>
-                <th>
-                  Deadline
-                </th>
-                <th>
-                  Submissions
-                </th>
-                <th>
-                  Responses
-                </th>
-                <th>
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  First Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <thead>
+                <tr>
+                  <th>
+                    Session Name
+                  </th>
+                  <th>
+                    Deadline
+                  </th>
+                  <th>
+                    Submissions
+                  </th>
+                  <th>
+                    Responses
+                  </th>
+                  <th>
+                    Action(s)
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Submitted 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+                    First Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Submitted 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Not Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right disabled"
+                      href="/web/student/sessions/result?courseid=CS1231&fsname=First%20Session"
+                      id="view-responses-btn-0"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=CS1231&fsname=First%20Session"
+                      id="edit-submit-btn-0"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       Edit Submission 
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Not Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right disabled"
-                    href="/web/student/sessions/result?courseid=CS1231&fsname=First%20Session"
-                    id="view-responses-btn-0"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=CS1231&fsname=First%20Session"
-                    id="edit-submit-btn-0"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     Edit Submission 
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  Second Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Closed 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Not Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right disabled"
-                    href="/web/student/sessions/result?courseid=CS1231&fsname=Second%20Session"
-                    id="view-responses-btn-1"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=CS1231&fsname=Second%20Session"
-                    id="view-submit-btn-1"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     View Submission 
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                    Second Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Closed 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Not Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right disabled"
+                      href="/web/student/sessions/result?courseid=CS1231&fsname=Second%20Session"
+                      id="view-responses-btn-1"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=CS1231&fsname=Second%20Session"
+                      id="view-submit-btn-1"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       View Submission 
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
       <div
         class="card bg-light top-padded"
@@ -317,123 +319,125 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <thead>
-              <tr>
-                <th>
-                  Session Name
-                </th>
-                <th>
-                  Deadline
-                </th>
-                <th>
-                  Submissions
-                </th>
-                <th>
-                  Responses
-                </th>
-                <th>
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  Third Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <thead>
+                <tr>
+                  <th>
+                    Session Name
+                  </th>
+                  <th>
+                    Deadline
+                  </th>
+                  <th>
+                    Submissions
+                  </th>
+                  <th>
+                    Responses
+                  </th>
+                  <th>
+                    Action(s)
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Submitted 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+                    Third Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Submitted 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Not Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right disabled"
+                      href="/web/student/sessions/result?courseid=LSM1306&fsname=Third%20Session"
+                      id="view-responses-btn-0"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=LSM1306&fsname=Third%20Session"
+                      id="edit-submit-btn-0"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       Edit Submission 
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Not Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right disabled"
-                    href="/web/student/sessions/result?courseid=LSM1306&fsname=Third%20Session"
-                    id="view-responses-btn-0"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=LSM1306&fsname=Third%20Session"
-                    id="edit-submit-btn-0"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     Edit Submission 
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  Fourth Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Closed 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Not Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right disabled"
-                    href="/web/student/sessions/result?courseid=LSM1306&fsname=Fourth%20Session"
-                    id="view-responses-btn-1"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=LSM1306&fsname=Fourth%20Session"
-                    id="view-submit-btn-1"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     View Submission 
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                    Fourth Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Closed 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Not Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right disabled"
+                      href="/web/student/sessions/result?courseid=LSM1306&fsname=Fourth%20Session"
+                      id="view-responses-btn-1"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=LSM1306&fsname=Fourth%20Session"
+                      id="view-submit-btn-1"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       View Submission 
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
     </div>
   </tm-loading-retry>
@@ -568,123 +572,125 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <thead>
-              <tr>
-                <th>
-                  Session Name
-                </th>
-                <th>
-                  Deadline
-                </th>
-                <th>
-                  Submissions
-                </th>
-                <th>
-                  Responses
-                </th>
-                <th>
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  First Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <thead>
+                <tr>
+                  <th>
+                    Session Name
+                  </th>
+                  <th>
+                    Deadline
+                  </th>
+                  <th>
+                    Submissions
+                  </th>
+                  <th>
+                    Responses
+                  </th>
+                  <th>
+                    Action(s)
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Submitted 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
+                    First Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Submitted 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right"
+                      href="/web/student/sessions/result?courseid=CS2103&fsname=First%20Session"
+                      id="view-responses-btn-0"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=CS2103&fsname=First%20Session"
+                      id="edit-submit-btn-0"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       Edit Submission 
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td
+                    class="text-break"
                   >
-                     Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right"
-                    href="/web/student/sessions/result?courseid=CS2103&fsname=First%20Session"
-                    id="view-responses-btn-0"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=CS2103&fsname=First%20Session"
-                    id="edit-submit-btn-0"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     Edit Submission 
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td
-                  class="text-break"
-                >
-                  Second Session
-                </td>
-                <td>
-                  <span>
-                     Sat, 02 Feb 2019, 04:15 PM +08 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Pending 
-                  </span>
-                </td>
-                <td>
-                  <span
-                    class="ngb-tooltip-class"
-                  >
-                     Not Published 
-                  </span>
-                </td>
-                <td>
-                  <a
-                    class="btn btn-light btn-sm btn-margin-right disabled"
-                    href="/web/student/sessions/result?courseid=CS2103&fsname=Second%20Session"
-                    id="view-responses-btn-1"
-                    tmrouterlink="/web/student/sessions/result"
-                  >
-                     View Responses 
-                  </a>
-                  <a
-                    class="btn btn-light btn-sm"
-                    href="/web/student/sessions/submission?courseid=CS2103&fsname=Second%20Session"
-                    id="start-submit-btn-1"
-                    tmrouterlink="/web/student/sessions/submission"
-                  >
-                     Start Submission 
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                    Second Session
+                  </td>
+                  <td>
+                    <span>
+                       Sat, 02 Feb 2019, 04:15 PM +08 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Pending 
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      class="ngb-tooltip-class"
+                    >
+                       Not Published 
+                    </span>
+                  </td>
+                  <td>
+                    <a
+                      class="btn btn-light btn-sm btn-margin-right disabled"
+                      href="/web/student/sessions/result?courseid=CS2103&fsname=Second%20Session"
+                      id="view-responses-btn-1"
+                      tmrouterlink="/web/student/sessions/result"
+                    >
+                       View Responses 
+                    </a>
+                    <a
+                      class="btn btn-light btn-sm"
+                      href="/web/student/sessions/submission?courseid=CS2103&fsname=Second%20Session"
+                      id="start-submit-btn-1"
+                      tmrouterlink="/web/student/sessions/submission"
+                    >
+                       Start Submission 
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
     </div>
   </tm-loading-retry>
@@ -817,23 +823,25 @@ exports[`StudentHomePageComponent should snap with no feedback session over 2 co
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <tbody>
-              <tr>
-                <th
-                  class="align-center white"
-                >
-                   Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
-                </th>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <tbody>
+                <tr>
+                  <th
+                    class="align-center white"
+                  >
+                     Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
+                  </th>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
       <div
         class="card bg-light top-padded"
@@ -859,23 +867,25 @@ exports[`StudentHomePageComponent should snap with no feedback session over 2 co
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <tbody>
-              <tr>
-                <th
-                  class="align-center white"
-                >
-                   Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
-                </th>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <tbody>
+                <tr>
+                  <th
+                    class="align-center white"
+                  >
+                     Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
+                  </th>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
     </div>
   </tm-loading-retry>
@@ -966,23 +976,25 @@ exports[`StudentHomePageComponent should snap with no feedback sessions 1`] = `
             </a>
           </div>
         </div>
-        <div
-          class="table-responsive"
-        >
-          <table
-            class="table table-striped table-bordered margin-0"
+        <tm-loading-retry>
+          <div
+            class="table-responsive"
           >
-            <tbody>
-              <tr>
-                <th
-                  class="align-center white"
-                >
-                   Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
-                </th>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <table
+              class="table table-striped table-bordered margin-0"
+            >
+              <tbody>
+                <tr>
+                  <th
+                    class="align-center white"
+                  >
+                     Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified. 
+                  </th>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
     </div>
   </tm-loading-retry>

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.html
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.html
@@ -30,81 +30,85 @@
           </div>
         </div>
 
-        <div class="table-responsive">
-          <table class="table table-striped table-bordered margin-0" *ngIf="studentCourse.feedbackSessions && studentCourse.feedbackSessions.length">
-            <thead>
-            <tr>
-              <th>Session Name</th>
-              <th>Deadline</th>
-              <th>Submissions</th>
-              <th>Responses</th>
-              <th>Action(s)</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr *ngFor="let session of studentCourse.feedbackSessions; index as i">
-              <ng-container>
-                <td class="text-break">{{ session.session.feedbackSessionName }}</td>
-                <td *ngIf="session.session.submissionEndTimestamp">
-                  <span [ngbTooltip]="getSubmissionEndDateTooltip(session)" [ngClass]="{'ngb-tooltip-class' : hasStudentExtension(session.session)}">
-                    {{ getSubmissionEndDate(session) }}
-                  </span>
-                </td>
-                <td>
-                  <span [ngbTooltip]="getSubmissionStatusTooltip(session)" class="ngb-tooltip-class">
-                    {{ getSubmissionStatus(session) }}
-                  </span>
-                </td>
-                <td>
-                  <span [ngbTooltip]="getResponseStatusTooltip(session.isPublished)" class="ngb-tooltip-class">
-                    {{ session.isPublished | sessionResponseStatus }}
-                  </span>
-                </td>
-                <td>
-                  <a [ngClass]="{'disabled' : !session.isPublished}"
-                     tmRouterLink="/web/student/sessions/result" [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
-                     id="view-responses-btn-{{i}}" class="btn btn-light btn-sm btn-margin-right">
-                    View Responses
-                  </a>
-                  <a *ngIf="session.isWaitingToOpen" id="disabled-start-submit-btn-{{i}}" class="btn btn-light btn-sm disabled">
-                    Start Submission
-                  </a>
-                  <a *ngIf="session.isOpened && !session.isSubmitted"
-                     tmRouterLink="/web/student/sessions/submission"
-                     [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
-                     id="start-submit-btn-{{i}}"
-                     class="btn btn-light btn-sm">
-                    Start Submission
-                  </a>
-                  <a *ngIf="session.isOpened && session.isSubmitted"
-                     tmRouterLink="/web/student/sessions/submission"
-                     [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
-                     id="edit-submit-btn-{{i}}"
-                     class="btn btn-light btn-sm">
-                    Edit Submission
-                  </a>
-                  <a *ngIf="!session.isOpened && !session.isWaitingToOpen"
-                     tmRouterLink="/web/student/sessions/submission"
-                     [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
-                     id="view-submit-btn-{{i}}" class="btn btn-light btn-sm">
-                    View Submission
-                  </a>
-                </td>
-              </ng-container>
-            </tr>
-            </tbody>
-          </table>
+        <tm-loading-retry [shouldShowRetry]="studentCourse.hasFeedbackSessionsLoadingFailed"
+                          [message]="'Failed to load feedback sessions for the course'"
+                          (retryEvent)="loadFeedbackSessionsForCourse(studentCourse.courseId)">
+          <div class="table-responsive" *tmIsLoading="studentCourse.isFeedbackSessionsLoading">
+            <table class="table table-striped table-bordered margin-0" *ngIf="studentCourse.feedbackSessions && studentCourse.feedbackSessions.length">
+              <thead>
+              <tr>
+                <th>Session Name</th>
+                <th>Deadline</th>
+                <th>Submissions</th>
+                <th>Responses</th>
+                <th>Action(s)</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr *ngFor="let session of studentCourse.feedbackSessions; index as i">
+                <ng-container>
+                  <td class="text-break">{{ session.session.feedbackSessionName }}</td>
+                  <td *ngIf="session.session.submissionEndTimestamp">
+                    <span [ngbTooltip]="getSubmissionEndDateTooltip(session)" [ngClass]="{'ngb-tooltip-class' : hasStudentExtension(session.session)}">
+                      {{ getSubmissionEndDate(session) }}
+                    </span>
+                  </td>
+                  <td>
+                    <span [ngbTooltip]="getSubmissionStatusTooltip(session)" class="ngb-tooltip-class">
+                      {{ getSubmissionStatus(session) }}
+                    </span>
+                  </td>
+                  <td>
+                    <span [ngbTooltip]="getResponseStatusTooltip(session.isPublished)" class="ngb-tooltip-class">
+                      {{ session.isPublished | sessionResponseStatus }}
+                    </span>
+                  </td>
+                  <td>
+                    <a [ngClass]="{'disabled' : !session.isPublished}"
+                       tmRouterLink="/web/student/sessions/result" [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
+                       id="view-responses-btn-{{i}}" class="btn btn-light btn-sm btn-margin-right">
+                      View Responses
+                    </a>
+                    <a *ngIf="session.isWaitingToOpen" id="disabled-start-submit-btn-{{i}}" class="btn btn-light btn-sm disabled">
+                      Start Submission
+                    </a>
+                    <a *ngIf="session.isOpened && !session.isSubmitted"
+                       tmRouterLink="/web/student/sessions/submission"
+                       [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
+                       id="start-submit-btn-{{i}}"
+                       class="btn btn-light btn-sm">
+                      Start Submission
+                    </a>
+                    <a *ngIf="session.isOpened && session.isSubmitted"
+                       tmRouterLink="/web/student/sessions/submission"
+                       [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
+                       id="edit-submit-btn-{{i}}"
+                       class="btn btn-light btn-sm">
+                      Edit Submission
+                    </a>
+                    <a *ngIf="!session.isOpened && !session.isWaitingToOpen"
+                       tmRouterLink="/web/student/sessions/submission"
+                       [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
+                       id="view-submit-btn-{{i}}" class="btn btn-light btn-sm">
+                      View Submission
+                    </a>
+                  </td>
+                </ng-container>
+              </tr>
+              </tbody>
+            </table>
 
-          <table class="table table-striped table-bordered margin-0" *ngIf="!(studentCourse.feedbackSessions && studentCourse.feedbackSessions.length)">
-            <tbody>
-            <tr>
-              <th class="align-center white">
-                Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified.
-              </th>
-            </tr>
-            </tbody>
-          </table>
-        </div>
+            <table class="table table-striped table-bordered margin-0" *ngIf="!(studentCourse.isFeedbackSessionsLoading || studentCourse.feedbackSessions.length)">
+              <tbody>
+              <tr>
+                <th class="align-center white">
+                  Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified.
+                </th>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </tm-loading-retry>
       </div>
     </ng-container>
   </ng-template>

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -423,7 +423,7 @@ describe('StudentHomePageComponent', () => {
 
     component.loadStudentCourses();
 
-    expect(component.hasCoursesLoadingFailed).toBeTruthy();
+    expect(component.courses[0].hasFeedbackSessionsLoadingFailed).toBeTruthy();
   });
 
   it('should sort feedback sessions first by createdAtTimestamp upon loading', () => {

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -106,10 +106,10 @@ export class StudentHomePageComponent implements OnInit {
             isFeedbackSessionsLoading: true,
             hasFeedbackSessionsLoadingFailed: false,
           });
-          this.courses.sort((a: StudentCourse, b: StudentCourse) =>
-              ((a.course.courseId > b.course.courseId) ? 1 : -1));
           this.loadFeedbackSessionsForCourse(course.courseId);
         }
+        this.courses.sort((a: StudentCourse, b: StudentCourse) =>
+            ((a.course.courseId > b.course.courseId) ? 1 : -1));
       }, (e: ErrorMessageOutput) => {
         this.hasCoursesLoadingFailed = true;
         this.statusMessageService.showErrorToast(e.error.message);

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -135,7 +135,7 @@ export class StudentHomePageComponent implements OnInit {
           .subscribe((hasRes: HasResponses) => {
             if (!hasRes.hasResponsesBySession) {
               this.statusMessageService.showErrorToast(this.allStudentFeedbackSessionsNotReturned);
-              this.hasCoursesLoadingFailed = true;
+              courseRef.hasFeedbackSessionsLoadingFailed = true;
               return;
             }
 
@@ -147,7 +147,7 @@ export class StudentHomePageComponent implements OnInit {
 
             if (!isAllSessionsPresent) {
               this.statusMessageService.showErrorToast(this.allStudentFeedbackSessionsNotReturned);
-              this.hasCoursesLoadingFailed = true;
+              courseRef.hasFeedbackSessionsLoadingFailed = true;
               return;
             }
 


### PR DESCRIPTION
Fixes #11551

The original PR #11563 did not fix the issue completely. It moved the assignment of value to `isCourseLoading` after the sessions are loaded. This works only the case when there is 1 course.

When there are multiple courses, the first course that finish loading sessions will set `isCourseLoading = false` and therefore all remaining courses will be displayed with the wrong message again.

This PR reworks the mechanism of this. It adds a `isFeedbackSessionLoading` and `hasFeedbackSessionLoadingFailed` to every single courses. Loading of sessions will be independent and will have their own spinner/retry button now. For more information, see the recording below.

Before:

![11551-before](https://user-images.githubusercontent.com/10681776/164053991-9fbd8617-71e0-487b-8ecc-74825715e55f.gif)

After:

![11551-after](https://user-images.githubusercontent.com/10681776/164054017-a84d5111-361e-47bc-a43e-d9541be3ee3d.gif)

When it loads the courses successfully but failed to load the sessions:

![11551-dedicated-fail](https://user-images.githubusercontent.com/10681776/164054099-159ec507-5a52-4a06-83e1-99ff02f652fb.jpg)



