### PR TITLE
[#12048] V9: temporarily disable liquibase migrations

### DIFF
--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -30,7 +30,8 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
     @BeforeSuite
     public static void setUpClass() throws Exception {
         PGSQL.start();
-        DbMigrationUtil.resetDb(PGSQL.getJdbcUrl(), PGSQL.getUsername(), PGSQL.getPassword());
+        // Temporarily disable migration utility
+        // DbMigrationUtil.resetDb(PGSQL.getJdbcUrl(), PGSQL.getUsername(), PGSQL.getPassword());
         HibernateUtil.buildSessionFactory(PGSQL.getJdbcUrl(), PGSQL.getUsername(), PGSQL.getPassword());
 
         LogicStarter.initializeDependencies();
@@ -44,12 +45,11 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
     @BeforeMethod
     public void setUp() throws Exception {
         HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().begin();
-        DbMigrationUtil.resetDb(PGSQL.getJdbcUrl(), PGSQL.getUsername(), PGSQL.getPassword());
     }
 
     @AfterMethod
     public void tearDown() {
-        HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().commit();
+        HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
     }
 
     /**

--- a/src/it/java/teammates/it/test/DbMigrationUtil.java
+++ b/src/it/java/teammates/it/test/DbMigrationUtil.java
@@ -34,7 +34,6 @@ public final class DbMigrationUtil {
             Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(conn));
             try (Liquibase liquibase = new Liquibase("src/main/resources/db/changelog/db.changelog-root.xml",
                     new DirectoryResourceAccessor(file), database)) {
-                liquibase.dropAll();
                 liquibase.update();
             }
             conn.close();

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -49,7 +49,7 @@ public final class HibernateUtil {
                 .setProperty("hibernate.connection.username", username)
                 .setProperty("hibernate.connection.password", password)
                 .setProperty("hibernate.connection.url", dbUrl)
-                .setProperty("hibernate.hbm2ddl.auto", "validate")
+                .setProperty("hibernate.hbm2ddl.auto", "update")
                 .setProperty("show_sql", "true")
                 .setProperty("hibernate.current_session_context_class", "thread")
                 .addPackage("teammates.storage.sqlentity");


### PR DESCRIPTION
Part of #12048

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Temporarily disable liquidate migrations until while the db schema is still changing rapidly.