### PR TITLE
Create Student, Instructor and User Entities for PostgreSQL Migration

### DIFF
--- a/src/main/java/teammates/common/datatransfer/InstructorPermissionRole.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPermissionRole.java
@@ -1,0 +1,65 @@
+package teammates.common.datatransfer;
+
+import teammates.common.util.Const;
+
+/**
+ * Instructor Permission Role.
+ *
+ * {@link Const.InstructorPermissionRoleNames}
+ */
+public enum InstructorPermissionRole {
+    /**
+     * Co-owner.
+     */
+    INSTRUCTOR_PERMISSION_ROLE_COOWNER(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER),
+
+    /**
+     * Manager.
+     */
+    INSTRUCTOR_PERMISSION_ROLE_MANAGER(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER),
+
+    /**
+     * Observer.
+     */
+    INSTRUCTOR_PERMISSION_ROLE_OBSERVER(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER),
+
+    /**
+     * Tutor.
+     */
+    INSTRUCTOR_PERMISSION_ROLE_TUTOR(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR),
+
+    /**
+     * Custom.
+     */
+    INSTRUCTOR_PERMISSION_ROLE_CUSTOM(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+
+    private String roleName;
+
+    InstructorPermissionRole(String roleName) {
+        this.roleName = roleName;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    /**
+     * Get enum from string.
+     */
+    public static InstructorPermissionRole getEnum(String role) {
+        switch (role) {
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER:
+            return INSTRUCTOR_PERMISSION_ROLE_COOWNER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER:
+            return INSTRUCTOR_PERMISSION_ROLE_MANAGER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER:
+            return INSTRUCTOR_PERMISSION_ROLE_OBSERVER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR:
+            return INSTRUCTOR_PERMISSION_ROLE_TUTOR;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM:
+            return INSTRUCTOR_PERMISSION_ROLE_CUSTOM;
+        default:
+            return INSTRUCTOR_PERMISSION_ROLE_CUSTOM;
+        }
+    }
+}

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -10,8 +10,11 @@ import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
+import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.User;
 
 /**
  * Class containing utils for setting up the Hibernate session factory.
@@ -20,7 +23,8 @@ public final class HibernateUtil {
     private static SessionFactory sessionFactory;
 
     private static final List<Class<? extends BaseEntity>> ANNOTATED_CLASSES = List.of(Course.class,
-            FeedbackSession.class, Account.class, Notification.class, ReadNotification.class);
+            FeedbackSession.class, Account.class, Notification.class, ReadNotification.class,
+            User.class, Instructor.class, Student.class);
 
     private HibernateUtil() {
         // Utility class

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -25,16 +25,10 @@ import teammates.ui.output.InstructorPermissionRole;
  */
 @Entity
 @Table(name = "Instructors")
-// Might have to change this. Should follow User's PK. Same for Student
-@PrimaryKeyJoinColumn(name = "userId")
 public class Instructor { // TODO: extends User
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private int id;
-
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
-    private int userId;
+    private int id;
 
     @Column(nullable = false)
     private String registrationKey;
@@ -66,7 +60,6 @@ public class Instructor { // TODO: extends User
 
     private Instructor(InstructorBuilder builder) {
         this.setId(builder.id);
-        this.setUserId(builder.userId);
         this.setRegistrationKey(builder.registrationKey);
         this.setDisplayedToStudents(builder.isDisplayedToStudents);
         this.setDisplayName(builder.displayName);
@@ -88,14 +81,6 @@ public class Instructor { // TODO: extends User
 
     public void setId(int id) {
         this.id = id;
-    }
-
-    public int getUserId() {
-        return userId;
-    }
-
-    public void setUserId(int userId) {
-        this.userId = userId;
     }
 
     public String getRegistrationKey() {
@@ -156,7 +141,7 @@ public class Instructor { // TODO: extends User
 
     @Override
     public String toString() {
-        return "Instructor [id=" + id + ", userId=" + userId + ", registrationKey=" + registrationKey
+        return "Instructor [id=" + id + ", registrationKey=" + registrationKey
                 + ", isDisplayedToStudents=" + isDisplayedToStudents + ", displayName=" + displayName
                 + ", role=" + role + ", instructorPrivileges=" + instructorPrivileges
                 + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
@@ -188,7 +173,6 @@ public class Instructor { // TODO: extends User
      */
     public static class InstructorBuilder {
         private int id;
-        private int userId;
         private String registrationKey;
         private boolean isDisplayedToStudents;
         private String displayName;
@@ -197,11 +181,6 @@ public class Instructor { // TODO: extends User
 
         public InstructorBuilder(int id) {
             this.id = id;
-        }
-
-        public InstructorBuilder withUserId(int userId) {
-            this.userId = userId;
-            return this;
         }
 
         public InstructorBuilder withRegistrationKey(String registrationKey) {

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -1,0 +1,237 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import teammates.ui.output.InstructorPermissionRole;
+
+/**
+ * Represents an Instructor entity.
+ */
+@Entity
+@Table(name = "Instructors")
+// Might have to change this. Should follow User's PK. Same for Student
+@PrimaryKeyJoinColumn(name = "userId")
+public class Instructor { // TODO: extends User
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private int id;
+
+    @OneToOne(mappedBy = "id")
+    @Column(nullable = false)
+    private int userId;
+
+    @Column(nullable = false)
+    private String registrationKey;
+
+    @Column(nullable = false)
+    private boolean isDisplayedToStudents;
+
+    @Column(nullable = false)
+    private String displayName;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private InstructorPermissionRole role;
+
+    @Column(columnDefinition = "json", nullable = false)
+    private Map<String, String> instructorPrivileges;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column
+    private Instant updatedAt;
+
+    protected Instructor() {
+        // required by Hibernate
+    }
+
+    private Instructor(InstructorBuilder builder) {
+        this.setId(builder.id);
+        this.setUserId(builder.userId);
+        this.setRegistrationKey(builder.registrationKey);
+        this.setDisplayedToStudents(builder.isDisplayedToStudents);
+        this.setDisplayName(builder.displayName);
+        this.setRole(builder.role);
+        this.setInstructorPrivileges(builder.instructorPrivileges);
+
+        if (createdAt == null) {
+            this.setCreatedAt(Instant.now());
+        } else {
+            this.setCreatedAt(createdAt);
+        }
+
+        this.setUpdatedAt(updatedAt);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getRegistrationKey() {
+        return registrationKey;
+    }
+
+    public void setRegistrationKey(String registrationKey) {
+        this.registrationKey = registrationKey;
+    }
+
+    public boolean isDisplayedToStudents() {
+        return isDisplayedToStudents;
+    }
+
+    public void setDisplayedToStudents(boolean displayedToStudents) {
+        isDisplayedToStudents = displayedToStudents;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public InstructorPermissionRole getRole() {
+        return role;
+    }
+
+    public void setRole(InstructorPermissionRole role) {
+        this.role = role;
+    }
+
+    public Map<String, String> getInstructorPrivileges() {
+        return instructorPrivileges;
+    }
+
+    public void setInstructorPrivileges(Map<String, String> instructorPrivileges) {
+        this.instructorPrivileges = instructorPrivileges;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Instructor [id=" + id + ", userId=" + userId + ", registrationKey=" + registrationKey
+                + ", isDisplayedToStudents=" + isDisplayedToStudents + ", displayName=" + displayName
+                + ", role=" + role + ", instructorPrivileges=" + instructorPrivileges
+                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        // Instructor Id uniquely identifies an Instructor
+        return this.getId();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (this == obj) {
+            return true;
+        } else if (this.getClass() == obj.getClass()) {
+            Instructor otherInstructor = (Instructor) obj;
+
+            return Objects.equals(this.id, otherInstructor.id);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Builder for Instructor.
+     */
+    public static class InstructorBuilder {
+        private int id;
+        private int userId;
+        private String registrationKey;
+        private boolean isDisplayedToStudents;
+        private String displayName;
+        private InstructorPermissionRole role;
+        private Map<String, String> instructorPrivileges;
+
+        public InstructorBuilder(int id) {
+            this.id = id;
+        }
+
+        public InstructorBuilder withUserId(int userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public InstructorBuilder withRegistrationKey(String registrationKey) {
+            this.registrationKey = registrationKey;
+            return this;
+        }
+
+        public InstructorBuilder withIsDisplayedToStudents(boolean isDisplayedToStudents) {
+            this.isDisplayedToStudents = isDisplayedToStudents;
+            return this;
+        }
+
+        public InstructorBuilder withDisplayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public InstructorBuilder withRole(InstructorPermissionRole role) {
+            this.role = role;
+            return this;
+        }
+
+        public InstructorBuilder withInstructorPrivileges(
+                Map<String, String> instructorPrivileges) {
+            this.instructorPrivileges = instructorPrivileges;
+            return this;
+        }
+
+        public Instructor build() {
+            return new Instructor(this);
+        }
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -95,15 +95,20 @@ public class Instructor extends User {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
+    public boolean equals(Object other) {
+        if (other == null) {
             return false;
-        } else if (this == obj) {
+        } else if (this == other) {
             return true;
-        } else if (this.getClass() == obj.getClass()) {
-            Instructor otherInstructor = (Instructor) obj;
-
-            return Objects.equals(super.getId(), otherInstructor.getId());
+        } else if (this.getClass() == other.getClass()) {
+            Instructor otherInstructor = (Instructor) other;
+            return Objects.equals(super.getEmail(), otherInstructor.getEmail())
+                    && Objects.equals(super.getName(), otherInstructor.getName())
+                    && Objects.equals(super.getCourse().getId(), otherInstructor.getCourse().getId())
+                    && Objects.equals(super.getAccount().getGoogleId(),
+                            otherInstructor.getAccount().getGoogleId())
+                    && Objects.equals(this.displayName, otherInstructor.displayName)
+                    && Objects.equals(this.role, otherInstructor.role);
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -1,12 +1,8 @@
 package teammates.storage.sqlentity;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.ui.output.InstructorPermissionRole;
 
@@ -37,14 +33,6 @@ public class Instructor extends User {
 
     @Column(nullable = false)
     private String instructorPrivileges;
-
-    @CreationTimestamp
-    @Column(nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @UpdateTimestamp
-    @Column
-    private Instant updatedAt;
 
     protected Instructor() {
         // required by Hibernate
@@ -90,28 +78,12 @@ public class Instructor extends User {
         this.instructorPrivileges = instructorPrivileges;
     }
 
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Instant createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Instant getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Instant updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
     @Override
     public String toString() {
         return "Instructor [id=" + super.getId() + ", registrationKey=" + registrationKey
                 + ", isDisplayedToStudents=" + isDisplayedToStudents + ", displayName=" + displayName
                 + ", role=" + role + ", instructorPrivileges=" + instructorPrivileges
-                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
+                + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import teammates.ui.output.InstructorPermissionRole;
 
@@ -20,10 +19,6 @@ import teammates.ui.output.InstructorPermissionRole;
 @Entity
 @Table(name = "Instructors")
 public class Instructor extends User {
-    @OneToOne(mappedBy = "id")
-    @Column(nullable = false)
-    private int id;
-
     @Column(nullable = false)
     private String registrationKey;
 
@@ -67,14 +62,6 @@ public class Instructor extends User {
         }
 
         this.setUpdatedAt(updatedAt);
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
     }
 
     public String getRegistrationKey() {
@@ -135,7 +122,7 @@ public class Instructor extends User {
 
     @Override
     public String toString() {
-        return "Instructor [id=" + id + ", registrationKey=" + registrationKey
+        return "Instructor [id=" + super.getId() + ", registrationKey=" + registrationKey
                 + ", isDisplayedToStudents=" + isDisplayedToStudents + ", displayName=" + displayName
                 + ", role=" + role + ", instructorPrivileges=" + instructorPrivileges
                 + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
@@ -144,7 +131,7 @@ public class Instructor extends User {
     @Override
     public int hashCode() {
         // Instructor Id uniquely identifies an Instructor
-        return this.getId();
+        return super.getId();
     }
 
     @Override
@@ -156,7 +143,7 @@ public class Instructor extends User {
         } else if (this.getClass() == obj.getClass()) {
             Instructor otherInstructor = (Instructor) obj;
 
-            return Objects.equals(this.id, otherInstructor.id);
+            return Objects.equals(super.getId(), otherInstructor.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -8,15 +8,11 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import com.googlecode.objectify.annotation.Entity;
-import com.googlecode.objectify.annotation.Id;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import teammates.ui.output.InstructorPermissionRole;
 

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -1,15 +1,13 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
-import java.util.Map;
 import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import com.googlecode.objectify.annotation.Entity;
-
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToOne;
@@ -39,8 +37,8 @@ public class Instructor { // TODO: extends User
     @Enumerated(EnumType.STRING)
     private InstructorPermissionRole role;
 
-    @Column(columnDefinition = "json", nullable = false)
-    private Map<String, String> instructorPrivileges;
+    @Column(nullable = false)
+    private String instructorPrivileges;
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
@@ -111,11 +109,11 @@ public class Instructor { // TODO: extends User
         this.role = role;
     }
 
-    public Map<String, String> getInstructorPrivileges() {
+    public String getInstructorPrivileges() {
         return instructorPrivileges;
     }
 
-    public void setInstructorPrivileges(Map<String, String> instructorPrivileges) {
+    public void setInstructorPrivileges(String instructorPrivileges) {
         this.instructorPrivileges = instructorPrivileges;
     }
 
@@ -173,7 +171,7 @@ public class Instructor { // TODO: extends User
         private boolean isDisplayedToStudents;
         private String displayName;
         private InstructorPermissionRole role;
-        private Map<String, String> instructorPrivileges;
+        private String instructorPrivileges;
 
         public InstructorBuilder(int id) {
             this.id = id;
@@ -199,8 +197,7 @@ public class Instructor { // TODO: extends User
             return this;
         }
 
-        public InstructorBuilder withInstructorPrivileges(
-                Map<String, String> instructorPrivileges) {
+        public InstructorBuilder withInstructorPrivileges(String instructorPrivileges) {
             this.instructorPrivileges = instructorPrivileges;
             return this;
         }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -113,24 +113,7 @@ public class Instructor extends User {
 
     @Override
     public void sanitizeForSaving() {
-        if (role == null) {
-            role = InstructorPermissionRole
-                    .valueOf(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        } else {
-            role = InstructorPermissionRole
-                    .valueOf(SanitizationHelper.sanitizeName(role.name()));
-        }
-
-        if (displayName == null) {
-            displayName = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
-        } else {
-            displayName = SanitizationHelper.sanitizeName(displayName);
-        }
-
-        if (instructorPrivileges == null) {
-            instructorPrivileges = new InstructorPrivileges(
-                    Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER).toString();
-        }
+        displayName = SanitizationHelper.sanitizeName(displayName);
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -47,23 +47,6 @@ public class Instructor extends User {
         // required by Hibernate
     }
 
-    private Instructor(InstructorBuilder builder) {
-        this.setId(builder.id);
-        this.setRegistrationKey(builder.registrationKey);
-        this.setDisplayedToStudents(builder.isDisplayedToStudents);
-        this.setDisplayName(builder.displayName);
-        this.setRole(builder.role);
-        this.setInstructorPrivileges(builder.instructorPrivileges);
-
-        if (createdAt == null) {
-            this.setCreatedAt(Instant.now());
-        } else {
-            this.setCreatedAt(createdAt);
-        }
-
-        this.setUpdatedAt(updatedAt);
-    }
-
     public String getRegistrationKey() {
         return registrationKey;
     }
@@ -146,51 +129,6 @@ public class Instructor extends User {
             return Objects.equals(super.getId(), otherInstructor.getId());
         } else {
             return false;
-        }
-    }
-
-    /**
-     * Builder for Instructor.
-     */
-    public static class InstructorBuilder {
-        private int id;
-        private String registrationKey;
-        private boolean isDisplayedToStudents;
-        private String displayName;
-        private InstructorPermissionRole role;
-        private String instructorPrivileges;
-
-        public InstructorBuilder(int id) {
-            this.id = id;
-        }
-
-        public InstructorBuilder withRegistrationKey(String registrationKey) {
-            this.registrationKey = registrationKey;
-            return this;
-        }
-
-        public InstructorBuilder withIsDisplayedToStudents(boolean isDisplayedToStudents) {
-            this.isDisplayedToStudents = isDisplayedToStudents;
-            return this;
-        }
-
-        public InstructorBuilder withDisplayName(String displayName) {
-            this.displayName = displayName;
-            return this;
-        }
-
-        public InstructorBuilder withRole(InstructorPermissionRole role) {
-            this.role = role;
-            return this;
-        }
-
-        public InstructorBuilder withInstructorPrivileges(String instructorPrivileges) {
-            this.instructorPrivileges = instructorPrivileges;
-            return this;
-        }
-
-        public Instructor build() {
-            return new Instructor(this);
         }
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -128,7 +128,8 @@ public class Instructor extends User {
         }
 
         if (instructorPrivileges == null) {
-            instructorPrivileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER).toString();
+            instructorPrivileges = new InstructorPrivileges(
+                    Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER).toString();
         }
     }
 

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -7,12 +7,13 @@ import java.util.Objects;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import teammates.ui.output.InstructorPermissionRole;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
-import teammates.ui.output.InstructorPermissionRole;
 
 /**
  * Represents an Instructor entity.

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -57,7 +57,7 @@ public class Instructor { // TODO: extends User
     private Instant createdAt;
 
     @UpdateTimestamp
-    @Column
+    @Column(nullable = false)
     private Instant updatedAt;
 
     protected Instructor() {

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -4,11 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.util.Const;
+import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.SanitizationHelper;
-import teammates.ui.output.InstructorPermissionRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,7 +43,7 @@ public class Instructor extends User {
     private Instant createdAt;
 
     @UpdateTimestamp
-    @Column(nullable = false)
+    @Column
     private Instant updatedAt;
 
     protected Instructor() {
@@ -142,6 +143,6 @@ public class Instructor extends User {
     @Override
     public List<String> getInvalidityInfo() {
         // TODO Auto-generated method stub
-        return null;
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -19,7 +19,7 @@ import teammates.ui.output.InstructorPermissionRole;
  */
 @Entity
 @Table(name = "Instructors")
-public class Instructor { // TODO: extends User
+public class Instructor extends User {
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
     private int id;

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -130,5 +131,16 @@ public class Instructor extends User {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        // TODO Auto-generated method stub
+        return null;
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -4,6 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.common.util.FieldValidator;
+import teammates.common.util.SanitizationHelper;
 import teammates.ui.output.InstructorPermissionRole;
 
 import jakarta.persistence.Column;
@@ -109,12 +113,35 @@ public class Instructor extends User {
 
     @Override
     public void sanitizeForSaving() {
-        // TODO Auto-generated method stub
+        if (role == null) {
+            role = InstructorPermissionRole
+                    .valueOf(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+        } else {
+            role = InstructorPermissionRole
+                    .valueOf(SanitizationHelper.sanitizeName(role.name()));
+        }
+
+        if (displayName == null) {
+            displayName = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
+        } else {
+            displayName = SanitizationHelper.sanitizeName(displayName);
+        }
+
+        if (instructorPrivileges == null) {
+            instructorPrivileges = new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER).toString();
+        }
     }
 
     @Override
     public List<String> getInvalidityInfo() {
-        // TODO Auto-generated method stub
-        return new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+
+        addNonEmptyError(FieldValidator.getInvalidityInfoForCourseId(super.getCourse().getId()), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForPersonName(super.getName()), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForEmail(super.getEmail()), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForPersonName(displayName), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForRole(role.name()), errors);
+
+        return errors;
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -43,7 +43,7 @@ public class Student { // TODO: extends User
     @Column(nullable = false)
     private int userId;
     
-    @Column
+    @Column(nullable = false)
     private String comments;
     
     @CreationTimestamp
@@ -51,7 +51,7 @@ public class Student { // TODO: extends User
     private Instant createdAt;
     
     @UpdateTimestamp
-    @Column
+    @Column(nullable = false)
     private Instant updatedAt;
     
     protected Student() {

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -81,5 +82,16 @@ public class Student extends User {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        // TODO Auto-generated method stub
+        return null;
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -11,44 +10,43 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.PrimaryKeyJoinColumns;
 import jakarta.persistence.Table;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.JsonUtils;
 
 /**
- * An association class that represents the association Account -->
- * [enrolled in] --> Course.
+ * Represents a Student entity.
  */
 @Entity
-@Table(name = "Student")
-public class Student extends BaseEntity {
+@Table(name = "Students")
+@PrimaryKeyJoinColumns({
+    @PrimaryKeyJoinColumn(name = "teamId"),
+    @PrimaryKeyJoinColumn(name = "userId"),
+})
+public class Student extends User {
     // TODO
-    // [X] Map FKs (Done for Student)
-    // [ ] Ancestor User
-    // [ ] Fill other CourseStudent related methods
-    // [ ] Fill sanitizeForSaving and getInvalidityInfo if necessary
+    // [ ] Ancestor User, define Inheritance in it
+    // [X] Fill other CourseStudent related methods (nothing related to fill)
 
     // should this be auto incremented or generateId from CourseStudent
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    // note: set @OneToMany(mappedBy = "student") in Team
-    @ManyToOne
-    @JoinColumn(name = "id", foreignKey = @ForeignKey(name = "TEAM_ID_FK"), referencedColumnName = "id", nullable = false)
-    private Team team;
+    // not sure what to do with team yet as we can't do multiple inheritance
+    // have added a PKJoinColumn for teamId above before Class definition
+    @Column
+    private int teamId;
 
     // to cascade?
-    // note: to place @OneToOne annotation in User class for bidirectional r/s
-    @OneToOne
-    @JoinColumn(name = "id", foreignKey = @ForeignKey(name = "USER_ID_FK"), referencedColumnName = "id", nullable = false)
-    private User user;
+    // from hibernate docs: seems like we can omit this
+    // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
+    @Column
+    private int userId;
 
     @Column
     private String comments;
@@ -65,32 +63,6 @@ public class Student extends BaseEntity {
         // required by Hibernate
     }
 
-    public Student(StudentBuilder builder) {
-        this.setId(builder.id);
-        this.setTeam(builder.team);
-        this.setUser(builder.user);
-        this.setComments(builder.comments);
-
-        if (createdAt == null) {
-            this.setCreatedAt(Instant.now());
-        } else {
-            this.setCreatedAt(createdAt);
-        }
-
-        this.setUpdatedAt(updatedAt);
-    }
-
-    @Override
-    public void sanitizeForSaving() {
-        // TODO Auto-generated method stub
-    }
-
-    @Override
-    public List<String> getInvalidityInfo() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
     public int getId() {
         return id;
     }
@@ -99,20 +71,20 @@ public class Student extends BaseEntity {
         this.id = id;
     }
 
-    public Team getTeam() {
-        return team;
+    public int getTeamId() {
+        return teamId;
     }
 
-    public void setTeam(Team team) {
-        this.team = team;
+    public void setTeamId(int teamId) {
+        this.teamId = teamId;
     }
 
-    public User getUser() {
-        return user;
+    public int getUserId() {
+        return userId;
     }
 
-    public void setUser(User user) {
-        this.user = user;
+    public void setUserId(int userId) {
+        this.userId = userId;
     }
 
     public String getComments() {
@@ -137,6 +109,21 @@ public class Student extends BaseEntity {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public Student(StudentBuilder builder) {
+        this.setId(builder.id);
+        this.setTeamId(builder.teamId);
+        this.setUserId(builder.userId);
+        this.setComments(builder.comments);
+
+        if (createdAt == null) {
+            this.setCreatedAt(Instant.now());
+        } else {
+            this.setCreatedAt(createdAt);
+        }
+
+        this.setUpdatedAt(updatedAt);
     }
     
     @Override
@@ -170,21 +157,21 @@ public class Student extends BaseEntity {
      */
     public static class StudentBuilder {
         private int id;
-        private Team team;
-        private User user;
+        private int teamId;
+        private int userId;
         private String comments;
 
         public StudentBuilder(int id) {
             this.id = id;
         }
 
-        public StudentBuilder withTeam(Team team) {
-            this.team = team;
+        public StudentBuilder withTeamId(int teamId) {
+            this.teamId = teamId;
             return this;
         }
 
-        public StudentBuilder withUser(User user) {
-            this.user = user;
+        public StudentBuilder withUserId(int userId) {
+            this.userId = userId;
             return this;
         }
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -18,11 +18,6 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "Students")
 public class Student extends User {
-    // Cascade?
-    @OneToOne
-    @JoinColumn(name = "teamId")
-    private Team team;
-
     @Column(nullable = false)
     private String comments;
 
@@ -36,14 +31,6 @@ public class Student extends User {
 
     protected Student() {
         // required by Hibernate
-    }
-
-    public Team getTeam() {
-        return team;
-    }
-
-    public void setTeam(Team team) {
-        this.team = team;
     }
 
     public String getComments() {
@@ -72,14 +59,14 @@ public class Student extends User {
 
     @Override
     public String toString() {
-        return "Student [id=" + super.getId() + ", team=" + team + ", comments=" + comments
+        return "Student [id=" + super.getId() + ", team=" + super.getTeam() + ", comments=" + comments
                 + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override
     public int hashCode() {
         // Student Id uniquely identifies a Student
-        return this.getId();
+        return super.getId();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -17,7 +17,7 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Table(name = "Students")
-public class Student { // TODO: extends User
+public class Student extends User {
     // Cascade?
     // from hibernate docs: seems like we can omit this
     // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -1,0 +1,188 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.util.JsonUtils;
+
+/**
+ * An association class that represents the association Account -->
+ * [enrolled in] --> Course.
+ */
+@Entity
+@Table(name = "Student")
+public class Student extends BaseEntity {
+    // TODO
+    // [ ] Map FKs
+    // [ ] Ancestor User
+    // [ ] Fill other CourseStudent related methods
+    // [ ] Fill sanitizeForSaving and getInvalidityInfo if necessary
+    
+    // should this be auto incremented or generateId from CourseStudent
+    @Id
+    private int id;
+
+    @Column(nullable = false)
+    private int teamId;
+
+    @Column(nullable = false)
+    private int userId;
+
+    @Column
+    private String comments;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column
+    private Instant updatedAt;
+
+    protected Student() {
+        // required by Hibernate
+    }
+
+    public Student(StudentBuilder builder) {
+        this.setId(builder.id);
+        this.setUserId(builder.userId);
+        this.setTeamId(builder.teamId);
+        this.setComments(builder.comments);
+
+        if (createdAt == null) {
+            this.setCreatedAt(Instant.now());
+        } else {
+            this.setCreatedAt(createdAt);
+        }
+
+        this.setUpdatedAt(updatedAt);
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(int teamId) {
+        this.teamId = teamId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return JsonUtils.toJson(this, StudentAttributes.class);
+    }
+
+    @Override
+    public int hashCode() {
+        // Student Id uniquely identifies a Student
+        return this.getId();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (this == obj) {
+            return true;
+        } else if (this.getClass() == obj.getClass()) {
+            Student otherStudent = (Student) obj;
+
+            return Objects.equals(this.id, otherStudent.id);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Builder for Student
+     */
+    public static class StudentBuilder {
+        private int id;
+        private int teamId;
+        private int userId;
+        private String comments;
+
+        public StudentBuilder(int id) {
+            this.id = id;
+        }
+
+        public StudentBuilder withTeamId(int teamId) {
+            this.teamId = teamId;
+            return this;
+        }
+
+        public StudentBuilder withUserId(int userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public StudentBuilder withComments(String comments) {
+            this.comments = comments;
+            return this;
+        }
+
+        public Student build() {
+            return new Student(this);
+        }
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -12,11 +12,10 @@ import com.googlecode.objectify.annotation.Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.PrimaryKeyJoinColumns;
 import jakarta.persistence.Table;
-import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.common.util.JsonUtils;
 
 /**
  * Represents a Student entity.
@@ -32,12 +31,15 @@ public class Student { // TODO: extends User
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
+    // to cascade?
+    @OneToOne(mappedBy = "id")
     @Column(nullable = false)
     private int teamId;
 
     // to cascade?
     // from hibernate docs: seems like we can omit this
     // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
+    @OneToOne(mappedBy = "id")
     @Column(nullable = false)
     private int userId;
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -32,13 +32,13 @@ public class Student { // TODO: extends User
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    @Column
+    @Column(nullable = false)
     private int teamId;
 
     // to cascade?
     // from hibernate docs: seems like we can omit this
     // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
-    @Column
+    @Column(nullable = false)
     private int userId;
 
     @Column

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -22,27 +22,21 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Table(name = "Students")
-@PrimaryKeyJoinColumns({
-    @PrimaryKeyJoinColumn(name = "teamId"),
-    @PrimaryKeyJoinColumn(name = "userId"),
-})
 public class Student { // TODO: extends User
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private int id;
-
     // to cascade?
+    // from hibernate docs: seems like we can omit this
+    // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
-    private int teamId;
+    private int id;
 
     // to cascade?
     // from hibernate docs: seems like we can omit this
     // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
-    private int userId;
-    
+    private int teamId;
+
     @Column(nullable = false)
     private String comments;
     
@@ -61,7 +55,6 @@ public class Student { // TODO: extends User
     public Student(StudentBuilder builder) {
         this.setId(builder.id);
         this.setTeamId(builder.teamId);
-        this.setUserId(builder.userId);
         this.setComments(builder.comments);
 
         if (createdAt == null) {
@@ -87,14 +80,6 @@ public class Student { // TODO: extends User
 
     public void setTeamId(int teamId) {
         this.teamId = teamId;
-    }
-
-    public int getUserId() {
-        return userId;
-    }
-
-    public void setUserId(int userId) {
-        this.userId = userId;
     }
 
     public String getComments() {
@@ -123,8 +108,8 @@ public class Student { // TODO: extends User
     
     @Override
     public String toString() {
-        return "Student [id=" + id + ", teamId=" + teamId + ", userId=" + userId
-                + ", comments=" + comments + ", createdAt=" + createdAt
+        return "Student [id=" + id + ", teamId=" + teamId + ", comments=" + comments
+                + ", createdAt=" + createdAt
                 + ", updatedAt=" + updatedAt + "]";
     }
 
@@ -155,7 +140,6 @@ public class Student { // TODO: extends User
     public static class StudentBuilder {
         private int id;
         private int teamId;
-        private int userId;
         private String comments;
 
         public StudentBuilder(int id) {
@@ -164,11 +148,6 @@ public class Student { // TODO: extends User
 
         public StudentBuilder withTeamId(int teamId) {
             this.teamId = teamId;
-            return this;
-        }
-
-        public StudentBuilder withUserId(int userId) {
-            this.userId = userId;
             return this;
         }
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -42,20 +42,35 @@ public class Student { // TODO: extends User
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
     private int userId;
-
+    
     @Column
     private String comments;
-
+    
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
-
+    
     @UpdateTimestamp
     @Column
     private Instant updatedAt;
-
+    
     protected Student() {
         // required by Hibernate
+    }
+    
+    public Student(StudentBuilder builder) {
+        this.setId(builder.id);
+        this.setTeamId(builder.teamId);
+        this.setUserId(builder.userId);
+        this.setComments(builder.comments);
+
+        if (createdAt == null) {
+            this.setCreatedAt(Instant.now());
+        } else {
+            this.setCreatedAt(createdAt);
+        }
+
+        this.setUpdatedAt(updatedAt);
     }
 
     public int getId() {
@@ -104,21 +119,6 @@ public class Student { // TODO: extends User
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
-    }
-
-    public Student(StudentBuilder builder) {
-        this.setId(builder.id);
-        this.setTeamId(builder.teamId);
-        this.setUserId(builder.userId);
-        this.setComments(builder.comments);
-
-        if (createdAt == null) {
-            this.setCreatedAt(Instant.now());
-        } else {
-            this.setCreatedAt(createdAt);
-        }
-
-        this.setUpdatedAt(updatedAt);
     }
     
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -27,18 +27,11 @@ import teammates.common.util.JsonUtils;
     @PrimaryKeyJoinColumn(name = "teamId"),
     @PrimaryKeyJoinColumn(name = "userId"),
 })
-public class Student extends User {
-    // TODO
-    // [ ] Ancestor User, define Inheritance in it
-    // [X] Fill other CourseStudent related methods (nothing related to fill)
-
-    // should this be auto incremented or generateId from CourseStudent
+public class Student { // TODO: extends User
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    // not sure what to do with team yet as we can't do multiple inheritance
-    // have added a PKJoinColumn for teamId above before Class definition
     @Column
     private int teamId;
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -121,7 +121,9 @@ public class Student { // TODO: extends User
     
     @Override
     public String toString() {
-        return JsonUtils.toJson(this, StudentAttributes.class);
+        return "Student [id=" + id + ", teamId=" + teamId + ", userId=" + userId
+                + ", comments=" + comments + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -6,9 +6,8 @@ import java.util.Objects;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import com.googlecode.objectify.annotation.Entity;
-
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -33,19 +32,19 @@ public class Student { // TODO: extends User
 
     @Column(nullable = false)
     private String comments;
-    
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
-    
+
     @UpdateTimestamp
     @Column(nullable = false)
     private Instant updatedAt;
-    
+
     protected Student() {
         // required by Hibernate
     }
-    
+
     public Student(StudentBuilder builder) {
         this.setId(builder.id);
         this.setTeam(builder.team);
@@ -99,7 +98,7 @@ public class Student { // TODO: extends User
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
     }
-    
+
     @Override
     public String toString() {
         return "Student [id=" + id + ", team=" + team + ", comments=" + comments
@@ -133,7 +132,7 @@ public class Student { // TODO: extends User
      */
     public static class StudentBuilder {
         private int id;
-        private int team;
+        private Team team;
         private String comments;
 
         public StudentBuilder(int id) {

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -45,15 +45,20 @@ public class Student extends User {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
+    public boolean equals(Object other) {
+        if (other == null) {
             return false;
-        } else if (this == obj) {
+        } else if (this == other) {
             return true;
-        } else if (this.getClass() == obj.getClass()) {
-            Student otherStudent = (Student) obj;
-
-            return Objects.equals(super.getId(), otherStudent.getId());
+        } else if (this.getClass() == other.getClass()) {
+            Student otherStudent = (Student) other;
+            return Objects.equals(super.getCourse(), otherStudent.getCourse())
+                    && Objects.equals(super.getName(), otherStudent.getName())
+                    && Objects.equals(super.getEmail(), otherStudent.getEmail())
+                    && Objects.equals(super.getAccount().getGoogleId(),
+                            otherStudent.getAccount().getGoogleId())
+                    && Objects.equals(this.comments, otherStudent.comments);
+                    // && Objects.equals(this.team, otherStudent.team)
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import teammates.common.util.FieldValidator;
+import teammates.common.util.SanitizationHelper;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -58,12 +61,20 @@ public class Student extends User {
 
     @Override
     public void sanitizeForSaving() {
-        // TODO Auto-generated method stub
+        comments = SanitizationHelper.sanitizeTextField(comments);
     }
 
     @Override
     public List<String> getInvalidityInfo() {
-        // TODO Auto-generated method stub
-        return new ArrayList<>();
+        assert comments != null;
+
+        List<String> errors = new ArrayList<>();
+
+        addNonEmptyError(FieldValidator.getInvalidityInfoForCourseId(super.getCourse().getId()), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForEmail(super.getEmail()), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForStudentRoleComments(comments), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForPersonName(super.getName()), errors);
+
+        return errors;
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -8,8 +8,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 /**
@@ -59,7 +57,8 @@ public class Student extends User {
 
     @Override
     public String toString() {
-        return "Student [id=" + super.getId() + ", team=" + super.getTeam() + ", comments=" + comments
+        // return "Student [id=" + super.getId() + ", team=" + super.getTeam() + ", comments=" + comments
+        return "Student [id=" + super.getId() + ", comments=" + comments
                 + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -1,12 +1,8 @@
 package teammates.storage.sqlentity;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,14 +17,6 @@ public class Student extends User {
     @Column(nullable = false)
     private String comments;
 
-    @CreationTimestamp
-    @Column(nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @UpdateTimestamp
-    @Column
-    private Instant updatedAt;
-
     protected Student() {
         // required by Hibernate
     }
@@ -41,27 +29,11 @@ public class Student extends User {
         this.comments = comments;
     }
 
-    public Instant getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Instant createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Instant getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Instant updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
     @Override
     public String toString() {
         // return "Student [id=" + super.getId() + ", team=" + super.getTeam() + ", comments=" + comments
         return "Student [id=" + super.getId() + ", comments=" + comments
-                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
+                + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -11,6 +11,12 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.JsonUtils;
@@ -23,20 +29,26 @@ import teammates.common.util.JsonUtils;
 @Table(name = "Student")
 public class Student extends BaseEntity {
     // TODO
-    // [ ] Map FKs
+    // [X] Map FKs (Done for Student)
     // [ ] Ancestor User
     // [ ] Fill other CourseStudent related methods
     // [ ] Fill sanitizeForSaving and getInvalidityInfo if necessary
-    
+
     // should this be auto incremented or generateId from CourseStudent
     @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    @Column(nullable = false)
-    private int teamId;
+    // note: set @OneToMany(mappedBy = "student") in Team
+    @ManyToOne
+    @JoinColumn(name = "id", foreignKey = @ForeignKey(name = "TEAM_ID_FK"), referencedColumnName = "id", nullable = false)
+    private Team team;
 
-    @Column(nullable = false)
-    private int userId;
+    // to cascade?
+    // note: to place @OneToOne annotation in User class for bidirectional r/s
+    @OneToOne
+    @JoinColumn(name = "id", foreignKey = @ForeignKey(name = "USER_ID_FK"), referencedColumnName = "id", nullable = false)
+    private User user;
 
     @Column
     private String comments;
@@ -55,8 +67,8 @@ public class Student extends BaseEntity {
 
     public Student(StudentBuilder builder) {
         this.setId(builder.id);
-        this.setUserId(builder.userId);
-        this.setTeamId(builder.teamId);
+        this.setTeam(builder.team);
+        this.setUser(builder.user);
         this.setComments(builder.comments);
 
         if (createdAt == null) {
@@ -87,20 +99,20 @@ public class Student extends BaseEntity {
         this.id = id;
     }
 
-    public int getTeamId() {
-        return teamId;
+    public Team getTeam() {
+        return team;
     }
 
-    public void setTeamId(int teamId) {
-        this.teamId = teamId;
+    public void setTeam(Team team) {
+        this.team = team;
     }
 
-    public int getUserId() {
-        return userId;
+    public User getUser() {
+        return user;
     }
 
-    public void setUserId(int userId) {
-        this.userId = userId;
+    public void setUser(User user) {
+        this.user = user;
     }
 
     public String getComments() {
@@ -126,7 +138,7 @@ public class Student extends BaseEntity {
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
     }
-
+    
     @Override
     public String toString() {
         return JsonUtils.toJson(this, StudentAttributes.class);
@@ -158,21 +170,21 @@ public class Student extends BaseEntity {
      */
     public static class StudentBuilder {
         private int id;
-        private int teamId;
-        private int userId;
+        private Team team;
+        private User user;
         private String comments;
 
         public StudentBuilder(int id) {
             this.id = id;
         }
 
-        public StudentBuilder withTeamId(int teamId) {
-            this.teamId = teamId;
+        public StudentBuilder withTeam(Team team) {
+            this.team = team;
             return this;
         }
 
-        public StudentBuilder withUserId(int userId) {
-            this.userId = userId;
+        public StudentBuilder withUser(User user) {
+            this.user = user;
             return this;
         }
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -58,7 +58,7 @@ public class Student extends User {
                     && Objects.equals(super.getAccount().getGoogleId(),
                             otherStudent.getAccount().getGoogleId())
                     && Objects.equals(this.comments, otherStudent.comments);
-                    // && Objects.equals(this.team, otherStudent.team)
+            // && Objects.equals(this.team, otherStudent.team)
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -7,14 +7,10 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import com.googlecode.objectify.annotation.Entity;
-import com.googlecode.objectify.annotation.Id;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
-import jakarta.persistence.PrimaryKeyJoinColumns;
 import jakarta.persistence.Table;
 
 /**
@@ -23,19 +19,17 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "Students")
 public class Student { // TODO: extends User
-    // to cascade?
+    // Cascade?
     // from hibernate docs: seems like we can omit this
     // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
     @OneToOne(mappedBy = "id")
     @Column(nullable = false)
     private int id;
 
-    // to cascade?
-    // from hibernate docs: seems like we can omit this
-    // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
-    @OneToOne(mappedBy = "id")
-    @Column(nullable = false)
-    private int teamId;
+    // Cascade?
+    @OneToOne
+    @JoinColumn(name = "teamId")
+    private Team team;
 
     @Column(nullable = false)
     private String comments;
@@ -54,7 +48,7 @@ public class Student { // TODO: extends User
     
     public Student(StudentBuilder builder) {
         this.setId(builder.id);
-        this.setTeamId(builder.teamId);
+        this.setTeam(builder.team);
         this.setComments(builder.comments);
 
         if (createdAt == null) {
@@ -74,12 +68,12 @@ public class Student { // TODO: extends User
         this.id = id;
     }
 
-    public int getTeamId() {
-        return teamId;
+    public Team getTeam() {
+        return team;
     }
 
-    public void setTeamId(int teamId) {
-        this.teamId = teamId;
+    public void setTeam(Team team) {
+        this.team = team;
     }
 
     public String getComments() {
@@ -108,7 +102,7 @@ public class Student { // TODO: extends User
     
     @Override
     public String toString() {
-        return "Student [id=" + id + ", teamId=" + teamId + ", comments=" + comments
+        return "Student [id=" + id + ", team=" + team + ", comments=" + comments
                 + ", createdAt=" + createdAt
                 + ", updatedAt=" + updatedAt + "]";
     }
@@ -139,15 +133,15 @@ public class Student { // TODO: extends User
      */
     public static class StudentBuilder {
         private int id;
-        private int teamId;
+        private int team;
         private String comments;
 
         public StudentBuilder(int id) {
             this.id = id;
         }
 
-        public StudentBuilder withTeamId(int teamId) {
-            this.teamId = teamId;
+        public StudentBuilder withTeam(Team team) {
+            this.team = team;
             return this;
         }
 

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -38,20 +38,6 @@ public class Student extends User {
         // required by Hibernate
     }
 
-    public Student(StudentBuilder builder) {
-        this.setId(builder.id);
-        this.setTeam(builder.team);
-        this.setComments(builder.comments);
-
-        if (createdAt == null) {
-            this.setCreatedAt(Instant.now());
-        } else {
-            this.setCreatedAt(createdAt);
-        }
-
-        this.setUpdatedAt(updatedAt);
-    }
-
     public Team getTeam() {
         return team;
     }
@@ -108,33 +94,6 @@ public class Student extends User {
             return Objects.equals(super.getId(), otherStudent.getId());
         } else {
             return false;
-        }
-    }
-
-    /**
-     * Builder for Student
-     */
-    public static class StudentBuilder {
-        private int id;
-        private Team team;
-        private String comments;
-
-        public StudentBuilder(int id) {
-            this.id = id;
-        }
-
-        public StudentBuilder withTeam(Team team) {
-            this.team = team;
-            return this;
-        }
-
-        public StudentBuilder withComments(String comments) {
-            this.comments = comments;
-            return this;
-        }
-
-        public Student build() {
-            return new Student(this);
         }
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,7 +26,7 @@ public class Student extends User {
     private Instant createdAt;
 
     @UpdateTimestamp
-    @Column(nullable = false)
+    @Column
     private Instant updatedAt;
 
     protected Student() {
@@ -92,6 +93,6 @@ public class Student extends User {
     @Override
     public List<String> getInvalidityInfo() {
         // TODO Auto-generated method stub
-        return null;
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -19,13 +19,6 @@ import jakarta.persistence.Table;
 @Table(name = "Students")
 public class Student extends User {
     // Cascade?
-    // from hibernate docs: seems like we can omit this
-    // https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table
-    @OneToOne(mappedBy = "id")
-    @Column(nullable = false)
-    private int id;
-
-    // Cascade?
     @OneToOne
     @JoinColumn(name = "teamId")
     private Team team;
@@ -57,14 +50,6 @@ public class Student extends User {
         }
 
         this.setUpdatedAt(updatedAt);
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
     }
 
     public Team getTeam() {
@@ -101,9 +86,8 @@ public class Student extends User {
 
     @Override
     public String toString() {
-        return "Student [id=" + id + ", team=" + team + ", comments=" + comments
-                + ", createdAt=" + createdAt
-                + ", updatedAt=" + updatedAt + "]";
+        return "Student [id=" + super.getId() + ", team=" + team + ", comments=" + comments
+                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override
@@ -121,7 +105,7 @@ public class Student extends User {
         } else if (this.getClass() == obj.getClass()) {
             Student otherStudent = (Student) obj;
 
-            return Objects.equals(this.id, otherStudent.id);
+            return Objects.equals(super.getId(), otherStudent.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -31,7 +31,6 @@ public class Student extends User {
 
     @Override
     public String toString() {
-        // return "Student [id=" + super.getId() + ", team=" + super.getTeam() + ", comments=" + comments
         return "Student [id=" + super.getId() + ", comments=" + comments
                 + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";
     }

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -30,8 +30,9 @@ public abstract class User extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "accountId")
     private Account account;
-
+    
     @ManyToOne
+    @JoinColumn(name = "courseId")
     private Course course;
 
     /*

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -1,8 +1,6 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -126,45 +124,5 @@ public abstract class User extends BaseEntity {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
-    }
-
-    @Override
-    public String toString() {
-        // return "User [id=" + id + ", account=" + account + ", course=" + course
-        //         + ", team=" + team + ", name=" + name + ", email=" + email
-        return "User [id=" + id + ", course=" + course + ", name=" + name + ", email=" + email
-                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
-    }
-
-    @Override
-    public int hashCode() {
-        // User Id uniquely identifies a User
-        return this.getId();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        } else if (this == obj) {
-            return true;
-        } else if (this.getClass() == obj.getClass()) {
-            User otherUser = (User) obj;
-
-            return Objects.equals(this.id, otherUser.id);
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void sanitizeForSaving() {
-        // TODO Auto-generated method stub
-    }
-
-    @Override
-    public List<String> getInvalidityInfo() {
-        // TODO Auto-generated method stub
-        return null;
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
+import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -12,7 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
@@ -31,8 +31,7 @@ public abstract class User extends BaseEntity {
     */
 
     @OneToMany
-    @JoinColumn(name = "courseId")
-    private Course course;
+    private List<Course> courses;
 
     /*
     @ManyToOne
@@ -76,12 +75,12 @@ public abstract class User extends BaseEntity {
     }
     */
 
-    public Course getCourse() {
-        return course;
+    public List<Course> getCourses() {
+        return courses;
     }
 
-    public void setCourse(Course course) {
-        this.course = course;
+    public void setCourses(List<Course> courses) {
+        this.courses = courses;
     }
 
     /*

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -25,7 +25,7 @@ public abstract class User extends BaseEntity {
     private int id;
 
     /*
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "accountId")
     private Account account;
     */

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -1,0 +1,149 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "Users")
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private int id;
+
+    @OneToOne
+    @JoinColumn(name = "accountId")
+    private Account account;
+
+    @OneToOne
+    @JoinColumn(name = "courseId")
+    private Course course;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected User() {
+        // required by Hibernate
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public Course getCourse() {
+        return course;
+    }
+
+    public void setCourse(Course course) {
+        this.course = course;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "User [id=" + id + ", account=" + account + ", course=" + course
+                + ", name=" + name + ", email=" + email + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        // User Id uniquely identifies a User
+        return this.getId();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (this == obj) {
+            return true;
+        } else if (this.getClass() == obj.getClass()) {
+            User otherUser = (User) obj;
+
+            return Objects.equals(this.id, otherUser.id);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -16,6 +16,9 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
+/**
+ * Represents a User entity.
+ */
 @Entity
 @Table(name = "Users")
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -30,7 +30,7 @@ public abstract class User extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "accountId")
     private Account account;
-    
+
     @ManyToOne
     @JoinColumn(name = "courseId")
     private Course course;

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
@@ -33,6 +34,10 @@ public abstract class User extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "courseId")
     private Course course;
+
+    @ManyToOne
+    @JoinColumn(name = "teamId")
+    private Team team;
 
     @Column(nullable = false)
     private String name;
@@ -76,6 +81,14 @@ public abstract class User extends BaseEntity {
         this.course = course;
     }
 
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
     public String getName() {
         return name;
     }
@@ -111,8 +124,8 @@ public abstract class User extends BaseEntity {
     @Override
     public String toString() {
         return "User [id=" + id + ", account=" + account + ", course=" + course
-                + ", name=" + name + ", email=" + email + ", createdAt=" + createdAt
-                + ", updatedAt=" + updatedAt + "]";
+                + ", team=" + team + ", name=" + name + ", email=" + email
+                + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlentity;
 
 import java.time.Instant;
-import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -15,7 +14,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 /**
@@ -33,8 +31,8 @@ public abstract class User extends BaseEntity {
     @JoinColumn(name = "accountId")
     private Account account;
 
-    @OneToMany
-    private List<Course> courses;
+    @ManyToOne
+    private Course course;
 
     /*
     @ManyToOne
@@ -76,12 +74,12 @@ public abstract class User extends BaseEntity {
         this.account = account;
     }
 
-    public List<Course> getCourses() {
-        return courses;
+    public Course getCourse() {
+        return course;
     }
 
-    public void setCourses(List<Course> courses) {
-        this.courses = courses;
+    public void setCourse(Course course) {
+        this.course = course;
     }
 
     /*

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -13,7 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -30,7 +30,7 @@ public abstract class User extends BaseEntity {
     private Account account;
     */
 
-    @OneToOne
+    @OneToMany
     @JoinColumn(name = "courseId")
     private Course course;
 

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -13,6 +13,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
@@ -27,11 +29,9 @@ public abstract class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    /*
     @ManyToOne
     @JoinColumn(name = "accountId")
     private Account account;
-    */
 
     @OneToMany
     private List<Course> courses;
@@ -68,7 +68,6 @@ public abstract class User extends BaseEntity {
         this.id = id;
     }
 
-    /*
     public Account getAccount() {
         return account;
     }
@@ -76,7 +75,6 @@ public abstract class User extends BaseEntity {
     public void setAccount(Account account) {
         this.account = account;
     }
-    */
 
     public List<Course> getCourses() {
         return courses;

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -15,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
@@ -27,17 +26,21 @@ public abstract class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
+    /*
     @OneToOne
     @JoinColumn(name = "accountId")
     private Account account;
+    */
 
     @OneToOne
     @JoinColumn(name = "courseId")
     private Course course;
 
+    /*
     @ManyToOne
     @JoinColumn(name = "teamId")
     private Team team;
+    */
 
     @Column(nullable = false)
     private String name;
@@ -65,6 +68,7 @@ public abstract class User extends BaseEntity {
         this.id = id;
     }
 
+    /*
     public Account getAccount() {
         return account;
     }
@@ -72,6 +76,7 @@ public abstract class User extends BaseEntity {
     public void setAccount(Account account) {
         this.account = account;
     }
+    */
 
     public Course getCourse() {
         return course;
@@ -81,6 +86,7 @@ public abstract class User extends BaseEntity {
         this.course = course;
     }
 
+    /*
     public Team getTeam() {
         return team;
     }
@@ -88,6 +94,7 @@ public abstract class User extends BaseEntity {
     public void setTeam(Team team) {
         this.team = team;
     }
+    */
 
     public String getName() {
         return name;
@@ -123,8 +130,9 @@ public abstract class User extends BaseEntity {
 
     @Override
     public String toString() {
-        return "User [id=" + id + ", account=" + account + ", course=" + course
-                + ", team=" + team + ", name=" + name + ", email=" + email
+        // return "User [id=" + id + ", account=" + account + ", course=" + course
+        //         + ", team=" + team + ", name=" + name + ", email=" + email
+        return "User [id=" + id + ", course=" + course + ", name=" + name + ", email=" + email
                 + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt + "]";
     }
 


### PR DESCRIPTION
Part of #12048.

**Outline**

This PR creates the new Student and Instructor Entity to be used for PostgreSQL Migration.

Below are the findings for the 4 available inheritance strategies in [Hibernate](https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance):

**MappedSuperclass**
- Not scalable. If we use this, ancestors cannot contain associations with other entities
- Each DB table contains both base and sub classes properties

**Single Table**
- Performant (polymorphic query performance) as only 1 table needs to be accessed when querying parent entities. Best performance among the other strategies
- However, can no longer use NOT NULL constraints on subclass entity properties. I think this means that the identifying attributes of the rows of subclasses can be nullable?
- For our case of Student/Instructor IS-A User, we will only have 1 table in the DB, i.e., User, with all the fields combined. This means Single Table is out of our options? Student is a User but it shouldn't have Instructor attributes/data.
- Could use discriminator values which is used to differentiate between rows belonging to separate subclass types.

**[Joined Table aka Table-per-subclass mapping strategy (This has been selected)](https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#entity-inheritance-joined-table)**
- TLDR: An inherited state is retrieved by joining with the table of the superclass
- Great because the PK of User appears in its child classes, e.g., In Student/Instructor
- Performance issue as retrieving entities requires joins between the tables, expensive for large number of records. Number of joins is higher when we query parent class as it will join with every single related child
- Discriminator column not required. But each subclass must declare a table column holding the object identifier (which is kind of what we want as each subclass table contains the FKs to the base class, User; PKs of sub class tables are also FKs to the superclass table PK. If @PKJoinCol not set, the PK/FK cols are assumed to have the same names as the PK cols of primary table of the superclass)
- When using polymorphic queries, base class table must be joined with all subclass tables to fetch every associated subclass instance

**Table per Class**
- Performance issue because we union in the background when we query the base class i.e., User
- Each table defines all persistent states of the class, including the inherited state.
- If we want to use polymorphic associations (eg An association to the superclass of our hierarchy), we need to use union subclass mapping. This requires multiple UNION queries, be aware of performance implications of a large class hierarchy. Also, not all database systems support UNION ALL. PostgreSQL81Dialectk supports UNION ALL