### PR TITLE
Create notification DB layer for v9 migration

### DIFF
--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -11,7 +11,7 @@ import teammates.storage.sqlentity.Notification;
  *
  * @see Notification
  */
-public class NotificationsDb extends EntitiesDb<Notification> {
+public final class NotificationsDb extends EntitiesDb<Notification> {
 
     private static final NotificationsDb instance = new NotificationsDb();
 

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -1,0 +1,89 @@
+package teammates.storage.sqlapi;
+
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Notification;
+
+/**
+ * Handles CRUD operations for notifications.
+ *
+ * @see Notification
+ */
+public class NotificationsDb extends EntitiesDb<Notification> {
+
+    private static final NotificationsDb instance = new NotificationsDb();
+
+    private NotificationsDb() {
+        // prevent initialization
+    }
+
+    public static NotificationsDb inst() {
+        return instance;
+    }
+
+    /**
+     * Creates a notification.
+     */
+    public Notification createNotification(Notification notification)
+            throws InvalidParametersException, EntityAlreadyExistsException {
+        assert notification != null;
+
+        notification.sanitizeForSaving();
+        if (!notification.isValid()) {
+            throw new InvalidParametersException(notification.getInvalidityInfo());
+        }
+
+        if (getNotification(notification.getNotificationId().toString()) != null) {
+            throw new EntityAlreadyExistsException(String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS,
+                    notification.toString()));
+        }
+
+        persist(notification);
+        return notification;
+    }
+
+    /**
+     * Gets a notification by its unique ID.
+     */
+    public Notification getNotification(String notificationId) {
+        assert notificationId != null;
+
+        return HibernateUtil.getSessionFactory().getCurrentSession().get(Notification.class, notificationId);
+    }
+
+    /**
+     * Updates a notification with {@link Notification}.
+     */
+    public Notification updateNotification(Notification notification)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert notification != null;
+
+        notification.sanitizeForSaving();
+
+        if (!notification.isValid()) {
+            throw new InvalidParametersException(notification.getInvalidityInfo());
+        }
+
+        if (getNotification(notification.getNotificationId().toString()) == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
+        }
+
+        return merge(notification);
+    }
+
+    /**
+     * Deletes a notification by its unique ID.
+     *
+     * <p>Fails silently if there is no such notification.
+     */
+    public void deleteNotification(String notificationId) {
+        assert notificationId != null;
+
+        Notification notification = getNotification(notificationId);
+        if (notification != null) {
+            delete(notification);
+        }
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/Notification.java
+++ b/src/main/java/teammates/storage/sqlentity/Notification.java
@@ -11,9 +11,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
-import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.util.FieldValidator;
-import teammates.common.util.JsonUtils;
 import teammates.common.util.SanitizationHelper;
 
 import jakarta.persistence.Column;

--- a/src/main/java/teammates/storage/sqlentity/Notification.java
+++ b/src/main/java/teammates/storage/sqlentity/Notification.java
@@ -187,7 +187,9 @@ public class Notification extends BaseEntity {
 
     @Override
     public String toString() {
-        return JsonUtils.toJson(this, NotificationAttributes.class);
+        return "Notification [id=" + notificationId + ", startTime=" + startTime + ", endTime=" + endTime
+                + ", style=" + style + ", targetUser=" + targetUser + ", shown=" + shown + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override


### PR DESCRIPTION
Part of #12048

Create notification DB layer with CRUD. Minor update to notification sql entity to fix the wrong implementation.