### PR TITLE
[#12043] Navigation menu got collapsed

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -6,7 +6,7 @@
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="navbar-collapse" [ngStyle]="{display: isCollapsed ? 'none' : 'block'}">
-    <ul class="nav navbar-nav mr-auto" *ngIf="isValidUser">
+    <ul class="nav navbar-nav flex-nowrap mr-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>
           <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>{{ navItem.display }}</a>


### PR DESCRIPTION
Fixes #12043

**Outline of Solution**

Added flex-nowrap bootstrap class so as to prevent unpredictable wrapping
 Please find below screenshots for reference:

* Before flex-nowrap

![navbar_issue_before](https://user-images.githubusercontent.com/79571862/216822360-4f0b5dd7-52cf-4b90-a3e2-6a9caebce48c.jpg)

* After flex-nowrap

![navbar_issue_after](https://user-images.githubusercontent.com/79571862/216822493-c27c71fe-90d2-4e89-a051-26ccb7d39a42.jpg)
