### PR TITLE
[#11794] Update instructor help page

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
@@ -199,7 +199,7 @@
         Click the <button class="btn btn-secondary btn-sm">Edit</button> button in the last column of the row corresponding to Student A.
       </li>
       <li>
-        A new page will open that allows you to <button class="btn btn-link" (click)="collapseStudentEditDetails.emit(true);">edit the student's profile</button>, including a field to edit the student's section.<br>
+        A new page will open that allows you to <a (click)="collapseStudentEditDetails.emit(true);" [tmRouterLink]="">edit the student's profile</a>, including a field to edit the student's section.<br>
       </li>
       <li>
         After editing the section name, click <button class="btn btn-primary btn-sm">Save Changes</button> to confirm Student A's new section.
@@ -247,7 +247,12 @@
       When a course has ended, you can archive it so that it doesn't appear in your home page. Course, student and session details of an archived course are still stored on TEAMMATES. However, you cannot edit, create feedback sessions for or enroll students in an archived course.
     </p>
     <p>
-      In your <b>Home</b> page, you will see panels for each course and a table of feedback sessions inside it, similar to the example below.<br>
+      In your <b>Home</b> page, you will see panels for each course and a table of feedback sessions inside it, similar to the example below:
+    </p>
+    <!--    <tm-example-box *ngIf="questionsToCollapsed[CoursesSectionQuestions.COURSE_ARCHIVE]" @collapseAnim>-->
+    <!--    TODO: add instructor home page course component example here -->
+    <!--    </tm-example-box>-->
+    <p>
       Click on the <button class="btn btn-primary btn-sm" type="button">Course <span class="caret"></span></button> button on the card heading of the course you want to archive.<br>
       Then select <button class="btn btn-secondary btn-sm" type="button">Archive</button> in the drop-down menu and click <b>OK</b> to confirm.
     </p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-courses-section/instructor-help-courses-section.component.html
@@ -247,12 +247,7 @@
       When a course has ended, you can archive it so that it doesn't appear in your home page. Course, student and session details of an archived course are still stored on TEAMMATES. However, you cannot edit, create feedback sessions for or enroll students in an archived course.
     </p>
     <p>
-      In your <b>Home</b> page, you will see panels for each course and a table of feedback sessions inside it, similar to the example below:
-    </p>
-    <!--    <tm-example-box *ngIf="questionsToCollapsed[CoursesSectionQuestions.COURSE_ARCHIVE]" @collapseAnim>-->
-    <!--    TODO: add instructor home page course component example here -->
-    <!--    </tm-example-box>-->
-    <p>
+      In your <b>Home</b> page, you will see panels for each course and a table of feedback sessions inside it, similar to the example below.<br>
       Click on the <button class="btn btn-primary btn-sm" type="button">Course <span class="caret"></span></button> button on the card heading of the course you want to archive.<br>
       Then select <button class="btn btn-secondary btn-sm" type="button">Archive</button> in the drop-down menu and click <b>OK</b> to confirm.
     </p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -151,7 +151,7 @@
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
       </li>
       <li>
-        <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.SESSION_CANNOT_SUBMIT, section: Sections.sessions}">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+        <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.SUBMIT_FOR_STUDENT, section: Sections.sessions}">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
     <p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -37,7 +37,7 @@
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g., project groups) and sections (e.g., tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled, as there is nothing for students to do in TEAMMATES until a session opens for submissions.<br>
-        TEAMMATES emails access instructions to students only when there is an action for them to perform e.g., when a session opens for submissions.
+        TEAMMATES will send an email with access instructions to students only when there is an action for them to perform e.g., when a session opens for submissions.
       </li>
       <li>
         <b><a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR, section: Sections.courses}">Add instructors to the course</a></b><br>
@@ -132,7 +132,7 @@
       Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL, section: Sections.sessions}">here</a> to find out remedies if some students say they did not receive the TEAMMATES emails as expected.
     </p>
     <p>
-      See <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.EXTEND_SESSION_DEADLINE, section: Sections.sessions}">here</a> to find how to extend the deadline for all students, or for specific students.
+      Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.EXTEND_SESSION_DEADLINE, section: Sections.sessions}">here</a> to find how to extend the deadline for all students, or for specific students.
     </p>
     <p>
       While not normally needed, if you would like students to access TEAMMATES sooner (e.g., if you would like them to fill in their profile page in advance), you can get them to ‘join’ the course earlier by following these steps:
