### PR TITLE
[#12081] Landmark questions in submit feedback page

### DIFF
--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -2,8 +2,8 @@
   <div>
     <b class="feedback-path-title">Feedback Path</b> (Who is giving feedback about whom?)
   </div>
-  <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px overflow-scroll" autoClose="outside">
-    <button id="btn-feedback-path" class="btn btn-light white-space-normal" ngbDropdownToggle [disabled]="!model.isEditable || commonFeedbackPaths.size === 1">
+  <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
+    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle [disabled]="!model.isEditable || commonFeedbackPaths.size === 1">
       <span *ngIf="!model.isUsingOtherFeedbackPath">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}
       </span>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -234,12 +234,12 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             </div>
             <div
               autoclose="outside"
-              class="margin-top-15px overflow-scroll dropdown"
+              class="margin-top-15px w-100 dropdown"
               ngbdropdown=""
             >
               <button
                 aria-expanded="false"
-                class="dropdown-toggle btn btn-light white-space-normal"
+                class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                 disabled=""
                 id="btn-feedback-path"
                 ngbdropdowntoggle=""

--- a/src/web/app/components/question-submission-form/question-submission-form-model.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form-model.ts
@@ -50,6 +50,7 @@ export interface QuestionSubmissionFormModel {
 
   isLoading: boolean;
   isLoaded: boolean;
+  isTabExpanded: boolean;
 }
 
 /**

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,10 +1,10 @@
 <div id="question-submission-form" class="card">
-  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="this.model.isTabExpanded = handleClick($event);"
-    [ngClass]="isSaved ? 'bg-success' : 'bg-primary'">
+  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="this.model.isTabExpanded = !this.model.isTabExpanded;"
+    [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
     <div class="collapse-caret">
-      <tm-panel-chevron [isExpanded]="model.isTabExpanded"></tm-panel-chevron>
+      <tm-panel-chevron [isExpanded]="model.isTabExpanded" aria-hidden="true"></tm-panel-chevron>
     </div>
-    <i class="fas fa-check me-2" *ngIf="isSaved"></i>
+    <i class="fas fa-check me-2" *ngIf="isSaved" aria-hidden="true"></i>
     <h2 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h2>
   </button>
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,208 +1,213 @@
 <div id="question-submission-form" class="card">
-  <div class="card-header bg-primary text-white question-header"
+  <div class="card-header bg-primary text-white question-header cursor-pointer" (click)="this.model.isTabExpanded = handleClick($event);"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'">
+    <div class="collapse-caret">
+      <tm-panel-chevron [isExpanded]="model.isTabExpanded"></tm-panel-chevron>
+    </div>
     <i class="fas fa-check me-2" *ngIf="isSaved"></i>
     <h3 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h3>
   </div>
 
-  <div class="card-body" *tmIsLoading="model.isLoading">
-    <div class="card mb-3" *ngIf="model.questionDescription">
-      <div class="card-header">
-        <b>More details</b>
-      </div>
-      <div id="question-description" class="card-body" [innerHTML]="model.questionDescription | safeHtml"></div>
-    </div>
-
-    <div class="card-body visibility-card">
-      <p class="text-secondary">Only the following persons can see your responses: </p>
-      <ul id="visibility-list" class="text-secondary">
-        <li *ngIf="model.recipientType === FeedbackParticipantType.SELF">You can see your own feedback in the results page later on.</li>
-        <ng-container *ngFor="let visibilityType of FeedbackVisibilityType | enumToArray">
-          <li *ngIf="visibilityStateMachine.isVisibilityTypeApplicable(visibilityType) && visibilityStateMachine.hasAnyVisibilityControl(visibilityType)">
-            {{ visibilityType | visibilityEntityName:model.recipientType:model.numberOfEntitiesToGiveFeedbackToSetting:model.customNumberOfEntitiesToGiveFeedbackTo }} {{ visibilityStateMachine.getVisibilityControlUnderVisibilityType(visibilityType) | visibilityCapability }}
-          </li>
-        </ng-container>
-        <li *ngIf="!visibilityStateMachine.hasAnyVisibilityControlForAll()">No-one can see your responses</li>
-      </ul>
-    </div>
-
-    <tm-contribution-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONTRIB"
-                                          [questionDetails]="model.questionDetails" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-contribution-question-instruction>
-    <tm-text-question-instruction *ngIf="model.questionType === FeedbackQuestionType.TEXT"></tm-text-question-instruction>
-    <tm-num-scale-question-instruction *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE"></tm-num-scale-question-instruction>
-    <tm-text-question-constraint *ngIf="model.questionType === FeedbackQuestionType.TEXT"></tm-text-question-constraint>
-    <tm-num-scale-question-constraint *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE"></tm-num-scale-question-constraint>
-    <tm-rank-options-question-instruction *ngIf="model.questionType === FeedbackQuestionType.RANK_OPTIONS" [questionDetails]="model.questionDetails"></tm-rank-options-question-instruction>
-    <tm-msq-question-constraint *ngIf="model.questionType === FeedbackQuestionType.MSQ" [questionDetails]="model.questionDetails"></tm-msq-question-constraint>
-    <tm-rank-recipients-question-instruction *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [questionDetails]="model.questionDetails"></tm-rank-recipients-question-instruction>
-    <tm-constsum-options-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [questionDetails]="model.questionDetails"></tm-constsum-options-question-instruction>
-    <tm-constsum-recipients-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
-                                                 [questionDetails]="model.questionDetails" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-constsum-recipients-question-instruction>
-
-    <div class="form-row margin-top-30px margin-bottom-0px">
-      <div class="col-2">
-        <p *ngIf="model.recipientType !== FeedbackParticipantType.NONE && model.recipientType !== FeedbackParticipantType.SELF" >
-          <span class="ngb-tooltip-class font-bold" ngbTooltip="The party being evaluated or given feedback to">Evaluee/Recipient</span>
-        </p>
-      </div>
-      <div class="form-check" *ngIf="hasSectionTeam">
-          <input type="checkbox" id="showSectionTeam" name="showSectionTeam" value="sectionTeam" (change)="toggleSectionTeam($event)">
-          <label class="form-check-label ms-1" for="showSectionTeam">Show Section/Team</label>
+  <div *ngIf="model.isTabExpanded" @collapseAnim>
+    <div class="card-body" *tmIsLoading="model.isLoading">
+      <div class="card mb-3" *ngIf="model.questionDescription">
+        <div class="card-header">
+          <b>More details</b>
         </div>
-    </div>
+        <div id="question-description" class="card-body" [innerHTML]="model.questionDescription | safeHtml"></div>
+      </div>
 
-    <div class="alert alert-primary" role="alert" *ngIf="model.giverType === FeedbackParticipantType.TEAMS">
-      Please note that you are submitting this response on behalf of your team.
-    </div>
+      <div class="card-body visibility-card">
+        <p class="text-secondary">Only the following persons can see your responses: </p>
+        <ul id="visibility-list" class="text-secondary">
+          <li *ngIf="model.recipientType === FeedbackParticipantType.SELF">You can see your own feedback in the results page later on.</li>
+          <ng-container *ngFor="let visibilityType of FeedbackVisibilityType | enumToArray">
+            <li *ngIf="visibilityStateMachine.isVisibilityTypeApplicable(visibilityType) && visibilityStateMachine.hasAnyVisibilityControl(visibilityType)">
+              {{ visibilityType | visibilityEntityName:model.recipientType:model.numberOfEntitiesToGiveFeedbackToSetting:model.customNumberOfEntitiesToGiveFeedbackTo }} {{ visibilityStateMachine.getVisibilityControlUnderVisibilityType(visibilityType) | visibilityCapability }}
+            </li>
+          </ng-container>
+          <li *ngIf="!visibilityStateMachine.hasAnyVisibilityControlForAll()">No-one can see your responses</li>
+        </ul>
+      </div>
 
-    <div class="row">
-      <div class="evaluee-col col-12">
-        <div class="row" *ngFor="let recipientSubmissionFormModel of model.recipientSubmissionForms; let i = index; trackBy: trackRecipientSubmissionFormByFn">
-          <div class="col-md-5 col-xs-12 margin-top-20px" *ngIf="model.recipientType !== FeedbackParticipantType.SELF && model.recipientType !== FeedbackParticipantType.NONE">
-            <div id="recipient-name-{{ i }}" *ngIf="formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT">
-              <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
-            </div>
-            <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
-              <select id="recipient-dropdown" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
-                      (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
-                      [disabled]="isFormsDisabled">
-                <option value=""></option>
-                <ng-container *ngFor="let recipient of model.recipientList">
-                  <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ getSelectionOptionLabel(recipient) }}</option>
-                </ng-container>
-              </select>
-              <div class="col-auto text-start">
-                ({{ model.recipientType | recipientTypeName: model.giverType }})
+      <tm-contribution-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONTRIB"
+                                            [questionDetails]="model.questionDetails" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-contribution-question-instruction>
+      <tm-text-question-instruction *ngIf="model.questionType === FeedbackQuestionType.TEXT"></tm-text-question-instruction>
+      <tm-num-scale-question-instruction *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE"></tm-num-scale-question-instruction>
+      <tm-text-question-constraint *ngIf="model.questionType === FeedbackQuestionType.TEXT"></tm-text-question-constraint>
+      <tm-num-scale-question-constraint *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE"></tm-num-scale-question-constraint>
+      <tm-rank-options-question-instruction *ngIf="model.questionType === FeedbackQuestionType.RANK_OPTIONS" [questionDetails]="model.questionDetails"></tm-rank-options-question-instruction>
+      <tm-msq-question-constraint *ngIf="model.questionType === FeedbackQuestionType.MSQ" [questionDetails]="model.questionDetails"></tm-msq-question-constraint>
+      <tm-rank-recipients-question-instruction *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [questionDetails]="model.questionDetails"></tm-rank-recipients-question-instruction>
+      <tm-constsum-options-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [questionDetails]="model.questionDetails"></tm-constsum-options-question-instruction>
+      <tm-constsum-recipients-question-instruction *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
+                                                  [questionDetails]="model.questionDetails" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-constsum-recipients-question-instruction>
+
+      <div class="form-row margin-top-30px margin-bottom-0px">
+        <div class="col-2">
+          <p *ngIf="model.recipientType !== FeedbackParticipantType.NONE && model.recipientType !== FeedbackParticipantType.SELF" >
+            <span class="ngb-tooltip-class font-bold" ngbTooltip="The party being evaluated or given feedback to">Evaluee/Recipient</span>
+          </p>
+        </div>
+        <div class="form-check" *ngIf="hasSectionTeam">
+            <input type="checkbox" id="showSectionTeam" name="showSectionTeam" value="sectionTeam" (change)="toggleSectionTeam($event)">
+            <label class="form-check-label ms-1" for="showSectionTeam">Show Section/Team</label>
+          </div>
+      </div>
+
+      <div class="alert alert-primary" role="alert" *ngIf="model.giverType === FeedbackParticipantType.TEAMS">
+        Please note that you are submitting this response on behalf of your team.
+      </div>
+
+      <div class="row">
+        <div class="evaluee-col col-12">
+          <div class="row" *ngFor="let recipientSubmissionFormModel of model.recipientSubmissionForms; let i = index; trackBy: trackRecipientSubmissionFormByFn">
+            <div class="col-md-5 col-xs-12 margin-top-20px" *ngIf="model.recipientType !== FeedbackParticipantType.SELF && model.recipientType !== FeedbackParticipantType.NONE">
+              <div id="recipient-name-{{ i }}" *ngIf="formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT">
+                <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
+              </div>
+              <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
+                <select id="recipient-dropdown" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
+                        (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
+                        [disabled]="isFormsDisabled">
+                  <option value=""></option>
+                  <ng-container *ngFor="let recipient of model.recipientList">
+                    <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ getSelectionOptionLabel(recipient) }}</option>
+                  </ng-container>
+                </select>
+                <div class="col-auto text-start">
+                  ({{ model.recipientType | recipientTypeName: model.giverType }})
+                </div>
               </div>
             </div>
-          </div>
-          <div class="margin-top-20px" [ngClass]="isMCQDropDownEnabled ? 'col-12' : 'col'">
-            <tm-contribution-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="model.questionDetails"
+            <div class="margin-top-20px" [ngClass]="isMCQDropDownEnabled ? 'col-12' : 'col'">
+              <tm-contribution-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="model.questionDetails"
+                                                        [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                        [shouldShowHelpLink]="i === 0"
+                                                        (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                        [isDisabled]="isFormsDisabled"
+              ></tm-contribution-question-edit-answer-form>
+              <tm-text-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.TEXT" [questionDetails]="model.questionDetails"
+                                                [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                [isDisabled]="isFormsDisabled"
+              ></tm-text-question-edit-answer-form>
+              <tm-rank-options-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RANK_OPTIONS" [questionDetails]="model.questionDetails"
+                                                        [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                        (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                        [isDisabled]="isFormsDisabled"></tm-rank-options-question-edit-answer-form>
+              <tm-rank-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [questionDetails]="model.questionDetails"
+                                                            [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                            (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                            [isDisabled]="isFormsDisabled" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-rank-recipients-question-edit-answer-form>
+              <tm-num-scale-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE" [questionDetails]="model.questionDetails"
                                                       [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                      [shouldShowHelpLink]="i === 0"
                                                       (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
                                                       [isDisabled]="isFormsDisabled"
-            ></tm-contribution-question-edit-answer-form>
-            <tm-text-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.TEXT" [questionDetails]="model.questionDetails"
-                                              [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                              (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                              [isDisabled]="isFormsDisabled"
-            ></tm-text-question-edit-answer-form>
-            <tm-rank-options-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RANK_OPTIONS" [questionDetails]="model.questionDetails"
-                                                       [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                       (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                       [isDisabled]="isFormsDisabled"></tm-rank-options-question-edit-answer-form>
-            <tm-rank-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [questionDetails]="model.questionDetails"
-                                                          [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                          (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                          [isDisabled]="isFormsDisabled" [numOfRecipients]="model.recipientSubmissionForms.length"></tm-rank-recipients-question-edit-answer-form>
-            <tm-num-scale-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE" [questionDetails]="model.questionDetails"
-                                                    [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                    (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                    [isDisabled]="isFormsDisabled"
-            ></tm-num-scale-question-edit-answer-form>
-            <tm-mcq-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.MCQ" [questionDetails]="model.questionDetails"
-                                                    [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                    (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                    [isDisabled]="isFormsDisabled"
-                                                    [id]="model.feedbackQuestionId + recipientSubmissionFormModel.recipientIdentifier"
-                                                    (cssRefresh)=refreshCssForDropdownMCQ($event)
-            ></tm-mcq-question-edit-answer-form>
-            <tm-msq-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.MSQ" [questionDetails]="model.questionDetails"
-                                              [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                              (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                              [isDisabled]="isFormsDisabled"
-            ></tm-msq-question-edit-answer-form>
-            <tm-rubric-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RUBRIC" [questionDetails]="model.questionDetails"
-                                                 [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                 (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                 [isDisabled]="isFormsDisabled"
-                                                 [id]="model.feedbackQuestionId + recipientSubmissionFormModel.recipientIdentifier"></tm-rubric-question-edit-answer-form>
-            <tm-constsum-options-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [questionDetails]="model.questionDetails"
-                                                           [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                           (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                           [isDisabled]="isFormsDisabled">
-            </tm-constsum-options-question-edit-answer-form>
-            <tm-constsum-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [questionDetails]="model.questionDetails"
-                                                           [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                           (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                           [isDisabled]="isFormsDisabled"></tm-constsum-recipients-question-edit-answer-form>
-          </div>
-
-          <div id="comment-section" *ngIf="allowedToHaveParticipantComment" class="col-12 margin-bottom-20px margin-top-10px indent">
-            <div *ngIf="recipientSubmissionFormModel.commentByGiver && recipientSubmissionFormModel.commentByGiver.originalComment else newComment">
-              <tm-comment-row [mode]="CommentRowMode.EDIT" [isVisibilityOptionEnabled]="false"
-                              [model]="recipientSubmissionFormModel.commentByGiver"
-                              (modelChange)="triggerRecipientSubmissionFormChange(i, 'commentByGiver', $event)"
-                              [isFeedbackParticipantComment]="true"
-                              [questionShowResponsesTo]="model.showResponsesTo"
-                              [shouldHideSavingButton]="true"
-                              (deleteCommentEvent)="triggerDeleteCommentEvent(i)"
-                              (closeEditingEvent)="discardEditedParticipantComment(i)"
-                              [isDisabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)"></tm-comment-row>
-              <div class="alert alert-warning margin-top-10px" role="alert" *ngIf="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
-                You must provide a valid response in order to give a comment or your comment will not be saved!
-              </div>
+              ></tm-num-scale-question-edit-answer-form>
+              <tm-mcq-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.MCQ" [questionDetails]="model.questionDetails"
+                                                      [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                      (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                      [isDisabled]="isFormsDisabled"
+                                                      [id]="model.feedbackQuestionId + recipientSubmissionFormModel.recipientIdentifier"
+                                                      (cssRefresh)=refreshCssForDropdownMCQ($event)
+              ></tm-mcq-question-edit-answer-form>
+              <tm-msq-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.MSQ" [questionDetails]="model.questionDetails"
+                                                [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                [isDisabled]="isFormsDisabled"
+              ></tm-msq-question-edit-answer-form>
+              <tm-rubric-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.RUBRIC" [questionDetails]="model.questionDetails"
+                                                  [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                  (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                  [isDisabled]="isFormsDisabled"
+                                                  [id]="model.feedbackQuestionId + recipientSubmissionFormModel.recipientIdentifier"></tm-rubric-question-edit-answer-form>
+              <tm-constsum-options-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [questionDetails]="model.questionDetails"
+                                                            [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                            (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                            [isDisabled]="isFormsDisabled">
+              </tm-constsum-options-question-edit-answer-form>
+              <tm-constsum-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [questionDetails]="model.questionDetails"
+                                                            [responseDetails]="recipientSubmissionFormModel.responseDetails"
+                                                            (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
+                                                            [isDisabled]="isFormsDisabled"></tm-constsum-recipients-question-edit-answer-form>
             </div>
-            <ng-template #newComment>
-              <div style="display: inline-block;" [ngbTooltip]="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails) ? 'Give a valid response in order to comment' : ''">
-                <button id="btn-add-comment" *ngIf="!recipientSubmissionFormModel.commentByGiver" class="btn btn-light btn-sm"
-                        (click)="addNewParticipantCommentToResponse(i)"
-                        [disabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
-                  <i class="fas fa-comment"></i> [Optional] Comment on your response
-                </button>
-              </div>
-              <div *ngIf="recipientSubmissionFormModel.commentByGiver">
-                <tm-comment-row [mode]="CommentRowMode.ADD" [isVisibilityOptionEnabled]="false"
+
+            <div id="comment-section" *ngIf="allowedToHaveParticipantComment" class="col-12 margin-bottom-20px margin-top-10px indent">
+              <div *ngIf="recipientSubmissionFormModel.commentByGiver && recipientSubmissionFormModel.commentByGiver.originalComment else newComment">
+                <tm-comment-row [mode]="CommentRowMode.EDIT" [isVisibilityOptionEnabled]="false"
+                                [model]="recipientSubmissionFormModel.commentByGiver"
+                                (modelChange)="triggerRecipientSubmissionFormChange(i, 'commentByGiver', $event)"
                                 [isFeedbackParticipantComment]="true"
                                 [questionShowResponsesTo]="model.showResponsesTo"
                                 [shouldHideSavingButton]="true"
-                                [model]="recipientSubmissionFormModel.commentByGiver"
-                                (modelChange)="triggerRecipientSubmissionFormChange(i, 'commentByGiver', $event)"
-                                (closeEditingEvent)="cancelAddingNewParticipantComment(i)"
+                                (deleteCommentEvent)="triggerDeleteCommentEvent(i)"
+                                (closeEditingEvent)="discardEditedParticipantComment(i)"
                                 [isDisabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)"></tm-comment-row>
                 <div class="alert alert-warning margin-top-10px" role="alert" *ngIf="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
                   You must provide a valid response in order to give a comment or your comment will not be saved!
                 </div>
               </div>
-            </ng-template>
+              <ng-template #newComment>
+                <div style="display: inline-block;" [ngbTooltip]="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails) ? 'Give a valid response in order to comment' : ''">
+                  <button id="btn-add-comment" *ngIf="!recipientSubmissionFormModel.commentByGiver" class="btn btn-light btn-sm"
+                          (click)="addNewParticipantCommentToResponse(i)"
+                          [disabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
+                    <i class="fas fa-comment"></i> [Optional] Comment on your response
+                  </button>
+                </div>
+                <div *ngIf="recipientSubmissionFormModel.commentByGiver">
+                  <tm-comment-row [mode]="CommentRowMode.ADD" [isVisibilityOptionEnabled]="false"
+                                  [isFeedbackParticipantComment]="true"
+                                  [questionShowResponsesTo]="model.showResponsesTo"
+                                  [shouldHideSavingButton]="true"
+                                  [model]="recipientSubmissionFormModel.commentByGiver"
+                                  (modelChange)="triggerRecipientSubmissionFormChange(i, 'commentByGiver', $event)"
+                                  (closeEditingEvent)="cancelAddingNewParticipantComment(i)"
+                                  [isDisabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)"></tm-comment-row>
+                  <div class="alert alert-warning margin-top-10px" role="alert" *ngIf="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
+                    You must provide a valid response in order to give a comment or your comment will not be saved!
+                  </div>
+                </div>
+              </ng-template>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="col-12 constraint-margins">
-      <tm-contribution-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONTRIB"
-                                           [recipientSubmissionForms]="model.recipientSubmissionForms"
-                                           [questionDetails]="model.questionDetails"
-                                           (isValidEvent)="updateValidity($event)"
-      ></tm-contribution-question-constraint>
-      <tm-rank-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS"
-                                              [recipientSubmissionForms]="model.recipientSubmissionForms"
-                                              [questionDetails]="model.questionDetails"
-                                              (isValidEvent)="updateValidity($event)"
-      ></tm-rank-recipients-question-constraint>
-      <tm-constsum-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
-                                                  [recipientSubmissionForms]="model.recipientSubmissionForms"
-                                                  [questionDetails]="model.questionDetails"
-                                                  (isValidEvent)="updateValidity($event)"
-      ></tm-constsum-recipients-question-constraint>
-    </div>
+      <div class="col-12 constraint-margins">
+        <tm-contribution-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONTRIB"
+                                            [recipientSubmissionForms]="model.recipientSubmissionForms"
+                                            [questionDetails]="model.questionDetails"
+                                            (isValidEvent)="updateValidity($event)"
+        ></tm-contribution-question-constraint>
+        <tm-rank-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS"
+                                                [recipientSubmissionForms]="model.recipientSubmissionForms"
+                                                [questionDetails]="model.questionDetails"
+                                                (isValidEvent)="updateValidity($event)"
+        ></tm-rank-recipients-question-constraint>
+        <tm-constsum-recipients-question-constraint *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS"
+                                                    [recipientSubmissionForms]="model.recipientSubmissionForms"
+                                                    [questionDetails]="model.questionDetails"
+                                                    (isValidEvent)="updateValidity($event)"
+        ></tm-constsum-recipients-question-constraint>
+      </div>
 
-    <div class="alert alert-warning" role="alert" *ngIf="!model.recipientList.length && model.isLoaded">
-      <span *ngIf="model.recipientType === FeedbackParticipantType.OWN_TEAM_MEMBERS">This question is for team members and you don't have any team members. Therefore, you will not be able to answer this question.</span>
-      <span *ngIf="model.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF">This question is for other teams in this course and this course doesn't have any other team. Therefore, you will not be able to answer this question.</span>
-      <span *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS_EXCLUDING_SELF">This question is for other students in this course and this course doesn't have any other student. Therefore, you will not be able to answer this question.</span>
-    </div>
+      <div class="alert alert-warning" role="alert" *ngIf="!model.recipientList.length && model.isLoaded">
+        <span *ngIf="model.recipientType === FeedbackParticipantType.OWN_TEAM_MEMBERS">This question is for team members and you don't have any team members. Therefore, you will not be able to answer this question.</span>
+        <span *ngIf="model.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF">This question is for other teams in this course and this course doesn't have any other team. Therefore, you will not be able to answer this question.</span>
+        <span *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS_EXCLUDING_SELF">This question is for other students in this course and this course doesn't have any other student. Therefore, you will not be able to answer this question.</span>
+      </div>
 
-    <div class="row" *ngIf="model.recipientList.length > 0">
-      <div class="col-12 text-center">
-        <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
-                ngbTooltip="You can save your responses for this question at any time and come back later to continue."
-                (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled">
-          <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
-          <span>{{ isQuestionCountOne ? "Submit Response" : "Submit Response for Question " + model.questionNumber }}</span>
-        </button>
+      <div class="row" *ngIf="model.recipientList.length > 0">
+        <div class="col-12 text-center">
+          <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
+                  ngbTooltip="You can save your responses for this question at any time and come back later to continue."
+                  (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled">
+            <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
+            <span>{{ isQuestionCountOne ? "Submit Response" : "Submit Response for Question " + model.questionNumber }}</span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,12 +1,12 @@
 <div id="question-submission-form" class="card">
-  <div class="card-header bg-primary text-white question-header cursor-pointer" (click)="this.model.isTabExpanded = handleClick($event);"
+  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="this.model.isTabExpanded = handleClick($event);"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'">
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="model.isTabExpanded"></tm-panel-chevron>
     </div>
     <i class="fas fa-check me-2" *ngIf="isSaved"></i>
-    <h3 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h3>
-  </div>
+    <h2 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h2>
+  </button>
 
   <div *ngIf="model.isTabExpanded" @collapseAnim>
     <div class="card-body" *tmIsLoading="model.isLoading">

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,5 +1,5 @@
 <div id="question-submission-form" class="card">
-  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="this.model.isTabExpanded = !this.model.isTabExpanded;"
+  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="handleClick();"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="model.isTabExpanded" aria-hidden="true"></tm-panel-chevron>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -2,7 +2,7 @@
   <div class="card-header bg-primary text-white question-header"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'">
     <i class="fas fa-check me-2" *ngIf="isSaved"></i>
-    <span id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</span>
+    <h3 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h3>
   </div>
 
   <div class="card-body" *tmIsLoading="model.isLoading">

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -57,7 +57,7 @@
 }
 
 #question-details {
-  font-size: 0.875rem;
+  font-size: .875rem;
   margin-bottom: 0;
   line-height: inherit;
   font-weight: inherit;

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -55,3 +55,10 @@
 .font-bold {
   font-weight: bold;
 }
+
+#question-details {
+  font-size: 0.875rem;
+  margin-bottom: 0;
+  line-height: inherit;
+  font-weight: inherit;
+}

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -62,3 +62,7 @@
   line-height: inherit;
   font-weight: inherit;
 }
+
+.collapse-caret {
+  margin-right: 10px;
+}

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
   FeedbackNumericalScaleQuestionDetails,
@@ -13,6 +14,7 @@ import {
 import { AjaxLoadingModule } from '../ajax-loading/ajax-loading.module';
 import { CommentBoxModule } from '../comment-box/comment-box.module';
 import { LoadingSpinnerModule } from '../loading-spinner/loading-spinner.module';
+import { PanelChevronModule } from '../panel-chevron/panel-chevron.module';
 import { QuestionConstraintModule } from '../question-types/question-constraint/question-constraint.module';
 import {
   QuestionEditAnswerFormModule,
@@ -91,6 +93,7 @@ const testNumscaleQuestionSubmissionForm: QuestionSubmissionFormModel = {
   showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
   isLoading: false,
   isLoaded: true,
+  isTabExpanded: true,
 };
 
 describe('QuestionSubmissionFormComponent', () => {
@@ -116,6 +119,8 @@ describe('QuestionSubmissionFormComponent', () => {
         NgbModule,
         LoadingSpinnerModule,
         AjaxLoadingModule,
+        BrowserAnimationsModule,
+        PanelChevronModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -167,7 +167,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     }
   }
 
-  handleClick(): Void {
+  handleClick(): void {
     this.model.isTabExpanded = !this.model.isTabExpanded;
   }
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -9,6 +9,7 @@ import {
   NumberOfEntitiesToGiveFeedbackToSetting,
 } from '../../../types/api-output';
 import { VisibilityControl } from '../../../types/visibility-control';
+import { collapseAnim } from '../teammates-common/collapse-anim';
 import { CommentRowModel } from '../comment-box/comment-row/comment-row.component';
 import { CommentRowMode } from '../comment-box/comment-row/comment-row.mode';
 import {
@@ -26,6 +27,7 @@ import {
   selector: 'tm-question-submission-form',
   templateUrl: './question-submission-form.component.html',
   styleUrls: ['./question-submission-form.component.scss'],
+  animations: [collapseAnim],
 })
 export class QuestionSubmissionFormComponent implements DoCheck {
 
@@ -86,6 +88,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   model: QuestionSubmissionFormModel = {
     isLoading: false,
     isLoaded: false,
+    isTabExpanded: true,
     feedbackQuestionId: '',
 
     questionNumber: 0,
@@ -162,6 +165,14 @@ export class QuestionSubmissionFormComponent implements DoCheck {
         this.isSaved = false;
       }
     }
+  }
+
+  handleClick(event: Event): boolean {
+    console.log("helpppp");
+    if (event.target) {
+      return !this.model.isTabExpanded;
+    }
+    return this.model.isTabExpanded;
   }
 
   private compareByName(firstRecipient: FeedbackResponseRecipient,

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -167,7 +167,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     }
   }
 
-  handleClick() {
+  handleClick(): Void {
     this.model.isTabExpanded = !this.model.isTabExpanded;
   }
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -167,11 +167,8 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     }
   }
 
-  handleClick(event: Event): boolean {
-    if (event.target) {
-      return !this.model.isTabExpanded;
-    }
-    return this.model.isTabExpanded;
+  handleClick() {
+    this.model.isTabExpanded = !this.model.isTabExpanded;
   }
 
   private compareByName(firstRecipient: FeedbackResponseRecipient,

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -9,9 +9,9 @@ import {
   NumberOfEntitiesToGiveFeedbackToSetting,
 } from '../../../types/api-output';
 import { VisibilityControl } from '../../../types/visibility-control';
-import { collapseAnim } from '../teammates-common/collapse-anim';
 import { CommentRowModel } from '../comment-box/comment-row/comment-row.component';
 import { CommentRowMode } from '../comment-box/comment-row/comment-row.mode';
+import { collapseAnim } from '../teammates-common/collapse-anim';
 import {
   FeedbackRecipientLabelType,
   FeedbackResponseRecipient,
@@ -168,7 +168,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   }
 
   handleClick(event: Event): boolean {
-    console.log("helpppp");
     if (event.target) {
       return !this.model.isTabExpanded;
     }

--- a/src/web/app/components/question-submission-form/question-submission-form.module.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.module.ts
@@ -5,6 +5,7 @@ import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { AjaxLoadingModule } from '../ajax-loading/ajax-loading.module';
 import { CommentBoxModule } from '../comment-box/comment-box.module';
 import { LoadingSpinnerModule } from '../loading-spinner/loading-spinner.module';
+import { PanelChevronModule } from '../panel-chevron/panel-chevron.module';
 import { QuestionConstraintModule } from '../question-types/question-constraint/question-constraint.module';
 import {
   QuestionEditAnswerFormModule,
@@ -33,6 +34,7 @@ import { RecipientTypeNamePipe } from './recipient-type-name.pipe';
     CommentBoxModule,
     LoadingSpinnerModule,
     AjaxLoadingModule,
+    PanelChevronModule,
   ],
   declarations: [
     QuestionSubmissionFormComponent,

--- a/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
@@ -1,7 +1,11 @@
 <div class="plain-text-area" *ngIf="!questionDetails.shouldAllowRichText">
   <textarea [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled"></textarea>
 </div>
-<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
+<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" 
+                     [richText]="responseDetails.answer" 
+                     (richTextChange)="triggerResponseDetailsChange('answer', $event)" 
+                     [isDisabled]="isDisabled"
+></tm-rich-text-editor>
 <div class="margin-top-7px text-secondary text-end">
   <div id="recommended-length" *ngIf="questionDetails.recommendedLength">
     Recommended length for the answer: {{ questionDetails.recommendedLength }} words

--- a/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
@@ -1,11 +1,7 @@
 <div class="plain-text-area" *ngIf="!questionDetails.shouldAllowRichText">
   <textarea [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled"></textarea>
 </div>
-<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" 
-                     [richText]="responseDetails.answer" 
-                     (richTextChange)="triggerResponseDetailsChange('answer', $event)" 
-                     [isDisabled]="isDisabled"
-></tm-rich-text-editor>
+<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
 <div class="margin-top-7px text-secondary text-end">
   <div id="recommended-length" *ngIf="questionDetails.recommendedLength">
     Recommended length for the answer: {{ questionDetails.recommendedLength }} words

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -91,11 +91,6 @@ nav {
   .footer {
     padding: 5px 15px;
   }
-
-  // .footer .row {
-  //   margin-left: 0;
-  //   margin-right: 0;
-  // }
 }
 
 .navbar-toggler {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -1510,6 +1510,7 @@ export const EXAMPLE_MCQ_QUESTION_WITH_WEIGHTS_MODEL: QuestionEditFormModel = {
 export const EXAMPLE_RESPONDER_RUBRIC_SUBMISSION_FORM_MODEL: QuestionSubmissionFormModel = {
   isLoading: false,
   isLoaded: true,
+  isTabExpanded: true,
   recipientList: [
     {
       recipientIdentifier: 'alice',

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1442,12 +1442,12 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     </div>
                     <div
                       autoclose="outside"
-                      class="margin-top-15px overflow-scroll"
+                      class="margin-top-15px w-100"
                       ngbdropdown=""
                     >
                       <button
                         aria-expanded="false"
-                        class="dropdown-toggle btn btn-light white-space-normal"
+                        class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
@@ -2181,12 +2181,12 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     </div>
                     <div
                       autoclose="outside"
-                      class="margin-top-15px overflow-scroll"
+                      class="margin-top-15px w-100"
                       ngbdropdown=""
                     >
                       <button
                         aria-expanded="false"
-                        class="dropdown-toggle btn btn-light white-space-normal"
+                        class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
@@ -4004,12 +4004,12 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                 </div>
                 <div
                   autoclose="outside"
-                  class="margin-top-15px overflow-scroll"
+                  class="margin-top-15px w-100"
                   ngbdropdown=""
                 >
                   <button
                     aria-expanded="false"
-                    class="dropdown-toggle btn btn-light white-space-normal"
+                    class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                     id="btn-feedback-path"
                     ngbdropdowntoggle=""
                   >

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -892,12 +892,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -908,6 +911,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -1162,12 +1166,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -1178,6 +1185,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -1317,12 +1325,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -1427,12 +1438,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -1443,6 +1457,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -1731,12 +1746,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -1747,6 +1765,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -1925,12 +1944,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -1941,6 +1963,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -2133,12 +2156,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -2149,6 +2175,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -2570,12 +2597,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -2586,6 +2616,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -2868,12 +2899,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -2884,6 +2918,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -3124,12 +3159,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -3140,6 +3178,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -3548,12 +3587,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -3564,6 +3606,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -3823,12 +3866,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -3839,6 +3885,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -3978,12 +4025,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -4088,12 +4138,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -4104,6 +4157,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -4398,12 +4452,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -4414,6 +4471,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -4593,12 +4651,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -4609,6 +4670,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -4802,12 +4864,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -4818,6 +4883,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -5240,12 +5306,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -5256,6 +5325,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -5547,12 +5617,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -5563,6 +5636,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2
@@ -5804,12 +5878,15 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form"
         >
           <button
+            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron>
+              <tm-panel-chevron
+                aria-hidden="true"
+              >
                 <div
                   class="chevron"
                 >
@@ -5820,6 +5897,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <i
+              aria-hidden="true"
               class="fas fa-check me-2"
             />
             <h2

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -891,245 +891,264 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 1: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   Other students in the course can see your response, but not the name of the recipient, or your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, but not the name of the recipient, or your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     Other students in the course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Unknown 
-                      </b>
-                      <span>
-                        (Team)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Unknown 
+                        </b>
+                        <span>
+                          (Team)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-mcq-question-edit-answer-form>
-                      <tr>
-                        <td>
-                          <div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-mcq-question-edit-answer-form>
+                        <tr>
+                          <td>
+                            <div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 1
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                                  <input
+                                    class="margin-right-15px"
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 1
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 2
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                                  <input
+                                    class="margin-right-15px"
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 2
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 3
-                                </span>
-                              </label>
+                                  <input
+                                    class="margin-right-15px"
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 3
+                                  </span>
+                                </label>
+                              </div>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tm-mcq-question-edit-answer-form>
-                  </div>
-                  <div
-                    class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
-                  >
-                    <div>
-                      <tm-comment-row>
-                        <div
-                          class="card"
-                        >
+                          </td>
+                        </tr>
+                      </tm-mcq-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="col-12 margin-bottom-20px margin-top-10px indent"
+                      id="comment-section"
+                    >
+                      <div>
+                        <tm-comment-row>
                           <div
-                            class="card-body"
+                            class="card"
                           >
                             <div
-                              class="row comment-row"
+                              class="card-body"
                             >
                               <div
-                                class="col-12"
+                                class="row comment-row"
                               >
-                                <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
-                                >
-                                   Comment by response giver. 
-                                </span>
-                                <i
-                                  aria-hidden="true"
-                                  class="fa fa-eye"
-                                />
                                 <div
-                                  class="float-end"
+                                  class="col-12"
                                 >
-                                  <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    id="btn-edit-comment"
-                                    ngbtooltip="Edit this comment"
-                                    type="button"
+                                  <span
+                                    class="text-secondary"
+                                    id="by-response-giver"
                                   >
-                                    <i
-                                      class="fas fa-pencil-alt"
-                                    />
-                                  </button>
-                                  <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    id="btn-delete-comment"
-                                    ngbtooltip="Delete this comment"
-                                    type="button"
+                                     Comment by response giver. 
+                                  </span>
+                                  <i
+                                    aria-hidden="true"
+                                    class="fa fa-eye"
+                                  />
+                                  <div
+                                    class="float-end"
                                   >
-                                    <i
-                                      class="fas fa-trash"
-                                    />
-                                  </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm"
+                                      id="btn-edit-comment"
+                                      ngbtooltip="Edit this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-pencil-alt"
+                                      />
+                                    </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm btn-margin-left"
+                                      id="btn-delete-comment"
+                                      ngbtooltip="Delete this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-trash"
+                                      />
+                                    </button>
+                                  </div>
                                 </div>
-                              </div>
-                              <div
-                                class="col-12"
-                                id="comment-text"
-                              >
-                                comment text
+                                <div
+                                  class="col-12"
+                                  id="comment-text"
+                                >
+                                  comment text
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                      </tm-comment-row>
+                        </tm-comment-row>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
+              <div
+                class="col-12 constraint-margins"
+              >
+              </div>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -1142,130 +1161,149 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 3: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   Your team members can see your response, but not the name of the recipient, or your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, but not the name of the recipient, or your name 
-                </li>
-              </ul>
-            </div>
-            <tm-text-question-instruction />
-            <tm-text-question-constraint />
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     Your team members can see your response, but not the name of the recipient, or your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-text-question-instruction />
+              <tm-text-question-constraint />
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Unknown 
-                      </b>
-                      <span>
-                        (Instructor)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Unknown 
+                        </b>
+                        <span>
+                          (Instructor)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-text-question-edit-answer-form>
-                      <div
-                        class="plain-text-area"
-                      >
-                        <textarea
-                          class="ng-untouched ng-pristine ng-valid"
-                        />
-                      </div>
-                      <div
-                        class="margin-top-7px text-secondary text-end"
-                      >
-                      </div>
-                    </tm-text-question-edit-answer-form>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-text-question-edit-answer-form>
+                        <div
+                          class="plain-text-area"
+                        >
+                          <textarea
+                            class="ng-untouched ng-pristine ng-valid"
+                          />
+                        </div>
+                        <div
+                          class="margin-top-7px text-secondary text-end"
+                        >
+                        </div>
+                      </tm-text-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
+              <div
+                class="col-12 constraint-margins"
+              >
+              </div>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -1278,85 +1316,104 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
-            <h3
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
+            <h2
               id="question-details"
             >
               <b>
                 Question 2: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
+                class="card mb-3"
               >
-                <b>
-                  More details
-                </b>
+                <div
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
               </div>
               <div
-                class="card-body"
-                id="question-description"
+                class="card-body visibility-card"
               >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving teams can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
                 </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving teams can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
               </div>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="evaluee-col col-12"
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
+                >
+                </div>
+              </div>
+              <div
+                class="col-12 constraint-margins"
               >
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
             </div>
           </div>
         </div>
@@ -1369,278 +1426,297 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 4: 
               </b>
               MSQ question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-msq-question-constraint>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="text-start fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Choose 
-                  <strong>
-                     at least 1
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Choose 
-                  <strong>
-                     no more than 2
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-msq-question-constraint>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-msq-question-constraint>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="text-start fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Choose 
+                    <strong>
+                       at least 1
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Choose 
+                    <strong>
+                       no more than 2
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-msq-question-constraint>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-msq-question-edit-answer-form>
-                      <tr>
-                        <td>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-msq-question-edit-answer-form>
+                        <tr>
+                          <td>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                type="checkbox"
-                              />
-                              <strong>
-                                first
-                              </strong>
-                            </label>
-                          </div>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  first
+                                </strong>
+                              </label>
+                            </div>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                type="checkbox"
-                              />
-                              <strong>
-                                second
-                              </strong>
-                            </label>
-                          </div>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  second
+                                </strong>
+                              </label>
+                            </div>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                type="checkbox"
-                              />
-                              <strong>
-                                third
-                              </strong>
-                            </label>
-                          </div>
-                        </td>
-                      </tr>
-                    </tm-msq-question-edit-answer-form>
-                  </div>
-                  <div
-                    class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
-                  >
-                    <div>
-                      <tm-comment-row>
-                        <div
-                          class="card"
-                        >
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  third
+                                </strong>
+                              </label>
+                            </div>
+                          </td>
+                        </tr>
+                      </tm-msq-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="col-12 margin-bottom-20px margin-top-10px indent"
+                      id="comment-section"
+                    >
+                      <div>
+                        <tm-comment-row>
                           <div
-                            class="card-body"
+                            class="card"
                           >
                             <div
-                              class="row comment-row"
+                              class="card-body"
                             >
                               <div
-                                class="col-12"
+                                class="row comment-row"
                               >
-                                <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
-                                >
-                                   Comment by response giver. 
-                                </span>
-                                <i
-                                  aria-hidden="true"
-                                  class="fa fa-eye"
-                                />
                                 <div
-                                  class="float-end"
+                                  class="col-12"
                                 >
-                                  <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    id="btn-edit-comment"
-                                    ngbtooltip="Edit this comment"
-                                    type="button"
+                                  <span
+                                    class="text-secondary"
+                                    id="by-response-giver"
                                   >
-                                    <i
-                                      class="fas fa-pencil-alt"
-                                    />
-                                  </button>
-                                  <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    id="btn-delete-comment"
-                                    ngbtooltip="Delete this comment"
-                                    type="button"
+                                     Comment by response giver. 
+                                  </span>
+                                  <i
+                                    aria-hidden="true"
+                                    class="fa fa-eye"
+                                  />
+                                  <div
+                                    class="float-end"
                                   >
-                                    <i
-                                      class="fas fa-trash"
-                                    />
-                                  </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm"
+                                      id="btn-edit-comment"
+                                      ngbtooltip="Edit this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-pencil-alt"
+                                      />
+                                    </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm btn-margin-left"
+                                      id="btn-delete-comment"
+                                      ngbtooltip="Delete this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-trash"
+                                      />
+                                    </button>
+                                  </div>
                                 </div>
-                              </div>
-                              <div
-                                class="col-12"
-                                id="comment-text"
-                              >
-                                comment text
+                                <div
+                                  class="col-12"
+                                  id="comment-text"
+                                >
+                                  comment text
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                      </tm-comment-row>
+                        </tm-comment-row>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-4"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 4
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-4"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 4
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1654,168 +1730,187 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 5: 
               </b>
               numerical scale question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-num-scale-question-instruction />
-            <tm-num-scale-question-constraint />
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-num-scale-question-instruction />
+              <tm-num-scale-question-constraint />
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-num-scale-question-edit-answer-form>
                       <div
-                        class="form-row text-start"
+                        id="recipient-name-0"
                       >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-num-scale-question-edit-answer-form>
                         <div
-                          class="col-md-2 col-xs-5"
+                          class="form-row text-start"
                         >
-                          <input
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            max="10"
-                            min="1"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
-                          />
-                        </div>
-                        <div
-                          class="col-md-9 col-xs-6 text-secondary"
-                          id="possible-values"
-                        >
-                           Possible values: [1,
+                          <div
+                            class="col-md-2 col-xs-5"
+                          >
+                            <input
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              max="10"
+                              min="1"
+                              step="1"
+                              tmdisablewheel=""
+                              type="number"
+                            />
+                          </div>
+                          <div
+                            class="col-md-9 col-xs-6 text-secondary"
+                            id="possible-values"
+                          >
+                             Possible values: [1,
              2,
              3,
              ...,
              8,
              9,
              10] 
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="row mt-1"
-                      >
                         <div
-                          class="col-12"
+                          class="row mt-1"
                         >
+                          <div
+                            class="col-12"
+                          >
+                          </div>
                         </div>
-                      </div>
-                      <br />
-                    </tm-num-scale-question-edit-answer-form>
+                        <br />
+                      </tm-num-scale-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-5"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 5
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-5"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 5
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1829,182 +1924,201 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 6: 
               </b>
               constant sum question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-constsum-recipients-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="total-points-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Total points distributed should 
-                  <strong>
-                    add up to 20.
-                  </strong>
-                </p>
-              </div>
-            </tm-constsum-recipients-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-constsum-recipients-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="total-points-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Total points distributed should 
+                    <strong>
+                      add up to 20.
+                    </strong>
+                  </p>
+                </div>
+              </tm-constsum-recipients-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-constsum-recipients-question-edit-answer-form>
-                      <div>
-                        <div
-                          class="form-group"
-                        >
-                          <input
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            min="0"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
-                          />
-                        </div>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-constsum-recipients-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-constsum-recipients-question-edit-answer-form>
+                        <div>
+                          <div
+                            class="form-group"
+                          >
+                            <input
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              min="0"
+                              step="1"
+                              tmdisablewheel=""
+                              type="number"
+                            />
+                          </div>
+                        </div>
+                      </tm-constsum-recipients-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-constsum-recipients-question-constraint>
-                <div
-                  class="row"
-                >
-                  <div
-                    class="col-12"
-                  >
-                    <p
-                      class="text-danger"
-                    >
-                      <span
-                        class="fa fa-times"
-                      />
-                       Actual total is 7! Distribute the remaining 13 points.
-                    </p>
-                  </div>
-                </div>
-              </tm-constsum-recipients-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-6"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-constsum-recipients-question-constraint>
+                  <div
+                    class="row"
+                  >
+                    <div
+                      class="col-12"
+                    >
+                      <p
+                        class="text-danger"
+                      >
+                        <span
+                          class="fa fa-times"
+                        />
+                         Actual total is 7! Distribute the remaining 13 points.
+                      </p>
+                    </div>
+                  </div>
+                </tm-constsum-recipients-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 6
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-6"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 6
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2018,411 +2132,430 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 7: 
               </b>
               contribution question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-contribution-question-instruction>
-            </tm-contribution-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-contribution-question-instruction>
+              </tm-contribution-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-contribution-question-edit-answer-form>
                       <div
-                        class="row"
+                        id="recipient-name-0"
                       >
-                        <div
-                          class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <select
-                            class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              class="color-positive fw-bold"
-                              value="1: 100"
-                            >
-                              Equal share
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="2: 200"
-                            >
-                              Equal share + 100%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="3: 195"
-                            >
-                              Equal share + 95%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="4: 190"
-                            >
-                              Equal share + 90%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="5: 185"
-                            >
-                              Equal share + 85%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="6: 180"
-                            >
-                              Equal share + 80%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="7: 175"
-                            >
-                              Equal share + 75%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="8: 170"
-                            >
-                              Equal share + 70%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="9: 165"
-                            >
-                              Equal share + 65%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="10: 160"
-                            >
-                              Equal share + 60%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="11: 155"
-                            >
-                              Equal share + 55%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="12: 150"
-                            >
-                              Equal share + 50%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="13: 145"
-                            >
-                              Equal share + 45%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="14: 140"
-                            >
-                              Equal share + 40%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="15: 135"
-                            >
-                              Equal share + 35%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="16: 130"
-                            >
-                              Equal share + 30%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="17: 125"
-                            >
-                              Equal share + 25%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="18: 120"
-                            >
-                              Equal share + 20%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="19: 115"
-                            >
-                              Equal share + 15%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="20: 110"
-                            >
-                              Equal share + 10%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="21: 105"
-                            >
-                              Equal share + 5%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="22: 95"
-                            >
-                              Equal share - 5%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="23: 90"
-                            >
-                              Equal share - 10%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="24: 85"
-                            >
-                              Equal share - 15%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="25: 80"
-                            >
-                              Equal share - 20%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="26: 75"
-                            >
-                              Equal share - 25%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="27: 70"
-                            >
-                              Equal share - 30%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="28: 65"
-                            >
-                              Equal share - 35%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="29: 60"
-                            >
-                              Equal share - 40%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="30: 55"
-                            >
-                              Equal share - 45%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="31: 50"
-                            >
-                              Equal share - 50%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="32: 45"
-                            >
-                              Equal share - 55%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="33: 40"
-                            >
-                              Equal share - 60%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="34: 35"
-                            >
-                              Equal share - 65%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="35: 30"
-                            >
-                              Equal share - 70%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="36: 25"
-                            >
-                              Equal share - 75%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="37: 20"
-                            >
-                              Equal share - 80%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="38: 15"
-                            >
-                              Equal share - 85%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="39: 10"
-                            >
-                              Equal share - 90%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="40: 5"
-                            >
-                              Equal share - 95%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="41: 0"
-                            >
-                              0%
-                            </option>
-                          </select>
-                        </div>
-                        <div
-                          class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <button
-                            class="btn btn-link"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-exclamation-circle"
-                            />
-                             More info about the 
-                            <code>
-                              Equal Share
-                            </code>
-                             scale
-                          </button>
-                        </div>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-contribution-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-contribution-question-edit-answer-form>
+                        <div
+                          class="row"
+                        >
+                          <div
+                            class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
+                          >
+                            <select
+                              class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                class="color-positive fw-bold"
+                                value="1: 100"
+                              >
+                                Equal share
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="2: 200"
+                              >
+                                Equal share + 100%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="3: 195"
+                              >
+                                Equal share + 95%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="4: 190"
+                              >
+                                Equal share + 90%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="5: 185"
+                              >
+                                Equal share + 85%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="6: 180"
+                              >
+                                Equal share + 80%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="7: 175"
+                              >
+                                Equal share + 75%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="8: 170"
+                              >
+                                Equal share + 70%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="9: 165"
+                              >
+                                Equal share + 65%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="10: 160"
+                              >
+                                Equal share + 60%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="11: 155"
+                              >
+                                Equal share + 55%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="12: 150"
+                              >
+                                Equal share + 50%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="13: 145"
+                              >
+                                Equal share + 45%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="14: 140"
+                              >
+                                Equal share + 40%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="15: 135"
+                              >
+                                Equal share + 35%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="16: 130"
+                              >
+                                Equal share + 30%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="17: 125"
+                              >
+                                Equal share + 25%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="18: 120"
+                              >
+                                Equal share + 20%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="19: 115"
+                              >
+                                Equal share + 15%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="20: 110"
+                              >
+                                Equal share + 10%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="21: 105"
+                              >
+                                Equal share + 5%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="22: 95"
+                              >
+                                Equal share - 5%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="23: 90"
+                              >
+                                Equal share - 10%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="24: 85"
+                              >
+                                Equal share - 15%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="25: 80"
+                              >
+                                Equal share - 20%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="26: 75"
+                              >
+                                Equal share - 25%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="27: 70"
+                              >
+                                Equal share - 30%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="28: 65"
+                              >
+                                Equal share - 35%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="29: 60"
+                              >
+                                Equal share - 40%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="30: 55"
+                              >
+                                Equal share - 45%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="31: 50"
+                              >
+                                Equal share - 50%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="32: 45"
+                              >
+                                Equal share - 55%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="33: 40"
+                              >
+                                Equal share - 60%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="34: 35"
+                              >
+                                Equal share - 65%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="35: 30"
+                              >
+                                Equal share - 70%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="36: 25"
+                              >
+                                Equal share - 75%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="37: 20"
+                              >
+                                Equal share - 80%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="38: 15"
+                              >
+                                Equal share - 85%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="39: 10"
+                              >
+                                Equal share - 90%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="40: 5"
+                              >
+                                Equal share - 95%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="41: 0"
+                              >
+                                0%
+                              </option>
+                            </select>
+                          </div>
+                          <div
+                            class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
+                          >
+                            <button
+                              class="btn btn-link"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-exclamation-circle"
+                              />
+                               More info about the 
+                              <code>
+                                Equal Share
+                              </code>
+                               scale
+                            </button>
+                          </div>
+                        </div>
+                      </tm-contribution-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-contribution-question-constraint>
-              </tm-contribution-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-7"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-contribution-question-constraint>
+                </tm-contribution-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 7
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-7"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 7
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2436,272 +2569,291 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 8: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rubric-question-edit-answer-form>
-                      <table
-                        class="table table-bordered desktop-view"
-                      >
-                        <tbody>
-                          <tr>
-                            <td />
-                            <td
-                              class="fw-bold"
-                            >
-                              choice 1
-                            </td>
-                            <td
-                              class="fw-bold"
-                            >
-                              choice 2
-                            </td>
-                          </tr>
-                          <tr
-                            class="row-answered"
-                          >
-                            <td>
-                              subquestion 1
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id0-desktop"
-                                  type="radio"
-                                />
-                                 description 1 
-                              </label>
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id0-desktop"
-                                  type="radio"
-                                />
-                                 description 2 
-                              </label>
-                            </td>
-                          </tr>
-                          <tr
-                            class="row-answered"
-                          >
-                            <td>
-                              subquestion 2
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id1-desktop"
-                                  type="radio"
-                                />
-                                 description 3 
-                              </label>
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id1-desktop"
-                                  type="radio"
-                                />
-                                 description 4 
-                              </label>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
                       <div
-                        class="mobile-view"
+                        id="recipient-name-0"
                       >
-                        <div
-                          class="card"
-                        >
-                          <div
-                            class="card-header bg-light"
-                          >
-                             subquestion 1 
-                          </div>
-                          <div
-                            class="card-body row-answered"
-                          >
-                            <div>
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id0-mobile"
-                                  type="radio"
-                                />
-                                 choice 1 - description 1 
-                              </label>
-                            </div>
-                            <div>
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id0-mobile"
-                                  type="radio"
-                                />
-                                 choice 2 - description 2 
-                              </label>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="card"
-                        >
-                          <div
-                            class="card-header bg-light"
-                          >
-                             subquestion 2 
-                          </div>
-                          <div
-                            class="card-body row-answered"
-                          >
-                            <div>
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id1-mobile"
-                                  type="radio"
-                                />
-                                 choice 1 - description 3 
-                              </label>
-                            </div>
-                            <div>
-                              <label>
-                                <input
-                                  name="feedback-question-id-rubricbarry-harris-id1-mobile"
-                                  type="radio"
-                                />
-                                 choice 2 - description 4 
-                              </label>
-                            </div>
-                          </div>
-                        </div>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-rubric-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rubric-question-edit-answer-form>
+                        <table
+                          class="table table-bordered desktop-view"
+                        >
+                          <tbody>
+                            <tr>
+                              <td />
+                              <td
+                                class="fw-bold"
+                              >
+                                choice 1
+                              </td>
+                              <td
+                                class="fw-bold"
+                              >
+                                choice 2
+                              </td>
+                            </tr>
+                            <tr
+                              class="row-answered"
+                            >
+                              <td>
+                                subquestion 1
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id0-desktop"
+                                    type="radio"
+                                  />
+                                   description 1 
+                                </label>
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id0-desktop"
+                                    type="radio"
+                                  />
+                                   description 2 
+                                </label>
+                              </td>
+                            </tr>
+                            <tr
+                              class="row-answered"
+                            >
+                              <td>
+                                subquestion 2
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id1-desktop"
+                                    type="radio"
+                                  />
+                                   description 3 
+                                </label>
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id1-desktop"
+                                    type="radio"
+                                  />
+                                   description 4 
+                                </label>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <div
+                          class="mobile-view"
+                        >
+                          <div
+                            class="card"
+                          >
+                            <div
+                              class="card-header bg-light"
+                            >
+                               subquestion 1 
+                            </div>
+                            <div
+                              class="card-body row-answered"
+                            >
+                              <div>
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id0-mobile"
+                                    type="radio"
+                                  />
+                                   choice 1 - description 1 
+                                </label>
+                              </div>
+                              <div>
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id0-mobile"
+                                    type="radio"
+                                  />
+                                   choice 2 - description 2 
+                                </label>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="card"
+                          >
+                            <div
+                              class="card-header bg-light"
+                            >
+                               subquestion 2 
+                            </div>
+                            <div
+                              class="card-body row-answered"
+                            >
+                              <div>
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id1-mobile"
+                                    type="radio"
+                                  />
+                                   choice 1 - description 3 
+                                </label>
+                              </div>
+                              <div>
+                                <label>
+                                  <input
+                                    name="feedback-question-id-rubricbarry-harris-id1-mobile"
+                                    type="radio"
+                                  />
+                                   choice 2 - description 4 
+                                </label>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </tm-rubric-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-8"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 8
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-8"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 8
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2715,230 +2867,249 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 9: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-rank-options-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    at least 
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    no more than 
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-rank-options-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-rank-options-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      at least 
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      no more than 
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-rank-options-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rank-options-question-edit-answer-form>
-                      <div
-                        class="form-group row text-start"
-                      >
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rank-options-question-edit-answer-form>
                         <div
-                          class="col-md-5 col-xs-12 text-md-end col-form-label"
+                          class="form-group row text-start"
                         >
-                          <strong>
-                            option 1
-                          </strong>
-                        </div>
-                        <div
-                          class="col-md-7 col-xs-12 text-md-start"
-                        >
-                          <select
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                          <div
+                            class="col-md-5 col-xs-12 text-md-end col-form-label"
                           >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              value="1: 1"
-                            >
-                              1
-                            </option>
-                            <option
-                              value="2: 2"
-                            >
-                              2
-                            </option>
-                          </select>
-                        </div>
-                      </div>
-                      <div
-                        class="form-group row text-start"
-                      >
-                        <div
-                          class="col-md-5 col-xs-12 text-md-end col-form-label"
-                        >
-                          <strong>
-                            option 2
-                          </strong>
-                        </div>
-                        <div
-                          class="col-md-7 col-xs-12 text-md-start"
-                        >
-                          <select
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            <strong>
+                              option 1
+                            </strong>
+                          </div>
+                          <div
+                            class="col-md-7 col-xs-12 text-md-start"
                           >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              value="1: 1"
+                            <select
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                              1
-                            </option>
-                            <option
-                              value="2: 2"
-                            >
-                              2
-                            </option>
-                          </select>
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                value="1: 1"
+                              >
+                                1
+                              </option>
+                              <option
+                                value="2: 2"
+                              >
+                                2
+                              </option>
+                            </select>
+                          </div>
                         </div>
-                      </div>
-                      <div>
-                      </div>
-                    </tm-rank-options-question-edit-answer-form>
+                        <div
+                          class="form-group row text-start"
+                        >
+                          <div
+                            class="col-md-5 col-xs-12 text-md-end col-form-label"
+                          >
+                            <strong>
+                              option 2
+                            </strong>
+                          </div>
+                          <div
+                            class="col-md-7 col-xs-12 text-md-start"
+                          >
+                            <select
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                value="1: 1"
+                              >
+                                1
+                              </option>
+                              <option
+                                value="2: 2"
+                              >
+                                2
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                        <div>
+                        </div>
+                      </tm-rank-options-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-9"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 9
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-9"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 9
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2952,184 +3123,203 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 10: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-rank-recipients-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    at least 1
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                     no more than 2
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-rank-recipients-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-rank-recipients-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      at least 1
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                       no more than 2
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-rank-recipients-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rank-recipients-question-edit-answer-form>
                       <div
-                        class="margin-bottom-15px"
+                        id="recipient-name-0"
                       >
-                        <select
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="0: -999"
-                          />
-                          <option
-                            value="1: 1"
-                          >
-                            1
-                          </option>
-                        </select>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-rank-recipients-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rank-recipients-question-edit-answer-form>
+                        <div
+                          class="margin-bottom-15px"
+                        >
+                          <select
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                          >
+                            <option
+                              value="0: -999"
+                            />
+                            <option
+                              value="1: 1"
+                            >
+                              1
+                            </option>
+                          </select>
+                        </div>
+                      </tm-rank-recipients-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-rank-recipients-question-constraint>
-                <div>
-                </div>
-              </tm-rank-recipients-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  id="btn-submit-qn-10"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-rank-recipients-question-constraint>
+                  <div>
+                  </div>
+                </tm-rank-recipients-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 10
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    id="btn-submit-qn-10"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 10
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -3357,250 +3547,269 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 1: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   Other students in the course can see your response, but not the name of the recipient, or your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, but not the name of the recipient, or your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     Other students in the course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Unknown 
-                      </b>
-                      <span>
-                        (Team)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Unknown 
+                        </b>
+                        <span>
+                          (Team)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-mcq-question-edit-answer-form>
-                      <tr>
-                        <td>
-                          <div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-mcq-question-edit-answer-form>
+                        <tr>
+                          <td>
+                            <div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  disabled=""
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 1
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                                  <input
+                                    class="margin-right-15px"
+                                    disabled=""
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 1
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  disabled=""
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 2
-                                </span>
-                              </label>
-                            </div>
-                            <div
-                              class="radio"
-                            >
-                              <label
-                                class="margin-right-15px"
+                                  <input
+                                    class="margin-right-15px"
+                                    disabled=""
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 2
+                                  </span>
+                                </label>
+                              </div>
+                              <div
+                                class="radio"
                               >
-                                <input
+                                <label
                                   class="margin-right-15px"
-                                  disabled=""
-                                  name="mcq-feedback-question-id-mcqbarry-harris-id"
-                                  type="radio"
-                                />
-                                <span
-                                  class="option-text"
-                                  id="radioOptionSpan"
                                 >
-                                  choice 3
-                                </span>
-                              </label>
+                                  <input
+                                    class="margin-right-15px"
+                                    disabled=""
+                                    name="mcq-feedback-question-id-mcqbarry-harris-id"
+                                    type="radio"
+                                  />
+                                  <span
+                                    class="option-text"
+                                    id="radioOptionSpan"
+                                  >
+                                    choice 3
+                                  </span>
+                                </label>
+                              </div>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tm-mcq-question-edit-answer-form>
-                  </div>
-                  <div
-                    class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
-                  >
-                    <div>
-                      <tm-comment-row>
-                        <div
-                          class="card"
-                        >
+                          </td>
+                        </tr>
+                      </tm-mcq-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="col-12 margin-bottom-20px margin-top-10px indent"
+                      id="comment-section"
+                    >
+                      <div>
+                        <tm-comment-row>
                           <div
-                            class="card-body"
+                            class="card"
                           >
                             <div
-                              class="row comment-row"
+                              class="card-body"
                             >
                               <div
-                                class="col-12"
+                                class="row comment-row"
                               >
-                                <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
-                                >
-                                   Comment by response giver. 
-                                </span>
-                                <i
-                                  aria-hidden="true"
-                                  class="fa fa-eye"
-                                />
                                 <div
-                                  class="float-end"
+                                  class="col-12"
                                 >
-                                  <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    disabled=""
-                                    id="btn-edit-comment"
-                                    ngbtooltip="Edit this comment"
-                                    type="button"
+                                  <span
+                                    class="text-secondary"
+                                    id="by-response-giver"
                                   >
-                                    <i
-                                      class="fas fa-pencil-alt"
-                                    />
-                                  </button>
-                                  <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    disabled=""
-                                    id="btn-delete-comment"
-                                    ngbtooltip="Delete this comment"
-                                    type="button"
+                                     Comment by response giver. 
+                                  </span>
+                                  <i
+                                    aria-hidden="true"
+                                    class="fa fa-eye"
+                                  />
+                                  <div
+                                    class="float-end"
                                   >
-                                    <i
-                                      class="fas fa-trash"
-                                    />
-                                  </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm"
+                                      disabled=""
+                                      id="btn-edit-comment"
+                                      ngbtooltip="Edit this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-pencil-alt"
+                                      />
+                                    </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm btn-margin-left"
+                                      disabled=""
+                                      id="btn-delete-comment"
+                                      ngbtooltip="Delete this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-trash"
+                                      />
+                                    </button>
+                                  </div>
                                 </div>
-                              </div>
-                              <div
-                                class="col-12"
-                                id="comment-text"
-                              >
-                                comment text
+                                <div
+                                  class="col-12"
+                                  id="comment-text"
+                                >
+                                  comment text
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                      </tm-comment-row>
+                        </tm-comment-row>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
+              <div
+                class="col-12 constraint-margins"
+              >
+              </div>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -3613,130 +3822,149 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 3: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   Your team members can see your response, but not the name of the recipient, or your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, but not the name of the recipient, or your name 
-                </li>
-              </ul>
-            </div>
-            <tm-text-question-instruction />
-            <tm-text-question-constraint />
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     Your team members can see your response, but not the name of the recipient, or your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, but not the name of the recipient, or your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-text-question-instruction />
+              <tm-text-question-constraint />
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Unknown 
-                      </b>
-                      <span>
-                        (Instructor)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Unknown 
+                        </b>
+                        <span>
+                          (Instructor)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-text-question-edit-answer-form>
-                      <div
-                        class="plain-text-area"
-                      >
-                        <textarea
-                          class="ng-untouched ng-pristine ng-valid"
-                        />
-                      </div>
-                      <div
-                        class="margin-top-7px text-secondary text-end"
-                      >
-                      </div>
-                    </tm-text-question-edit-answer-form>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-text-question-edit-answer-form>
+                        <div
+                          class="plain-text-area"
+                        >
+                          <textarea
+                            class="ng-untouched ng-pristine ng-valid"
+                          />
+                        </div>
+                        <div
+                          class="margin-top-7px text-secondary text-end"
+                        >
+                        </div>
+                      </tm-text-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
+              <div
+                class="col-12 constraint-margins"
+              >
+              </div>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -3749,85 +3977,104 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
-            <h3
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
+            <h2
               id="question-details"
             >
               <b>
                 Question 2: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
+                class="card mb-3"
               >
-                <b>
-                  More details
-                </b>
+                <div
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
               </div>
               <div
-                class="card-body"
-                id="question-description"
+                class="card-body visibility-card"
               >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving teams can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
                 </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving teams can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
               </div>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="evaluee-col col-12"
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
+                >
+                </div>
+              </div>
+              <div
+                class="col-12 constraint-margins"
               >
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
             </div>
           </div>
         </div>
@@ -3840,284 +4087,303 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 4: 
               </b>
               MSQ question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-msq-question-constraint>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="text-start fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Choose 
-                  <strong>
-                     at least 1
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Choose 
-                  <strong>
-                     no more than 2
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-msq-question-constraint>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-msq-question-constraint>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="text-start fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Choose 
+                    <strong>
+                       at least 1
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Choose 
+                    <strong>
+                       no more than 2
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-msq-question-constraint>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-msq-question-edit-answer-form>
-                      <tr>
-                        <td>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-msq-question-edit-answer-form>
+                        <tr>
+                          <td>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                disabled=""
-                                type="checkbox"
-                              />
-                              <strong>
-                                first
-                              </strong>
-                            </label>
-                          </div>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  disabled=""
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  first
+                                </strong>
+                              </label>
+                            </div>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                disabled=""
-                                type="checkbox"
-                              />
-                              <strong>
-                                second
-                              </strong>
-                            </label>
-                          </div>
-                          <div
-                            class="check-box"
-                          >
-                            <label
-                              class="margin-right-15px"
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  disabled=""
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  second
+                                </strong>
+                              </label>
+                            </div>
+                            <div
+                              class="check-box"
                             >
-                              <input
+                              <label
                                 class="margin-right-15px"
-                                disabled=""
-                                type="checkbox"
-                              />
-                              <strong>
-                                third
-                              </strong>
-                            </label>
-                          </div>
-                        </td>
-                      </tr>
-                    </tm-msq-question-edit-answer-form>
-                  </div>
-                  <div
-                    class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
-                  >
-                    <div>
-                      <tm-comment-row>
-                        <div
-                          class="card"
-                        >
+                              >
+                                <input
+                                  class="margin-right-15px"
+                                  disabled=""
+                                  type="checkbox"
+                                />
+                                <strong>
+                                  third
+                                </strong>
+                              </label>
+                            </div>
+                          </td>
+                        </tr>
+                      </tm-msq-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="col-12 margin-bottom-20px margin-top-10px indent"
+                      id="comment-section"
+                    >
+                      <div>
+                        <tm-comment-row>
                           <div
-                            class="card-body"
+                            class="card"
                           >
                             <div
-                              class="row comment-row"
+                              class="card-body"
                             >
                               <div
-                                class="col-12"
+                                class="row comment-row"
                               >
-                                <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
-                                >
-                                   Comment by response giver. 
-                                </span>
-                                <i
-                                  aria-hidden="true"
-                                  class="fa fa-eye"
-                                />
                                 <div
-                                  class="float-end"
+                                  class="col-12"
                                 >
-                                  <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    disabled=""
-                                    id="btn-edit-comment"
-                                    ngbtooltip="Edit this comment"
-                                    type="button"
+                                  <span
+                                    class="text-secondary"
+                                    id="by-response-giver"
                                   >
-                                    <i
-                                      class="fas fa-pencil-alt"
-                                    />
-                                  </button>
-                                  <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    disabled=""
-                                    id="btn-delete-comment"
-                                    ngbtooltip="Delete this comment"
-                                    type="button"
+                                     Comment by response giver. 
+                                  </span>
+                                  <i
+                                    aria-hidden="true"
+                                    class="fa fa-eye"
+                                  />
+                                  <div
+                                    class="float-end"
                                   >
-                                    <i
-                                      class="fas fa-trash"
-                                    />
-                                  </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm"
+                                      disabled=""
+                                      id="btn-edit-comment"
+                                      ngbtooltip="Edit this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-pencil-alt"
+                                      />
+                                    </button>
+                                    <button
+                                      class="btn btn-outline-primary btn-sm btn-margin-left"
+                                      disabled=""
+                                      id="btn-delete-comment"
+                                      ngbtooltip="Delete this comment"
+                                      type="button"
+                                    >
+                                      <i
+                                        class="fas fa-trash"
+                                      />
+                                    </button>
+                                  </div>
                                 </div>
-                              </div>
-                              <div
-                                class="col-12"
-                                id="comment-text"
-                              >
-                                comment text
+                                <div
+                                  class="col-12"
+                                  id="comment-text"
+                                >
+                                  comment text
+                                </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                      </tm-comment-row>
+                        </tm-comment-row>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-4"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 4
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-4"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 4
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -4131,169 +4397,188 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 5: 
               </b>
               numerical scale question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-num-scale-question-instruction />
-            <tm-num-scale-question-constraint />
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-num-scale-question-instruction />
+              <tm-num-scale-question-constraint />
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-num-scale-question-edit-answer-form>
                       <div
-                        class="form-row text-start"
+                        id="recipient-name-0"
                       >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-num-scale-question-edit-answer-form>
                         <div
-                          class="col-md-2 col-xs-5"
+                          class="form-row text-start"
                         >
-                          <input
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            max="10"
-                            min="1"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
-                          />
-                        </div>
-                        <div
-                          class="col-md-9 col-xs-6 text-secondary"
-                          id="possible-values"
-                        >
-                           Possible values: [1,
+                          <div
+                            class="col-md-2 col-xs-5"
+                          >
+                            <input
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              max="10"
+                              min="1"
+                              step="1"
+                              tmdisablewheel=""
+                              type="number"
+                            />
+                          </div>
+                          <div
+                            class="col-md-9 col-xs-6 text-secondary"
+                            id="possible-values"
+                          >
+                             Possible values: [1,
              2,
              3,
              ...,
              8,
              9,
              10] 
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="row mt-1"
-                      >
                         <div
-                          class="col-12"
+                          class="row mt-1"
                         >
+                          <div
+                            class="col-12"
+                          >
+                          </div>
                         </div>
-                      </div>
-                      <br />
-                    </tm-num-scale-question-edit-answer-form>
+                        <br />
+                      </tm-num-scale-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-5"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 5
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-5"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 5
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -4307,183 +4592,202 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 6: 
               </b>
               constant sum question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-constsum-recipients-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="total-points-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Total points distributed should 
-                  <strong>
-                    add up to 20.
-                  </strong>
-                </p>
-              </div>
-            </tm-constsum-recipients-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-constsum-recipients-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="total-points-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Total points distributed should 
+                    <strong>
+                      add up to 20.
+                    </strong>
+                  </p>
+                </div>
+              </tm-constsum-recipients-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-constsum-recipients-question-edit-answer-form>
-                      <div>
-                        <div
-                          class="form-group"
-                        >
-                          <input
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            min="0"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
-                          />
-                        </div>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-constsum-recipients-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-constsum-recipients-question-edit-answer-form>
+                        <div>
+                          <div
+                            class="form-group"
+                          >
+                            <input
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              min="0"
+                              step="1"
+                              tmdisablewheel=""
+                              type="number"
+                            />
+                          </div>
+                        </div>
+                      </tm-constsum-recipients-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-constsum-recipients-question-constraint>
-                <div
-                  class="row"
-                >
-                  <div
-                    class="col-12"
-                  >
-                    <p
-                      class="text-danger"
-                    >
-                      <span
-                        class="fa fa-times"
-                      />
-                       Actual total is 7! Distribute the remaining 13 points.
-                    </p>
-                  </div>
-                </div>
-              </tm-constsum-recipients-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-6"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-constsum-recipients-question-constraint>
+                  <div
+                    class="row"
+                  >
+                    <div
+                      class="col-12"
+                    >
+                      <p
+                        class="text-danger"
+                      >
+                        <span
+                          class="fa fa-times"
+                        />
+                         Actual total is 7! Distribute the remaining 13 points.
+                      </p>
+                    </div>
+                  </div>
+                </tm-constsum-recipients-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 6
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-6"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 6
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -4497,412 +4801,431 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 7: 
               </b>
               contribution question
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-contribution-question-instruction>
-            </tm-contribution-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-contribution-question-instruction>
+              </tm-contribution-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-contribution-question-edit-answer-form>
                       <div
-                        class="row"
+                        id="recipient-name-0"
                       >
-                        <div
-                          class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <select
-                            class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              class="color-positive fw-bold"
-                              value="1: 100"
-                            >
-                              Equal share
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="2: 200"
-                            >
-                              Equal share + 100%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="3: 195"
-                            >
-                              Equal share + 95%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="4: 190"
-                            >
-                              Equal share + 90%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="5: 185"
-                            >
-                              Equal share + 85%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="6: 180"
-                            >
-                              Equal share + 80%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="7: 175"
-                            >
-                              Equal share + 75%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="8: 170"
-                            >
-                              Equal share + 70%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="9: 165"
-                            >
-                              Equal share + 65%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="10: 160"
-                            >
-                              Equal share + 60%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="11: 155"
-                            >
-                              Equal share + 55%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="12: 150"
-                            >
-                              Equal share + 50%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="13: 145"
-                            >
-                              Equal share + 45%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="14: 140"
-                            >
-                              Equal share + 40%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="15: 135"
-                            >
-                              Equal share + 35%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="16: 130"
-                            >
-                              Equal share + 30%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="17: 125"
-                            >
-                              Equal share + 25%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="18: 120"
-                            >
-                              Equal share + 20%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="19: 115"
-                            >
-                              Equal share + 15%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="20: 110"
-                            >
-                              Equal share + 10%
-                            </option>
-                            <option
-                              class="color-positive"
-                              value="21: 105"
-                            >
-                              Equal share + 5%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="22: 95"
-                            >
-                              Equal share - 5%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="23: 90"
-                            >
-                              Equal share - 10%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="24: 85"
-                            >
-                              Equal share - 15%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="25: 80"
-                            >
-                              Equal share - 20%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="26: 75"
-                            >
-                              Equal share - 25%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="27: 70"
-                            >
-                              Equal share - 30%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="28: 65"
-                            >
-                              Equal share - 35%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="29: 60"
-                            >
-                              Equal share - 40%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="30: 55"
-                            >
-                              Equal share - 45%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="31: 50"
-                            >
-                              Equal share - 50%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="32: 45"
-                            >
-                              Equal share - 55%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="33: 40"
-                            >
-                              Equal share - 60%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="34: 35"
-                            >
-                              Equal share - 65%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="35: 30"
-                            >
-                              Equal share - 70%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="36: 25"
-                            >
-                              Equal share - 75%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="37: 20"
-                            >
-                              Equal share - 80%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="38: 15"
-                            >
-                              Equal share - 85%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="39: 10"
-                            >
-                              Equal share - 90%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="40: 5"
-                            >
-                              Equal share - 95%
-                            </option>
-                            <option
-                              class="color-negative"
-                              value="41: 0"
-                            >
-                              0%
-                            </option>
-                          </select>
-                        </div>
-                        <div
-                          class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <button
-                            class="btn btn-link"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-exclamation-circle"
-                            />
-                             More info about the 
-                            <code>
-                              Equal Share
-                            </code>
-                             scale
-                          </button>
-                        </div>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-contribution-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-contribution-question-edit-answer-form>
+                        <div
+                          class="row"
+                        >
+                          <div
+                            class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
+                          >
+                            <select
+                              class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                class="color-positive fw-bold"
+                                value="1: 100"
+                              >
+                                Equal share
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="2: 200"
+                              >
+                                Equal share + 100%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="3: 195"
+                              >
+                                Equal share + 95%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="4: 190"
+                              >
+                                Equal share + 90%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="5: 185"
+                              >
+                                Equal share + 85%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="6: 180"
+                              >
+                                Equal share + 80%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="7: 175"
+                              >
+                                Equal share + 75%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="8: 170"
+                              >
+                                Equal share + 70%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="9: 165"
+                              >
+                                Equal share + 65%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="10: 160"
+                              >
+                                Equal share + 60%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="11: 155"
+                              >
+                                Equal share + 55%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="12: 150"
+                              >
+                                Equal share + 50%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="13: 145"
+                              >
+                                Equal share + 45%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="14: 140"
+                              >
+                                Equal share + 40%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="15: 135"
+                              >
+                                Equal share + 35%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="16: 130"
+                              >
+                                Equal share + 30%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="17: 125"
+                              >
+                                Equal share + 25%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="18: 120"
+                              >
+                                Equal share + 20%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="19: 115"
+                              >
+                                Equal share + 15%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="20: 110"
+                              >
+                                Equal share + 10%
+                              </option>
+                              <option
+                                class="color-positive"
+                                value="21: 105"
+                              >
+                                Equal share + 5%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="22: 95"
+                              >
+                                Equal share - 5%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="23: 90"
+                              >
+                                Equal share - 10%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="24: 85"
+                              >
+                                Equal share - 15%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="25: 80"
+                              >
+                                Equal share - 20%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="26: 75"
+                              >
+                                Equal share - 25%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="27: 70"
+                              >
+                                Equal share - 30%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="28: 65"
+                              >
+                                Equal share - 35%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="29: 60"
+                              >
+                                Equal share - 40%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="30: 55"
+                              >
+                                Equal share - 45%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="31: 50"
+                              >
+                                Equal share - 50%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="32: 45"
+                              >
+                                Equal share - 55%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="33: 40"
+                              >
+                                Equal share - 60%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="34: 35"
+                              >
+                                Equal share - 65%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="35: 30"
+                              >
+                                Equal share - 70%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="36: 25"
+                              >
+                                Equal share - 75%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="37: 20"
+                              >
+                                Equal share - 80%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="38: 15"
+                              >
+                                Equal share - 85%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="39: 10"
+                              >
+                                Equal share - 90%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="40: 5"
+                              >
+                                Equal share - 95%
+                              </option>
+                              <option
+                                class="color-negative"
+                                value="41: 0"
+                              >
+                                0%
+                              </option>
+                            </select>
+                          </div>
+                          <div
+                            class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
+                          >
+                            <button
+                              class="btn btn-link"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-exclamation-circle"
+                              />
+                               More info about the 
+                              <code>
+                                Equal Share
+                              </code>
+                               scale
+                            </button>
+                          </div>
+                        </div>
+                      </tm-contribution-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-contribution-question-constraint>
-              </tm-contribution-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-7"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-contribution-question-constraint>
+                </tm-contribution-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 7
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-7"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 7
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -4916,281 +5239,300 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 8: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rubric-question-edit-answer-form>
-                      <table
-                        class="table table-bordered desktop-view"
-                      >
-                        <tbody>
-                          <tr>
-                            <td />
-                            <td
-                              class="fw-bold"
-                            >
-                              choice 1
-                            </td>
-                            <td
-                              class="fw-bold"
-                            >
-                              choice 2
-                            </td>
-                          </tr>
-                          <tr
-                            class="row-answered"
-                          >
-                            <td>
-                              subquestion 1
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id0-desktop"
-                                  type="radio"
-                                />
-                                 description 1 
-                              </label>
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id0-desktop"
-                                  type="radio"
-                                />
-                                 description 2 
-                              </label>
-                            </td>
-                          </tr>
-                          <tr
-                            class="row-answered"
-                          >
-                            <td>
-                              subquestion 2
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id1-desktop"
-                                  type="radio"
-                                />
-                                 description 3 
-                              </label>
-                            </td>
-                            <td
-                              class="text-secondary answer-cell"
-                            >
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id1-desktop"
-                                  type="radio"
-                                />
-                                 description 4 
-                              </label>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
                       <div
-                        class="mobile-view"
+                        id="recipient-name-0"
                       >
-                        <div
-                          class="card"
-                        >
-                          <div
-                            class="card-header bg-light"
-                          >
-                             subquestion 1 
-                          </div>
-                          <div
-                            class="card-body row-answered"
-                          >
-                            <div>
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id0-mobile"
-                                  type="radio"
-                                />
-                                 choice 1 - description 1 
-                              </label>
-                            </div>
-                            <div>
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id0-mobile"
-                                  type="radio"
-                                />
-                                 choice 2 - description 2 
-                              </label>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="card"
-                        >
-                          <div
-                            class="card-header bg-light"
-                          >
-                             subquestion 2 
-                          </div>
-                          <div
-                            class="card-body row-answered"
-                          >
-                            <div>
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id1-mobile"
-                                  type="radio"
-                                />
-                                 choice 1 - description 3 
-                              </label>
-                            </div>
-                            <div>
-                              <label>
-                                <input
-                                  disabled=""
-                                  name="feedback-question-id-rubricbarry-harris-id1-mobile"
-                                  type="radio"
-                                />
-                                 choice 2 - description 4 
-                              </label>
-                            </div>
-                          </div>
-                        </div>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-rubric-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rubric-question-edit-answer-form>
+                        <table
+                          class="table table-bordered desktop-view"
+                        >
+                          <tbody>
+                            <tr>
+                              <td />
+                              <td
+                                class="fw-bold"
+                              >
+                                choice 1
+                              </td>
+                              <td
+                                class="fw-bold"
+                              >
+                                choice 2
+                              </td>
+                            </tr>
+                            <tr
+                              class="row-answered"
+                            >
+                              <td>
+                                subquestion 1
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id0-desktop"
+                                    type="radio"
+                                  />
+                                   description 1 
+                                </label>
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id0-desktop"
+                                    type="radio"
+                                  />
+                                   description 2 
+                                </label>
+                              </td>
+                            </tr>
+                            <tr
+                              class="row-answered"
+                            >
+                              <td>
+                                subquestion 2
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id1-desktop"
+                                    type="radio"
+                                  />
+                                   description 3 
+                                </label>
+                              </td>
+                              <td
+                                class="text-secondary answer-cell"
+                              >
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id1-desktop"
+                                    type="radio"
+                                  />
+                                   description 4 
+                                </label>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <div
+                          class="mobile-view"
+                        >
+                          <div
+                            class="card"
+                          >
+                            <div
+                              class="card-header bg-light"
+                            >
+                               subquestion 1 
+                            </div>
+                            <div
+                              class="card-body row-answered"
+                            >
+                              <div>
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id0-mobile"
+                                    type="radio"
+                                  />
+                                   choice 1 - description 1 
+                                </label>
+                              </div>
+                              <div>
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id0-mobile"
+                                    type="radio"
+                                  />
+                                   choice 2 - description 2 
+                                </label>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="card"
+                          >
+                            <div
+                              class="card-header bg-light"
+                            >
+                               subquestion 2 
+                            </div>
+                            <div
+                              class="card-body row-answered"
+                            >
+                              <div>
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id1-mobile"
+                                    type="radio"
+                                  />
+                                   choice 1 - description 3 
+                                </label>
+                              </div>
+                              <div>
+                                <label>
+                                  <input
+                                    disabled=""
+                                    name="feedback-question-id-rubricbarry-harris-id1-mobile"
+                                    type="radio"
+                                  />
+                                   choice 2 - description 4 
+                                </label>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </tm-rubric-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-8"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 8
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-8"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 8
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -5204,231 +5546,250 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 9: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-rank-options-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    at least 
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    no more than 
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-rank-options-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-rank-options-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      at least 
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      no more than 
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-rank-options-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
+                      <div
+                        id="recipient-name-0"
+                      >
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rank-options-question-edit-answer-form>
-                      <div
-                        class="form-group row text-start"
-                      >
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rank-options-question-edit-answer-form>
                         <div
-                          class="col-md-5 col-xs-12 text-md-end col-form-label"
+                          class="form-group row text-start"
                         >
-                          <strong>
-                            option 1
-                          </strong>
-                        </div>
-                        <div
-                          class="col-md-7 col-xs-12 text-md-start"
-                        >
-                          <select
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                          <div
+                            class="col-md-5 col-xs-12 text-md-end col-form-label"
                           >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              value="1: 1"
-                            >
-                              1
-                            </option>
-                            <option
-                              value="2: 2"
-                            >
-                              2
-                            </option>
-                          </select>
-                        </div>
-                      </div>
-                      <div
-                        class="form-group row text-start"
-                      >
-                        <div
-                          class="col-md-5 col-xs-12 text-md-end col-form-label"
-                        >
-                          <strong>
-                            option 2
-                          </strong>
-                        </div>
-                        <div
-                          class="col-md-7 col-xs-12 text-md-start"
-                        >
-                          <select
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            <strong>
+                              option 1
+                            </strong>
+                          </div>
+                          <div
+                            class="col-md-7 col-xs-12 text-md-start"
                           >
-                            <option
-                              value="0: -999"
-                            />
-                            <option
-                              value="1: 1"
+                            <select
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                              1
-                            </option>
-                            <option
-                              value="2: 2"
-                            >
-                              2
-                            </option>
-                          </select>
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                value="1: 1"
+                              >
+                                1
+                              </option>
+                              <option
+                                value="2: 2"
+                              >
+                                2
+                              </option>
+                            </select>
+                          </div>
                         </div>
-                      </div>
-                      <div>
-                      </div>
-                    </tm-rank-options-question-edit-answer-form>
+                        <div
+                          class="form-group row text-start"
+                        >
+                          <div
+                            class="col-md-5 col-xs-12 text-md-end col-form-label"
+                          >
+                            <strong>
+                              option 2
+                            </strong>
+                          </div>
+                          <div
+                            class="col-md-7 col-xs-12 text-md-start"
+                          >
+                            <select
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="0: -999"
+                              />
+                              <option
+                                value="1: 1"
+                              >
+                                1
+                              </option>
+                              <option
+                                value="2: 2"
+                              >
+                                2
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                        <div>
+                        </div>
+                      </tm-rank-options-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-9"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 9
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-9"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 9
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -5442,185 +5803,204 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form"
         >
-          <div
-            class="card-header bg-primary text-white question-header bg-success"
+          <button
+            class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
+            <div
+              class="collapse-caret"
+            >
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
+            </div>
             <i
               class="fas fa-check me-2"
             />
-            <h3
+            <h2
               id="question-details"
             >
               <b>
                 Question 10: 
               </b>
               question brief
-            </h3>
-          </div>
+            </h2>
+          </button>
           <div
-            class="card-body"
+            class="ng-trigger ng-trigger-collapseAnim ng-animating"
+            style=""
           >
             <div
-              class="card mb-3"
+              class="card-body"
+              style=""
             >
               <div
-                class="card-header"
-              >
-                <b>
-                  More details
-                </b>
-              </div>
-              <div
-                class="card-body"
-                id="question-description"
-              >
-                question description
-              </div>
-            </div>
-            <div
-              class="card-body visibility-card"
-            >
-              <p
-                class="text-secondary"
-              >
-                Only the following persons can see your responses: 
-              </p>
-              <ul
-                class="text-secondary"
-                id="visibility-list"
-              >
-                <li>
-                   The receiving students can see your response, the name of the recipient, and your name 
-                </li>
-                <li>
-                   Instructors in this course can see your response, the name of the recipient, and your name 
-                </li>
-              </ul>
-            </div>
-            <tm-rank-recipients-question-instruction>
-              <div
-                class="text-info"
-              >
-                <p
-                  class="fw-bold"
-                >
-                  Note:
-                </p>
-                <p
-                  id="min-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                    at least 1
-                  </strong>
-                   options. 
-                </p>
-                <p
-                  id="max-options-message"
-                >
-                  <span
-                    class="fa fa-info-circle"
-                  />
-                   Rank 
-                  <strong>
-                     no more than 2
-                  </strong>
-                   options. 
-                </p>
-              </div>
-            </tm-rank-recipients-question-instruction>
-            <div
-              class="form-row margin-top-30px margin-bottom-0px"
-            >
-              <div
-                class="col-2"
-              >
-                <p>
-                  <span
-                    class="ngb-tooltip-class font-bold"
-                    ngbtooltip="The party being evaluated or given feedback to"
-                  >
-                    Evaluee/Recipient
-                  </span>
-                </p>
-              </div>
-            </div>
-            <div
-              class="row"
-            >
-              <div
-                class="evaluee-col col-12"
+                class="card mb-3"
               >
                 <div
-                  class="row"
+                  class="card-header"
+                >
+                  <b>
+                    More details
+                  </b>
+                </div>
+                <div
+                  class="card-body"
+                  id="question-description"
+                >
+                  question description
+                </div>
+              </div>
+              <div
+                class="card-body visibility-card"
+              >
+                <p
+                  class="text-secondary"
+                >
+                  Only the following persons can see your responses: 
+                </p>
+                <ul
+                  class="text-secondary"
+                  id="visibility-list"
+                >
+                  <li>
+                     The receiving students can see your response, the name of the recipient, and your name 
+                  </li>
+                  <li>
+                     Instructors in this course can see your response, the name of the recipient, and your name 
+                  </li>
+                </ul>
+              </div>
+              <tm-rank-recipients-question-instruction>
+                <div
+                  class="text-info"
+                >
+                  <p
+                    class="fw-bold"
+                  >
+                    Note:
+                  </p>
+                  <p
+                    id="min-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                      at least 1
+                    </strong>
+                     options. 
+                  </p>
+                  <p
+                    id="max-options-message"
+                  >
+                    <span
+                      class="fa fa-info-circle"
+                    />
+                     Rank 
+                    <strong>
+                       no more than 2
+                    </strong>
+                     options. 
+                  </p>
+                </div>
+              </tm-rank-recipients-question-instruction>
+              <div
+                class="form-row margin-top-30px margin-bottom-0px"
+              >
+                <div
+                  class="col-2"
+                >
+                  <p>
+                    <span
+                      class="ngb-tooltip-class font-bold"
+                      ngbtooltip="The party being evaluated or given feedback to"
+                    >
+                      Evaluee/Recipient
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="evaluee-col col-12"
                 >
                   <div
-                    class="col-md-5 col-xs-12 margin-top-20px"
+                    class="row"
                   >
                     <div
-                      id="recipient-name-0"
+                      class="col-md-5 col-xs-12 margin-top-20px"
                     >
-                      <b>
-                        Barry Harris 
-                      </b>
-                      <span>
-                        (Student)
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="margin-top-20px col"
-                  >
-                    <tm-rank-recipients-question-edit-answer-form>
                       <div
-                        class="margin-bottom-15px"
+                        id="recipient-name-0"
                       >
-                        <select
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="0: -999"
-                          />
-                          <option
-                            value="1: 1"
-                          >
-                            1
-                          </option>
-                        </select>
+                        <b>
+                          Barry Harris 
+                        </b>
+                        <span>
+                          (Student)
+                        </span>
                       </div>
-                    </tm-rank-recipients-question-edit-answer-form>
+                    </div>
+                    <div
+                      class="margin-top-20px col"
+                    >
+                      <tm-rank-recipients-question-edit-answer-form>
+                        <div
+                          class="margin-bottom-15px"
+                        >
+                          <select
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
+                          >
+                            <option
+                              value="0: -999"
+                            />
+                            <option
+                              value="1: 1"
+                            >
+                              1
+                            </option>
+                          </select>
+                        </div>
+                      </tm-rank-recipients-question-edit-answer-form>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="col-12 constraint-margins"
-            >
-              <tm-rank-recipients-question-constraint>
-                <div>
-                </div>
-              </tm-rank-recipients-question-constraint>
-            </div>
-            <div
-              class="row"
-            >
               <div
-                class="col-12 text-center"
+                class="col-12 constraint-margins"
               >
-                <button
-                  class="btn btn-success"
-                  disabled=""
-                  id="btn-submit-qn-10"
-                  ngbtooltip="You can save your responses for this question at any time and come back later to continue."
-                  type="submit"
+                <tm-rank-recipients-question-constraint>
+                  <div>
+                  </div>
+                </tm-rank-recipients-question-constraint>
+              </div>
+              <div
+                class="row"
+              >
+                <div
+                  class="col-12 text-center"
                 >
-                  <span>
-                    Submit Response for Question 10
-                  </span>
-                </button>
+                  <button
+                    class="btn btn-success"
+                    disabled=""
+                    id="btn-submit-qn-10"
+                    ngbtooltip="You can save your responses for this question at any time and come back later to continue."
+                    type="submit"
+                  >
+                    <span>
+                      Submit Response for Question 10
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -897,14 +897,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 1: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -1148,14 +1148,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 3: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -1281,14 +1281,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           <div
             class="card-header bg-primary text-white question-header"
           >
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 2: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -1375,14 +1375,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 4: 
               </b>
               MSQ question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -1660,14 +1660,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 5: 
               </b>
               numerical scale question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -1835,14 +1835,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 6: 
               </b>
               constant sum question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -2024,14 +2024,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 7: 
               </b>
               contribution question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -2442,14 +2442,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 8: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -2721,14 +2721,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 9: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -2958,14 +2958,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 10: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -3363,14 +3363,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 1: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -3619,14 +3619,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 3: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -3752,14 +3752,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           <div
             class="card-header bg-primary text-white question-header"
           >
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 2: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -3846,14 +3846,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 4: 
               </b>
               MSQ question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -4137,14 +4137,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 5: 
               </b>
               numerical scale question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -4313,14 +4313,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 6: 
               </b>
               constant sum question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -4503,14 +4503,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 7: 
               </b>
               contribution question
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -4922,14 +4922,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 8: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -5210,14 +5210,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 9: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"
@@ -5448,14 +5448,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             <i
               class="fas fa-check me-2"
             />
-            <span
+            <h3
               id="question-details"
             >
               <b>
                 Question 10: 
               </b>
               question brief
-            </span>
+            </h3>
           </div>
           <div
             class="card-body"

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -324,6 +325,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testMcqQuestionSubmissionForm2: QuestionSubmissionFormModel = {
@@ -348,6 +350,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: false,
+    isTabExpanded: true,
   };
 
   const testTextQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -371,6 +374,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testMsqQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -398,6 +402,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testNumscaleQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -422,6 +427,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testConstsumQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -449,6 +455,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testContribQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -471,6 +478,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testRubricQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -497,6 +505,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testRankOptionsQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -519,6 +528,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testRankRecipientsQuestionSubmissionForm: QuestionSubmissionFormModel = {
@@ -543,6 +553,7 @@ describe('SessionSubmissionPageComponent', () => {
     showRecipientNameTo: [FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.INSTRUCTORS],
     isLoading: false,
     isLoaded: true,
+    isTabExpanded: true,
   };
 
   const testInfo: AuthInfo = {
@@ -597,6 +608,7 @@ describe('SessionSubmissionPageComponent', () => {
         QuestionSubmissionFormModule,
         LoadingSpinnerModule,
         LoadingRetryModule,
+        BrowserAnimationsModule,
       ],
       providers: [
         {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -477,6 +477,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               const model: QuestionSubmissionFormModel = {
                 isLoading: false,
                 isLoaded: false,
+                isTabExpanded: true,
                 feedbackQuestionId: feedbackQuestion.feedbackQuestionId,
 
                 questionNumber: feedbackQuestion.questionNumber,


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Landmark questions](https://github.com/TEAMMATES/teammates/projects/16#card-88047383)

**Outline of Solution**

Landmark questions by making question titles headers (`h2`). This allows the screenreader to pick them up, and in turn enables easier navigation up and down the page. Also added CSS for the `#question-details` to make it look the same as before (i.e. like a `span` instead of a `h2`).

Made questions collapsible by introducing a `isTabExpanded` field to the model. It is set to `true` by default. The mechanics are similar to collapsible questions in other pages.

Changed `div` to a `button`, which is more WCAG compliant (according to [this](https://stackoverflow.com/questions/32659099/making-a-clickable-div-accessible-through-tab-structure)) and immediately allows for tab index and keyboard control. Also added several `aria` attributes.

I also noticed that the previous PR #12096 messed up the feedback path panel dropdown as the dropdown was being considered an overflow. Hence, it didn't show up properly (on any screen size). I've reverted the changes and made a temporary fix for the feedback path button so that it doesn't overflow, but because of this, the dropdown once again overflows...
