### PR TITLE
[#10992] Refactor frontend test data resources

### DIFF
--- a/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-audit-logs-page/instructor-audit-logs-page.component.spec.ts
@@ -6,19 +6,11 @@ import { CourseService } from '../../../services/course.service';
 import { LogService } from '../../../services/log.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import {
-  Course,
-  FeedbackSession,
-  FeedbackSessionLog,
-  FeedbackSessionLogType,
-  FeedbackSessionPublishStatus,
-  FeedbackSessionSubmissionStatus,
-  ResponseVisibleSetting,
-  SessionVisibleSetting,
-  Student,
-} from '../../../types/api-output';
 import { SortBy } from '../../../types/sort-properties';
 import { ColumnData } from '../../components/sortable-table/sortable-table.component';
+import TestCourses from '../../test-resources/courses';
+import TestFeedbackSessionLogs from '../../test-resources/feedback-session-logs';
+import TestStudents from '../../test-resources/students';
 import { InstructorAuditLogsPageComponent } from './instructor-audit-logs-page.component';
 import { InstructorAuditLogsPageModule } from './instructor-audit-logs-page.module';
 
@@ -38,108 +30,6 @@ describe('InstructorAuditLogsPageComponent', () => {
     { header: 'Section', sortBy: SortBy.SECTION_NAME },
     { header: 'Team', sortBy: SortBy.TEAM_NAME },
   ];
-  const testCourse1: Course = {
-    courseId: 'CS9999',
-    courseName: 'CS9999',
-    institute: 'Test Institute',
-    timeZone: 'Asia/Singapore',
-    creationTimestamp: 0,
-    deletionTimestamp: 0,
-    privileges: {
-      canModifyCourse: true,
-      canModifySession: true,
-      canModifyStudent: true,
-      canModifyInstructor: true,
-      canViewStudentInSections: true,
-      canModifySessionCommentsInSections: true,
-      canViewSessionInSections: true,
-      canSubmitSessionInSections: true,
-    },
-  };
-  const testCourse2: Course = {
-    courseId: 'MA1234',
-    courseName: 'MA1234',
-    institute: 'Test Institute',
-    timeZone: 'Asia/Singapore',
-    creationTimestamp: 0,
-    deletionTimestamp: 0,
-    privileges: {
-      canModifyCourse: true,
-      canModifySession: true,
-      canModifyStudent: true,
-      canModifyInstructor: true,
-      canViewStudentInSections: true,
-      canModifySessionCommentsInSections: true,
-      canViewSessionInSections: true,
-      canSubmitSessionInSections: true,
-    },
-  };
-  const testCourse3: Course = {
-    courseId: 'EE1111',
-    courseName: 'EE1111',
-    institute: 'Test Institute',
-    timeZone: 'Asia/Singapore',
-    creationTimestamp: 0,
-    deletionTimestamp: 0,
-    privileges: {
-      canModifyCourse: false,
-      canModifySession: false,
-      canModifyStudent: false,
-      canModifyInstructor: false,
-      canViewStudentInSections: true,
-      canModifySessionCommentsInSections: true,
-      canViewSessionInSections: true,
-      canSubmitSessionInSections: true,
-    },
-  };
-  const emptyStudent: Student = {
-    courseId: '', email: '', name: '', sectionName: '', teamName: '',
-  };
-  const testStudent: Student = {
-    email: 'doejohn@email.com',
-    courseId: 'CS9999',
-    name: 'Doe John',
-    teamName: 'team 1',
-    sectionName: 'section 1',
-  };
-  const testFeedbackSession: FeedbackSession = {
-    feedbackSessionName: 'Feedback Session 1',
-    courseId: 'CS9999',
-    timeZone: 'Asia/Singapore',
-    instructions: '',
-    submissionStartTimestamp: 0,
-    submissionEndTimestamp: 1549095330000,
-    gracePeriod: 0,
-    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
-    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
-    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
-    publishStatus: FeedbackSessionPublishStatus.PUBLISHED,
-    isClosingEmailEnabled: true,
-    isPublishedEmailEnabled: true,
-    createdAtTimestamp: 0,
-    studentDeadlines: {},
-    instructorDeadlines: {},
-  };
-  const testLogs1: FeedbackSessionLog = {
-    feedbackSessionData: testFeedbackSession,
-    feedbackSessionLogEntries: [
-      {
-        studentData: testStudent,
-        feedbackSessionLogType: FeedbackSessionLogType.SUBMISSION,
-        timestamp: 0,
-      },
-    ],
-  };
-  const testLogs2: FeedbackSessionLog = {
-    feedbackSessionData: testFeedbackSession,
-    feedbackSessionLogEntries: [
-      {
-        studentData: testStudent,
-        feedbackSessionLogType: FeedbackSessionLogType.SUBMISSION,
-        timestamp: 0,
-      },
-    ],
-  };
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -172,17 +62,17 @@ describe('InstructorAuditLogsPageComponent', () => {
   });
 
   it('should snap when searching for details in search form', () => {
-    component.courses = [testCourse1, testCourse2];
+    component.courses = [TestCourses.cs9999, TestCourses.ma1234];
     component.formModel = {
       logsDateFrom: { year: 1997, month: 9, day: 11 },
       logsTimeFrom: { hour: 23, minute: 59 },
       logsDateTo: { year: 1998, month: 9, day: 11 },
       logsTimeTo: { hour: 15, minute: 0 },
-      courseId: 'CS9999',
-      studentEmail: 'doejohn@email.com',
+      courseId: TestCourses.cs9999.courseName,
+      studentEmail: TestStudents.johnDoe.email,
     };
     component.courseToStudents = {
-      CS9999: [testStudent],
+      CS9999: [TestStudents.johnDoe],
       MA1234: [],
     };
     component.isLoading = false;
@@ -225,7 +115,7 @@ describe('InstructorAuditLogsPageComponent', () => {
     const courseSpy: SpyInstance = jest.spyOn(courseService, 'getAllCoursesAsInstructor')
         .mockReturnValue(of({
           courses: [
-            testCourse1, testCourse2, testCourse3,
+            TestCourses.cs9999, TestCourses.ma1234, TestCourses.ee1111,
           ],
         }));
 
@@ -234,9 +124,9 @@ describe('InstructorAuditLogsPageComponent', () => {
     expect(component.isLoading).toBeFalsy();
     expect(courseSpy).toBeCalledWith('active');
     expect(component.courses.length).toEqual(2);
-    expect(component.courses).toContainEqual(testCourse1);
-    expect(component.courses).toContainEqual(testCourse2);
-    expect(component.courses).not.toContainEqual(testCourse3);
+    expect(component.courses).toContainEqual(TestCourses.cs9999);
+    expect(component.courses).toContainEqual(TestCourses.ma1234);
+    expect(component.courses).not.toContainEqual(TestCourses.ee1111);
 
     // courseToStudents not loaded on init
     expect(component.courseToStudents).toMatchObject({});
@@ -246,40 +136,46 @@ describe('InstructorAuditLogsPageComponent', () => {
     const studentSpy: SpyInstance = jest.spyOn(studentService, 'getStudentsFromCourse')
         .mockReturnValue(of({
           students: [
-            testStudent,
+            TestStudents.johnDoe,
           ],
         }));
 
-    component.formModel.courseId = testCourse1.courseId;
+    component.formModel.courseId = TestCourses.cs9999.courseId;
     component.loadStudents();
 
-    expect(component.courseToStudents[testCourse1.courseId][0]).toEqual(emptyStudent);
-    expect(component.courseToStudents[testCourse1.courseId][1]).toEqual(testStudent);
-    expect(studentSpy).toHaveBeenNthCalledWith(1, { courseId: testCourse1.courseId });
+    expect(component.courseToStudents[TestCourses.cs9999.courseId][0]).toEqual(TestStudents.emptyStudent);
+    expect(component.courseToStudents[TestCourses.cs9999.courseId][1]).toEqual(TestStudents.johnDoe);
+    expect(studentSpy).toHaveBeenNthCalledWith(1, { courseId: TestCourses.cs9999.courseId });
   });
 
   it('should load students from cache if present', () => {
     const studentSpy: SpyInstance = jest.spyOn(studentService, 'getStudentsFromCourse')
         .mockReturnValue(of({
           students: [
-            testStudent,
+            TestStudents.johnDoe,
           ],
         }));
 
-    component.formModel.courseId = testCourse1.courseId;
-    component.courseToStudents[testCourse1.courseId] = [emptyStudent];
+    component.formModel.courseId = TestCourses.cs9999.courseId;
+    component.courseToStudents[TestCourses.cs9999.courseId] = [TestStudents.emptyStudent];
     component.loadStudents();
 
-    expect(component.courseToStudents[testCourse1.courseId].length).toEqual(1);
-    expect(component.courseToStudents[testCourse1.courseId][0]).toEqual(emptyStudent);
+    expect(component.courseToStudents[TestCourses.cs9999.courseId].length).toEqual(1);
+    expect(component.courseToStudents[TestCourses.cs9999.courseId][0]).toEqual(TestStudents.emptyStudent);
     expect(studentSpy).not.toHaveBeenCalled();
   });
 
   it('should search for logs using feedback course timezone when search button is clicked', () => {
     const logSpy: SpyInstance = jest.spyOn(logService, 'searchFeedbackSessionLog')
-        .mockReturnValue(of({ feedbackSessionLogs: [testLogs1, testLogs2] }));
+        .mockReturnValue(of(
+            {
+              feedbackSessionLogs: [
+                    TestFeedbackSessionLogs.testLogs1,
+                    TestFeedbackSessionLogs.testLogs2,
+              ],
+            }));
     const timeSpy: SpyInstance = jest.spyOn(timezoneService, 'resolveLocalDateTime');
-    const tzOffset: number = timezoneService.getTzOffsets()[testCourse1.timeZone];
+    const tzOffset: number = timezoneService.getTzOffsets()[TestCourses.cs9999.timeZone];
 
     component.isLoading = false;
     component.isSearching = false;
@@ -288,11 +184,11 @@ describe('InstructorAuditLogsPageComponent', () => {
       logsTimeFrom: { hour: 23, minute: 59 },
       logsDateTo: { year: 2020, month: 12, day: 31 },
       logsTimeTo: { hour: 23, minute: 59 },
-      courseId: testCourse1.courseId,
-      studentEmail: testStudent.email,
+      courseId: TestCourses.cs9999.courseId,
+      studentEmail: TestStudents.johnDoe.email,
     };
-    component.courses = [testCourse1];
-    component.courseToStudents = { CS9999: [testStudent] };
+    component.courses = [TestCourses.cs9999];
+    component.courseToStudents = { CS9999: [TestStudents.johnDoe] };
     fixture.detectChanges();
 
     fixture.debugElement.nativeElement.querySelector('#search-button').click();
@@ -301,15 +197,15 @@ describe('InstructorAuditLogsPageComponent', () => {
     expect(timeSpy).toHaveBeenCalledWith(
       component.formModel.logsDateFrom,
       component.formModel.logsTimeFrom,
-      testCourse1.timeZone,
+      TestCourses.cs9999.timeZone,
       true,
     );
     expect(logSpy).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith({
-      courseId: testCourse1.courseId,
+      courseId: TestCourses.cs9999.courseId,
       searchFrom: (new Date('2020-12-31T00:00+00:00').getTime() - tzOffset * 60 * 1000).toString(),
       searchUntil: (new Date('2021-01-01T00:00+00:00').getTime() - tzOffset * 60 * 1000).toString(),
-      studentEmail: testStudent.email,
+      studentEmail: TestStudents.johnDoe.email,
     });
 
     expect(component.searchResults.length).toEqual(2);

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
@@ -8,41 +8,15 @@ import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
-import { Course, Instructor, InstructorPermissionRole, JoinState, Student } from '../../../types/api-output';
+import { Instructor, InstructorPermissionRole, JoinState } from '../../../types/api-output';
 import { SimpleModalModule } from '../../components/simple-modal/simple-modal.module';
 import { StudentListRowModel } from '../../components/student-list/student-list.component';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
+import TestCourses from '../../test-resources/courses';
+import TestInstructors from '../../test-resources/instructors';
+import TestStudents from '../../test-resources/students';
 import { InstructorCourseDetailsPageComponent } from './instructor-course-details-page.component';
 import { InstructorCourseDetailsPageModule } from './instructor-course-details-page.module';
-
-const course: Course = {
-  courseId: 'CS101',
-  courseName: 'Introduction to CS',
-  timeZone: '',
-  institute: 'Test Institute',
-  creationTimestamp: 0,
-  deletionTimestamp: 0,
-};
-
-const testStudent: Student = {
-  name: 'Jamie',
-  email: 'jamie@gmail.com',
-  joinState: JoinState.NOT_JOINED,
-  teamName: 'Team 1',
-  sectionName: 'Tutorial Group 1',
-  courseId: 'CS101',
-};
-
-const testInstructor: Instructor = {
-  courseId: course.courseId,
-  joinState: JoinState.JOINED,
-  googleId: 'Hock',
-  name: 'Hock',
-  email: 'hock@gmail.com',
-  role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-  displayedToStudentsAs: 'Hock',
-  isDisplayedToStudents: false,
-};
 
 describe('InstructorCourseDetailsPageComponent', () => {
   let component: InstructorCourseDetailsPageComponent;
@@ -87,22 +61,12 @@ describe('InstructorCourseDetailsPageComponent', () => {
       numOfTeams: 0,
       numOfStudents: 0,
     };
-    const coOwner: Instructor = {
-      courseId: course.courseId,
-      joinState: JoinState.JOINED,
-      googleId: 'Hodor',
-      name: 'Hodor',
-      email: 'hodor@gmail.com',
-      role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-      displayedToStudentsAs: 'Hodor',
-      isDisplayedToStudents: true,
-    };
     const courseDetails: any = {
-      course,
+      course: TestCourses.cs101,
       stats,
     };
     component.courseDetails = courseDetails;
-    component.instructors = [coOwner];
+    component.instructors = [TestInstructors.hodor];
     component.isLoadingCsv = false;
     component.isStudentsLoading = false;
 
@@ -117,7 +81,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
       numOfStudents: 1,
     };
     const coOwner: Instructor = {
-      courseId: course.courseId,
+      courseId: TestCourses.cs101.courseId,
       joinState: JoinState.JOINED,
       googleId: 'Bran',
       name: 'Bran',
@@ -127,11 +91,11 @@ describe('InstructorCourseDetailsPageComponent', () => {
       isDisplayedToStudents: false,
     };
     const courseDetails: any = {
-      course,
+      course: TestCourses.cs101,
       stats,
     };
     const studentListRowModel: StudentListRowModel = {
-      student: testStudent,
+      student: TestStudents.jamie,
       isAllowedToViewStudentInSection: true,
       isAllowedToModifyStudent: true,
     };
@@ -157,17 +121,17 @@ describe('InstructorCourseDetailsPageComponent', () => {
       numOfStudents: 1,
     };
     const courseDetails: any = {
-      course,
+      course: TestCourses.cs101,
       stats,
     };
     const studentListRowModel: StudentListRowModel = {
-      student: testStudent,
+      student: TestStudents.jamie,
       isAllowedToViewStudentInSection: true,
       isAllowedToModifyStudent: true,
     };
     component.students = [studentListRowModel];
     component.courseDetails = courseDetails;
-    component.instructors = [testInstructor];
+    component.instructors = [TestInstructors.hock];
     component.isLoadingCsv = false;
     component.isStudentsLoading = false;
     fixture.detectChanges();
@@ -191,7 +155,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
       numOfStudents: 350,
     };
     const courseDetails: any = {
-      course,
+      course: TestCourses.cs101,
       stats,
     };
     component.courseDetails = courseDetails;
@@ -205,7 +169,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
           expect(args).toEqual('All the students have been removed from the course');
         });
 
-    component.deleteAllStudentsFromCourse(course.courseId);
+    component.deleteAllStudentsFromCourse(TestCourses.cs101.courseId);
 
     // given a limit of 100 students per call and 350 students,
     // there should be four calls in total
@@ -219,7 +183,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
       numOfStudents: 1,
     };
     const courseDetails: any = {
-      course,
+      course: TestCourses.cs101,
       stats,
     };
     component.courseDetails = courseDetails;
@@ -235,7 +199,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
       expect(args).toEqual('This is the error message.');
     });
 
-    component.deleteAllStudentsFromCourse(course.courseId);
+    component.deleteAllStudentsFromCourse(TestCourses.cs101.courseId);
 
     expect(spy).toBeCalled();
   });

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
@@ -7,7 +7,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 import { CourseService } from '../../../services/course.service';
 import { InstructorService } from '../../../services/instructor.service';
-import { Instructor, InstructorPermissionRole, JoinState } from '../../../types/api-output';
+import { InstructorPermissionRole, JoinState } from '../../../types/api-output';
 import { InstructorCreateRequest } from '../../../types/api-request';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
@@ -15,6 +15,8 @@ import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-s
 import { SimpleModalModule } from '../../components/simple-modal/simple-modal.module';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
+import TestCourses from '../../test-resources/courses';
+import TestInstructors from '../../test-resources/instructors';
 import {
   CustomPrivilegeSettingPanelComponent,
 } from './custom-privilege-setting-panel/custom-privilege-setting-panel.component';
@@ -24,8 +26,6 @@ import {
   InstructorEditPanelComponent,
 } from './instructor-edit-panel/instructor-edit-panel.component';
 import { ViewRolePrivilegesModalComponent } from './view-role-privileges-modal/view-role-privileges-modal.component';
-import TestCourses from '../../test-resources/courses';
-import TestInstructors from '../../test-resources/instructors';
 
 const emptyInstructorPanel: InstructorEditPanel = {
   googleId: '',
@@ -317,18 +317,11 @@ describe('InstructorCourseEditPageComponent', () => {
   });
 
   it('should snap with some instructor details', () => {
-    const instructor: Instructor = {
-      name: 'Instructor A',
-      email: 'instructora@example.com',
-      courseId: component.courseId,
-      joinState: JoinState.JOINED,
-    };
-
     component.instructorDetailPanels = [
       {
-        originalInstructor: instructor,
-        originalPanel: component.getInstructorEditPanelModel(instructor),
-        editPanel: component.getInstructorEditPanelModel(instructor),
+        originalInstructor: TestInstructors.harryPotter,
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.harryPotter),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.harryPotter),
       },
     ];
 

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
@@ -7,7 +7,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 import { CourseService } from '../../../services/course.service';
 import { InstructorService } from '../../../services/instructor.service';
-import { Course, Instructor, InstructorPermissionRole, JoinState } from '../../../types/api-output';
+import { Instructor, InstructorPermissionRole, JoinState } from '../../../types/api-output';
 import { InstructorCreateRequest } from '../../../types/api-request';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
@@ -24,36 +24,8 @@ import {
   InstructorEditPanelComponent,
 } from './instructor-edit-panel/instructor-edit-panel.component';
 import { ViewRolePrivilegesModalComponent } from './view-role-privileges-modal/view-role-privileges-modal.component';
-
-const testCourse: Course = {
-  courseId: 'exampleId',
-  courseName: 'Example Course',
-  institute: 'Test Institute',
-  timeZone: 'UTC (UTC)',
-  creationTimestamp: 0,
-  deletionTimestamp: 1000,
-};
-
-const testInstructor1: Instructor = {
-  courseId: 'exampleId',
-  email: 'instructor1@gmail.com',
-  joinState: JoinState.JOINED,
-  name: 'Instructor 1',
-};
-
-const testInstructor2: Instructor = {
-  courseId: 'exampleId',
-  email: 'instructor2@gmail.com',
-  joinState: JoinState.NOT_JOINED,
-  name: 'Instructor 2',
-};
-
-const testInstructor3: Instructor = {
-  courseId: 'exampleId',
-  email: 'instructor3@gmail.com',
-  joinState: JoinState.NOT_JOINED,
-  name: 'Instructor 3',
-};
+import TestCourses from '../../test-resources/courses';
+import TestInstructors from '../../test-resources/instructors';
 
 const emptyInstructorPanel: InstructorEditPanel = {
   googleId: '',
@@ -127,20 +99,20 @@ describe('InstructorCourseEditPageComponent', () => {
   });
 
   it('should load correct course details for given API output', () => {
-    jest.spyOn(courseService, 'getCourseAsInstructor').mockReturnValue(of(testCourse));
+    jest.spyOn(courseService, 'getCourseAsInstructor').mockReturnValue(of(TestCourses.cs101));
 
     component.loadCourseInfo();
 
-    expect(component.course.courseId).toBe('exampleId');
-    expect(component.course.courseName).toBe('Example Course');
-    expect(component.course.timeZone).toBe('UTC (UTC)');
-    expect(component.course.creationTimestamp).toBe(0);
-    expect(component.course.deletionTimestamp).toBe(1000);
+    expect(component.course.courseId).toBe(TestCourses.cs101.courseId);
+    expect(component.course.courseName).toBe(TestCourses.cs101.courseName);
+    expect(component.course.timeZone).toBe(TestCourses.cs101.timeZone);
+    expect(component.course.creationTimestamp).toBe(TestCourses.cs101.creationTimestamp);
+    expect(component.course.deletionTimestamp).toBe(TestCourses.cs101.deletionTimestamp);
     expect(component.hasCourseLoadingFailed).toBeFalsy();
   });
 
   it('should not change course details if CANCEL is requested', () => {
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
     component.isCourseLoading = false;
     component.originalCourse = { ...component.course };
     fixture.detectChanges();
@@ -153,11 +125,11 @@ describe('InstructorCourseEditPageComponent', () => {
     button.click();
 
     expect(component.isEditingCourse).toBeFalsy();
-    expect(component.course.courseName).toBe('Example Course');
+    expect(component.course.courseName).toBe('Introduction to CS');
   });
 
   it('should update course details if SAVE is requested', () => {
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
     component.isCourseLoading = false;
     fixture.detectChanges();
 
@@ -166,13 +138,13 @@ describe('InstructorCourseEditPageComponent', () => {
     fixture.detectChanges();
 
     jest.spyOn(courseService, 'updateCourse').mockReturnValue(of({
-      courseId: 'exampleId',
+      courseId: TestCourses.cs101.courseId,
       courseName: 'Example Course Changed',
       isCourseDeleted: false,
-      timeZone: 'UTC (UTC)',
-      institute: 'Test institute',
-      creationTimestamp: 0,
-      deletionTimestamp: 1000,
+      timeZone: TestCourses.cs101.timeZone,
+      institute: TestCourses.cs101.institute,
+      creationTimestamp: TestCourses.cs101.creationTimestamp,
+      deletionTimestamp: TestCourses.cs101.deletionTimestamp,
     }));
 
     const button: any = fixture.debugElement.nativeElement.querySelector('#btn-save-course');
@@ -184,33 +156,33 @@ describe('InstructorCourseEditPageComponent', () => {
 
   it('should load correct instructors details for given API output', () => {
     jest.spyOn(instructorService, 'loadInstructors').mockReturnValue(of({
-      instructors: [testInstructor1, testInstructor2],
+      instructors: [TestInstructors.hock, TestInstructors.hodor],
     }));
 
     component.loadCourseInstructors();
 
-    expect(component.instructorDetailPanels[0].originalInstructor).toEqual(testInstructor1);
-    expect(component.instructorDetailPanels[1].originalInstructor).toEqual(testInstructor2);
+    expect(component.instructorDetailPanels[0].originalInstructor).toEqual(TestInstructors.hock);
+    expect(component.instructorDetailPanels[1].originalInstructor).toEqual(TestInstructors.hodor);
     expect(component.isInstructorsLoading).toBeFalsy();
   });
 
   it('should not add instructor if CANCEL is requested', () => {
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
     component.isCourseLoading = false;
     component.instructorDetailPanels = [
       {
-        originalInstructor: { ...testInstructor1 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor1),
-        editPanel: component.getInstructorEditPanelModel(testInstructor1),
+        originalInstructor: { ...TestInstructors.hock },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
       },
       {
-        originalInstructor: { ...testInstructor2 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor2),
-        editPanel: component.getInstructorEditPanelModel(testInstructor2),
+        originalInstructor: { ...TestInstructors.hodor },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
       },
     ];
     component.isAddingNewInstructor = true;
-    component.newInstructorPanel = component.getInstructorEditPanelModel(testInstructor3);
+    component.newInstructorPanel = component.getInstructorEditPanelModel(TestInstructors.jane);
     component.newInstructorPanel.isEditing = true;
     fixture.detectChanges();
 
@@ -230,23 +202,23 @@ describe('InstructorCourseEditPageComponent', () => {
         name: params.requestBody.name,
       }));
 
-    component.course = testCourse;
-    component.courseId = testCourse.courseId;
+    component.course = TestCourses.cs101;
+    component.courseId = TestCourses.cs101.courseId;
     component.isCourseLoading = false;
     component.instructorDetailPanels = [
       {
-        originalInstructor: { ...testInstructor1 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor1),
-        editPanel: component.getInstructorEditPanelModel(testInstructor1),
+        originalInstructor: { ...TestInstructors.hock },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
       },
       {
-        originalInstructor: { ...testInstructor2 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor2),
-        editPanel: component.getInstructorEditPanelModel(testInstructor2),
+        originalInstructor: { ...TestInstructors.hodor },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
       },
     ];
     component.isAddingNewInstructor = true;
-    component.newInstructorPanel = component.getInstructorEditPanelModel(testInstructor3);
+    component.newInstructorPanel = component.getInstructorEditPanelModel(TestInstructors.jane);
     component.newInstructorPanel.isEditing = true;
     fixture.detectChanges();
 
@@ -257,25 +229,25 @@ describe('InstructorCourseEditPageComponent', () => {
     expect(component.isAddingNewInstructor).toBeFalsy();
     expect(component.isSavingNewInstructor).toBeFalsy();
     expect(component.instructorDetailPanels.length).toBe(3);
-    expect(component.instructorDetailPanels[2].originalInstructor).toEqual(testInstructor3);
+    expect(component.instructorDetailPanels[2].originalInstructor).toEqual(TestInstructors.jane);
     expect(component.newInstructorPanel).toEqual(emptyInstructorPanel);
   });
 
   it('should re-order if instructor is deleted', () => {
     jest.spyOn(instructorService, 'deleteInstructor').mockReturnValue(of({}));
 
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
     component.isCourseLoading = false;
     component.instructorDetailPanels = [
       {
-        originalInstructor: { ...testInstructor1 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor1),
-        editPanel: component.getInstructorEditPanelModel(testInstructor1),
+        originalInstructor: { ...TestInstructors.hock },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
       },
       {
-        originalInstructor: { ...testInstructor2 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor2),
-        editPanel: component.getInstructorEditPanelModel(testInstructor2),
+        originalInstructor: { ...TestInstructors.hodor },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hodor),
       },
     ];
 
@@ -288,7 +260,7 @@ describe('InstructorCourseEditPageComponent', () => {
     fixture.detectChanges();
 
     expect(component.instructorDetailPanels.length).toBe(1);
-    expect(component.instructorDetailPanels[0].originalInstructor).toEqual(testInstructor2);
+    expect(component.instructorDetailPanels[0].originalInstructor).toEqual(TestInstructors.hodor);
   });
 
   it('should re-send reminder email for new instructors', () => {
@@ -297,18 +269,18 @@ describe('InstructorCourseEditPageComponent', () => {
     }));
     jest.spyOn(courseService, 'remindInstructorForJoin').mockImplementation(mockReminderFunction);
 
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
     component.isCourseLoading = false;
     component.instructorDetailPanels = [
       {
-        originalInstructor: { ...testInstructor1 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor1),
-        editPanel: component.getInstructorEditPanelModel(testInstructor1),
+        originalInstructor: { ...TestInstructors.hock },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.hock),
       },
       {
-        originalInstructor: { ...testInstructor2 },
-        originalPanel: component.getInstructorEditPanelModel(testInstructor2),
-        editPanel: component.getInstructorEditPanelModel(testInstructor2),
+        originalInstructor: { ...TestInstructors.jane },
+        originalPanel: component.getInstructorEditPanelModel(TestInstructors.jane),
+        editPanel: component.getInstructorEditPanelModel(TestInstructors.jane),
       },
     ];
     fixture.detectChanges();
@@ -321,7 +293,7 @@ describe('InstructorCourseEditPageComponent', () => {
     button = document.getElementsByClassName('modal-btn-ok').item(0);
     button.click();
 
-    expect(mockReminderFunction).toBeCalledWith(testCourse.courseId, testInstructor2.email);
+    expect(mockReminderFunction).toBeCalledWith(TestCourses.cs101.courseId, TestInstructors.jane.email);
   });
 
   it('should snap with default fields', () => {
@@ -329,7 +301,7 @@ describe('InstructorCourseEditPageComponent', () => {
   });
 
   it('should snap with course details', () => {
-    component.course = testCourse;
+    component.course = TestCourses.cs101;
 
     fixture.detectChanges();
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -10,13 +10,16 @@ import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
-import { Course, CourseArchive, Courses, JoinState, Students } from '../../../types/api-output';
+import { CourseArchive, Courses, JoinState, Students } from '../../../types/api-output';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
 import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
+import TestCourseModels from '../../test-resources/course-models';
+import TestCourses from '../../test-resources/courses';
+import { date1, date2, date3, date4, date5, date6 } from '../../test-resources/dates';
 import { AddCourseFormModule } from './add-course-form/add-course-form.module';
 import { InstructorCoursesPageComponent } from './instructor-courses-page.component';
 
@@ -27,13 +30,6 @@ describe('InstructorCoursesPageComponent', () => {
   let studentService: StudentService;
   let timezoneService: TimezoneService;
   let simpleModalService: SimpleModalService;
-
-  const date1: Date = new Date('2018-11-05T08:15:30');
-  const date2: Date = new Date('2019-02-02T08:15:30');
-  const date3: Date = new Date('2002-11-05T08:15:30');
-  const date4: Date = new Date('2003-11-05T08:15:30');
-  const date5: Date = new Date('2002-12-05T08:15:30');
-  const date6: Date = new Date('2003-12-05T08:15:30');
 
   const activeCoursesSnap: any[] = [
     {
@@ -119,70 +115,6 @@ describe('InstructorCoursesPageComponent', () => {
       students: 2,
       unregistered: 2,
     },
-  };
-
-  const courseCS1231: Course = {
-    courseId: 'CS1231',
-    courseName: 'Discrete Structures',
-    creationTimestamp: date1.getTime(),
-    deletionTimestamp: 0,
-    timeZone: 'UTC',
-    institute: 'Test Institute',
-  };
-
-  const courseCS3281: Course = {
-    courseId: 'CS3281',
-    courseName: 'Thematic Systems Project I',
-    creationTimestamp: date3.getTime(),
-    deletionTimestamp: date4.getTime(),
-    timeZone: 'UTC',
-    institute: 'Test Institute',
-  };
-
-  const courseCS3282: Course = {
-    courseId: 'CS3282',
-    courseName: 'Thematic Systems Project II',
-    creationTimestamp: date5.getTime(),
-    deletionTimestamp: date6.getTime(),
-    timeZone: 'UTC',
-    institute: 'Test Institute',
-  };
-
-  const courseST4234: Course = {
-    courseId: 'ST4234',
-    courseName: 'Bayesian Statistics',
-    creationTimestamp: date2.getTime(),
-    deletionTimestamp: 0,
-    timeZone: 'UTC',
-    institute: 'Test Institute',
-  };
-
-  const courseModelCS1231: any = {
-    course: courseCS1231,
-    canModifyCourse: true,
-    canModifyStudent: true,
-    isLoadingCourseStats: false,
-  };
-
-  const courseModelCS3281: any = {
-    course: courseCS3281,
-    canModifyCourse: true,
-    canModifyStudent: true,
-    isLoadingCourseStats: false,
-  };
-
-  const courseModelCS3282: any = {
-    course: courseCS3282,
-    canModifyCourse: true,
-    canModifyStudent: false,
-    isLoadingCourseStats: false,
-  };
-
-  const courseModelST4234: any = {
-    course: courseST4234,
-    canModifyCourse: false,
-    canModifyStudent: true,
-    isLoadingCourseStats: false,
   };
 
   const students: Students = {
@@ -302,13 +234,13 @@ describe('InstructorCoursesPageComponent', () => {
     const courseSpy: SpyInstance = jest.spyOn(courseService, 'getAllCoursesAsInstructor').mockImplementation(
       (courseStatus: string): Observable<Courses> => {
         if (courseStatus === 'active') {
-          return of({ courses: [courseCS1231] });
+          return of({ courses: [TestCourses.cs1231] });
         }
         if (courseStatus === 'archived') {
-          return of({ courses: [courseCS3281, courseCS3282] });
+          return of({ courses: [TestCourses.cs3281, TestCourses.cs3282] });
         }
         // softDeleted
-        return of({ courses: [courseST4234] });
+        return of({ courses: [TestCourses.st4234] });
       });
 
     component.loadInstructorCourses();
@@ -334,7 +266,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should get the course statistics', () => {
-    component.activeCourses = [courseModelCS1231];
+    component.activeCourses = [TestCourseModels.cs1231CourseModel];
     const studentSpy: SpyInstance = jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(of(students));
     component.getCourseStats(0);
 
@@ -352,7 +284,7 @@ describe('InstructorCoursesPageComponent', () => {
       courseId: 'CS1231',
       isArchived: true,
     };
-    component.activeCourses = [courseModelCS1231];
+    component.activeCourses = [TestCourseModels.cs1231CourseModel];
     const courseSpy: SpyInstance = jest.spyOn(courseService, 'changeArchiveStatus')
         .mockReturnValue(of(courseArchiveCS1231));
     component.changeArchiveStatus('CS1231', true);
@@ -370,7 +302,7 @@ describe('InstructorCoursesPageComponent', () => {
       courseId: 'CS1231',
       isArchived: false,
     };
-    component.archivedCourses = [courseModelCS1231];
+    component.archivedCourses = [TestCourseModels.cs1231CourseModel];
     const courseSpy: SpyInstance = jest.spyOn(courseService, 'changeArchiveStatus')
         .mockReturnValue(of(courseArchiveCS1231));
     component.changeArchiveStatus('CS1231', false);
@@ -384,8 +316,8 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should soft delete a course', async () => {
-    component.activeCourses = [courseModelCS1231];
-    const courseSpy: SpyInstance = jest.spyOn(courseService, 'binCourse').mockReturnValue(of(courseCS1231));
+    component.activeCourses = [TestCourseModels.cs1231CourseModel];
+    const courseSpy: SpyInstance = jest.spyOn(courseService, 'binCourse').mockReturnValue(of(TestCourses.cs1231));
     jest.spyOn(simpleModalService, 'openConfirmationModal')
         .mockReturnValue(createMockNgbModalRef());
 
@@ -399,7 +331,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should permanently delete a course', async () => {
-    component.archivedCourses = [courseModelCS1231];
+    component.archivedCourses = [TestCourseModels.cs1231CourseModel];
     const courseSpy: SpyInstance = jest.spyOn(courseService, 'deleteCourse')
         .mockReturnValue(of({ message: 'Message' }));
     jest.spyOn(simpleModalService, 'openConfirmationModal').mockReturnValue(
@@ -415,7 +347,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should show add course form and disable button when clicking on add new course', () => {
-    component.activeCourses = [courseModelCS3282];
+    component.activeCourses = [TestCourseModels.cs3282CourseModel];
     component.isLoading = false;
     fixture.detectChanges();
 
@@ -429,7 +361,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should disable enroll button when instructor cannot modify student', () => {
-    component.activeCourses = [courseModelCS3282];
+    component.activeCourses = [TestCourseModels.cs3282CourseModel];
     component.isLoading = false;
     fixture.detectChanges();
 
@@ -439,7 +371,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should disable delete button when instructor cannot modify active course', () => {
-    component.activeCourses = [courseModelST4234];
+    component.activeCourses = [TestCourseModels.st4234CourseModel];
     component.isLoading = false;
     fixture.detectChanges();
 
@@ -449,7 +381,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should disable delete button when instructor cannot modify archived course', () => {
-    component.archivedCourses = [courseModelST4234];
+    component.archivedCourses = [TestCourseModels.st4234CourseModel];
     component.isLoading = false;
     component.isArchivedCourseExpanded = true;
     fixture.detectChanges();
@@ -460,7 +392,7 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should disable restore and permanently delete buttons when instructor cannot modify deleted course', () => {
-    component.softDeletedCourses = [courseModelST4234];
+    component.softDeletedCourses = [TestCourseModels.st4234CourseModel];
     component.isLoading = false;
     component.isRecycleBinExpanded = true;
     fixture.detectChanges();
@@ -475,7 +407,12 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should sort courses by their IDs', () => {
-    component.activeCourses = [courseModelCS3282, courseModelST4234, courseModelCS1231, courseModelCS3281];
+    component.activeCourses = [
+      TestCourseModels.cs3282CourseModel,
+      TestCourseModels.st4234CourseModel,
+      TestCourseModels.cs1231CourseModel,
+      TestCourseModels.cs3281CourseModel,
+    ];
     component.isLoading = false;
     fixture.detectChanges();
 
@@ -488,7 +425,12 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should sort courses by their names', () => {
-    component.activeCourses = [courseModelCS3282, courseModelST4234, courseModelCS1231, courseModelCS3281];
+    component.activeCourses = [
+      TestCourseModels.cs3282CourseModel,
+      TestCourseModels.st4234CourseModel,
+      TestCourseModels.cs1231CourseModel,
+      TestCourseModels.cs3281CourseModel,
+    ];
     component.isLoading = false;
     fixture.detectChanges();
 
@@ -501,7 +443,12 @@ describe('InstructorCoursesPageComponent', () => {
   });
 
   it('should sort courses by their creation dates', () => {
-    component.activeCourses = [courseModelCS3282, courseModelST4234, courseModelCS1231, courseModelCS3281];
+    component.activeCourses = [
+      TestCourseModels.cs3282CourseModel,
+      TestCourseModels.st4234CourseModel,
+      TestCourseModels.cs1231CourseModel,
+      TestCourseModels.cs3281CourseModel,
+    ];
     component.isLoading = false;
     fixture.detectChanges();
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -10,7 +10,7 @@ import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
-import { CourseArchive, Courses, JoinState, Students } from '../../../types/api-output';
+import { CourseArchive, Courses, Students } from '../../../types/api-output';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
@@ -20,6 +20,7 @@ import { TeammatesRouterModule } from '../../components/teammates-router/teammat
 import TestCourseModels from '../../test-resources/course-models';
 import TestCourses from '../../test-resources/courses';
 import { date1, date2, date3, date4, date5, date6 } from '../../test-resources/dates';
+import TestStudents from '../../test-resources/students';
 import { AddCourseFormModule } from './add-course-form/add-course-form.module';
 import { InstructorCoursesPageComponent } from './instructor-courses-page.component';
 
@@ -119,78 +120,14 @@ describe('InstructorCoursesPageComponent', () => {
 
   const students: Students = {
     students: [
-      {
-        email: 'alice.b.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Alice Betsy',
-        comments: "This student's name is Alice Betsy",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 1',
-        sectionName: 'Tutorial Group 1',
-      },
-      {
-        email: 'benny.c.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Benny Charles',
-        comments: "This student's name is Benny Charles",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 1',
-        sectionName: 'Tutorial Group 1',
-      },
-      {
-        email: 'charlie.d.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Charlie Davis',
-        comments: "This student's name is Charlie Davis",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 2',
-        sectionName: 'Tutorial Group 2',
-      },
-      {
-        email: 'danny.e.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Danny Engrid',
-        comments: "This student's name is Danny Engrid",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 1',
-        sectionName: 'Tutorial Group 1',
-      },
-      {
-        email: 'emma.f.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Emma Farrell',
-        comments: "This student's name is Emma Farrell",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 1',
-        sectionName: 'Tutorial Group 1',
-      },
-      {
-        email: 'francis.g.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Francis Gabriel',
-        comments: "This student's name is Francis Gabriel",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 2',
-        sectionName: 'Tutorial Group 2',
-      },
-      {
-        email: 'gene.h.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Gene Hudson',
-        comments: "This student's name is Gene Hudson",
-        joinState: JoinState.JOINED,
-        teamName: 'Team 2',
-        sectionName: 'Tutorial Group 2',
-      },
-      {
-        email: 'hugh.i.tmms@gmail.tmt',
-        courseId: 'test.exa-demo',
-        name: 'Hugh Ivanov',
-        comments: "This student's name is Hugh Ivanov",
-        joinState: JoinState.NOT_JOINED,
-        teamName: 'Team 3',
-        sectionName: 'Tutorial Group 2',
-      },
+      TestStudents.alice,
+      TestStudents.benny,
+      TestStudents.charlie,
+      TestStudents.danny,
+      TestStudents.emma,
+      TestStudents.francis,
+      TestStudents.gene,
+      TestStudents.hugh,
     ],
   };
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -29,7 +29,7 @@ import { SimpleModalType } from '../../components/simple-modal/simple-modal-type
 import { collapseAnim } from '../../components/teammates-common/collapse-anim';
 import { ErrorMessageOutput } from '../../error-message-output';
 
-interface CourseModel {
+export interface CourseModel {
   course: Course;
   canModifyCourse: boolean;
   canModifyStudent: boolean;

--- a/src/web/app/test-resources/course-models/index.ts
+++ b/src/web/app/test-resources/course-models/index.ts
@@ -1,0 +1,39 @@
+import { CourseModel } from '../../pages-instructor/instructor-courses-page/instructor-courses-page.component';
+import TestCourses from '../courses';
+
+const cs1231CourseModel: CourseModel = {
+  course: TestCourses.cs1231,
+  canModifyCourse: true,
+  canModifyStudent: true,
+  isLoadingCourseStats: false,
+};
+
+const cs3281CourseModel: CourseModel = {
+  course: TestCourses.cs3281,
+  canModifyCourse: true,
+  canModifyStudent: true,
+  isLoadingCourseStats: false,
+};
+
+const cs3282CourseModel: CourseModel = {
+  course: TestCourses.cs3282,
+  canModifyCourse: false,
+  canModifyStudent: false,
+  isLoadingCourseStats: false,
+};
+
+const st4234CourseModel: CourseModel = {
+  course: TestCourses.st4234,
+  canModifyCourse: false,
+  canModifyStudent: true,
+  isLoadingCourseStats: false,
+};
+
+const TestCourseModels = {
+  cs1231CourseModel,
+  cs3281CourseModel,
+  cs3282CourseModel,
+  st4234CourseModel,
+};
+
+export default TestCourseModels;

--- a/src/web/app/test-resources/courses/index.ts
+++ b/src/web/app/test-resources/courses/index.ts
@@ -1,0 +1,62 @@
+import { Course } from '../../../types/api-output';
+
+const cs9999: Course = {
+  courseId: 'CS9999',
+  courseName: 'CS9999',
+  institute: 'Test Institute',
+  timeZone: 'Asia/Singapore',
+  creationTimestamp: 0,
+  deletionTimestamp: 0,
+  privileges: {
+    canModifyCourse: true,
+    canModifySession: true,
+    canModifyStudent: true,
+    canModifyInstructor: true,
+    canViewStudentInSections: true,
+    canModifySessionCommentsInSections: true,
+    canViewSessionInSections: true,
+    canSubmitSessionInSections: true,
+  },
+};
+
+const ma1234: Course = {
+  courseId: 'MA1234',
+  courseName: 'MA1234',
+  institute: 'Test Institute',
+  timeZone: 'Asia/Singapore',
+  creationTimestamp: 0,
+  deletionTimestamp: 0,
+  privileges: {
+    canModifyCourse: true,
+    canModifySession: true,
+    canModifyStudent: true,
+    canModifyInstructor: true,
+    canViewStudentInSections: true,
+    canModifySessionCommentsInSections: true,
+    canViewSessionInSections: true,
+    canSubmitSessionInSections: true,
+  },
+};
+
+const ee1111: Course = {
+  courseId: 'EE1111',
+  courseName: 'EE1111',
+  institute: 'Test Institute',
+  timeZone: 'Asia/Singapore',
+  creationTimestamp: 0,
+  deletionTimestamp: 0,
+  privileges: {
+    canModifyCourse: false,
+    canModifySession: false,
+    canModifyStudent: false,
+    canModifyInstructor: false,
+    canViewStudentInSections: true,
+    canModifySessionCommentsInSections: true,
+    canViewSessionInSections: true,
+    canSubmitSessionInSections: true,
+  },
+};
+
+const TestCourses = { cs9999, ma1234, ee1111 };
+
+export default TestCourses;

--- a/src/web/app/test-resources/courses/index.ts
+++ b/src/web/app/test-resources/courses/index.ts
@@ -57,6 +57,15 @@ const ee1111: Course = {
   },
 };
 
-const TestCourses = { cs9999, ma1234, ee1111 };
+const cs101: Course = {
+  courseId: 'CS101',
+  courseName: 'Introduction to CS',
+  timeZone: '',
+  institute: 'Test Institute',
+  creationTimestamp: 0,
+  deletionTimestamp: 0,
+};
+
+const TestCourses = { cs9999, ma1234, ee1111, cs101 };
 
 export default TestCourses;

--- a/src/web/app/test-resources/courses/index.ts
+++ b/src/web/app/test-resources/courses/index.ts
@@ -1,4 +1,5 @@
 import { Course } from '../../../types/api-output';
+import { date1, date2, date3, date4, date5, date6 } from '../dates';
 
 const cs9999: Course = {
   courseId: 'CS9999',
@@ -66,6 +67,51 @@ const cs101: Course = {
   deletionTimestamp: 0,
 };
 
-const TestCourses = { cs9999, ma1234, ee1111, cs101 };
+const cs1231: Course = {
+  courseId: 'CS1231',
+  courseName: 'Discrete Structures',
+  creationTimestamp: date1.getTime(),
+  deletionTimestamp: 0,
+  timeZone: 'UTC',
+  institute: 'Test Institute',
+};
+
+const cs3281: Course = {
+  courseId: 'CS3281',
+  courseName: 'Thematic Systems Project I',
+  creationTimestamp: date3.getTime(),
+  deletionTimestamp: date4.getTime(),
+  timeZone: 'UTC',
+  institute: 'Test Institute',
+};
+
+const cs3282: Course = {
+  courseId: 'CS3282',
+  courseName: 'Thematic Systems Project II',
+  creationTimestamp: date5.getTime(),
+  deletionTimestamp: date6.getTime(),
+  timeZone: 'UTC',
+  institute: 'Test Institute',
+};
+
+const st4234: Course = {
+  courseId: 'ST4234',
+  courseName: 'Bayesian Statistics',
+  creationTimestamp: date2.getTime(),
+  deletionTimestamp: 0,
+  timeZone: 'UTC',
+  institute: 'Test Institute',
+};
+
+const TestCourses = {
+  cs9999,
+  ma1234,
+  ee1111,
+  cs101,
+  cs1231,
+  cs3281,
+  cs3282,
+  st4234,
+};
 
 export default TestCourses;

--- a/src/web/app/test-resources/dates.ts
+++ b/src/web/app/test-resources/dates.ts
@@ -1,0 +1,6 @@
+export const date1: Date = new Date('2018-11-05T08:15:30');
+export const date2: Date = new Date('2019-02-02T08:15:30');
+export const date3: Date = new Date('2002-11-05T08:15:30');
+export const date4: Date = new Date('2003-11-05T08:15:30');
+export const date5: Date = new Date('2002-12-05T08:15:30');
+export const date6: Date = new Date('2003-12-05T08:15:30');

--- a/src/web/app/test-resources/feedback-session-logs/index.ts
+++ b/src/web/app/test-resources/feedback-session-logs/index.ts
@@ -1,0 +1,29 @@
+import { FeedbackSessionLog, FeedbackSessionLogType } from '../../../types/api-output';
+import TestFeedbackSessions from '../feedback-sessions';
+import TestStudents from '../students';
+
+const testLogs1: FeedbackSessionLog = {
+  feedbackSessionData: TestFeedbackSessions.testFeedbackSession,
+  feedbackSessionLogEntries: [
+    {
+      studentData: TestStudents.johnDoe,
+      feedbackSessionLogType: FeedbackSessionLogType.SUBMISSION,
+      timestamp: 0,
+    },
+  ],
+};
+
+const testLogs2: FeedbackSessionLog = {
+  feedbackSessionData: TestFeedbackSessions.testFeedbackSession,
+  feedbackSessionLogEntries: [
+    {
+      studentData: TestStudents.johnDoe,
+      feedbackSessionLogType: FeedbackSessionLogType.SUBMISSION,
+      timestamp: 0,
+    },
+  ],
+};
+
+const TestFeedbackSessionLogs = { testLogs1, testLogs2 };
+
+export default TestFeedbackSessionLogs;

--- a/src/web/app/test-resources/feedback-sessions/index.ts
+++ b/src/web/app/test-resources/feedback-sessions/index.ts
@@ -1,0 +1,29 @@
+import {
+    FeedbackSession, FeedbackSessionPublishStatus,
+    FeedbackSessionSubmissionStatus,
+    ResponseVisibleSetting,
+    SessionVisibleSetting,
+} from '../../../types/api-output';
+
+const testFeedbackSession: FeedbackSession = {
+  feedbackSessionName: 'Feedback Session 1',
+  courseId: 'CS9999',
+  timeZone: 'Asia/Singapore',
+  instructions: '',
+  submissionStartTimestamp: 0,
+  submissionEndTimestamp: 1549095330000,
+  gracePeriod: 0,
+  sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+  responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+  submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+  publishStatus: FeedbackSessionPublishStatus.PUBLISHED,
+  isClosingEmailEnabled: true,
+  isPublishedEmailEnabled: true,
+  createdAtTimestamp: 0,
+  studentDeadlines: {},
+  instructorDeadlines: {},
+};
+
+const TestFeedbackSessions = { testFeedbackSession };
+
+export default TestFeedbackSessions;

--- a/src/web/app/test-resources/instructors/index.ts
+++ b/src/web/app/test-resources/instructors/index.ts
@@ -23,6 +23,13 @@ const hodor: Instructor = {
   isDisplayedToStudents: true,
 };
 
+const harryPotter: Instructor = {
+  name: 'Harry Potter',
+  email: 'harry@example.com',
+  courseId: TestCourses.cs101.courseId,
+  joinState: JoinState.JOINED,
+};
+
 const jane: Instructor = {
   courseId: TestCourses.cs101.courseId,
   joinState: JoinState.NOT_JOINED,
@@ -30,6 +37,6 @@ const jane: Instructor = {
   email: 'jane@gmail.com',
 };
 
-const TestInstructors = { hock, hodor, jane };
+const TestInstructors = { hock, hodor, jane, harryPotter };
 
 export default TestInstructors;

--- a/src/web/app/test-resources/instructors/index.ts
+++ b/src/web/app/test-resources/instructors/index.ts
@@ -1,0 +1,28 @@
+import { Instructor, InstructorPermissionRole, JoinState } from '../../../types/api-output';
+import TestCourses from '../courses';
+
+const hock: Instructor = {
+  courseId: TestCourses.cs101.courseId,
+  joinState: JoinState.JOINED,
+  googleId: 'Hock',
+  name: 'Hock',
+  email: 'hock@gmail.com',
+  role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+  displayedToStudentsAs: 'Hock',
+  isDisplayedToStudents: false,
+};
+
+const hodor: Instructor = {
+  courseId: TestCourses.cs101.courseId,
+  joinState: JoinState.JOINED,
+  googleId: 'Hodor',
+  name: 'Hodor',
+  email: 'hodor@gmail.com',
+  role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+  displayedToStudentsAs: 'Hodor',
+  isDisplayedToStudents: true,
+};
+
+const TestInstructors = { hock, hodor };
+
+export default TestInstructors;

--- a/src/web/app/test-resources/instructors/index.ts
+++ b/src/web/app/test-resources/instructors/index.ts
@@ -23,6 +23,13 @@ const hodor: Instructor = {
   isDisplayedToStudents: true,
 };
 
-const TestInstructors = { hock, hodor };
+const jane: Instructor = {
+  courseId: TestCourses.cs101.courseId,
+  joinState: JoinState.NOT_JOINED,
+  name: 'Jane',
+  email: 'jane@gmail.com',
+};
+
+const TestInstructors = { hock, hodor, jane };
 
 export default TestInstructors;

--- a/src/web/app/test-resources/students/index.ts
+++ b/src/web/app/test-resources/students/index.ts
@@ -1,0 +1,21 @@
+import { Student } from '../../../types/api-output';
+
+const emptyStudent: Student = {
+  courseId: '',
+  email: '',
+  name: '',
+  sectionName: '',
+  teamName: '',
+};
+
+const johnDoe: Student = {
+  email: 'doejohn@email.com',
+  courseId: 'CS9999',
+  name: 'Doe John',
+  teamName: 'team 1',
+  sectionName: 'section 1',
+};
+
+const TestStudents = { emptyStudent, johnDoe };
+
+export default TestStudents;

--- a/src/web/app/test-resources/students/index.ts
+++ b/src/web/app/test-resources/students/index.ts
@@ -25,6 +25,98 @@ const jamie: Student = {
   courseId: 'CS101',
 };
 
-const TestStudents = { emptyStudent, johnDoe, jamie };
+const alice: Student = {
+  email: 'alice.b.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Alice Betsy',
+  comments: "This student's name is Alice Betsy",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 1',
+  sectionName: 'Tutorial Group 1',
+};
+
+const benny: Student = {
+  email: 'benny.c.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Benny Charles',
+  comments: "This student's name is Benny Charles",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 1',
+  sectionName: 'Tutorial Group 1',
+};
+
+const charlie: Student = {
+  email: 'charlie.d.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Charlie Davis',
+  comments: "This student's name is Charlie Davis",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 2',
+  sectionName: 'Tutorial Group 2',
+};
+
+const danny: Student = {
+  email: 'danny.e.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Danny Engrid',
+  comments: "This student's name is Danny Engrid",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 1',
+  sectionName: 'Tutorial Group 1',
+};
+
+const emma: Student = {
+  email: 'emma.f.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Emma Farrell',
+  comments: "This student's name is Emma Farrell",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 1',
+  sectionName: 'Tutorial Group 1',
+};
+
+const francis: Student = {
+  email: 'francis.g.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Francis Gabriel',
+  comments: "This student's name is Francis Gabriel",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 2',
+  sectionName: 'Tutorial Group 2',
+};
+
+const gene: Student = {
+  email: 'gene.h.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Gene Hudson',
+  comments: "This student's name is Gene Hudson",
+  joinState: JoinState.JOINED,
+  teamName: 'Team 2',
+  sectionName: 'Tutorial Group 2',
+};
+
+const hugh: Student = {
+  email: 'hugh.i.tmms@gmail.tmt',
+  courseId: 'test.exa-demo',
+  name: 'Hugh Ivanov',
+  comments: "This student's name is Hugh Ivanov",
+  joinState: JoinState.NOT_JOINED,
+  teamName: 'Team 3',
+  sectionName: 'Tutorial Group 2',
+};
+
+const TestStudents = {
+  emptyStudent,
+  johnDoe,
+  jamie,
+  alice,
+  benny,
+  charlie,
+  danny,
+  emma,
+  francis,
+  gene,
+  hugh,
+};
 
 export default TestStudents;

--- a/src/web/app/test-resources/students/index.ts
+++ b/src/web/app/test-resources/students/index.ts
@@ -1,4 +1,4 @@
-import { Student } from '../../../types/api-output';
+import { JoinState, Student } from '../../../types/api-output';
 
 const emptyStudent: Student = {
   courseId: '',
@@ -16,6 +16,15 @@ const johnDoe: Student = {
   sectionName: 'section 1',
 };
 
-const TestStudents = { emptyStudent, johnDoe };
+const jamie: Student = {
+  name: 'Jamie',
+  email: 'jamie@gmail.com',
+  joinState: JoinState.NOT_JOINED,
+  teamName: 'Team 1',
+  sectionName: 'Tutorial Group 1',
+  courseId: 'CS101',
+};
+
+const TestStudents = { emptyStudent, johnDoe, jamie };
 
 export default TestStudents;


### PR DESCRIPTION
Fixes #10992

**Outline of Solution**

In the issue, it says to extract the test objects into JSON files. 

I believe that a better idea is just to use typescript files instead.
1. Can nest objects easily.
2. Can rely on type safety.
3. Does not need extra parsing.

**Note** 

This will be a very large PR and I am not sure if I will have the time to complete it. 

Requesting an initial review to make sure I am not headed in the wrong direction. 