@@ -142,7 +142,7 @@
         In the <b>Courses</b> page, click the <button class="btn btn-light btn-sm dropdown-toggle">Other Actions</button> button of the course, and select <b>View</b> in the drop-down menu.
       </li>
       <li>
-        Then, click <button class="btn btn-sm btn-primary"><i class="fa fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.
+        Then, click the <button class="btn btn-sm btn-primary"><i class="fa fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.
       </li>
     </ol>
     <p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -134,7 +134,7 @@
     <p>
       Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.EXTEND_SESSION_DEADLINE, section: Sections.sessions}">here</a> to find how to extend the deadline for all students, or for specific students.
     </p>
-    <p>
+    <p> 
       While not normally needed, if you would like students to access TEAMMATES sooner (e.g., if you would like them to fill in their profile page in advance), you can get them to ‘join’ the course earlier by following these steps:
     </p>
     <ol>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -139,7 +139,7 @@
     </p>
     <ol>
       <li>
-        In the <b>Courses</b> page, click the <button class="btn btn-light btn-sm dropdown-toggle">Other Actions</button> button of the course, and select <button class="btn btn-light btn-sm">View</button> in the drop-down menu.
+        In the <b>Courses</b> page, click the <button class="btn btn-light btn-sm dropdown-toggle">Other Actions</button> button of the course, and select <b>View</b> in the drop-down menu.
       </li>
       <li>
         Then, click <button class="btn btn-sm btn-primary"><i class="fa fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -35,9 +35,9 @@
       <li>
         <b><a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ADD_STUDENTS, section: Sections.courses}">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
-        Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
+        Students can be enrolled into teams (e.g., project groups) and sections (e.g., tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled, as there is nothing for students to do in TEAMMATES until a session opens for submissions.<br>
-        TEAMMATES emails access instruction to students only when there is an action for them to perform e.g., when a session opens for submission.
+        TEAMMATES emails access instructions to students only when there is an action for them to perform e.g., when a session opens for submissions.
       </li>
       <li>
         <b><a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR, section: Sections.courses}">Add instructors to the course</a></b><br>
@@ -126,7 +126,7 @@
     </ul>
     <p>
       You can manually send reminders to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.<br>
-      In addition, you are welcome to (but not required to) use your own email announcements (outside of TEAMMATES) to inform students to lookout for these TEAMMATES emails.
+      In addition, you are welcome to (but not required to) use your own email announcements (outside of TEAMMATES) to inform students to look out for these TEAMMATES emails.
     </p>
     <p>
       Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL, section: Sections.sessions}">here</a> to find out remedies if some students say they did not receive the TEAMMATES emails as expected.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -36,7 +36,8 @@
         <b><a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ADD_STUDENTS, section: Sections.courses}">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
-        TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
+        TEAMMATES will <b>not</b> automatically notify students that they have been enrolled, as there is nothing for students to do in TEAMMATES until a session opens for submissions.<br>
+        TEAMMATES emails access instruction to students only when there is an action for them to perform e.g., when a session opens for submission.
       </li>
       <li>
         <b><a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ADD_INSTRUCTOR, section: Sections.courses}">Add instructors to the course</a></b><br>
@@ -59,7 +60,7 @@
     <ol>
       <li>
         <b>Create a session</b><br>
-        Go to the <b>Sessions</b> page and create a session. Choose between:
+        Go to the <b>Sessions</b> page and create a session. Choose among:
       </li>
       <ul>
         <li>Session with my own questions</li>
@@ -67,10 +68,14 @@
           <li>Creates an empty feedback session</li>
           <li>Allows you to craft custom questions that fit your needs</li>
         </ul>
-        <li>Session using template: team peer evaluation</li>
+        <li>Session using template: team peer feedback (point-based)</li>
         <ul>
           <li>Provides 5 standard questions for team peer evaluations</li>
-          <li> Allows you to modify/remove the given questions and add your own questions as required</li>
+          <li>Allows you to modify/remove the given questions and add your own questions as required</li>
+        </ul>
+        <li>Session using template: team peer feedback (percentage-based)</li>
+        <ul>
+          <li>Similar to above, but uses a percentage-based question (instead of a point-based question) to determine the contribution level of team members</li>
         </ul>
       </ul>
       <li>
