### PR TITLE
[#11759] Instructor editing questions: tweak the confirmation dialog for cancelling an edit

### DIFF
--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -257,8 +257,8 @@ export class QuestionEditFormComponent {
     }
     const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
         `Discard unsaved ${isNewQuestion ? 'question' : 'edits'}?`, SimpleModalType.WARNING,
-        'Warning: Any unsaved changes will be lost', 
-        {cancelMessage: "No, go back to editing"});
+        'Warning: Any unsaved changes will be lost',
+        { cancelMessage: 'No, go back to editing' });
     modalRef.result.then(() => {
       this.discardChanges();
     }, () => {});

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -257,7 +257,8 @@ export class QuestionEditFormComponent {
     }
     const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
         `Discard unsaved ${isNewQuestion ? 'question' : 'edits'}?`, SimpleModalType.WARNING,
-        'Warning: Any unsaved changes will be lost');
+        'Warning: Any unsaved changes will be lost', 
+        {cancelMessage: "No, go back to editing"});
     modalRef.result.then(() => {
       this.discardChanges();
     }, () => {});


### PR DESCRIPTION
Fixes #11759 

**Outline of Solution**

I changed the argument of the confirmation model to match the issue's request.
![image](https://user-images.githubusercontent.com/67757044/167340669-c5dcdd9b-3b0b-4724-a1fd-3122c1b6039d.png)
