### PR TITLE
[#11724] Admin page header tabs do not fit header at certain screen sizes

### DIFF
--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -43,7 +43,6 @@ nav {
 }
 
 .navbar {
-  padding: 0 80px;
   z-index: 1000;
 }
 


### PR DESCRIPTION
Fixes #11724
- Removed the extra padding present in header