### PR TITLE
[#12021] Update Jetty library to 10 or 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,17 +48,17 @@ dependencies {
 
     annotationProcessor(objectify)
 
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.16.0")
-    implementation(platform("com.google.cloud:google-cloud-bom:0.189.0"))
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.8.1")
+    implementation(platform("com.google.cloud:google-cloud-bom:0.176.0"))
     implementation("com.google.cloud:google-cloud-datastore")
     implementation("com.google.cloud:google-cloud-tasks")
     implementation("com.google.cloud:google-cloud-logging")
-    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.google.code.gson:gson:2.9.0")
     implementation("com.google.guava:guava:31.1-jre")
     implementation(objectify)
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1")
-    implementation("com.helger.commons:ph-commons:11.0.1") // necessary to add SpotBugs suppression
-    implementation("com.mailjet:mailjet-client:5.2.2")
+    implementation("com.helger:ph-commons:9.5.5") // necessary to add SpotBugs suppression
+    implementation("com.mailjet:mailjet-client:5.2.0")
     implementation("com.sendgrid:sendgrid-java:4.9.3")
     implementation("com.sun.jersey:jersey-client:1.19.4")
     implementation("com.sun.jersey:jersey-core:1.19.4")
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.eclipse.jetty:jetty-server")
     implementation("org.eclipse.jetty:jetty-webapp")
     implementation("org.eclipse.jetty:jetty-annotations")
-    implementation("org.jsoup:jsoup:1.15.3")
+    implementation("org.jsoup:jsoup:1.15.2")
 
     testAnnotationProcessor(testng)
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,27 +48,28 @@ dependencies {
 
     annotationProcessor(objectify)
 
-    implementation("com.google.auth:google-auth-library-oauth2-http:1.8.1")
-    implementation(platform("com.google.cloud:google-cloud-bom:0.176.0"))
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.16.0")
+    implementation(platform("com.google.cloud:google-cloud-bom:0.189.0"))
     implementation("com.google.cloud:google-cloud-datastore")
     implementation("com.google.cloud:google-cloud-tasks")
     implementation("com.google.cloud:google-cloud-logging")
-    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.google.guava:guava:31.1-jre")
     implementation(objectify)
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1")
-    implementation("com.helger:ph-commons:9.5.5") // necessary to add SpotBugs suppression
-    implementation("com.mailjet:mailjet-client:5.2.0")
+    implementation("com.helger.commons:ph-commons:11.0.1") // necessary to add SpotBugs suppression
+    implementation("com.mailjet:mailjet-client:5.2.2")
     implementation("com.sendgrid:sendgrid-java:4.9.3")
     implementation("com.sun.jersey:jersey-client:1.19.4")
     implementation("com.sun.jersey:jersey-core:1.19.4")
     implementation("com.sun.jersey.contribs:jersey-multipart:1.19.4")
     implementation("org.apache.solr:solr-solrj:8.11.1")
-    implementation(platform("org.eclipse.jetty:jetty-bom:9.4.48.v20220622"))
+    implementation(platform("org.eclipse.jetty:jetty-bom:10.0.13"))
+    implementation("org.eclipse.jetty:jetty-slf4j-impl")
     implementation("org.eclipse.jetty:jetty-server")
     implementation("org.eclipse.jetty:jetty-webapp")
     implementation("org.eclipse.jetty:jetty-annotations")
-    implementation("org.jsoup:jsoup:1.15.2")
+    implementation("org.jsoup:jsoup:1.15.3")
 
     testAnnotationProcessor(testng)
 

--- a/src/main/java/teammates/main/Application.java
+++ b/src/main/java/teammates/main/Application.java
@@ -73,7 +73,6 @@ public final class Application {
             }
         };
 
-
         server.setHandler(webapp);
         server.setStopAtShutdown(true);
         server.addEventListener(customLifeCycleListener);

--- a/src/main/java/teammates/main/Application.java
+++ b/src/main/java/teammates/main/Application.java
@@ -3,13 +3,9 @@ package teammates.main;
 import java.io.File;
 import java.time.zone.ZoneRulesProvider;
 
-import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.eclipse.jetty.util.log.StdErrLog;
-import org.eclipse.jetty.webapp.Configuration.ClassList;
-import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import teammates.common.util.Config;
@@ -32,7 +28,6 @@ public final class Application {
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException") // ok to ignore as this is a startup method
     public static void main(String[] args) throws Exception {
-        System.setProperty("org.eclipse.jetty.util.log.class", StdErrLog.class.getName());
         System.setProperty("org.eclipse.jetty.LEVEL", "INFO");
 
         Server server = new Server(Config.getPort());
@@ -42,7 +37,6 @@ public final class Application {
         String classPath = Application.class.getProtectionDomain().getCodeSource().getLocation().getFile();
         String warPath = new File(classPath).getParentFile().getParentFile().getAbsolutePath();
         webapp.setWar(warPath);
-        ClassList classlist = ClassList.setServerDefault(server);
 
         if (Config.isDevServerLoginEnabled()) {
             // For dev server, we dynamically add servlet to serve the dev server login page.
@@ -52,14 +46,7 @@ public final class Application {
             webapp.addServlet(devServerLoginServlet, "/devServerLogin");
         }
 
-        // Enable Jetty annotation scanning
-        classlist.addBefore(
-                JettyWebXmlConfiguration.class.getName(),
-                AnnotationConfiguration.class.getName());
-
-        server.setHandler(webapp);
-        server.setStopAtShutdown(true);
-        server.addLifeCycleListener(new LifeCycle.Listener() {
+        LifeCycle.Listener customLifeCycleListener = new LifeCycle.Listener() {
             @Override
             public void lifeCycleStarting(LifeCycle event) {
                 log.startup();
@@ -84,7 +71,12 @@ public final class Application {
             public void lifeCycleStopped(LifeCycle event) {
                 // do nothing
             }
-        });
+        };
+
+
+        server.setHandler(webapp);
+        server.setStopAtShutdown(true);
+        server.addEventListener(customLifeCycleListener);
 
         server.start();
 


### PR DESCRIPTION
Fixes #12021

**Outline of Solution**
Upgrade from Jetty 9 to Jetty 10
- Refactored deprecated class in Jetty 9
- The Jetty Logging facade is deprecated and moved to Slf4j instead, using the standard `jetty-sl4fj-impl `implement which equivalent to the previous `StdError` facade implementation
- Remove deprecated `ClassList` configuration as look like it no longer needed
- Move `LifeCycle.Listener` to an object and add to server as `EventListerner` instead as there is no `addLifeCycleListener` anymore.