### PR TITLE
[#11586] Fix errors due to missed instances of trimming of `@gmail.com`

### DIFF
--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -103,12 +103,17 @@ public final class AccountsDb extends EntitiesDb<Account, AccountAttributes> {
     }
 
     private Account getAccountEntity(String googleId) {
-        Account account = load().id(googleId).now();
-        if (account == null) {
-            return null;
+        if (googleId.toLowerCase().contains("@gmail.com")) {
+            Account accountWithGoogleId = load().id(googleId.split("@")[0]).now();
+            Account accountWithEmail = load().id(googleId).now();
+            return accountWithGoogleId == null ? accountWithEmail : accountWithGoogleId;
         }
-
-        return account;
+        if (!googleId.toLowerCase().contains("@")) {
+            Account accountWithGoogleId = load().id(googleId).now();
+            Account accountWithEmail = load().id(googleId.concat("@gmail.com")).now();
+            return accountWithGoogleId == null ? accountWithEmail : accountWithGoogleId;
+        }
+        return load().id(googleId).now();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -347,7 +347,29 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private Instructor getInstructorEntityForGoogleId(String courseId, String googleId) {
-        return getInstructorsForGoogleIdQuery(googleId)
+        if (googleId.toLowerCase().contains("@gmail.com")) {
+            Instructor instructorWithGoogleId = load()
+                    .filter("googleId =", googleId.split("@")[0])
+                    .filter("courseId =", courseId)
+                    .first().now();
+            Instructor instructorWithEmail = load()
+                    .filter("googleId =", googleId)
+                    .filter("courseId =", courseId)
+                    .first().now();
+            return instructorWithGoogleId == null ? instructorWithEmail : instructorWithGoogleId;
+        }
+        if (!googleId.toLowerCase().contains("@")) {
+            Instructor instructorWithGoogleId = load()
+                    .filter("googleId =", googleId)
+                    .filter("courseId =", courseId)
+                    .first().now();
+            Instructor instructorWithEmail = load()
+                    .filter("googleId =", googleId.concat("@gmail.com"))
+                    .filter("courseId =", courseId)
+                    .first().now();
+            return instructorWithGoogleId == null ? instructorWithEmail : instructorWithGoogleId;
+        }
+        return load().filter("googleId =", googleId)
                 .filter("courseId =", courseId)
                 .first().now();
     }
@@ -408,7 +430,19 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     private List<Instructor> getInstructorEntitiesForGoogleId(String googleId) {
-        return getInstructorsForGoogleIdQuery(googleId).list();
+        if (googleId.toLowerCase().contains("@gmail.com")) {
+            List<Instructor> instructorWithGoogleId = load().filter("googleId =", googleId.split("@")[0]).list();
+            List<Instructor> instructorWithEmail = load().filter("googleId =", googleId).list();
+            instructorWithGoogleId.addAll(instructorWithEmail);
+            return instructorWithGoogleId;
+        }
+        if (!googleId.toLowerCase().contains("@")) {
+            List<Instructor> instructorWithGoogleId = load().filter("googleId =", googleId).list();
+            List<Instructor> instructorWithEmail = load().filter("googleId =", googleId.concat("@gmail.com")).list();
+            instructorWithGoogleId.addAll(instructorWithEmail);
+            return instructorWithGoogleId;
+        }
+        return load().filter("googleId =", googleId).list();
     }
 
     /**
@@ -417,7 +451,31 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
      */
     private List<Instructor> getInstructorEntitiesForGoogleId(String googleId, boolean omitArchived) {
         if (omitArchived) {
-            return getInstructorsForGoogleIdQuery(googleId)
+            if (googleId.toLowerCase().contains("@gmail.com")) {
+                List<Instructor> instructorsWithGoogleId = load()
+                        .filter("googleId =", googleId.split("@")[0])
+                        .filter("isArchived =", false)
+                        .list();
+                List<Instructor> instructorsWithEmail = load()
+                        .filter("googleId =", googleId)
+                        .filter("isArchived =", false)
+                        .list();
+                instructorsWithGoogleId.addAll(instructorsWithEmail);
+                return instructorsWithGoogleId;
+            }
+            if (!googleId.toLowerCase().contains("@")) {
+                List<Instructor> instructorsWithGoogleId = load()
+                        .filter("googleId =", googleId)
+                        .filter("isArchived =", false)
+                        .list();
+                List<Instructor> instructorsWithEmail = load()
+                        .filter("googleId =", googleId.concat("@gmail.com"))
+                        .filter("isArchived =", false)
+                        .list();
+                instructorsWithGoogleId.addAll(instructorsWithEmail);
+                return instructorsWithGoogleId;
+            }
+            return load().filter("googleId =", googleId)
                     .filter("isArchived =", false)
                     .list();
         }

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -438,7 +438,19 @@ public final class StudentsDb extends EntitiesDb<CourseStudent, StudentAttribute
     }
 
     private List<CourseStudent> getCourseStudentEntitiesForGoogleId(String googleId) {
-        return getCourseStudentsForGoogleIdQuery(googleId).list();
+        if (googleId.toLowerCase().contains("@gmail.com")) {
+            List<CourseStudent> studentWithGoogleId = load().filter("googleId =", googleId.split("@")[0]).list();
+            List<CourseStudent> studentWithEmail = load().filter("googleId =", googleId).list();
+            studentWithGoogleId.addAll(studentWithEmail);
+            return studentWithGoogleId;
+        }
+        if (!googleId.toLowerCase().contains("@")) {
+            List<CourseStudent> studentWithGoogleId = load().filter("googleId =", googleId).list();
+            List<CourseStudent> studentWithEmail = load().filter("googleId =", googleId.concat("@gmail.com")).list();
+            studentWithGoogleId.addAll(studentWithEmail);
+            return studentWithGoogleId;
+        }
+        return load().filter("googleId =", googleId).list();
     }
 
     private List<CourseStudent> getCourseStudentEntitiesForTeam(String teamName, String courseId) {


### PR DESCRIPTION
Part of #11586

**Outline of Solution**

- > java.lang.AssertionError: Trying to create a course for a non-existent instructor [abcd@gmail.com](mailto:abcd@gmail.com)
at teammates.logic.core.CoursesLogic.createCourseAndInstructor(CoursesLogic.java:104)

  As the above error due to PR #11903 was caused by some missing code to deal with the old `Account` data, the corresponding code has been added.
- Also, when debugging, some flaws to the query logic were discovered. Firstly, filtered queries involving `googleId` should be done in one go instead of splitting them up so that the target entity could be searched. Secondly, when retrieving courses of an instructor, `Instructor` entities of both `googleId` and `email` should be retrieved to include courses created before and after the change.