@@ -103,7 +108,7 @@
   <h2 id="session-invites">3. Wait for your session to open</h2>
   <div>
     <p>
-      After you have set up your session, you're all set! <b>You do not have to inform students when a session opens.</b>
+      After you have set up your session, you're all set!
     </p>
     <p>
       TEAMMATES automatically sends emails to students and instructors according to the preferences you specify when you create a session. The default settings are:
@@ -120,10 +125,30 @@
       </li>
     </ul>
     <p>
-      You can manually send reminders to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
+      You can manually send reminders to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.<br>
+      In addition, you are welcome to (but not required to) use your own email announcements (outside of TEAMMATES) to inform students to lookout for these TEAMMATES emails.
     </p>
     <p>
-      In addition, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course and click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
+      Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL, section: Sections.sessions}">here</a> to find out remedies if some students say they did not receive the TEAMMATES emails as expected.
+    </p>
+    <p>
+      See <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.EXTEND_SESSION_DEADLINE, section: Sections.sessions}">here</a> to find how to extend the deadline for all students, or for specific students.
+    </p>
+    <p>
+      While not normally needed, if you would like students to access TEAMMATES sooner (e.g., if you would like them to fill in their profile page in advance), you can get them to ‘join’ the course earlier by following these steps:
+    </p>
+    <ol>
+      <li>
+        Click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page.
+      </li>
+      <li>
+        Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.
+      </li>
+    </ol>
+    <p>
+      Caution: ‘joining’ TEAMMATES requires students to use a Google account to authenticate themselves.
+      Joining a TEAMMATES course is optional for students; they can still submit responses and view session results without joining, by using access links TEAMMATES sends them.
+      However, some non-essential features such as creating a profile page are only available to students who have joined.
     </p>
   </div>
   <p align="right">
@@ -185,7 +210,7 @@
         <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: StudentsSectionQuestions.STUDENT_EDIT_DETAILS, section: Sections.students}">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
       </li>
       <li>
-        Search: <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: StudentsSectionQuestions.STUDENT_SEARCH, section: Sections.students}">search for students, teams or sections</a>, or <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.SESSION_SEARCH, section: Sections.sessions}">search for questions, responses or comments</a>.
+        Search: <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: StudentsSectionQuestions.STUDENT_SEARCH, section: Sections.students}">search for students, teams or sections</a>.
       </li>
       <li>
         <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: CoursesSectionQuestions.COURSE_ARCHIVE, section: Sections.courses}">Archive old courses</a>: archive old courses that you no longer need actively.
@@ -203,7 +228,7 @@
     <p>
       If you have doubts, comments, or questions about using TEAMMATES, just
       <a href="mailto:{{supportEmail}}">email us</a>.
-      We respond within 24 hours.
+      We usually respond within 24 hours.
     </p>
   </div>
   <p align="right">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -134,7 +134,7 @@
     <p>
       Click <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.EXTEND_SESSION_DEADLINE, section: Sections.sessions}">here</a> to find how to extend the deadline for all students, or for specific students.
     </p>
-    <p> 
+    <p>
       While not normally needed, if you would like students to access TEAMMATES sooner (e.g., if you would like them to fill in their profile page in advance), you can get them to ‘join’ the course earlier by following these steps:
     </p>
     <ol>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -139,10 +139,10 @@
     </p>
     <ol>
       <li>
-        Click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page.
+        In the <b>Courses</b> page, click the <button class="btn btn-light btn-sm dropdown-toggle">Other Actions</button> button of the course, and select <button class="btn btn-light btn-sm">View</button> in the drop-down menu.
       </li>
       <li>
-        Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.
+        Then, click <button class="btn btn-sm btn-primary"><i class="fa fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to ‘join’ TEAMMATES immediately.
       </li>
     </ol>
     <p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -6,7 +6,7 @@
         <p>
           Have questions about how to use TEAMMATES? This page answers some frequently asked questions.
           <br> If you are new to TEAMMATES, our <a [tmRouterLink]="instructorGettingStartedPath">Getting Started</a> guide will introduce you to the basic functions of TEAMMATES.
-          <br> If you have any remaining questions, don't hesitate to <a href="mailto:{{ supportEmail }}">email us</a>. We respond within 24 hours.
+          <br> If you have any remaining questions, don't hesitate to <a href="mailto:{{ supportEmail }}">email us</a>. We usually respond within 24 hours.
         </p>
         <div class="row">
           <div class="col-md-9">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -217,7 +217,7 @@
       Note that the email generation can take up to 30 minutes from the session start time.
     </p>
     <p>
