### PR TITLE
[#12048] Add Account Entity

### DIFF
--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -6,9 +6,12 @@ import org.hibernate.SessionFactory;
 import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.cfg.Configuration;
 
+import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.ReadNotification;
 
 /**
  * Class containing utils for setting up the Hibernate session factory.
@@ -17,7 +20,7 @@ public final class HibernateUtil {
     private static SessionFactory sessionFactory;
 
     private static final List<Class<? extends BaseEntity>> ANNOTATED_CLASSES = List.of(Course.class,
-            FeedbackSession.class);
+            FeedbackSession.class, Account.class, Notification.class, ReadNotification.class);
 
     private HibernateUtil() {
         // Utility class

--- a/src/main/java/teammates/storage/sqlentity/Account.java
+++ b/src/main/java/teammates/storage/sqlentity/Account.java
@@ -1,0 +1,164 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import teammates.common.util.FieldValidator;
+import teammates.common.util.SanitizationHelper;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+/**
+ * Represents a unique account in the system.
+ */
+@Entity
+@Table(name = "Accounts")
+public class Account extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private String googleId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @OneToMany(mappedBy = "account")
+    private List<ReadNotification> readNotifications;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column
+    private Instant updatedAt;
+
+    protected Account() {
+        // required by Hibernate
+    }
+
+    public Account(String googleId, String name, String email) {
+        this.googleId = googleId;
+        this.name = name;
+        this.email = email;
+        this.readNotifications = new ArrayList<>();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getGoogleId() {
+        return googleId;
+    }
+
+    public void setGoogleId(String googleId) {
+        this.googleId = googleId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public List<ReadNotification> getReadNotifications() {
+        return readNotifications;
+    }
+
+    public void setReadNotifications(List<ReadNotification> readNotifications) {
+        this.readNotifications = readNotifications;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        List<String> errors = new ArrayList<>();
+
+        addNonEmptyError(FieldValidator.getInvalidityInfoForGoogleId(googleId), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForPersonName(name), errors);
+        addNonEmptyError(FieldValidator.getInvalidityInfoForEmail(email), errors);
+
+        return errors;
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        this.googleId = SanitizationHelper.sanitizeGoogleId(googleId);
+        this.name = SanitizationHelper.sanitizeName(name);
+        this.email = SanitizationHelper.sanitizeEmail(email);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        } else if (this == other) {
+            return true;
+        } else if (this.getClass() == other.getClass()) {
+            Account otherAccount = (Account) other;
+            return Objects.equals(this.email, otherAccount.email)
+                    && Objects.equals(this.name, otherAccount.name)
+                    && Objects.equals(this.googleId, otherAccount.googleId)
+                    && Objects.equals(this.id, otherAccount.id);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Account [id=" + id + ", googleId=" + googleId + ", name=" + name + ", email=" + email
+                + ", readNotifications=" + readNotifications + ", createdAt=" + createdAt + ", updatedAt=" + updatedAt
+                + "]";
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/Notification.java
+++ b/src/main/java/teammates/storage/sqlentity/Notification.java
@@ -20,6 +20,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 /**
@@ -55,6 +56,9 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false)
     private boolean shown;
+
+    @OneToMany(mappedBy = "notification")
+    private List<ReadNotification> readNotifications;
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
@@ -159,6 +163,14 @@ public class Notification extends BaseEntity {
         return shown;
     }
 
+    public List<ReadNotification> getReadNotifications() {
+        return readNotifications;
+    }
+
+    public void setReadNotifications(List<ReadNotification> readNotifications) {
+        this.readNotifications = readNotifications;
+    }
+
     /**
      * Sets the notification as shown to the user.
      * Only allowed to change value from false to true.
@@ -185,8 +197,9 @@ public class Notification extends BaseEntity {
 
     @Override
     public String toString() {
-        return "Notification [id=" + notificationId + ", startTime=" + startTime + ", endTime=" + endTime
-                + ", style=" + style + ", targetUser=" + targetUser + ", shown=" + shown + ", createdAt=" + createdAt
+        return "Notification [notificationId=" + notificationId + ", startTime=" + startTime + ", endTime=" + endTime
+                + ", style=" + style + ", targetUser=" + targetUser + ", title=" + title + ", message=" + message
+                + ", shown=" + shown + ", readNotifications=" + readNotifications + ", createdAt=" + createdAt
                 + ", updatedAt=" + updatedAt + "]";
     }
 
@@ -204,7 +217,15 @@ public class Notification extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             Notification otherNotification = (Notification) other;
-            return Objects.equals(this.notificationId, otherNotification.getNotificationId());
+            return Objects.equals(this.notificationId, otherNotification.getNotificationId())
+                && Objects.equals(this.startTime, otherNotification.startTime)
+                && Objects.equals(this.endTime, otherNotification.endTime)
+                && Objects.equals(this.style, otherNotification.style)
+                && Objects.equals(this.targetUser, otherNotification.targetUser)
+                && Objects.equals(this.title, otherNotification.title)
+                && Objects.equals(this.message, otherNotification.message)
+                && Objects.equals(this.shown, otherNotification.shown)
+                && Objects.equals(this.readNotifications, otherNotification.readNotifications);
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/ReadNotification.java
+++ b/src/main/java/teammates/storage/sqlentity/ReadNotification.java
@@ -1,0 +1,108 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Represents an association class between Accounts and Notifications.
+ * Keeps track of which Notifications have been read by an Account.
+ */
+@Entity
+@Table(name = "ReadNotifications")
+public class ReadNotification extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne
+    private Account account;
+
+    @ManyToOne
+    private Notification notification;
+
+    @Column(nullable = false)
+    private Instant readAt;
+
+    protected ReadNotification() {
+        // required by Hibernate
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Instant getReadAt() {
+        return readAt;
+    }
+
+    public void setReadAt(Instant readAt) {
+        this.readAt = readAt;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public Notification getNotification() {
+        return notification;
+    }
+
+    public void setNotification(Notification notification) {
+        this.notification = notification;
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // No sanitization required
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        } else if (this == other) {
+            return true;
+        } else if (this.getClass() == other.getClass()) {
+            ReadNotification otherReadNotifiation = (ReadNotification) other;
+            return Objects.equals(this.account, otherReadNotifiation.account)
+                    && Objects.equals(this.notification, otherReadNotifiation.notification)
+                    && Objects.equals(this.readAt, otherReadNotifiation.readAt)
+                    && Objects.equals(this.id, otherReadNotifiation.id);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ReadNotification [id=" + id + ", account=" + account + ", notification=" + notification + ", readAt="
+                + readAt + "]";
+    }
+}


### PR DESCRIPTION
Fixes #12048

**Outline of Solution**

- Add Account entity
- Add ReadNotification entity, which represents an association class between Account and Notification. Keeps track of which notifications have been read by which Accounts. Reason ManyToMany annotation was not used is that the association class has to have an extra readAt field that is not automatically populated if ManyToMany is used.