### PR TITLE
[#11511] Emailing submission links: Mention the proof-of-submission feature

### DIFF
--- a/src/main/resources/userEmailTemplate-deadlineExtension.html
+++ b/src/main/resources/userEmailTemplate-deadlineExtension.html
@@ -70,6 +70,9 @@ ${instructorPreamble}
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -59,6 +59,9 @@ ${instructorPreamble}
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
+++ b/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
@@ -5,6 +5,9 @@
 To view/submit feedback for the above session, please go to this Web address: ${submitUrl}
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: ${reportUrl}
 <br>
 <br>

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionGivenStudent.html
+++ b/src/test/resources/emails/deadlineExtensionGivenStudent.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionRevokedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedStudent.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
@@ -70,6 +70,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -63,6 +63,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -63,6 +63,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
@@ -63,6 +63,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailForInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailForInstructor.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailForStudent.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
@@ -63,6 +63,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -63,6 +63,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -59,6 +59,9 @@
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -16,6 +16,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br><br>
@@ -23,6 +26,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -34,6 +40,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -41,6 +50,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -16,6 +16,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br><br>
@@ -23,6 +26,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -34,6 +40,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -41,6 +50,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -34,6 +34,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br><br>
@@ -41,6 +44,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -52,6 +58,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -59,6 +68,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
@@ -44,6 +44,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br><br>
@@ -51,6 +54,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -62,6 +68,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -69,6 +78,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
@@ -16,6 +16,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br><br>
@@ -23,6 +26,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -34,6 +40,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -41,6 +50,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -41,6 +41,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br><br>
@@ -48,6 +51,9 @@ To view the responses for this session, please go to this Web address: <a href="
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -59,6 +65,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br><br>
@@ -66,6 +75,9 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+<br>
+<br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
@@ -16,6 +16,9 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTestingSanitizationCourse&fsname=Normal%20feedback%20session%20name&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTestingSanitizationCourse&fsname=Normal%20feedback%20session%20name&key=${regkey.enc}</a>
 <br>
 <br>
+After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+<br>
+<br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br>


### PR DESCRIPTION
Fixes #11511

**Outline of Solution**

Add new mention to proof-of-submission feature in all emails containing submission links.
