### PR TITLE
[#11770] viewing logs: instructor might think 'view' is same as 'submission'

### DIFF
--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts
@@ -204,7 +204,7 @@ export class InstructorAuditLogsPageComponent implements OnInit {
             { value: entry.studentData.name },
             {
               value: entry.feedbackSessionLogType.toString() as keyof typeof FeedbackSessionLogType
-                  === 'ACCESS' ? 'Viewed the submission page' : 'Submitted responses',
+                  === 'ACCESS' ? 'Viewed - In progress' : 'Submitted responses',
             },
             { value: entry.studentData.email },
             { value: entry.studentData.sectionName },


### PR DESCRIPTION
Fixes #11770

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
Changed the logs' activity name from "**Viewed the submission page**" to "**Viewed-In progress**" to solve the slight usability issue.
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
The modifications are in src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.ts. 
<!-- This portion can be skipped if the fix is trivial. -->