-      <b>Do not use the ‘publish’ feature for this purpose.</b> That feature is for making the responses available for viewing,
+      <span class="text-danger">Do not use the ‘publish’ feature for this purpose.</span> That feature is for making the responses available for viewing,
       which you are likely to do after the session deadline is over, unless you want the responses to become visible as they are being collected.
     </p>
   </tm-instructor-help-panel>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -207,11 +207,11 @@
   <!-- Question -->
   <tm-instructor-help-panel #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION)"
                             [id]="SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION"
-                            headerText="How do I let students know about the session?"
+                            headerText="How do I let students know about a session?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION]">
     <p>
       No action is required from you for this. TEAMMATES will send an email (containing submission instructions) to each respondent when the session opens for submissions.
-      After that email has been sent out (you will receive a copy of it, for your reference), you are welcome to inform respondents using another means (outside of TEAMMATES) to lookout for the TEAMMATES email.
+      After that email has been sent out (you will receive a copy of it, for your reference), you are welcome to inform respondents using another means (outside of TEAMMATES) to look out for the TEAMMATES email.
     </p>
     <p>
       Note that the email generation can take up to 30 minutes from the session start time.
@@ -224,7 +224,7 @@
   <!-- Question -->
   <tm-instructor-help-panel #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL)"
                             [id]="SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL"
-                            headerText="What if a student says they didn’t receive the TEAMMATES email, as they were supposed to?"
+                            headerText="What should I do if students say they didn’t receive the TEAMMATES email, as they were supposed to?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL]">
     <p>
       Here are some remedies:
@@ -234,12 +234,12 @@
         Use the <button class="btn btn-sm btn-secondary">Remind</button> button on your <b>Home</b> page (there is one for each session) to resend emails to specific students or all those who haven't submitted yet. Also, ask students to check their spam box.
       </li>
       <li>
-        Ask students to go to <a href="https://teammatesv4.appspot.com/web/front/help/session-links-recovery">https://teammatesv4.appspot.com/web/front/help/session-links-recovery</a>, and request TEAMMATES to resend the links.
+        Ask students to go to <a href="https://teammatesv4.appspot.com/web/front/help/session-links-recovery">https://teammatesv4.appspot.com/web/front/help/session-links-recovery</a> and request TEAMMATES to resend the links.
         They should specify the exact email address that was used to enroll them in TEAMMATES.
       </li>
       <li>
         Failing all above, ask students to email us at <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a> We can resend the email using an alternate means.
-        When they email us, they should use the email account currently registered in TEAMMATES (for identification).
+        When they email us, they should use the email address currently registered in TEAMMATES (for identification).
       </li>
     </ol>
   </tm-instructor-help-panel>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -210,10 +210,10 @@
   <!-- Question -->
   <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SESSION_CANNOT_SUBMIT)"
                             [id]="SessionsSectionQuestions.SESSION_CANNOT_SUBMIT"
-                            headerText="What should I do if a student says he/she cannot submit an evaluation due to a technical glitch?"
+                            headerText="Can I submit responses on behalf of a student?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SESSION_CANNOT_SUBMIT]">
     <p>
-      Instructors can submit responses on behalf of a student. To do so:
+      Yes, instructors can submit responses on behalf of a student. To do so:
     </p>
     <ol>
       <li>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -234,7 +234,7 @@
         Use the <button class="btn btn-sm btn-secondary">Remind</button> button on your <b>Home</b> page (there is one for each session) to resend emails to specific students or all those who haven't submitted yet. Also, ask students to check their spam box.
       </li>
       <li>
-        Ask students to go to <a tmRouterLink="/web/front/help/session-links-recovery">{{ frontendUrl + "/web/front/help/session-links-recovery" }}</a> and request TEAMMATES to resend the links.
+        Ask students to go to <a tmRouterLink="/web/front/help/session-links-recovery">the session links recovery page</a> and request TEAMMATES to resend the links.
         They should specify the exact email address that was used to enroll them in TEAMMATES.
       </li>
       <li>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -234,7 +234,7 @@
         Use the <button class="btn btn-sm btn-secondary">Remind</button> button on your <b>Home</b> page (there is one for each session) to resend emails to specific students or all those who haven't submitted yet. Also, ask students to check their spam box.
       </li>
       <li>
