### PR TITLE
[#12065] Student viewing rubric results: average doesn't match

### DIFF
--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
@@ -132,7 +132,8 @@ export class RubricQuestionStatisticsCalculation
           this.calculateSubQuestionWeightAverage(perRecipientStats.answers);
       perRecipientStats.weightsAverage = this.calculateWeightsAverage(this.weights);
       // Overall weighted sum = sum of total chosen weight for all sub questions
-      perRecipientStats.overallWeightedSum = perRecipientStats.subQuestionTotalChosenWeight.reduce((a, b) => a + b);
+      perRecipientStats.overallWeightedSum =
+        +(perRecipientStats.subQuestionTotalChosenWeight.reduce((a, b) => a + b)).toFixed(2);
       // Overall weighted average = overall weighted sum / total number of responses
       perRecipientStats.overallWeightAverage = +(perRecipientStats.overallWeightedSum
           / this.calculateNumResponses(perRecipientStats.answersSum)).toFixed(2);
@@ -201,7 +202,7 @@ export class RubricQuestionStatisticsCalculation
     const averages: number[] = [];
     // Divide each column sum by total number of responses, then convert to percentage
     for (let i: number = 0; i < answersSum.length; i += 1) {
-      averages[i] = +(answersSum[i] * 100 / numResponses).toFixed(2);
+      averages[i] = numResponses === 0 ? 0 : +(answersSum[i] * 100 / numResponses).toFixed(2);
     }
     return averages;
   }

--- a/src/web/app/components/question-types/question-statistics/test-data/rubricQuestionResponses.json
+++ b/src/web/app/components/question-types/question-statistics/test-data/rubricQuestionResponses.json
@@ -66,15 +66,15 @@
       "percentages": [
         [50, 50], [50, 50], [100, 0]
       ],
-      "percentagesAverage": [33.33, 16.67],
+      "percentagesAverage": [66.67, 33.33],
       "recipientEmail": "alice@gmail.com",
       "recipientName": "Alice",
       "recipientTeam": "Team 1",
       "subQuestionTotalChosenWeight": [1, 1, 0.8],
       "subQuestionWeightAverage": [0.5, 0.5, 0.4],
       "weightsAverage": [0.23, 0.77],
-      "overallWeightedSum": 0.56,
-      "overallWeightAverage": 0.09
+      "overallWeightedSum": 2.8,
+      "overallWeightAverage": 0.47
     },
     "Bob": {
       "answers": [
@@ -84,15 +84,15 @@
       "percentages": [
         [100, 0], [50, 50], [100, 0]
       ],
-      "percentagesAverage": [41.67, 8.33],
+      "percentagesAverage": [83.33, 16.67],
       "recipientEmail": "bob@gmail.com",
       "recipientName": "Bob",
       "recipientTeam": "Team 2",
       "subQuestionTotalChosenWeight": [0.4, 1, 0.8],
       "subQuestionWeightAverage": [0.2, 0.5, 0.4],
       "weightsAverage": [0.23, 0.77],
-      "overallWeightedSum": 0.54,
-      "overallWeightAverage": 0.09
+      "overallWeightedSum": 2.2,
+      "overallWeightAverage": 0.37
     }
   }
 }

--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -392,8 +392,8 @@ Team,Recipient Name,Recipient Email,Sub Question,Yes,No,Total,Average
 
 Per Recipient Statistics (Overall)
 Team,Recipient Name,Recipient Email,Yes,No,Total,Average
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,50% (1) [1.25],50% (1) [-1.7],-0.22,-0.11
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,50% (1) [1.25],50% (1) [-1.7],-0.22,-0.11
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,50% (1) [1.25],50% (1) [-1.7],-0.45,-0.23
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,50% (1) [1.25],50% (1) [-1.7],-0.45,-0.23
 \\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,100% (2) [1.25],0% (0) [-1.7],2.5,1.25
 \\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,100% (1) [1.25],0% (0) [-1.7],1.25,1.25
 


### PR DESCRIPTION
Fixes #12065

**Outline of Solution**

Fixes calculations for rubric statistics:

- Percentage average for each recipient is now calculated using the ratio of number of responses in each column to total number of responses.
- Overall weighted sum is calculated by summing the total chosen weight for each subquestion.
