### PR TITLE
[#12011] Instructor Viewing Student Activities: Bug Fix and Enhancement

### DIFF
--- a/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
@@ -296,9 +296,9 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
           return true;
         });
 
-    let logRowsData: SortableTableCellData[][] = filteredStudents.map((student: Student) => {
+    const logRowsData: SortableTableCellData[][] = filteredStudents.map((student: Student) => {
       let status: string;
-      let entry: FeedbackSessionLogEntry | undefined = undefined;
+      let entry;
       let dataStyle: string = 'font-family:monospace; white-space:pre;';
       let statusPrefix = this.logTypeToActivityDisplay(this.formModel.logType);
       const studentKey = this.getStudentKey(log, student.email);
@@ -328,7 +328,7 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
     });
 
     if (this.formModel.logType === 'access,submission') {
-      let additionalRowsData: SortableTableCellData[][] = [];
+      const additionalRowsData: SortableTableCellData[][] = [];
 
       for (const row of logRowsData) {
         const wordsInStatus = row[0].value.split(' ');
@@ -354,12 +354,12 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
           additionalRowsData.push([
             {
               value: status,
-              style: dataStyle
+              style: dataStyle,
             },
             { value: student.name },
             { value: student.email },
             { value: student.sectionName },
-            { value: student.teamName }
+            { value: student.teamName },
           ]);
         } else if (activityType === 'Submitted') {
           const accessLogs = log.feedbackSessionLogEntries.filter((fsLog: FeedbackSessionLogEntry) =>
@@ -380,12 +380,12 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
           additionalRowsData.push([
             {
               value: status,
-              style: dataStyle
+              style: dataStyle,
             },
             { value: student.name },
             { value: student.email },
             { value: student.sectionName },
-            { value: student.teamName }
+            { value: student.teamName },
           ]);
         }
       }

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
@@ -306,13 +306,14 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
           .map((student: Student) => {
             let status: string;
             let dataStyle: string = 'font-family:monospace; white-space:pre;';
-            const statusPrefix = this.logTypeToActivityDisplay(this.formModel.logType);
+            let statusPrefix = this.logTypeToActivityDisplay(this.formModel.logType);
             const studentKey = this.getStudentKey(log, student.email);
 
             if (studentKey in this.studentToLog) {
               const entry: FeedbackSessionLogEntry = this.studentToLog[studentKey];
               const timestamp: string = this.timezoneService.formatToString(
                   entry.timestamp, log.feedbackSessionData.timeZone, this.LOGS_DATE_TIME_FORMAT);
+              statusPrefix = this.logTypeToActivityDisplay(entry.feedbackSessionLogType);
               status = `${statusPrefix} at ${timestamp}`;
             } else {
               const timestamp: string = this.timezoneService.formatToString(


### PR DESCRIPTION
Fixes #12011.

**Outline of Solution**

- [X] Fix bug with wrong status prefix based off drop down selection
- [X] Show latest log for each selected activity type instead of showing latest log of all types

Previously, we generate the status prefix for each activity log based on the selected activity type from the drop down list in the filter container. This showed the wrong description for the logs.

We should instead use the `FeedbackSessionLogEntry`'s type to generate the status prefix/description for these logs.

Additionally, we only show the latest log (be it access or submission) for when the `session access and submission` activity type has been selected for filtering. The image below shows the output after fixing the bug of wrong status prefix due to using the drop down selection's type to generate the prefix.

![image](https://user-images.githubusercontent.com/46486515/213102107-c0526c15-30cb-42bd-97d0-5bedb97a458a.png)

Now, we will show the latest log for both access and submission feedback session log type.

![image](https://user-images.githubusercontent.com/46486515/213101403-23e9dce8-87f9-483f-98e6-a1083bc037a0.png)