### PR TITLE
[#11764] Give an easy way to extend deadline for non-submitters

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -183,7 +183,7 @@
             <div class="row">
               <a class="pl-3 pt-2"
                 tmRouterLink="/web/instructor/sessions/individual-extension"
-                [queryParams]="{ courseid: model.courseId, fsname: model.feedbackSessionName }">
+                [queryParams]="{ courseid: model.courseId, fsname: model.feedbackSessionName, preselectnonsubmitters: false }">
                 Individual Deadline Extensions
                 <i class="fas fa-edit"></i>
               </a>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1086,7 +1086,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                   >
                     <a
                       class="pl-3 pt-2"
-                      href="/web/instructor/sessions/individual-extension?courseid=testId&fsname=test%20session"
+                      href="/web/instructor/sessions/individual-extension?courseid=testId&fsname=test%20session&preselectnonsubmitters=false"
                       tmrouterlink="/web/instructor/sessions/individual-extension"
                     >
                        Individual Deadline Extensions 
@@ -3484,7 +3484,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                   >
                     <a
                       class="pl-3 pt-2"
-                      href="/web/instructor/sessions/individual-extension?courseid=&fsname="
+                      href="/web/instructor/sessions/individual-extension?courseid=&fsname=&preselectnonsubmitters=false"
                       tmrouterlink="/web/instructor/sessions/individual-extension"
                     >
                        Individual Deadline Extensions 

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
@@ -23,6 +23,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -495,6 +496,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -967,6 +969,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession={[Function Boolean]}
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -1220,6 +1223,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -1641,6 +1645,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -2027,6 +2032,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -2501,6 +2507,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
   isLoadingAllInstructors={[Function Boolean]}
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -2768,6 +2775,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
   isLoadingAllInstructors="false"
   isLoadingAllStudents={[Function Boolean]}
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -3023,6 +3031,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -3279,6 +3288,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -3535,6 +3545,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}
@@ -3894,6 +3905,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   isLoadingAllInstructors="false"
   isLoadingAllStudents="false"
   isLoadingFeedbackSession="false"
+  isPreSelectingNonSubmitters="false"
   isSubmittingDeadlines="false"
   ngbModal={[Function NgbModal]}
   route={[Function Object]}

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
@@ -15,6 +15,7 @@ import {
   FeedbackSession,
   FeedbackSessionPublishStatus,
   FeedbackSessionSubmissionStatus,
+  FeedbackSessionSubmittedGiverSet,
   Instructor,
   Instructors,
   JoinState,
@@ -107,6 +108,10 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     instructors: [testInstructor1, testInstructor2],
   };
 
+  const testFeedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet = {
+    giverIdentifiers: [testStudent2.email],
+  };
+
   const testTimeString = '5 Apr 2000 2:00:00';
 
   let component: InstructorSessionIndividualExtensionPageComponent;
@@ -133,6 +138,7 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
               queryParams: of({
                 courseid: testCourse.courseId,
                 feedbackSessionName: testFeedbackSession.feedbackSessionName,
+                preselectnonsubmitters: 'false',
               }),
             },
           },
@@ -458,5 +464,50 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     expect(extendButton.disabled).toBeFalsy();
     expect(deleteButton.textContent).toEqual('Delete');
     expect(deleteButton.disabled).toBeFalsy();
