### PR TITLE
[#11991] Student submitting fewer responses than allowed: show empty responses at the bottom when reloading the submission page

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -93,7 +93,7 @@ const testNumscaleQuestionSubmissionForm: QuestionSubmissionFormModel = {
   isLoaded: true,
 };
 
-fdescribe('QuestionSubmissionFormComponent', () => {
+describe('QuestionSubmissionFormComponent', () => {
   let component: QuestionSubmissionFormComponent;
   let fixture: ComponentFixture<QuestionSubmissionFormComponent>;
 
@@ -131,7 +131,7 @@ fdescribe('QuestionSubmissionFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  fit('should set model', () => {
+  it('should set model', () => {
     const model: QuestionSubmissionFormModel = testNumscaleQuestionSubmissionForm;
     component.formModel = model;
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -93,7 +93,7 @@ const testNumscaleQuestionSubmissionForm: QuestionSubmissionFormModel = {
   isLoaded: true,
 };
 
-describe('QuestionSubmissionFormComponent', () => {
+fdescribe('QuestionSubmissionFormComponent', () => {
   let component: QuestionSubmissionFormComponent;
   let fixture: ComponentFixture<QuestionSubmissionFormComponent>;
 
@@ -131,7 +131,7 @@ describe('QuestionSubmissionFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set model', () => {
+  fit('should set model', () => {
     const model: QuestionSubmissionFormModel = testNumscaleQuestionSubmissionForm;
     component.formModel = model;
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -131,7 +131,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
     const indexes: Map<String, number> = new Map();
     this.model.recipientList.forEach((recipient: FeedbackResponseRecipient, index: number) => {
-      indexes.set(recipient.recipientIdentifier, index+1);
+      indexes.set(recipient.recipientIdentifier, index + 1);
     });
 
     this.model.recipientSubmissionForms.sort((firstRecipient: FeedbackResponseRecipientSubmissionFormModel,

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -131,13 +131,13 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
     const indexes: Map<String, number> = new Map();
     this.model.recipientList.forEach((recipient: FeedbackResponseRecipient, index: number) => {
-      indexes.set(recipient.recipientIdentifier, index);
+      indexes.set(recipient.recipientIdentifier, index+1);
     });
 
     this.model.recipientSubmissionForms.sort((firstRecipient: FeedbackResponseRecipientSubmissionFormModel,
       secondRecipient: FeedbackResponseRecipientSubmissionFormModel) => {
-      const firstRecipientIndex: number = indexes.get(firstRecipient.recipientIdentifier) || 0;
-      const secondRecipientIndex: number = indexes.get(secondRecipient.recipientIdentifier) || 0;
+      const firstRecipientIndex: number = indexes.get(firstRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
+      const secondRecipientIndex: number = indexes.get(secondRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
 
       return firstRecipientIndex - secondRecipientIndex;
     });


### PR DESCRIPTION
Fixes #11991

**Outline of Solution**

Fix made by having empty responses having a higher index when sorting.
The index made to index+1 since it will conflict with the first element and result in lexicographically unsorted order.

