### PR TITLE
[#11853] Warning-message-for-potentially-destructive-edits-of-questions-not-shown-under-specific-conditions

### DIFF
--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -281,7 +281,7 @@ export class QuestionEditFormComponent {
       const doChangesNeedWarning: boolean = this.model.isQuestionDetailsChanged
         || this.model.isVisibilityChanged
         || this.model.isFeedbackPathChanged;
-      if (!this.model.isQuestionHasResponses || !doChangesNeedWarning) {
+      if (!doChangesNeedWarning) {
         this.saveExistingQuestionEvent.emit();
       } else if (this.model.isFeedbackPathChanged) {
         // warn user that editing feedback path will delete all messages


### PR DESCRIPTION
Warning message for potentially destructive edits of questions not shown under specific conditions #11853

Fixes #11853
Removed check for isquestionhasresponses due to the check not being updated under specific conditions.


**Outline of Solution**
The solution involves removing the check for this/model.isQuestionHasResponses. This solution works by weakening the condition for the If statement. Which can fix the issue as described in #11853