### PR TITLE
[#11772] Set `FeedbackContributionQuestionDetails.isZeroSum` of old questions to `false`

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForContributionQuestionDetailsIsZeroSum.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForContributionQuestionDetailsIsZeroSum.java
@@ -1,0 +1,53 @@
+package teammates.client.scripts;
+
+import java.time.Instant;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.questions.FeedbackContributionQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.storage.entity.FeedbackQuestion;
+
+/**
+ * Script to set isZeroSum as false in all old feedback contribution questions before the addition of the isZeroSum
+ * field in feedback contribution questions.
+ *
+ * <p>See issue #11772</p>
+ */
+public class DataMigrationForContributionQuestionDetailsIsZeroSum extends
+        DataMigrationEntitiesBaseScript<FeedbackQuestion> {
+
+    public static void main(String[] args) {
+        new DataMigrationForContributionQuestionDetailsIsZeroSum().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<FeedbackQuestion> getFilterQuery() {
+        return ofy().load().type(FeedbackQuestion.class)
+                .filter("questionType =", FeedbackQuestionType.CONTRIB);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(FeedbackQuestion question) {
+        // This is the timestamp of V8.18.0 release, where the addition of the isZeroSum field in feedback contribution
+        // question is deployed
+        return question.getUpdatedAt().isBefore(Instant.parse("2022-07-11T07:47:00.00Z"));
+    }
+
+    @Override
+    protected void migrateEntity(FeedbackQuestion question) {
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.valueOf(question);
+        FeedbackContributionQuestionDetails fcqd = (FeedbackContributionQuestionDetails) fqa.getQuestionDetails();
+        fcqd.setZeroSum(false);
+        question.setQuestionText(fcqd.getJsonString());
+
+        saveEntityDeferred(question);
+    }
+
+}


### PR DESCRIPTION
Part of #11772

**Outline of Solution**

1. Modify the default constructor for `FeedbackContributionQuestionDetails`, which is used in deserialization, such that `isZeroSum` is set to `false` by default if absent, as in old feedback contribution questions.
2. Write and run a data migration script to set `isZeroSum` of old questions to `false`.
3. Revert the logic for the default constructor such that both constructors, i.e. `FeedbackContributionQuestionDetails()` and `FeedbackContributionQuestionDetails(String questionText)`, have the same set of default values.
