### PR TITLE
[#11876] Improve UX of Progress Bars

### DIFF
--- a/src/web/app/components/progress-bar/progress-bar.component.ts
+++ b/src/web/app/components/progress-bar/progress-bar.component.ts
@@ -10,7 +10,7 @@ import { ProgressBarService } from '../../../services/progress-bar.service';
 })
 export class ProgressBarComponent implements OnInit {
 
-  progressPercentage: number = 0;
+  progressPercentage: number = 10;
 
   constructor(private progressBarService: ProgressBarService) { }
 


### PR DESCRIPTION
Fixes #11876.

**Outline of Solution**
Previously, the progress bar component starts with a default value of 0. This has caused some confusion to what the component is or its progress of the current task.

Let's instead give it a default value of `10%` for clarity. Now, the progress bars start from 10% and scales up as per usual to 100%.

An example for when copying a course:
![image](https://user-images.githubusercontent.com/46486515/208229769-a2d175c5-9c44-4daa-ae25-abd98a20f8eb.png)

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
