### PR TITLE
[#11755] Session closing soon' email: highlight 'No action is required if you have already submitted

### DIFF
--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -38,7 +38,7 @@ import teammates.logic.core.StudentsLogic;
  */
 public final class EmailGenerator {
     // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions";
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions, in case you have not submitted yet or wish to update your submission.";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
     private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -38,7 +38,8 @@ import teammates.logic.core.StudentsLogic;
  */
 public final class EmailGenerator {
     // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions, in case you have not submitted yet or wish to update your submission.";
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for "
+            + "submissions, in case you have not submitted yet or wish to update your submission";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
     private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -3,7 +3,7 @@
 ${instructorPreamble}
 
 <p>
-  The following feedback session ${status}.
+  Just a gentle reminder that the following feedback session ${status}.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is now open.
+  Just a gentle reminder that the following feedback session is now open.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionOpeningEmailForInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is now open.
+  Just a gentle reminder that the following feedback session is now open.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionOpeningEmailForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is now open.
+  Just a gentle reminder that the following feedback session is now open.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is now open.
+  Just a gentle reminder that the following feedback session is now open.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is now open.
+  Just a gentle reminder that the following feedback session is now open.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -8,7 +8,7 @@
 
 <p>
   Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
-<div>
+  <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
         <td style="padding:5px;">

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -7,8 +7,8 @@
 </p>
 
 <p>
-  The following feedback session is still open for submissions.
-  <div>
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
+<div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
         <td style="padding:5px;">

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -3,8 +3,8 @@
 
 
 <p>
-  The following feedback session is still open for submissions.
-  <div>
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
+<div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
         <td style="padding:5px;">

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -4,7 +4,7 @@
 
 <p>
   Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
-<div>
+  <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
         <td style="padding:5px;">

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is still open for submissions.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>


### PR DESCRIPTION
Fixes #11755

**Outline of Solution** 


Tweak **The following feedback session is still open for submissions.** to **Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.** 

Change the FEEDBACK_STATUS_SESSION_OPEN in EmailGenerator and userEmailTemplate-feedbackSession.html.
 
Make same changes in **src/test/resources/emails/** for test cases: 

The affected email would be like the following screenshot.
<img width="1389" alt="Screen Shot 2022-05-10 at 11 28 23 PM" src="https://user-images.githubusercontent.com/40664138/167961259-5b78a996-2d71-44d8-8977-73da22ebea0c.png">

