### PR TITLE
[#12081] User-friendliness: Make header dropdowns focusable

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -9,7 +9,7 @@
     <ul class="nav navbar-nav flex-nowrap me-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>
-          <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>{{ navItem.display }}</a>
+          <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ navItem.display }}</a>
           <div class="dropdown-menu" ngbDropdownMenu>
             <a *ngFor="let childItem of navItem.children" class="dropdown-item" [tmRouterLink]="childItem.url" (click)="toggleCollapse();closeModal()">{{ childItem.display}}</a>
           </div>
@@ -22,14 +22,14 @@
     <ul class="nav navbar-nav me-auto" *ngIf="!isValidUser"></ul>
     <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="!user">
-        <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>Login</a>
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>Login</a>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" id="student-login-btn" [href]="studentLoginUrl">Student Login</a>
           <a class="dropdown-item" id="instructor-login-btn" [href]="instructorLoginUrl">Instructor Login</a>
         </div>
       </li>
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="user">
-        <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>{{ user }}</a>
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ user }}</a>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" tmRouterLink="/web/student" *ngIf="isStudent" (click)="closeModal()">To student pages</a>
           <a class="dropdown-item" tmRouterLink="/web/instructor" *ngIf="isInstructor" (click)="closeModal()">To instructor pages</a>

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -104,6 +104,7 @@ nav {
 .navbar-collapse,
 .dropdown-menu {
   background: #3C3C3C;
+  min-width: 0px;
 }
 
 .dropdown-divider {

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -104,7 +104,7 @@ nav {
 .navbar-collapse,
 .dropdown-menu {
   background: #3C3C3C;
-  min-width: 0px;
+  min-width: 0;
 }
 
 .dropdown-divider {


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Header: Make dropdowns interactable](https://github.com/TEAMMATES/teammates/projects/16#card-88044576)

**Outline of Solution**

Dropdown unable to be focused:
- Problem: Dropdown was not focusable since there was no `href` tag. 
- Solution: Add `tabindex="0"` tag

Symmetric margins:
- Problem: There was `min-width` specified by Bootstrap's `dropdown-menu`, which forced the dropdown list to be wider than it needs to be.
- Solution: Override `min-width` with `0px`.