### PR TITLE
[#12029] Fix team members cannot see responses received by team issue and add relevant tests

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -638,10 +638,6 @@ public final class FeedbackResponsesLogic {
                     && relatedQuestion.isResponseVisibleTo(FeedbackParticipantType.RECEIVER)
                     && response.getRecipient().equals(student.getTeam())) {
                 isVisibleResponse = true;
-            } else if (relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS_IN_SAME_SECTION
-                    && relatedQuestion.isResponseVisibleTo(FeedbackParticipantType.RECEIVER)
-                    && response.getRecipient().equals(student.getTeam())) {
-                isVisibleResponse = true;
             } else if (relatedQuestion.getGiverType() == FeedbackParticipantType.TEAMS
                     && response.getGiver().equals(student.getTeam())) {
                 isVisibleResponse = true;

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -632,7 +632,9 @@ public final class FeedbackResponsesLogic {
                 || !isInstructor && relatedQuestion.isResponseVisibleTo(FeedbackParticipantType.STUDENTS)) {
             isVisibleResponse = true;
         } else if (studentsEmailInTeam != null && !isInstructor) {
-            if (relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS
+            if ((relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS
+                    || relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS_IN_SAME_SECTION
+                    || relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS_EXCLUDING_SELF)
                     && relatedQuestion.isResponseVisibleTo(FeedbackParticipantType.RECEIVER)
                     && response.getRecipient().equals(student.getTeam())) {
                 isVisibleResponse = true;

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -1583,9 +1583,9 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         Map<String, List<FeedbackResponseAttributes>> questionResponseMapByReceiver =
                 frLogic.getSessionResultsForCourse(
-                        session.getFeedbackSessionName(), session.getCourseId(), instructor.getEmail(),
-                        null, sectionToTest, FeedbackResultFetchType.RECEIVER)
-                        .getQuestionResponseMap();
+                session.getFeedbackSessionName(), session.getCourseId(), instructor.getEmail(),
+                null, sectionToTest, FeedbackResultFetchType.RECEIVER)
+                .getQuestionResponseMap();
         questionResponseMapByReceiver.forEach((key, responses) -> {
             responses.forEach(resp -> {
                 assertEquals(sectionToTest, resp.getRecipientSection());

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -626,6 +626,8 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         FeedbackQuestionAttributes fq28 = responseVisibilityBundle.feedbackQuestions.get("FRV.qn8InSession2InCourse1");
         // stu -> team in same section : instructors
         FeedbackQuestionAttributes fq29 = responseVisibilityBundle.feedbackQuestions.get("FRV.qn9InSession2InCourse1");
+        // stu -> team excluding self : instructors, receiver
+        FeedbackQuestionAttributes fq30 = responseVisibilityBundle.feedbackQuestions.get("FRV.qn11InSession2InCourse1");
         // ins -> team : instructors
         FeedbackQuestionAttributes fq20 = responseVisibilityBundle.feedbackQuestions.get("FRV.qn10InSession2InCourse1");
 
@@ -675,6 +677,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         FeedbackResponseAttributes fr281 = responseVisibilityBundle.feedbackResponses.get("FRV.response1ForQ8S2C1");
         // stu8 -> team1
         FeedbackResponseAttributes fr291 = responseVisibilityBundle.feedbackResponses.get("FRV.response1ForQ9S2C1");
+        // stu1 -> team2
+        FeedbackResponseAttributes fr2111 = responseVisibilityBundle.feedbackResponses.get("FRV.response1ForQ11S2C1");
+        // stu6 -> team1
+        FeedbackResponseAttributes fr2112 = responseVisibilityBundle.feedbackResponses.get("FRV.response2ForQ11S2C1");
+        // stu7 -> team2
+        FeedbackResponseAttributes fr2113 = responseVisibilityBundle.feedbackResponses.get("FRV.response3ForQ11S2C1");
         // ins2 -> team2
         FeedbackResponseAttributes fr201 = responseVisibilityBundle.feedbackResponses.get("FRV.response1ForQ10S2C1");
 
@@ -701,6 +709,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
                 fr221, fq22, null));
         assertTrue(frLogic.isResponseVisibleForUser(instructor1.getEmail(), true, null, studentsEmailEmpty,
                 fr231, fq23, instructor1));
+        assertTrue(frLogic.isResponseVisibleForUser(student1.getEmail(), false, student1, studentsEmailInTeam1,
+                fr2111, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student6.getEmail(), false, student6, studentsEmailInTeam3,
+                fr2112, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student7.getEmail(), false, student7, studentsEmailInTeam3,
+                fr2113, fq30, null));
 
         ______TS("test if visible to other students");
 
@@ -749,6 +763,20 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
                 fr281, fq28, null));
         assertFalse(frLogic.isResponseVisibleForUser(student5.getEmail(), false, student5, studentsEmailInTeam2,
                 fr201, fq20, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student6.getEmail(), false, student6, studentsEmailInTeam3,
+                fr2111, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student7.getEmail(), false, student7, studentsEmailInTeam3,
+                fr2111, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student1.getEmail(), false, student1, studentsEmailInTeam1,
+                fr2112, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student2.getEmail(), false, student2, studentsEmailInTeam1,
+                fr2112, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student3.getEmail(), false, student3, studentsEmailInTeam1,
+                fr2112, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student4.getEmail(), false, student4, studentsEmailInTeam1,
+                fr2112, fq30, null));
+        assertTrue(frLogic.isResponseVisibleForUser(student4.getEmail(), false, student5, studentsEmailInTeam2,
+                fr2113, fq30, null));
 
         ______TS("test if visible to giver's team members");
 
@@ -868,6 +896,45 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
                 fr191, fq19, instructor6));
         assertFalse(frLogic.isResponseVisibleForUser(instructor6.getEmail(), true, null, studentsEmailEmpty,
                 fr232, fq23, instructor6));
+
+        assertTrue(frLogic.isResponseVisibleForUser(instructor1.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor1));
+        assertTrue(frLogic.isResponseVisibleForUser(instructor2.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor2));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor3.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor3));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor4.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor4));
+        assertTrue(frLogic.isResponseVisibleForUser(instructor5.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor5));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor6.getEmail(), true, null, studentsEmailEmpty,
+                fr2111, fq30, instructor6));
+
+        assertTrue(frLogic.isResponseVisibleForUser(instructor1.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor1));
+        assertTrue(frLogic.isResponseVisibleForUser(instructor2.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor2));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor3.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor3));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor4.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor4));
+        assertTrue(frLogic.isResponseVisibleForUser(instructor5.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor5));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor6.getEmail(), true, null, studentsEmailEmpty,
+                fr2112, fq30, instructor6));
+
+        assertTrue(frLogic.isResponseVisibleForUser(instructor1.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor1));
+        assertTrue(frLogic.isResponseVisibleForUser(instructor2.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor2));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor3.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor3));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor4.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor4));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor5.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor5));
+        assertFalse(frLogic.isResponseVisibleForUser(instructor6.getEmail(), true, null, studentsEmailEmpty,
+                fr2113, fq30, instructor6));
     }
 
     @Test
