### PR TITLE
[#11962] Decorative images are not hidden from accessibility tree

### DIFF
--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -20,7 +20,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -38,7 +38,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -56,7 +56,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -73,7 +73,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -90,7 +90,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -107,7 +107,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -124,7 +124,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -141,7 +141,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -158,7 +158,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -176,7 +176,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -198,7 +198,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -215,7 +215,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 
@@ -231,7 +231,7 @@
         </div>
       </div>
     </div>
-    <img src="assets/images/raised-edge.png">
+    <img src="assets/images/raised-edge.png" aria-hidden="true">
   </div>
 </section>
 

--- a/src/web/app/pages-static/index-page/index-page.component.html
+++ b/src/web/app/pages-static/index-page/index-page.component.html
@@ -16,7 +16,7 @@
 </main>
 
 <div class="text-center">
-  <img id="raisedEdge" src="assets/images/raised-edge.png">
+  <img id="raisedEdge" src="assets/images/raised-edge.png" aria-hidden="true">
 </div>
 
 <div class="row">


### PR DESCRIPTION
Fixes #11962

**Outline of Solution**

Issue has been solved by adding aria hidden to decorative images, therefore removing them from the accessibility tree on assistive technologies such as JAWs, Voiceover etc. [https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden](aria-hidden) alternatively this could be done by adding alt="" to the image.

Before: 
<img width="929" alt="image" src="https://user-images.githubusercontent.com/112479962/193684140-43b03d27-7da6-4dba-985c-f4401424702a.png">

After:
<img width="939" alt="image" src="https://user-images.githubusercontent.com/112479962/193685363-e1d5f984-1d12-4084-b716-e7c6e160283c.png">
