### PR TITLE
[#11858] Instructor viewing results: 'Other teams in the same section' path is causing timeout

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -375,8 +375,8 @@ public final class FeedbackQuestionsLogic {
                 if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
                     final String finalGiverSection = giverSection;
                     teamStudents = courseRoster.getStudents().stream()
-                            .filter(studentAttributes -> studentAttributes.getSection()
-                                    .equals(finalGiverSection)).collect(Collectors.toList());
+                            .filter(student -> student.getSection().equals(finalGiverSection))
+                            .collect(Collectors.toList());
                     teamToTeamMembersTable = CourseRoster.buildTeamToMembersTable(teamStudents);
                 } else {
                     teamToTeamMembersTable = courseRoster.getTeamToMembersTable();

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -364,12 +364,19 @@ public final class FeedbackQuestionsLogic {
         case TEAMS_IN_SAME_SECTION:
             Map<String, List<StudentAttributes>> teamToTeamMembersTable;
             List<StudentAttributes> teamStudents;
-            if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
-                teamStudents = studentsLogic.getStudentsForSection(giverSection, question.getCourseId());
+            if (courseRoster == null) {
+                if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                    teamStudents = studentsLogic.getStudentsForSection(giverSection, question.getCourseId());
+                } else {
+                    teamStudents = studentsLogic.getStudentsForCourse(question.getCourseId());
+                }
                 teamToTeamMembersTable = CourseRoster.buildTeamToMembersTable(teamStudents);
             } else {
-                if (courseRoster == null) {
-                    teamStudents = studentsLogic.getStudentsForCourse(question.getCourseId());
+                if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                    final String finalGiverSection = giverSection;
+                    teamStudents = courseRoster.getStudents().stream()
+                            .filter(studentAttributes -> studentAttributes.getSection()
+                                    .equals(finalGiverSection)).collect(Collectors.toList());
                     teamToTeamMembersTable = CourseRoster.buildTeamToMembersTable(teamStudents);
                 } else {
                     teamToTeamMembersTable = courseRoster.getTeamToMembersTable();


### PR DESCRIPTION
Fixes #11858

**Outline of Solution**
Timeout is believed to be caused by the building of missing responses for `Other teams in the same section`, where a query is made instead of utilizing the course roster provided. Hence, the fix is just to utilize the course roster.