### PR TITLE
[#11756] Session closing email contains no information about extended deadline

### DIFF
--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -424,8 +424,8 @@
         "student5InCourse1@gmail.tmt": "2027-04-30T23:00:00Z"
       },
       "instructorDeadlines": {
-        "instructor2@course1.tmt": "2027-04-30T23:00:00Z",
-        "instructor3@course1.tmt": "2027-04-30T23:00:00Z"
+        "instructor2@course1.tmt": "2027-05-01T22:00:00Z",
+        "instructor3@course1.tmt": "2027-05-01T22:00:00Z"
       }
     },
     "session2InCourse1": {
@@ -1220,7 +1220,7 @@
       "feedbackSessionName": "First feedback session",
       "userEmail": "instructor2@course1.tmt",
       "isInstructor": true,
-      "endTime": "2027-04-30T23:00:00Z",
+      "endTime": "2027-05-01T22:00:00Z",
       "sentClosingEmail": false,
       "sentClosedEmail": false,
       "createdAt": "2027-04-30T15:00:00Z",
@@ -1231,7 +1231,7 @@
       "feedbackSessionName": "First feedback session",
       "userEmail": "instructor3@course1.tmt",
       "isInstructor": true,
-      "endTime": "2027-04-30T23:00:00Z",
+      "endTime": "2027-05-01T22:00:00Z",
       "sentClosingEmail": false,
       "sentClosedEmail": false,
       "createdAt": "2027-04-30T15:00:00Z",

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -35,7 +35,7 @@
           </strong>
         </td>
         <td style="padding:5px;">
-          Fri, 30 Apr 2027, 11:59 PM SAST
+          Sat, 01 May 2027, 11:59 PM SAST (after extension)
         </td>
       </tr>
 

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -35,7 +35,7 @@
           </strong>
         </td>
         <td style="padding:5px;">
-          Fri, 30 Apr 2027, 11:59 PM SAST
+          Sat, 01 May 2027, 01:00 AM SAST (after extension)
         </td>
       </tr>
 


### PR DESCRIPTION
Fixes #11756

**Outline of Solution**

- Update deadline to show correct deadline after extension is accounted for
- If deadline has been extended, update deadline to `... (after extension)`

<img width="699" alt="Screen Shot 2022-04-22 at 10 51 18 PM" src="https://user-images.githubusercontent.com/60355570/164739226-a1a1683d-9a5f-4324-96fb-5b0cd889f485.png">

