### PR TITLE
[#9534] Deleting the last instructor in the course leaves a dangling course object in the database

### DIFF
--- a/src/e2e/resources/data/AdminAccountsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminAccountsPageE2ETest.json
@@ -5,6 +5,12 @@
       "name": "Teammates Instr2",
       "email": "AAccounts.instr2@gmail.tmt",
       "readNotifications": {}
+    },
+    "AAccounts.instr3": {
+      "googleId": "tm.e2e.AAccounts.instr3",
+      "name": "Teammates Instr3",
+      "email": "AAccounts.instr3@gmail.tmt",
+      "readNotifications": {}
     }
   },
   "courses": {
@@ -57,7 +63,7 @@
       "name": "Teammates Instr2",
       "email": "AAccounts.instr2@gmail.tmt",
       "role": "Co-owner",
-      "isDisplayedToStudents": false,
+      "isDisplayedToStudents": true,
       "displayedName": "Co-owner",
       "privileges": {
         "courseLevel": {
@@ -81,6 +87,29 @@
       "email": "AAccounts.instr2@gmail.tmt",
       "role": "Co-owner",
       "isDisplayedToStudents": false,
+      "displayedName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "AAccounts.instr3-AAccounts.CS2103": {
+      "googleId": "tm.e2e.AAccounts.instr3",
+      "courseId": "tm.e2e.AAccounts.CS2103",
+      "name": "Teammates Instr3",
+      "email": "AAccounts.instr3@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
       "displayedName": "Co-owner",
       "privileges": {
         "courseLevel": {

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -51,7 +51,7 @@ class DeleteInstructorAction extends Action {
         }
 
         // Deleting last instructor from the course is not allowed if you're not the admin
-        if (!userInfo.isAdmin && !hasAlternativeInstructor(courseId, instructor.getEmail())) {
+        if (!hasAlternativeInstructor(courseId, instructor.getEmail())) {
             throw new InvalidOperationException(
                     "The instructor you are trying to delete is the last instructor in the course. "
                     + "Deleting the last instructor from the course is not allowed.");

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -50,7 +50,7 @@ class DeleteInstructorAction extends Action {
             return new JsonResult("Instructor is successfully deleted.");
         }
 
-        // Deleting last instructor from the course is not allowed if you're not the admin
+        // Deleting last instructor from the course is not allowed (even by admins)
         if (!hasAlternativeInstructor(courseId, instructor.getEmail())) {
             throw new InvalidOperationException(
                     "The instructor you are trying to delete is the last instructor in the course. "

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -97,7 +97,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    protected void testExecute_adminDeletesLastInstructorByGoogleId_shouldPass() {
+    protected void testExecute_adminDeletesLastInstructorByGoogleId_shouldFail() {
         loginAsAdmin();
 
         InstructorAttributes instructor4 = typicalBundle.instructors.get("instructor4");
@@ -110,13 +110,12 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         assertEquals(logic.getInstructorsForCourse(instructor4.getCourseId()).size(), 1);
 
-        DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
-        JsonResult response = getJsonResult(deleteInstructorAction);
+        InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
+        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
+                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        MessageOutput msg = (MessageOutput) response.getOutput();
-        assertEquals("Instructor is successfully deleted.", msg.getMessage());
-
-        assertNull(logic.getInstructorForEmail(instructor4.getCourseId(), instructor4.getEmail()));
+        assertNotNull(logic.getInstructorForEmail(instructor4.getCourseId(), instructor4.getEmail()));
+        assertNotNull(logic.getInstructorForGoogleId(instructor4.getCourseId(), instructor4.getGoogleId()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #9534

**Outline of Solution**

1. Removed the truth check in `DeleteInstructorAction` that allowed admins to bypass the truth checking stopping the last instructor of a course from being deleted from said course.
2. Modified the corresponding unit test, `testExecute_deleteLastInstructorByGoogleId_shouldPass`, by flipping asserts, and renaming accordingly.
