### PR TITLE
[#11719] student submitting responses: inform that submitting individual responses is optional

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -43,6 +43,7 @@
 
     <div class="alert alert-primary" role="alert" *ngIf="model.giverType === FeedbackParticipantType.TEAMS">
       Please note that you are submitting this response on behalf of your team.
+      Please note tht submitting individual responese is optional
     </div>
 
     <div class="row">


### PR DESCRIPTION
Fixes #11719 
[#11719]

I have added the message in the note which is already present in the feedback page fixed the issue #11719 