-        Ask students to go to <a href="https://teammatesv4.appspot.com/web/front/help/session-links-recovery">https://teammatesv4.appspot.com/web/front/help/session-links-recovery</a> and request TEAMMATES to resend the links.
+        Ask students to go to <a tmRouterLink="/web/front/help/session-links-recovery">{{ frontendUrl + "/web/front/help/session-links-recovery" }}</a> and request TEAMMATES to resend the links.
         They should specify the exact email address that was used to enroll them in TEAMMATES.
       </li>
       <li>
@@ -288,7 +288,7 @@
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SESSION_VIEW_RESULTS]">
     <p>
       View responses to a session by clicking the <button class="btn btn-sm btn-secondary">Results</button> button of a session in the <b>Home</b> or <b>Sessions</b> page.<br>
-      Click <button class="btn btn-primary btn-s">Edit View</button> to sort the results in an order that best suits you.
+      Click <button class="btn btn-primary btn-sm">Edit View</button> to sort the results in an order that best suits you.
     </p>
     <p>5 different views are available, each denoting the order in which responses are grouped.
       Additionally, you can group the results by team, show or hide statistics, view missing responses and filter responses from a particular section.
@@ -362,7 +362,7 @@
         View the results of a session.
       </li>
       <li>
-        Click <button class="btn btn-light btn-s dropdown-toggle">View</button> dropdown and change the view type to <b>Group by - Giver &gt; Recipient &gt; Question</b> or <b>Group by - Recipient &gt; Giver &gt; Question</b>.
+        Click <button class="btn btn-light btn-sm dropdown-toggle">View</button> dropdown and change the view type to <b>Group by - Giver &gt; Recipient &gt; Question</b> or <b>Group by - Recipient &gt; Giver &gt; Question</b>.
       </li>
       <li>
         Click the <button type="button" class="btn btn-secondary btn-sm"><i class="fas fa-comment"></i>&nbsp;<i class="fas fa-plus"></i></button> icon on the right-hand side of the response you would like to comment on.
@@ -407,7 +407,7 @@
         <i class="far fa-trash-alt"></i> icon to delete the comment. The icons are visible on the right-hand side of the comment field.
       </li>
       <li>
-        If you are editing the comment, make your edits and click <button class="btn btn-primary btn-s">Save</button> to save changes.
+        If you are editing the comment, make your edits and click <button class="btn btn-primary btn-sm">Save</button> to save changes.
       </li>
       <li>
         If you are deleting the comment, click <b>OK</b> to confirm that you want to delete the comment.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -1,7 +1,7 @@
 <div>
   <h2 class="color-blue" *ngIf="!key || showQuestion.length > 0">Sessions</h2>
   <!--Section-->
-  <h4 *ngIf="displaySubsection(0, 4)">Setting Up Sessions</h4>
+  <h4 *ngIf="displaySubsection(0, 7)">Setting Up Sessions</h4>
   <!-- Question -->
   <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.TIPS_FOR_CONDUCTION_PEER_EVAL)"
                             [id]="SessionsSectionQuestions.TIPS_FOR_CONDUCTION_PEER_EVAL"
@@ -185,7 +185,7 @@
     </tm-example-box>
   </tm-instructor-help-panel>
   <!-- Question -->
-  <tm-instructor-help-panel class="instr-help-qn-last" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SESSION_PREVIEW)"
+  <tm-instructor-help-panel #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SESSION_PREVIEW)"
                             [id]="SessionsSectionQuestions.SESSION_PREVIEW"
                             headerText="How do I preview a session?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SESSION_PREVIEW]">
@@ -204,14 +204,62 @@
       ></tm-preview-session-panel>
     </tm-example-box>
   </tm-instructor-help-panel>
