### PR TITLE
[#11569] Move app ID and app version configuration out of build.properties

### DIFF
--- a/gradle.template.properties
+++ b/gradle.template.properties
@@ -2,6 +2,16 @@
 # Reference: https://docs.gradle.org/current/userguide/gradle_daemon.html
 org.gradle.daemon=false
 
+# This is the application ID of the app.
+# For dev server, this could be anything.
+# For staging server, this must match the name of your Google Cloud project.
+app.id = teammates-john
+
+# This is the version number of the app.
+# Use dashes instead of dots because GAE does not allow dots in version number.
+# e.g. app.version = 8-0-0
+app.version = 8-0-0
+
 # Use this property if you want to use a JDK other than the one specified in your PATH variable.
 # Windows users should use a forward slash (/) instead of the Windows default backward slash (\) while specifying the path.
 # e.g org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -4,20 +4,10 @@
 # Use '\' to escape ':' e.g., http\://google.com
 #-----------------------------------------------------------------------------
 
-# This is the application ID of the app.
-# For dev server, this could be anything.
-# For staging server, this must match the name of your Google Cloud project.
-app.id = teammates-john
-
 # This is the deployment region of the app.
 # For dev server, this could be anything.
 # For staging/production server, this must match the region of your GAE application.
 app.region=us-central1
-
-# This is the version number of the app.
-# Use dashes instead of dots because GAE does not allow dots in version number.
-# e.g. app.version = 8-0-0
-app.version = 8-0-0
 
 # This is the URL for the front-end which the user is going to access.
 # This affects all URLs sent in outbound emails.


### PR DESCRIPTION
Fixes #11569

**Outline of Solution**

Moved app ID and app version out of build.properties into gradle.properties
