### PR TITLE
[#12002] add Test case for InstructorAttributes valueOf

### DIFF
--- a/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
@@ -163,8 +163,11 @@ public class InstructorAttributesTest extends BaseAttributesTest {
     @Test
     public void testValueOf_withCreatedAtAndUpdatedAtAsNull_shouldUseDefaultValues() {
         Instructor instructor = new Instructor("valid.google.id", "valid-course-id", false,
-            "valid name", "valid@email.com", null,true, null, null);
+                "valid name", "valid@email.com", null,
+                true, null, null);
+
         instructor.setCreatedAt(null);
+
         InstructorAttributes instructorAttributes = InstructorAttributes.valueOf(instructor);
 
         assertEquals(instructor.getGoogleId(), instructorAttributes.getGoogleId());
@@ -179,7 +182,6 @@ public class InstructorAttributesTest extends BaseAttributesTest {
         assertEquals(new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER),
                 instructorAttributes.getPrivileges());
 
-        // Default CreatedAt and UpdatedAt
         assertEquals(Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP, instructorAttributes.getCreatedAt());
         assertEquals(Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP, instructorAttributes.getUpdatedAt());
     }

--- a/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/InstructorAttributesTest.java
@@ -161,6 +161,30 @@ public class InstructorAttributesTest extends BaseAttributesTest {
     }
 
     @Test
+    public void testValueOf_withCreatedAtAndUpdatedAtAsNull_shouldUseDefaultValues() {
+        Instructor instructor = new Instructor("valid.google.id", "valid-course-id", false,
+            "valid name", "valid@email.com", null,true, null, null);
+        instructor.setCreatedAt(null);
+        InstructorAttributes instructorAttributes = InstructorAttributes.valueOf(instructor);
+
+        assertEquals(instructor.getGoogleId(), instructorAttributes.getGoogleId());
+        assertEquals(instructor.getCourseId(), instructorAttributes.getCourseId());
+        assertEquals(instructor.getIsArchived(), instructorAttributes.isArchived());
+        assertEquals(instructor.getName(), instructorAttributes.getName());
+        assertEquals(instructor.getEmail(), instructorAttributes.getEmail());
+        assertEquals(instructor.getRegistrationKey(), instructorAttributes.getKey());
+        assertEquals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER, instructorAttributes.getRole());
+        assertEquals(instructor.isDisplayedToStudents(), instructorAttributes.isDisplayedToStudents());
+        assertEquals(Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, instructorAttributes.getDisplayedName());
+        assertEquals(new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER),
+                instructorAttributes.getPrivileges());
+
+        // Default CreatedAt and UpdatedAt
+        assertEquals(Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP, instructorAttributes.getCreatedAt());
+        assertEquals(Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP, instructorAttributes.getUpdatedAt());
+    }
+
+    @Test
     public void testIsRegistered() {
         InstructorAttributes instructor = InstructorAttributes
                 .builder("valid-course-id", "valid@email.com")


### PR DESCRIPTION
Fixes #

![imagem](https://iili.io/HYyrVQn.png)

- valueOf(Instructor) now has 100% coverage

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [x] Read and understood our PR guideline: https://teammates.github.io/teammates/process.html#step-4-submit-a-pr
  - [x] Added the issue number to the "Fixes" keyword above
  - [x] Titled the PR as specified in the abovementioned document
- [x] Made your changes on a branch other than `master` and `release`
- [x] Gone through all the changes in this PR and ensured that:
  - [x] They addressed one (and only one) issue
  - [ ] No unintended changes were made
- [x] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [x] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

Return default values, due to createdAt and updatedAt as null.
Default value got in Const utils.

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