+  <!-- Question -->
+  <tm-instructor-help-panel #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION)"
+                            [id]="SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION"
+                            headerText="How do I let students know about the session?"
+                            [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION]">
+    <p>
+      No action is required from you for this. TEAMMATES will send an email (containing submission instructions) to each respondent when the session opens for submissions.
+      After that email has been sent out (you will receive a copy of it, for your reference), you are welcome to inform respondents using another means (outside of TEAMMATES) to lookout for the TEAMMATES email.
+    </p>
+    <p>
+      Note that the email generation can take up to 30 minutes from the session start time.
+    </p>
+    <p>
+      <b>Do not use the ‘publish’ feature for this purpose.</b> That feature is for making the responses available for viewing,
+      which you are likely to do after the session deadline is over, unless you want the responses to become visible as they are being collected.
+    </p>
+  </tm-instructor-help-panel>
+  <!-- Question -->
+  <tm-instructor-help-panel #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL)"
+                            [id]="SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL"
+                            headerText="What if a student says they didn’t receive the TEAMMATES email, as they were supposed to?"
+                            [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL]">
+    <p>
+      Here are some remedies:
+    </p>
+    <ol>
+      <li>
+        Use the <button class="btn btn-sm btn-secondary">Remind</button> button on your <b>Home</b> page (there is one for each session) to resend emails to specific students or all those who haven't submitted yet. Also, ask students to check their spam box.
+      </li>
+      <li>
+        Ask students to go to <a href="https://teammatesv4.appspot.com/web/front/help/session-links-recovery">https://teammatesv4.appspot.com/web/front/help/session-links-recovery</a>, and request TEAMMATES to resend the links.
+        They should specify the exact email address that was used to enroll them in TEAMMATES.
+      </li>
+      <li>
+        Failing all above, ask students to email us at <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a> We can resend the email using an alternate means.
+        When they email us, they should use the email account currently registered in TEAMMATES (for identification).
+      </li>
+    </ol>
+  </tm-instructor-help-panel>
+  <!-- Question -->
+  <tm-instructor-help-panel class="instr-help-qn-last" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.EXTEND_SESSION_DEADLINE)"
+                            [id]="SessionsSectionQuestions.EXTEND_SESSION_DEADLINE"
+                            headerText="How do I extend the deadline of a session?"
+                            [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.EXTEND_SESSION_DEADLINE]">
+    <p>
+      To extend the deadline for all respondents, edit the session and change the end date/time as desired. This can be done at any time.
+    </p>
+  </tm-instructor-help-panel>
 
   <!--Section-->
-  <h4 *ngIf="displaySubsection(4, 7)">Managing Session Responses</h4>
+  <h4 *ngIf="displaySubsection(7, 10)">Managing Session Responses</h4>
   <!-- Question -->
-  <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SESSION_CANNOT_SUBMIT)"
-                            [id]="SessionsSectionQuestions.SESSION_CANNOT_SUBMIT"
+  <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SUBMIT_FOR_STUDENT)"
+                            [id]="SessionsSectionQuestions.SUBMIT_FOR_STUDENT"
                             headerText="Can I submit responses on behalf of a student?"
-                            [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SESSION_CANNOT_SUBMIT]">
+                            [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.SUBMIT_FOR_STUDENT]">
     <p>
       Yes, instructors can submit responses on behalf of a student. To do so:
     </p>
@@ -284,7 +332,7 @@
                             headerText="How do I view all the responses a student has given and received?"
                             [(isPanelExpanded)]="questionsToCollapsed[SessionsSectionQuestions.VIEW_ALL_RESPONSES]">
     <p>
-      To view the responses that Student A from Course B has given and received:
+      To view the responses that Student A from Course B has given and received (across all sessions in the course):
     </p>
     <ol>
       <li>
@@ -297,7 +345,7 @@
   </tm-instructor-help-panel>
 
   <!--Section-->
-  <h4 *ngIf="displaySubsection(7, 9)">Adding Comments to Responses</h4>
+  <h4 *ngIf="displaySubsection(10, 12)">Adding Comments to Responses</h4>
   <!-- Question -->
   <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.SESSION_ADD_COMMENTS)"
                             [id]="SessionsSectionQuestions.SESSION_ADD_COMMENTS"
@@ -368,7 +416,7 @@
   </tm-instructor-help-panel>
 
   <!--Section-->
-  <h4 *ngIf="displaySubsection(9, 13)">Restoring Deleted Sessions</h4>
+  <h4 *ngIf="displaySubsection(12, 16)">Restoring Deleted Sessions</h4>
   <!-- Question -->
   <tm-instructor-help-panel class="instr-help-qn-first" #question [hidden]="key && !showQuestion.includes(SessionsSectionQuestions.VIEW_DELETED_SESSION)"
                             [id]="SessionsSectionQuestions.VIEW_DELETED_SESSION"

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -46,6 +46,7 @@ import {
   EXAMPLE_TEMPLATE_SESSIONS,
 } from './instructor-help-sessions-data';
 import { SessionsSectionQuestions } from './sessions-section-questions';
