### PR TITLE
[#2488] Instructor: edit questions: give more recipient type options

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -662,6 +662,7 @@ public abstract class AppPage {
         case STUDENTS_IN_SAME_SECTION:
             return "Other students in the same section";
         case STUDENTS:
+            return "Students in the course";
         case STUDENTS_EXCLUDING_SELF:
             return "Other students in the course";
         case INSTRUCTORS:
@@ -669,6 +670,7 @@ public abstract class AppPage {
         case TEAMS_IN_SAME_SECTION:
             return "Other teams in the same section";
         case TEAMS:
+            return "Teams in the course";
         case TEAMS_EXCLUDING_SELF:
             return "Other teams in the course";
         case OWN_TEAM:

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -657,11 +657,13 @@ public class FeedbackSubmitPage extends AppPage {
     private String getRecipientString(FeedbackParticipantType recipientType) {
         switch(recipientType) {
         case TEAMS:
+        case TEAMS_EXCLUDING_SELF:
         case TEAMS_IN_SAME_SECTION:
             return "teams";
         case OWN_TEAM_MEMBERS:
             return "student";
         case STUDENTS:
+        case STUDENTS_EXCLUDING_SELF:
         case STUDENTS_IN_SAME_SECTION:
             return "students";
         case INSTRUCTORS:

--- a/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
@@ -221,7 +221,7 @@
       "questionDescription": "<p>Question description for qn1</p>",
       "questionNumber": 1,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 3,
       "showResponsesTo": [
         "INSTRUCTORS",
@@ -298,7 +298,7 @@
       },
       "questionNumber": 4,
       "giverType": "TEAMS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 3,
       "showResponsesTo": [
         "RECEIVER"
@@ -345,7 +345,7 @@
       },
       "questionNumber": 1,
       "giverType": "STUDENTS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 3,
       "showResponsesTo": [
         "INSTRUCTORS",
@@ -371,7 +371,7 @@
       },
       "questionNumber": 2,
       "giverType": "STUDENTS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 3,
       "showResponsesTo": [
         "RECEIVER"

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -96,7 +96,9 @@ public abstract class FeedbackQuestionDetails {
     public boolean shouldGenerateMissingResponses(FeedbackQuestionAttributes question) {
         // generate combinations against all students/teams are meaningless
         return question.getRecipientType() != FeedbackParticipantType.STUDENTS
-                && question.getRecipientType() != FeedbackParticipantType.TEAMS;
+                && question.getRecipientType() != FeedbackParticipantType.STUDENTS_EXCLUDING_SELF
+                && question.getRecipientType() != FeedbackParticipantType.TEAMS
+                && question.getRecipientType() != FeedbackParticipantType.TEAMS_EXCLUDING_SELF;
     }
 
     @Override

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -333,7 +333,8 @@ public final class FeedbackQuestionsLogic {
                     // instructor can only see students in allowed sections for him/her
                     continue;
                 }
-                // Ensure student does not evaluate himself if it's STUDENTS_EXCLUDING_SELF or STUDENTS_IN_SAME_SECTION
+                // Ensure student does not evaluate him/herself if it's STUDENTS_EXCLUDING_SELF or
+                // STUDENTS_IN_SAME_SECTION
                 if (giverEmail.equals(student.getEmail()) && generateOptionsFor != FeedbackParticipantType.STUDENTS) {
                     continue;
                 }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -333,10 +333,11 @@ public final class FeedbackQuestionsLogic {
                     // instructor can only see students in allowed sections for him/her
                     continue;
                 }
-                // Ensure student does not evaluate himself
-                if (!giverEmail.equals(student.getEmail())) {
-                    recipients.put(student.getEmail(), student.getName());
+                // Ensure student does not evaluate himself if it's STUDENTS_EXCLUDING_SELF or STUDENTS_IN_SAME_SECTION
+                if (giverEmail.equals(student.getEmail()) && generateOptionsFor != FeedbackParticipantType.STUDENTS) {
+                    continue;
                 }
+                recipients.put(student.getEmail(), student.getName());
             }
             break;
         case INSTRUCTORS:
@@ -381,11 +382,13 @@ public final class FeedbackQuestionsLogic {
                     // instructor can only see teams in allowed sections for him/her
                     continue;
                 }
-                // Ensure student('s team) does not evaluate own team.
-                if (!giverTeam.equals(team.getKey())) {
-                    // recipientEmail doubles as team name in this case.
-                    recipients.put(team.getKey(), team.getKey());
+                // Ensure student('s team) does not evaluate own team if it's TEAMS_EXCLUDING_SELF or
+                // TEAMS_IN_SAME_SECTION
+                if (giverTeam.equals(team.getKey()) && generateOptionsFor != FeedbackParticipantType.TEAMS) {
+                    continue;
                 }
+                // recipientEmail doubles as team name in this case.
+                recipients.put(team.getKey(), team.getKey());
             }
             break;
         case OWN_TEAM:

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -304,6 +304,7 @@ public final class FeedbackResponsesLogic {
         }
         boolean isStudentRecipientType =
                    question.getRecipientType().equals(FeedbackParticipantType.STUDENTS)
+                || question.getRecipientType().equals(FeedbackParticipantType.STUDENTS_EXCLUDING_SELF)
                 || question.getRecipientType().equals(FeedbackParticipantType.STUDENTS_IN_SAME_SECTION)
                 || question.getRecipientType().equals(FeedbackParticipantType.OWN_TEAM_MEMBERS)
                 || question.getRecipientType().equals(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF)

--- a/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
+++ b/src/test/resources/data/GetFeedbackQuestionRecipientsActionTest.json
@@ -1023,7 +1023,7 @@
       },
       "questionNumber": 2,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 1,
       "showResponsesTo": [
         "INSTRUCTORS",
@@ -1128,7 +1128,7 @@
       },
       "questionNumber": 1,
       "giverType": "TEAMS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 2,
       "showResponsesTo": [
         "RECEIVER"
@@ -1220,7 +1220,7 @@
       },
       "questionNumber": 1,
       "giverType": "TEAMS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 2,
       "showResponsesTo": [
         "RECEIVER"
@@ -1304,7 +1304,7 @@
       },
       "questionNumber": 1,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 4,
       "showResponsesTo": [
         "RECEIVER"

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -1122,7 +1122,7 @@
       },
       "questionNumber": 2,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 1,
       "showResponsesTo": [
         "INSTRUCTORS",
@@ -1227,7 +1227,7 @@
       },
       "questionNumber": 1,
       "giverType": "TEAMS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 2,
       "showResponsesTo": [
         "RECEIVER"
@@ -1269,7 +1269,7 @@
       },
       "questionNumber": 3,
       "giverType": "INSTRUCTORS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 2,
       "showResponsesTo": [
         "RECEIVER"
@@ -1290,7 +1290,7 @@
       },
       "questionNumber": 1,
       "giverType": "TEAMS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 2,
       "showResponsesTo": [
         "RECEIVER"
@@ -1374,7 +1374,7 @@
       },
       "questionNumber": 1,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 4,
       "showResponsesTo": [
         "RECEIVER"
@@ -1395,7 +1395,7 @@
       },
       "questionNumber": 1,
       "giverType": "INSTRUCTORS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 4,
       "showResponsesTo": [
         "RECEIVER"
@@ -1416,7 +1416,7 @@
       },
       "questionNumber": 1,
       "giverType": "STUDENTS",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 4,
       "showResponsesTo": [
         "RECEIVER"
@@ -1437,7 +1437,7 @@
       },
       "questionNumber": 1,
       "giverType": "INSTRUCTORS",
-      "recipientType": "TEAMS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 1,
       "showResponsesTo": [
         "RECEIVER"
@@ -1475,7 +1475,7 @@
       },
       "questionNumber": 1,
       "giverType": "SELF",
-      "recipientType": "STUDENTS",
+      "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numberOfEntitiesToGiveFeedbackTo": 10,
       "showResponsesTo": [],
       "showGiverNameTo": [],

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -175,8 +175,8 @@
 
     <div class="alert alert-warning" role="alert" *ngIf="!model.recipientList.length && model.isLoaded">
       <span *ngIf="model.recipientType === FeedbackParticipantType.OWN_TEAM_MEMBERS">This question is for team members and you don't have any team members. Therefore, you will not be able to answer this question.</span>
-      <span *ngIf="model.recipientType === FeedbackParticipantType.TEAMS">This question is for other teams in this course and this course doesn't have any other team. Therefore, you will not be able to answer this question.</span>
-      <span *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS">This question is for other students in this course and this course doesn't have any other student. Therefore, you will not be able to answer this question.</span>
+      <span *ngIf="model.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF">This question is for other teams in this course and this course doesn't have any other team. Therefore, you will not be able to answer this question.</span>
+      <span *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS_EXCLUDING_SELF">This question is for other students in this course and this course doesn't have any other student. Therefore, you will not be able to answer this question.</span>
     </div>
 
     <div class="row" *ngIf="model.recipientList.length > 0">

--- a/src/web/app/components/question-submission-form/recipient-type-name.pipe.ts
+++ b/src/web/app/components/question-submission-form/recipient-type-name.pipe.ts
@@ -15,9 +15,11 @@ export class RecipientTypeNamePipe implements PipeTransform {
   transform(recipientType: FeedbackParticipantType, giverType: FeedbackParticipantType): string {
     switch (recipientType) {
       case FeedbackParticipantType.TEAMS:
+      case FeedbackParticipantType.TEAMS_EXCLUDING_SELF:
       case FeedbackParticipantType.OWN_TEAM:
         return 'Team';
       case FeedbackParticipantType.STUDENTS:
+      case FeedbackParticipantType.STUDENTS_EXCLUDING_SELF:
         return 'Student';
       case FeedbackParticipantType.INSTRUCTORS:
         return 'Instructor';

--- a/src/web/app/components/visibility-messages/visibility-entity-name.pipe.ts
+++ b/src/web/app/components/visibility-messages/visibility-entity-name.pipe.ts
@@ -35,12 +35,14 @@ export class VisibilityEntityNamePipe implements PipeTransform {
             recipientEntityName = 'instructor';
             break;
           case FeedbackParticipantType.STUDENTS:
+          case FeedbackParticipantType.STUDENTS_EXCLUDING_SELF:
           case FeedbackParticipantType.STUDENTS_IN_SAME_SECTION:
           case FeedbackParticipantType.OWN_TEAM_MEMBERS:
           case FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF:
             recipientEntityName = 'student';
             break;
           case FeedbackParticipantType.TEAMS:
+          case FeedbackParticipantType.TEAMS_EXCLUDING_SELF:
           case FeedbackParticipantType.TEAMS_IN_SAME_SECTION:
           case FeedbackParticipantType.OWN_TEAM:
             recipientEntityName = 'team';
@@ -49,7 +51,9 @@ export class VisibilityEntityNamePipe implements PipeTransform {
             return 'unknown';
         }
 
-        if ([FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.STUDENTS, FeedbackParticipantType.TEAMS]
+        if ([FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.STUDENTS,
+          FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS,
+          FeedbackParticipantType.TEAMS_EXCLUDING_SELF]
             .includes(questionRecipientType)) {
           // if questionRecipientType is one of certain participant type, add the plural form
           if (numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -3983,47 +3983,57 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                             Giver (Self feedback)
                           </option>
                           <option
-                            value="1: STUDENTS_EXCLUDING_SELF"
+                            value="1: STUDENTS"
+                          >
+                            Students in the course
+                          </option>
+                          <option
+                            value="2: STUDENTS_EXCLUDING_SELF"
                           >
                             Other students in the course
                           </option>
                           <option
-                            value="2: STUDENTS_IN_SAME_SECTION"
+                            value="3: STUDENTS_IN_SAME_SECTION"
                           >
                             Other students in the same section
                           </option>
                           <option
-                            value="3: INSTRUCTORS"
+                            value="4: INSTRUCTORS"
                           >
                             Instructors in the course
                           </option>
                           <option
-                            value="4: TEAMS_EXCLUDING_SELF"
+                            value="5: TEAMS"
+                          >
+                            Teams in the course
+                          </option>
+                          <option
+                            value="6: TEAMS_EXCLUDING_SELF"
                           >
                             Other teams in the course
                           </option>
                           <option
-                            value="5: TEAMS_IN_SAME_SECTION"
+                            value="7: TEAMS_IN_SAME_SECTION"
                           >
                             Other teams in the same section
                           </option>
                           <option
-                            value="6: OWN_TEAM"
+                            value="8: OWN_TEAM"
                           >
                             Giver's team
                           </option>
                           <option
-                            value="7: OWN_TEAM_MEMBERS"
+                            value="9: OWN_TEAM_MEMBERS"
                           >
                             Giver's team members
                           </option>
                           <option
-                            value="8: OWN_TEAM_MEMBERS_INCLUDING_SELF"
+                            value="10: OWN_TEAM_MEMBERS_INCLUDING_SELF"
                           >
                             Giver's team members and Giver
                           </option>
                           <option
-                            value="9: NONE"
+                            value="11: NONE"
                           >
                             Nobody specific (For general class feedback)
                           </option>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -552,8 +552,10 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   getQuestionSubmissionFormMode(model: QuestionSubmissionFormModel): QuestionSubmissionFormMode {
     const isNumberOfEntitiesToGiveFeedbackToSettingLimited: boolean =
         (model.recipientType === FeedbackParticipantType.STUDENTS
+            || model.recipientType === FeedbackParticipantType.STUDENTS_EXCLUDING_SELF
             || model.recipientType === FeedbackParticipantType.STUDENTS_IN_SAME_SECTION
             || model.recipientType === FeedbackParticipantType.TEAMS
+            || model.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF
             || model.recipientType === FeedbackParticipantType.TEAMS_IN_SAME_SECTION
             || model.recipientType === FeedbackParticipantType.INSTRUCTORS)
         && model.numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM

--- a/src/web/services/feedback-questions.service.ts
+++ b/src/web/services/feedback-questions.service.ts
@@ -88,33 +88,33 @@ export class FeedbackQuestionsService {
       case FeedbackQuestionType.RUBRIC:
       case FeedbackQuestionType.CONSTSUM_OPTIONS:
         paths.set(FeedbackParticipantType.SELF,
-          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
-            FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
-            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS_EXCLUDING_SELF,
-            FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
+          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS,
+            FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
+            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS,
+            FeedbackParticipantType.TEAMS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
             FeedbackParticipantType.OWN_TEAM, FeedbackParticipantType.NONE]);
 
         paths.set(FeedbackParticipantType.STUDENTS,
-          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
-            FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
-            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS_EXCLUDING_SELF,
-            FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
+          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS,
+            FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
+            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS,
+            FeedbackParticipantType.TEAMS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
             FeedbackParticipantType.OWN_TEAM, FeedbackParticipantType.OWN_TEAM_MEMBERS,
             FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
             FeedbackParticipantType.NONE]);
 
         paths.set(FeedbackParticipantType.INSTRUCTORS,
-          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
+          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS,
             FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
-            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS_EXCLUDING_SELF,
+            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS,
             FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
             FeedbackParticipantType.OWN_TEAM, FeedbackParticipantType.NONE]);
 
         paths.set(FeedbackParticipantType.TEAMS,
-          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
-            FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
-            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS_EXCLUDING_SELF,
-            FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
+          [FeedbackParticipantType.SELF, FeedbackParticipantType.STUDENTS,
+            FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
+            FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.TEAMS,
+            FeedbackParticipantType.TEAMS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
             FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
             FeedbackParticipantType.NONE]);
         break;


### PR DESCRIPTION
Fixes #2488

**Outline of Solution**
* Add the new definition/logic for `STUDENTS` and `TEAMS`
* Add the new recipient type options, i.e. `STUDENTS` and `TEAMS`
