### PR TITLE
[#11779] Disable 'Individual Deadline Extensions' link

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -182,8 +182,15 @@
             </div>
             <div class="row">
               <a class="pl-3 pt-2"
+                *ngIf="formMode !== SessionEditFormMode.ADD"
                 tmRouterLink="/web/instructor/sessions/individual-extension"
                 [queryParams]="{ courseid: model.courseId, fsname: model.feedbackSessionName }">
+                Individual Deadline Extensions
+                <i class="fas fa-edit"></i>
+              </a>
+              <a class="pl-3 pt-2 disabled-link"
+                 *ngIf="formMode === SessionEditFormMode.ADD"
+                 ngbTooltip="You must save the new session before setting individual deadline extensions">
                 Individual Deadline Extensions
                 <i class="fas fa-edit"></i>
               </a>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.scss
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.scss
@@ -35,3 +35,8 @@
 .padding-left-7px {
   padding-left: 7px;
 }
+
+.disabled-link {
+  cursor: not-allowed;
+  color: gray;
+}


### PR DESCRIPTION
Fixes #11779

**Outline of Solution**

Show a disabled anchor tag when the form is in add mode. Also shows a tooltip on why the link is disabled.