+  });
+
+  it('should not automatically select students that have not submitted yet if preselectnonsubmitters is false', () => {
+    jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(of(students));
+    jest.spyOn(courseService, 'getCourseAsInstructor').mockReturnValue(of(testCourse));
+    jest.spyOn(feedbackSessionsService, 'getFeedbackSession').mockReturnValue(of(testFeedbackSession));
+    jest.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet')
+      .mockReturnValue(of(testFeedbackSessionSubmittedGiverSet)); // Alice and Alex have not submitted yet
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    const studentOneCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-0');
+    const studentTwoCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-1');
+    const studentThreeCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-2');
+
+    expect(component.isPreSelectingNonSubmitters).toBeFalsy();
+    expect(studentOneCheckBox.checked).toBeFalsy();
+    expect(studentTwoCheckBox.checked).toBeFalsy();
+    expect(studentThreeCheckBox.checked).toBeFalsy();
+  });
+
+  it('should automatically select students that have not submitted yet if preselectnonsubmitters is true', () => {
+    const activatedRoute = TestBed.inject(ActivatedRoute);
+    activatedRoute.queryParams = of({
+      courseid: testCourse.courseId,
+      feedbackSessionName: testFeedbackSession.feedbackSessionName,
+      preselectnonsubmitters: 'true',
+    });
+
+    jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(of(students));
+    jest.spyOn(courseService, 'getCourseAsInstructor').mockReturnValue(of(testCourse));
+    jest.spyOn(feedbackSessionsService, 'getFeedbackSession').mockReturnValue(of(testFeedbackSession));
+    jest.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet')
+      .mockReturnValue(of(testFeedbackSessionSubmittedGiverSet)); // Alice and Alex have not submitted yet
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    const studentOneCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-0');
+    const studentTwoCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-1');
+    const studentThreeCheckBox: any = fixture.debugElement.nativeElement.querySelector('#student-checkbox-2');
+
+    expect(component.isPreSelectingNonSubmitters).toBeTruthy();
+    expect(studentOneCheckBox.checked).toBeTruthy();
+    expect(studentTwoCheckBox.checked).toBeFalsy();
+    expect(studentThreeCheckBox.checked).toBeTruthy();
   });
 });

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -9,7 +9,7 @@
     <ng-template #extendDeadlineBtn>
       <button type="button" class="btn btn-secondary btn-sm button"
               [disabled]="session.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN">
-        Individual Deadline Extensions
+        Extend Deadline for All
       </button>
     </ng-template>
     <button id="btn-remind-all" class="btn btn-secondary btn-sm button" type="button" (click)="!isDisplayOnly && openSendReminderModal($event); $event.stopPropagation();"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -1,6 +1,15 @@
 <div id="no-response-panel" class="card-header bg-secondary text-white cursor-pointer" (click)="toggleTab()">
   Participants who have not responded to any question
   <div class="card-header-btn-toolbar">
+    <a *ngIf="session.submissionStatus === FeedbackSessionSubmissionStatus.OPEN; else extendDeadlineBtn" tmRouterLink="/web/instructor/sessions/individual-extension" [queryParams]="{ courseid: session.courseId, fsname: session.feedbackSessionName }">
+      <ng-container *ngTemplateOutlet="extendDeadlineBtn"></ng-container>
+    </a>
+    <ng-template #extendDeadlineBtn>
+      <button type="button" class="btn btn-secondary btn-sm button"
+              [disabled]="session.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN">
+        Individual Deadline Extensions
+      </button>
+    </ng-template>
     <button id="btn-remind-all" class="btn btn-secondary btn-sm button" type="button" (click)="!isDisplayOnly && openSendReminderModal($event); $event.stopPropagation();"
         [disabled]="session.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN">
       Remind All

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -1,7 +1,9 @@
 <div id="no-response-panel" class="card-header bg-secondary text-white cursor-pointer" (click)="toggleTab()">
   Participants who have not responded to any question
   <div class="card-header-btn-toolbar">
-    <a *ngIf="session.submissionStatus === FeedbackSessionSubmissionStatus.OPEN; else extendDeadlineBtn" tmRouterLink="/web/instructor/sessions/individual-extension" [queryParams]="{ courseid: session.courseId, fsname: session.feedbackSessionName }">
+    <a *ngIf="session.submissionStatus === FeedbackSessionSubmissionStatus.OPEN; else extendDeadlineBtn"
+        tmRouterLink="/web/instructor/sessions/individual-extension"
+        [queryParams]="{ courseid: session.courseId, fsname: session.feedbackSessionName, preselectnonsubmitters: true }">
       <ng-container *ngTemplateOutlet="extendDeadlineBtn"></ng-container>
     </a>
     <ng-template #extendDeadlineBtn>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
@@ -21,6 +22,7 @@ describe('InstructorSessionNoResponsePanelComponent', () => {
         PanelChevronModule,
         LoadingSpinnerModule,
         TeammatesRouterModule,
+        RouterTestingModule,
       ],
     })
     .compileComponents();


### PR DESCRIPTION
Fixes #11764 

**Outline of Solution**
Added a button next to the 'Remind All' button that takes the instructor to the individual extension page with the non-submitters pre-selected.

https://user-images.githubusercontent.com/8349063/176203771-b572d450-6ccd-429a-82fa-a700b93a4756.mp4


