### PR TITLE
[#11753] Differentiate button/dialog for individual/all-question submissions

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -184,7 +184,8 @@
         <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
                 ngbTooltip="You can save your responses for this question at any time and come back later to continue."
                 (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled"
-        ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>Submit Responses</button>
+        ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
+          {{ "Submit Responses to Question " + model.questionNumber }}</button>
       </div>
     </div>
   </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -185,9 +185,7 @@
                 ngbTooltip="You can save your responses for this question at any time and come back later to continue."
                 (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled">
           <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
-          <span>
-            {{ "Submit Response for Question " + model.questionNumber }}
-          </span>
+          <span>{{ "Submit Response for Question " + model.questionNumber }}</span>
         </button>
       </div>
     </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -183,9 +183,12 @@
       <div class="col-12 text-center">
         <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
                 ngbTooltip="You can save your responses for this question at any time and come back later to continue."
-                (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled"
-        ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
-          {{ "Submit Response for Question " + model.questionNumber }}</button>
+                (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled">
+          <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
+          <span>
+            {{ "Submit Response for Question " + model.questionNumber }}
+          </span>
+        </button>
       </div>
     </div>
   </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -185,7 +185,7 @@
                 ngbTooltip="You can save your responses for this question at any time and come back later to continue."
                 (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled"
         ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
-          {{ "Submit Responses to Question " + model.questionNumber }}</button>
+          {{ "Submit Response for Question " + model.questionNumber }}</button>
       </div>
     </div>
   </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1504,7 +1504,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 4
                 </button>
               </div>
             </div>
@@ -1668,7 +1668,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 5
                 </button>
               </div>
             </div>
@@ -1846,7 +1846,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 6
                 </button>
               </div>
             </div>
@@ -2251,7 +2251,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 7
                 </button>
               </div>
             </div>
@@ -2519,7 +2519,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 8
                 </button>
               </div>
             </div>
@@ -2745,7 +2745,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 9
                 </button>
               </div>
             </div>
@@ -2925,7 +2925,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 10
                 </button>
               </div>
             </div>
@@ -3854,7 +3854,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 4
                 </button>
               </div>
             </div>
@@ -4019,7 +4019,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 5
                 </button>
               </div>
             </div>
@@ -4198,7 +4198,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 6
                 </button>
               </div>
             </div>
@@ -4604,7 +4604,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 7
                 </button>
               </div>
             </div>
@@ -4881,7 +4881,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 8
                 </button>
               </div>
             </div>
@@ -5108,7 +5108,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 9
                 </button>
               </div>
             </div>
@@ -5289,7 +5289,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                  Submit Responses
+                   Submit Responses to Question 10
                 </button>
               </div>
             </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1504,7 +1504,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 4
+                  <span>
+                     Submit Response for Question 4 
+                  </span>
                 </button>
               </div>
             </div>
@@ -1668,7 +1670,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 5
+                  <span>
+                     Submit Response for Question 5 
+                  </span>
                 </button>
               </div>
             </div>
@@ -1846,7 +1850,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 6
+                  <span>
+                     Submit Response for Question 6 
+                  </span>
                 </button>
               </div>
             </div>
@@ -2251,7 +2257,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 7
+                  <span>
+                     Submit Response for Question 7 
+                  </span>
                 </button>
               </div>
             </div>
@@ -2519,7 +2527,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 8
+                  <span>
+                     Submit Response for Question 8 
+                  </span>
                 </button>
               </div>
             </div>
@@ -2745,7 +2755,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 9
+                  <span>
+                     Submit Response for Question 9 
+                  </span>
                 </button>
               </div>
             </div>
@@ -2925,7 +2937,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 10
+                  <span>
+                     Submit Response for Question 10 
+                  </span>
                 </button>
               </div>
             </div>
@@ -3854,7 +3868,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 4
+                  <span>
+                     Submit Response for Question 4 
+                  </span>
                 </button>
               </div>
             </div>
@@ -4019,7 +4035,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 5
+                  <span>
+                     Submit Response for Question 5 
+                  </span>
                 </button>
               </div>
             </div>
@@ -4198,7 +4216,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 6
+                  <span>
+                     Submit Response for Question 6 
+                  </span>
                 </button>
               </div>
             </div>
@@ -4604,7 +4624,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 7
+                  <span>
+                     Submit Response for Question 7 
+                  </span>
                 </button>
               </div>
             </div>
@@ -4881,7 +4903,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 8
+                  <span>
+                     Submit Response for Question 8 
+                  </span>
                 </button>
               </div>
             </div>
@@ -5108,7 +5132,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 9
+                  <span>
+                     Submit Response for Question 9 
+                  </span>
                 </button>
               </div>
             </div>
@@ -5289,7 +5315,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Response for Question 10
+                  <span>
+                     Submit Response for Question 10 
+                  </span>
                 </button>
               </div>
             </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1505,7 +1505,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 4 
+                    Submit Response for Question 4
                   </span>
                 </button>
               </div>
@@ -1671,7 +1671,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 5 
+                    Submit Response for Question 5
                   </span>
                 </button>
               </div>
@@ -1851,7 +1851,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 6 
+                    Submit Response for Question 6
                   </span>
                 </button>
               </div>
@@ -2258,7 +2258,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 7 
+                    Submit Response for Question 7
                   </span>
                 </button>
               </div>
@@ -2528,7 +2528,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 8 
+                    Submit Response for Question 8
                   </span>
                 </button>
               </div>
@@ -2756,7 +2756,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 9 
+                    Submit Response for Question 9
                   </span>
                 </button>
               </div>
@@ -2938,7 +2938,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 10 
+                    Submit Response for Question 10
                   </span>
                 </button>
               </div>
@@ -3869,7 +3869,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 4 
+                    Submit Response for Question 4
                   </span>
                 </button>
               </div>
@@ -4036,7 +4036,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 5 
+                    Submit Response for Question 5
                   </span>
                 </button>
               </div>
@@ -4217,7 +4217,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 6 
+                    Submit Response for Question 6
                   </span>
                 </button>
               </div>
@@ -4625,7 +4625,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 7 
+                    Submit Response for Question 7
                   </span>
                 </button>
               </div>
@@ -4904,7 +4904,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 8 
+                    Submit Response for Question 8
                   </span>
                 </button>
               </div>
@@ -5133,7 +5133,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 9 
+                    Submit Response for Question 9
                   </span>
                 </button>
               </div>
@@ -5316,7 +5316,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   type="submit"
                 >
                   <span>
-                     Submit Response for Question 10 
+                    Submit Response for Question 10
                   </span>
                 </button>
               </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1504,7 +1504,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 4
+                   Submit Response for Question 4
                 </button>
               </div>
             </div>
@@ -1668,7 +1668,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 5
+                   Submit Response for Question 5
                 </button>
               </div>
             </div>
@@ -1846,7 +1846,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 6
+                   Submit Response for Question 6
                 </button>
               </div>
             </div>
@@ -2251,7 +2251,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 7
+                   Submit Response for Question 7
                 </button>
               </div>
             </div>
@@ -2519,7 +2519,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 8
+                   Submit Response for Question 8
                 </button>
               </div>
             </div>
@@ -2745,7 +2745,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 9
+                   Submit Response for Question 9
                 </button>
               </div>
             </div>
@@ -2925,7 +2925,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 10
+                   Submit Response for Question 10
                 </button>
               </div>
             </div>
@@ -3854,7 +3854,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 4
+                   Submit Response for Question 4
                 </button>
               </div>
             </div>
@@ -4019,7 +4019,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 5
+                   Submit Response for Question 5
                 </button>
               </div>
             </div>
@@ -4198,7 +4198,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 6
+                   Submit Response for Question 6
                 </button>
               </div>
             </div>
@@ -4604,7 +4604,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 7
+                   Submit Response for Question 7
                 </button>
               </div>
             </div>
@@ -4881,7 +4881,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 8
+                   Submit Response for Question 8
                 </button>
               </div>
             </div>
@@ -5108,7 +5108,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 9
+                   Submit Response for Question 9
                 </button>
               </div>
             </div>
@@ -5289,7 +5289,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   ngbtooltip="You can save your responses for this question at any time and come back later to continue."
                   type="submit"
                 >
-                   Submit Responses to Question 10
+                   Submit Response for Question 10
                 </button>
               </div>
             </div>

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -1,8 +1,11 @@
 <div class="modal-header text-white"
      [ngClass]="{'bg-danger': hasFailToSaveQuestions, 'bg-success': !hasFailToSaveQuestions}">
   <h5 class="modal-title">
-    <span *ngIf="!hasFailToSaveQuestions">
-      <i class="fas fa-check-circle"></i> Responses submitted successfully!
+    <span *ngIf="!hasFailToSaveQuestions && questions.length === 1">
+      <i class="fas fa-check-circle"></i> Responses to question {{ questions[0].questionNumber }} submitted successfully!
+    </span>
+    <span *ngIf="!hasFailToSaveQuestions && questions.length > 1">
+      <i class="fas fa-check-circle"></i> Responses to all questions submitted successfully!
     </span>
     <span *ngIf="hasFailToSaveQuestions">
       <i class="fas fa-exclamation-circle"></i> Some response submissions failed!
@@ -29,7 +32,7 @@
     Please try to submit your responses again.
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length === 1">
-    Your responses for question {{ questions[0].questionNumber }} have been successfully recorded!
+    Your responses for <b> question {{ questions[0].questionNumber }} </b> have been successfully recorded!
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length > 1">
     All your responses have been successfully recorded!
@@ -40,6 +43,10 @@
   <p *ngIf="!hasFailToSaveQuestions">
     <b>You are encouraged to download the proof of submission, which will also contain your latest responses.</b>
   </p>
+  <span class="color-red" *ngIf="!hasFailToSaveQuestions && questions.length === 1">
+      <i class="fas fa-exclamation"></i>
+      Submitting question {{ questions[0].questionNumber }} does not submit other questions (if any).
+  </span>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn modal-btn-ok btn-info"

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -2,7 +2,7 @@
      [ngClass]="{'bg-danger': hasFailToSaveQuestions, 'bg-success': !hasFailToSaveQuestions}">
   <h5 class="modal-title">
     <span *ngIf="!hasFailToSaveQuestions && questions.length === 1">
-      <i class="fas fa-check-circle"></i> Responses to question {{ questions[0].questionNumber }} submitted successfully!
+      <i class="fas fa-check-circle"></i> Response to question {{ questions[0].questionNumber }} submitted successfully!
     </span>
     <span *ngIf="!hasFailToSaveQuestions && questions.length > 1">
       <i class="fas fa-check-circle"></i> Responses to all questions submitted successfully!
@@ -32,7 +32,7 @@
     Please try to submit your responses again.
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length === 1">
-    Your responses for <b> question {{ questions[0].questionNumber }} </b> have been successfully recorded!
+    Your response for <b> question {{ questions[0].questionNumber }} </b> have been successfully recorded!
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length > 1">
     All your responses have been successfully recorded!

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -32,7 +32,7 @@
     Please try to submit your responses again.
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length === 1">
-    Your response for <b> question {{ questions[0].questionNumber }} </b> have been successfully recorded!
+    Your response for <b> question {{ questions[0].questionNumber }} </b> has been successfully recorded!
   </p>
   <p *ngIf="!hasFailToSaveQuestions && questions.length > 1">
     All your responses have been successfully recorded!

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -43,7 +43,7 @@
   <p *ngIf="!hasFailToSaveQuestions">
     <b>You are encouraged to download the proof of submission, which will also contain your latest responses.</b>
   </p>
-  <span class="color-red" *ngIf="!hasFailToSaveQuestions && questions.length === 1">
+  <span class="text-danger" *ngIf="!hasFailToSaveQuestions && questions.length === 1">
       <i class="fas fa-exclamation"></i>
       Submitting question {{ questions[0].questionNumber }} does not submit other questions (if any).
   </span>

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -53,6 +53,10 @@ h6,
   color: #4379D1;
 }
 
+.color-red {
+  color: var(--red);
+}
+
 .hidden {
   display: none;
 }

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -53,10 +53,6 @@ h6,
   color: #4379D1;
 }
 
-.color-red {
-  color: var(--red);
-}
-
 .hidden {
   display: none;
 }


### PR DESCRIPTION
Fixes #11753 

**Outline of Solution**

* Button text for the individual question and all-question submission is now more specific.
* Dialog makes it clear that submitting an individual question does not submit all other questions.

| Individual question    | All questions |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/53614454/172632818-a31ea369-3f5d-4f09-963f-bd2117fbb2c2.png) | ![image](https://user-images.githubusercontent.com/53614454/172632931-ebd33f51-9a6a-4866-a9b5-a7ea6f860d4c.png)    |
| ![image](https://user-images.githubusercontent.com/53614454/172633058-696b6cf7-2be8-4e24-b85e-c9b0f23039fb.png) | ![image](https://user-images.githubusercontent.com/53614454/172633119-03b147c6-5fa2-4aa2-a488-2a04c45456d9.png) |