### PR TITLE
[#11917] `QuestionSubmissionFormComponent` sorts `recipientList` and `recipientSubmissionForms` before being loaded 

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -138,16 +138,17 @@ describe('QuestionSubmissionFormComponent', () => {
     expect(component.model).toBe(model);
   });
 
-  it('should arrange recipients according to alphabetical order of name after ngOnInit (Sorted recipient list)', () => {
+  it('should arrange recipients according to alphabetical order of name after ngDoCheck (Sorted recipient list)',
+   () => {
     const model: QuestionSubmissionFormModel = JSON.parse(JSON.stringify(testNumscaleQuestionSubmissionForm));
 
     component.formModel = model;
-    component.ngOnInit();
+    component.ngDoCheck();
 
     expect(model.recipientSubmissionForms).toEqual([formResponse3, formResponse4, formResponse2, formResponse1]);
   });
 
-  it('should arrange recipients according to alphabetical order of name after ngOnInit (Unsorted recipient list)',
+  it('should arrange recipients according to alphabetical order of name after ngDoCheck (Unsorted recipient list)',
     () => {
       const model: QuestionSubmissionFormModel = JSON.parse(JSON.stringify(testNumscaleQuestionSubmissionForm));
 
@@ -159,7 +160,7 @@ describe('QuestionSubmissionFormComponent', () => {
       ];
 
       component.formModel = model;
-      component.ngOnInit();
+      component.ngDoCheck();
 
       expect(model.recipientSubmissionForms).toEqual([formResponse3, formResponse4, formResponse2, formResponse1]);
     });

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, DoCheck, EventEmitter, Input, Output } from '@angular/core';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { VisibilityStateMachine } from '../../../services/visibility-state-machine';
@@ -26,7 +26,7 @@ import {
   templateUrl: './question-submission-form.component.html',
   styleUrls: ['./question-submission-form.component.scss'],
 })
-export class QuestionSubmissionFormComponent implements OnInit {
+export class QuestionSubmissionFormComponent implements DoCheck {
 
   // enum
   QuestionSubmissionFormMode: typeof QuestionSubmissionFormMode = QuestionSubmissionFormMode;
@@ -101,6 +101,7 @@ export class QuestionSubmissionFormComponent implements OnInit {
 
   visibilityStateMachine: VisibilityStateMachine;
   allowedToHaveParticipantComment: boolean = false;
+  isEveryRecipientSorted: boolean = false;
 
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,
               private feedbackResponseService: FeedbackResponsesService) {
@@ -109,8 +110,10 @@ export class QuestionSubmissionFormComponent implements OnInit {
             this.model.giverType, this.model.recipientType);
   }
 
-  ngOnInit(): void {
-    this.sortRecipientsByName();
+  ngDoCheck(): void {
+    if (this.model.isLoaded && !this.isEveryRecipientSorted) {
+      this.sortRecipientsByName();
+    }
   }
 
   /**
@@ -119,7 +122,7 @@ export class QuestionSubmissionFormComponent implements OnInit {
   private sortRecipientsByName(): void {
     this.model.recipientList.sort((firstRecipient: FeedbackResponseRecipient,
       secondRecipient: FeedbackResponseRecipient) =>
-      firstRecipient.recipientName.localeCompare(secondRecipient.recipientName));
+      secondRecipient.recipientName.localeCompare(firstRecipient.recipientName));
 
     const indexes: Map<String, number> = new Map();
     this.model.recipientList.forEach((recipient: FeedbackResponseRecipient, index: number) => {
@@ -133,6 +136,7 @@ export class QuestionSubmissionFormComponent implements OnInit {
 
       return firstRecipientIndex - secondRecipientIndex;
     });
+    this.isEveryRecipientSorted = true;
   }
 
   /**

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -70,7 +70,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   model: QuestionSubmissionFormModel = {
     isLoading: false,
-    isLoaded: true,
+    isLoaded: false,
     feedbackQuestionId: '',
 
     questionNumber: 0,
@@ -122,7 +122,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   private sortRecipientsByName(): void {
     this.model.recipientList.sort((firstRecipient: FeedbackResponseRecipient,
       secondRecipient: FeedbackResponseRecipient) =>
-      secondRecipient.recipientName.localeCompare(firstRecipient.recipientName));
+      firstRecipient.recipientName.localeCompare(secondRecipient.recipientName));
 
     const indexes: Map<String, number> = new Map();
     this.model.recipientList.forEach((recipient: FeedbackResponseRecipient, index: number) => {


### PR DESCRIPTION
Fixes #11917

**Outline of Solution**
- Updated the `QuestionSubmissionFormComponent` to use `DoCheck` instead of `OnInit` Lifecycle hook inorder to sort the recipients only after the model (which is an input) is loaded. 
- As mentioned in the [Angular documentation](https://angular.io/guide/lifecycle-hooks#docheck), `ngDoCheck` can be used to monitor changes that won't be catched by `ngOnChanges`. Hence the former was preferred.