+import {environment} from "../../../../environments/environment";
 
 /**
  * Sessions Section of the Instructor Help Page.
@@ -65,6 +66,7 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
   InstructorSessionResultSectionType: typeof InstructorSessionResultSectionType = InstructorSessionResultSectionType;
   SessionsSectionQuestions: typeof SessionsSectionQuestions = SessionsSectionQuestions;
 
+  readonly supportEmail: string = environment.supportEmail;
   readonly exampleCommentEditFormModel: CommentEditFormModel = EXAMPLE_COMMENT_EDIT_FORM_MODEL;
   readonly exampleSessionEditFormModel: SessionEditFormModel = EXAMPLE_SESSION_EDIT_FORM_MODEL;
   readonly exampleResponse: ResponseOutput = EXAMPLE_RESPONSE;
@@ -86,7 +88,10 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
     SessionsSectionQuestions.SESSION_NEW_FEEDBACK,
     SessionsSectionQuestions.SESSION_QUESTIONS,
     SessionsSectionQuestions.SESSION_PREVIEW,
-    SessionsSectionQuestions.SESSION_CANNOT_SUBMIT,
+    SessionsSectionQuestions.LET_STUDENT_KNOW_SESSION,
+    SessionsSectionQuestions.STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL,
+    SessionsSectionQuestions.EXTEND_SESSION_DEADLINE,
+    SessionsSectionQuestions.SUBMIT_FOR_STUDENT,
     SessionsSectionQuestions.SESSION_VIEW_RESULTS,
     SessionsSectionQuestions.VIEW_ALL_RESPONSES,
     SessionsSectionQuestions.SESSION_ADD_COMMENTS,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -66,6 +66,7 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
   SessionsSectionQuestions: typeof SessionsSectionQuestions = SessionsSectionQuestions;
 
   readonly supportEmail: string = environment.supportEmail;
+  readonly frontendUrl: string = environment.frontendUrl;
   readonly exampleCommentEditFormModel: CommentEditFormModel = EXAMPLE_COMMENT_EDIT_FORM_MODEL;
   readonly exampleSessionEditFormModel: SessionEditFormModel = EXAMPLE_SESSION_EDIT_FORM_MODEL;
   readonly exampleResponse: ResponseOutput = EXAMPLE_RESPONSE;

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -96,7 +96,6 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
     SessionsSectionQuestions.VIEW_ALL_RESPONSES,
     SessionsSectionQuestions.SESSION_ADD_COMMENTS,
     SessionsSectionQuestions.EDIT_DEL_COMMENT,
-    SessionsSectionQuestions.SESSION_SEARCH,
     SessionsSectionQuestions.VIEW_DELETED_SESSION,
     SessionsSectionQuestions.RESTORE_SESSION,
     SessionsSectionQuestions.PERMANENT_DEL_SESSION,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-
+import { environment } from '../../../../environments/environment';
 import { TemplateSession } from '../../../../services/feedback-sessions.service';
 import {
   Course,
@@ -46,7 +46,6 @@ import {
   EXAMPLE_TEMPLATE_SESSIONS,
 } from './instructor-help-sessions-data';
 import { SessionsSectionQuestions } from './sessions-section-questions';
-import {environment} from "../../../../environments/environment";
 
 /**
  * Sessions Section of the Instructor Help Page.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
@@ -33,11 +33,6 @@ export enum SessionsSectionQuestions {
   SESSION_ADD_COMMENTS = 'session-add-comments',
 
   /**
-   * How do I search for a feedback session question, response or comment on a response?
-   */
-  SESSION_SEARCH = 'session-search',
-
-  /**
    * How do I view sessions I have deleted?
    */
   VIEW_DELETED_SESSION = 'view-deleted-session',

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
@@ -70,16 +70,16 @@ export enum SessionsSectionQuestions {
   /**
    * How do I let students know about the session?
    */
-  LET_STUDENT_KNOW_SESSION = "let-student-know-session",
+  LET_STUDENT_KNOW_SESSION = 'let-student-know-session',
 
   /**
    * What if a student says they didn’t receive the TEAMMATES email, as they were supposed to?
    */
-  STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL = "student-did-not-receive-session-email",
+  STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL = 'student-did-not-receive-session-email',
 
   /**
    * How do I extend the deadline of a session?
    */
-  EXTEND_SESSION_DEADLINE = "extend-session-deadline",
+  EXTEND_SESSION_DEADLINE = 'extend-session-deadline',
 
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
@@ -68,12 +68,12 @@ export enum SessionsSectionQuestions {
   RESTORE_DEL_ALL = 'restore-del-all',
 
   /**
-   * How do I let students know about the session?
+   * How do I let students know about a session?
    */
   LET_STUDENT_KNOW_SESSION = 'let-student-know-session',
 
   /**
-   * What if a student says they didn’t receive the TEAMMATES email, as they were supposed to?
+   * What should I do if students say they didn’t receive the TEAMMATES email, as they were supposed to?
    */
   STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL = 'student-did-not-receive-session-email',
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/sessions-section-questions.ts
@@ -18,9 +18,9 @@ export enum SessionsSectionQuestions {
   SESSION_PREVIEW = 'session-preview',
 
   /**
-   * What should I do if a student says he/she cannot submit an evaluation due to a technical glitch?
+   * Can I submit responses on behalf of a student?
    */
-  SESSION_CANNOT_SUBMIT = 'session-cannot-submit',
+  SUBMIT_FOR_STUDENT = 'submit-for-student',
 
   /**
    * How do I view the results of my session?
@@ -71,4 +71,20 @@ export enum SessionsSectionQuestions {
    * How do I restore/delete all sessions from Recycle Bin?
    */
   RESTORE_DEL_ALL = 'restore-del-all',
+
+  /**
+   * How do I let students know about the session?
+   */
+  LET_STUDENT_KNOW_SESSION = "let-student-know-session",
+
+  /**
+   * What if a student says they didn’t receive the TEAMMATES email, as they were supposed to?
+   */
+  STUDENT_DID_NOT_RECEIVE_SESSION_EMAIL = "student-did-not-receive-session-email",
+
+  /**
+   * How do I extend the deadline of a session?
+   */
+  EXTEND_SESSION_DEADLINE = "extend-session-deadline",
+
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -145,9 +145,17 @@
                             headerText="Is it compulsory for students to use Google accounts?"
                             [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT]">
     <p>
-      Students can submit feedback and view results without having to login to TEAMMATES, unless they choose to link their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results. However, students
-      who link their TEAMMATES account with their Google account will be able to access a dashboard of all their sessions and results through the TEAMMATES website.
+      Students can submit feedback and view results without having to login to TEAMMATES, unless they choose to link their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results.
+      Following non-essential features are available only to users who have joined a TEAMMATES course using a Google account:
     </p>
+    <ol>
+      <li>
+        Creating a profile page to share more information about them (e.g., a photo) with classmates and instructors
+      </li>
+      <li>
+        Viewing all the courses/sessions in a single page, without needing to use submission links to access each
+      </li>
+    </ol>
   </tm-instructor-help-panel>
   <!--Question-->
   <tm-instructor-help-panel class="instr-help-qn-last" #question [hidden]="key && !showQuestion.includes(StudentsSectionQuestions.STUDENT_CHANGE_ID)"
@@ -155,7 +163,7 @@
                             headerText="How do I change the Google ID associated with a student?"
                             [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_CHANGE_ID]">
     <p>
-      At the moment, there is no way for students to update their own Google IDs.
+      At the moment, there is no way for students to update their own (or instructors to update their students’) Google IDs.
       <br> Please ask the student to <a href="mailto:{{ supportEmail }}">contact us</a> for assistance changing his/her Google ID.
     </p>
   </tm-instructor-help-panel>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -146,7 +146,7 @@
                             [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT]">
     <p>
       Students can submit feedback and view results without having to login to TEAMMATES, unless they choose to link their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results.
-      Following non-essential features are available only to users who have joined a TEAMMATES course using a Google account:
+      However, the following non-essential features are available only to users who have joined a TEAMMATES course using a Google account:
     </p>
     <ol>
       <li>


### PR DESCRIPTION
Part of #11794 . Made some changes to the instructor help pages.

Partially fixes #11794 . Reopen the issue after PR is merged.

Trying to create small PRs, so there're still more updates to the instructor pages needed, even besides #2874 and #8769 . However, the current contents on the help page should make sense as well, just not being comprehensive somewhere (probably).

I didn't do much content proof reading and there might still be some changes needed. @damithc 