### PR TITLE
[#12038] Testing convertSeverity in GoogleCloudLoggingService

### DIFF
--- a/src/main/java/teammates/logic/external/GoogleCloudLoggingService.java
+++ b/src/main/java/teammates/logic/external/GoogleCloudLoggingService.java
@@ -88,7 +88,10 @@ public class GoogleCloudLoggingService implements LogService {
         return new QueryLogsResults(logEntries, hasNextPage);
     }
 
-    private LogSeverity convertSeverity(Severity severity) {
+    /**
+     * Convert Severity to LogSeverity.
+     */
+    protected LogSeverity convertSeverity(Severity severity) {
         if (severity == Severity.ERROR) {
             return LogSeverity.ERROR;
         }

--- a/src/test/java/teammates/logic/external/GoogleCloudLogginServiceTest.java
+++ b/src/test/java/teammates/logic/external/GoogleCloudLogginServiceTest.java
@@ -1,0 +1,56 @@
+package teammates.logic.external;
+
+import org.testng.annotations.Test;
+
+import com.google.cloud.logging.Severity;
+
+import teammates.common.datatransfer.logs.LogSeverity;
+import teammates.test.BaseTestCase;
+
+/**
+ * SUT: {@link GoogleCloudLoggingService}.
+ */
+public class GoogleCloudLogginServiceTest extends BaseTestCase {
+
+    GoogleCloudLoggingService google = new GoogleCloudLoggingService();
+
+    /**
+     * Tests severityTrue.
+     */
+    @Test
+    public void testConvertSeverityTrue() {
+        // Input: Severity.ERROR, expected output: LogSeverity.ERROR
+        assertEquals(LogSeverity.ERROR, google.convertSeverity(Severity.ERROR));
+
+        // Input: Severity.WARNING, expected output: LogSeverity.WARNING
+        assertEquals(LogSeverity.WARNING, google.convertSeverity(Severity.WARNING));
+
+        // Input: Severity.INFO, expected output: LogSeverity.INFO
+        assertEquals(LogSeverity.INFO, google.convertSeverity(Severity.INFO));
+
+        // Input: Severity.NOTICE, expected output: LogSeverity.INFO
+        assertEquals(LogSeverity.INFO, google.convertSeverity(Severity.NOTICE));
+
+        // Input: Severity.CRITICAL, expected output: LogSeverity.CRITICAL
+        assertEquals(LogSeverity.CRITICAL, google.convertSeverity(Severity.CRITICAL));
+
+        // Input: Severity.ALERT, expected output: LogSeverity.CRITICAL
+        assertEquals(LogSeverity.CRITICAL, google.convertSeverity(Severity.ALERT));
+
+        // Input: Severity.EMERGENCY, expected output: LogSeverity.CRITICAL
+        assertEquals(LogSeverity.CRITICAL, google.convertSeverity(Severity.EMERGENCY));
+
+        // Input: Severity.DEBUG, expected output: LogSeverity.DEBUG
+        assertEquals(LogSeverity.DEBUG, google.convertSeverity(Severity.DEBUG));
+    }
+
+    /**
+     * Tests severityFalse.
+     */
+    @Test
+    public void testConvertSeverityFalse() {
+        // Input: value not present in the Severity enumeration, expected output: LogSeverity.DEFAULT
+        assertEquals(LogSeverity.DEFAULT, google.convertSeverity(null));
+    }
+
+}


### PR DESCRIPTION
<p dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; color: rgb(36, 41, 47); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Multiple condition test</p>

ID | Decision (line) | Condition | Situation for True | Situation for False
-- | -- | -- | -- | --
CD1 | 92 | severity == severity.ERROR | severity is equal to code 500 | severity is different from code 500
CD2 | 95 | severity == severity.WARNING | severity is equal to code 400 | severity is different from code 400
CD3 | 98 | severity == severity.INFO | severity is equal to code 200 | severity is different from code 200
CD4 | 98 | severity == severity.NOTICE | severity is equal to code 300 | severity is different from code 300
CD5 | 101 | severity == severity.CRITICAL | severity is equal to code 600 | severity is different from code 600
CD6 | 101 | severity == severity.ALERT | severity is equal to code 700 | severity is different from code 700
CD7 | 101 | severity == severity.EMERGENCY | severity is equal to code 800 | severity is different from code 800
CD8 | 104 | severity == severity.DEBUG | severity is equal to code 100 | severity is different from code 100

