### PR TITLE
[#11950] Fix bug with overflow of members count in error message

### DIFF
--- a/src/web/app/components/question-types/question-constraint/contribution-question-constraint.component.ts
+++ b/src/web/app/components/question-types/question-constraint/contribution-question-constraint.component.ts
@@ -110,9 +110,9 @@ export class ContributionQuestionConstraintComponent
       return `${Math.floor(this.totalAnsweredContributions / 100)} x Equal Share`;
     }
 
-    const excess = this.totalAnsweredContributions - this.totalRequiredContributions;
-
     if (this.totalAnsweredContributions > this.totalRequiredContributions) {
+      const excess = this.totalAnsweredContributions - this.totalRequiredContributions;
+
       return `${membersCount} x Equal Share + ${excess}%`;
     }
 

--- a/src/web/app/components/question-types/question-constraint/contribution-question-constraint.component.ts
+++ b/src/web/app/components/question-types/question-constraint/contribution-question-constraint.component.ts
@@ -99,12 +99,23 @@ export class ContributionQuestionConstraintComponent
     if (this.totalAnsweredContributions === 0) {
       return '0%';
     }
+
     if (this.totalAnsweredContributions / 100 < 1) {
       return `1 x Equal Share - ${100 - this.totalAnsweredContributions % 100}%`;
     }
-    if (this.totalAnsweredContributions % 100 === 0) {
+
+    const membersCount = this.totalRequiredContributions / 100;
+
+    if (this.totalAnsweredContributions % 100 === 0 && this.totalAnsweredContributions / 100 <= membersCount) {
       return `${Math.floor(this.totalAnsweredContributions / 100)} x Equal Share`;
     }
+
+    const excess = this.totalAnsweredContributions - this.totalRequiredContributions;
+
+    if (this.totalAnsweredContributions > this.totalRequiredContributions) {
+      return `${membersCount} x Equal Share + ${excess}%`;
+    }
+
     return `${Math.floor(this.totalAnsweredContributions / 100)} x Equal Share +  
         ${this.totalAnsweredContributions % 100}%`;
   }


### PR DESCRIPTION
Fixes #11950.

**Outline of Solution**

Previously, the zero-sum contribution question overflows when it exceeds the total required contribution percentage i.e. `Number of members in the team * 100%`, as it is not captured in the logic flow for the error message.

![image](https://user-images.githubusercontent.com/46486515/188321406-7e19efd9-5f0d-4a40-a96c-08cb4e6ebe8a.png)

Now, we have introduced another way of checking for this overflow and reducing the number of `Equal Share` with a cap based on the number of members in a team by `Total required contribution percentage / 100`. The excess will then be calculated separately.

And now, it should read `Current total 5 x Equal share + 100% ...` when the total required contribution percentage exceeds `n * 100`, where `n` is the number of members.

![image](https://user-images.githubusercontent.com/46486515/188321442-18c97bd8-887e-4a62-8209-fc7509b28c53.png)