@@ -1516,9 +1583,9 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         Map<String, List<FeedbackResponseAttributes>> questionResponseMapByReceiver =
                 frLogic.getSessionResultsForCourse(
-                session.getFeedbackSessionName(), session.getCourseId(), instructor.getEmail(),
-                null, sectionToTest, FeedbackResultFetchType.RECEIVER)
-                .getQuestionResponseMap();
+                        session.getFeedbackSessionName(), session.getCourseId(), instructor.getEmail(),
+                        null, sectionToTest, FeedbackResultFetchType.RECEIVER)
+                        .getQuestionResponseMap();
         questionResponseMapByReceiver.forEach((key, responses) -> {
             responses.forEach(resp -> {
                 assertEquals(sectionToTest, resp.getRecipientSection());

--- a/src/test/resources/data/FeedbackResponseVisibilityTest.json
+++ b/src/test/resources/data/FeedbackResponseVisibilityTest.json
@@ -710,6 +710,30 @@
       "showRecipientNameTo": [
         "INSTRUCTORS"
       ]
+    },
+    "FRV.qn11InSession2InCourse1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "FRV.idOfTypicalCourse1",
+      "questionDetails": {
+        "recommendedLength": 100,
+        "questionText": "Students to Team excluding self Text question",
+        "questionType": "TEXT"
+      },
+      "questionNumber": 11,
+      "giverType": "STUDENTS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 3,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
     }
   },
   "feedbackResponses": {
@@ -1023,6 +1047,45 @@
       "responseDetails": {
         "questionType": "TEXT",
         "answer": "My answer"
+      }
+    },
+    "FRV.response1ForQ11S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "FRV.idOfTypicalCourse1",
+      "feedbackQuestionId": "11",
+      "giver": "FRV.student1InCourse1@gmail.tmt",
+      "recipient": "Team 1.3",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1",
+      "responseDetails": {
+        "questionType": "TEXT",
+        "answer": "From student 1 to Team 1.3"
+      }
+    },
+    "FRV.response2ForQ11S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "FRV.idOfTypicalCourse1",
+      "feedbackQuestionId": "11",
+      "giver": "FRV.student6InCourse1@gmail.tmt",
+      "recipient": "Team 1.1</td></div>'\"",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1",
+      "responseDetails": {
+        "questionType": "TEXT",
+        "answer": "From student 6 to Team 1.1</td></div>'\""
+      }
+    },
+    "FRV.response3ForQ11S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "FRV.idOfTypicalCourse1",
+      "feedbackQuestionId": "11",
+      "giver": "FRV.student7InCourse1@gmail.tmt",
+      "recipient": "Team 1.2",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 2",
+      "responseDetails": {
+        "questionType": "TEXT",
+        "answer": "From student 7 to Team 1.2"
       }
     }
   },


### PR DESCRIPTION
Fixes #12029 

**Outline of Solution**
There are no logic handling questions with recipient type being `TEAM_EXCLUDING_SELF`. Therefore, additional logic is added to handle such situations in the method `isResponseVisibleForUser` in `FeedbackResponsesLogic`.

Relevant unit tests are also added.
