### PR TITLE
[#11911] Instructor copying course: Progress bar does not load when no feedback sessions are copied

### DIFF
--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -319,8 +319,8 @@ export class InstructorCoursesPageComponent implements OnInit {
     .subscribe(() => {
       // Wrap in a Promise to wait for all feedback sessions to be copied
       const promise: Promise<void> = new Promise<void>((resolve: () => void) => {
-        if (result.selectedFeedbackSessionList.size < 1) {
-          this.updateProgressBarHandler(1);
+        if (result.selectedFeedbackSessionList.size === 0) {
+          this.progressBarService.updateProgress(100);
           resolve();
 
           return;
@@ -330,8 +330,8 @@ export class InstructorCoursesPageComponent implements OnInit {
           this.copyFeedbackSession(session, result.newCourseId, result.oldCourseId)
             .pipe(finalize(() => {
               this.numberOfSessionsCopied += 1;
-              this.updateProgressBarHandler(
-                  Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy));
+              this.copyProgressPercentage = Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy);
+              this.progressBarService.updateProgress(this.copyProgressPercentage);
 
               if (this.numberOfSessionsCopied === this.totalNumberOfSessionsToCopy) {
                 resolve();
@@ -358,16 +358,6 @@ export class InstructorCoursesPageComponent implements OnInit {
       this.isCopyingCourse = false;
       this.hasLoadingFailed = true;
     });
-  }
-
-  /**
-   * Updates progress bar using ProgressBarService.
-   * This is a helper function used by {@link InstructorCoursesPageComponent#createCourse()} to
-   * reduce code duplication.
-   */
-  private updateProgressBarHandler(copyProgressPercentage: number): void {
-    this.copyProgressPercentage = copyProgressPercentage;
-    this.progressBarService.updateProgress(this.copyProgressPercentage);
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -319,6 +319,14 @@ export class InstructorCoursesPageComponent implements OnInit {
     .subscribe(() => {
       // Wrap in a Promise to wait for all feedback sessions to be copied
       const promise: Promise<void> = new Promise<void>((resolve: () => void) => {
+        if (result.selectedFeedbackSessionList.size < 1) {
+          this.copyProgressPercentage = 1;
+          this.progressBarService.updateProgress(this.copyProgressPercentage);
+
+          resolve();
+          return;
+        }
+
         result.selectedFeedbackSessionList.forEach((session: FeedbackSession) => {
           this.copyFeedbackSession(session, result.newCourseId, result.oldCourseId)
             .pipe(finalize(() => {

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -332,7 +332,7 @@ export class InstructorCoursesPageComponent implements OnInit {
               this.numberOfSessionsCopied += 1;
               this.updateProgressBarHandler(
                   Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy));
-              
+
               if (this.numberOfSessionsCopied === this.totalNumberOfSessionsToCopy) {
                 resolve();
               }

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -330,7 +330,8 @@ export class InstructorCoursesPageComponent implements OnInit {
           this.copyFeedbackSession(session, result.newCourseId, result.oldCourseId)
             .pipe(finalize(() => {
               this.numberOfSessionsCopied += 1;
-              this.copyProgressPercentage = Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy);
+              this.copyProgressPercentage =
+                Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy);
               this.progressBarService.updateProgress(this.copyProgressPercentage);
 
               if (this.numberOfSessionsCopied === this.totalNumberOfSessionsToCopy) {

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -320,10 +320,9 @@ export class InstructorCoursesPageComponent implements OnInit {
       // Wrap in a Promise to wait for all feedback sessions to be copied
       const promise: Promise<void> = new Promise<void>((resolve: () => void) => {
         if (result.selectedFeedbackSessionList.size < 1) {
-          this.copyProgressPercentage = 1;
-          this.progressBarService.updateProgress(this.copyProgressPercentage);
-
+          this.updateProgressBarHandler(1);
           resolve();
+
           return;
         }
 
@@ -331,9 +330,9 @@ export class InstructorCoursesPageComponent implements OnInit {
           this.copyFeedbackSession(session, result.newCourseId, result.oldCourseId)
             .pipe(finalize(() => {
               this.numberOfSessionsCopied += 1;
-              this.copyProgressPercentage =
-                Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy);
-              this.progressBarService.updateProgress(this.copyProgressPercentage);
+              this.updateProgressBarHandler(
+                  Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy));
+              
               if (this.numberOfSessionsCopied === this.totalNumberOfSessionsToCopy) {
                 resolve();
               }
@@ -359,6 +358,16 @@ export class InstructorCoursesPageComponent implements OnInit {
       this.isCopyingCourse = false;
       this.hasLoadingFailed = true;
     });
+  }
+
+  /**
+   * Updates progress bar using ProgressBarService.
+   * This is a helper function used by {@link InstructorCoursesPageComponent#createCourse()} to
+   * reduce code duplication.
+   */
+  private updateProgressBarHandler(copyProgressPercentage: number): void {
+    this.copyProgressPercentage = copyProgressPercentage;
+    this.progressBarService.updateProgress(this.copyProgressPercentage);
   }
 
   /**


### PR DESCRIPTION
Fixes #11911.

**Outline of Solution**

Previously, when an instructor creates a course by copying another course **without any feedback session** selected, user gets stuck on the copying and no progress is shown on the progress bar.

The fix is to check if there is any feedback session to copy, else we just need to resolve the `Promise` and this would update the progress bar as well.

Additionally, shifted out the `ProgressBarService` update lines as there are code duplications in the above fix and the current implementation (5e50c39).

https://user-images.githubusercontent.com/46486515/181818057-3c7f4922-5aa3-45eb-9c02-1035a08fdd27.mp4