### PR TITLE
[#12081] Tag all TEAMMATES pages with <main>

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -3,12 +3,12 @@ name: Accessibility Tests
 on:
   push:
     branches:
-      - master 
+      - master
       - release
       - user-friendliness
   pull_request:
     branches:
-      - master 
+      - master
       - release
       - user-friendliness
 jobs:
@@ -36,19 +36,19 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Update Property File 
+      - name: Update Property File
         run: mv src/e2e/resources/test.ci-${{ matrix.browser }}.properties src/e2e/resources/test.properties
       - name: Run Solr search service + local Datastore emulator
         run: docker-compose up -d
       - name: Create Config Files
-        run: ./gradlew createConfigs testClasses generateTypes 
+        run: ./gradlew createConfigs testClasses generateTypes
       - name: Install Frontend Dependencies
-        run: npm ci 
-      - name: Build Frontend Bundle 
+        run: npm ci
+      - name: Build Frontend Bundle
         run: npm run build
       - name: Start Server
         run: |
           ./gradlew serverRun &
           ./wait-for-server.sh
-      - name: Start Tests 
-        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew axeTests 
+      - name: Start Tests
+        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew axeTests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,12 +3,12 @@ name: E2E Tests
 on:
   push:
     branches:
-      - master 
+      - master
       - release
       - user-friendliness
   pull_request:
     branches:
-      - master 
+      - master
       - release
       - user-friendliness
   schedule:
@@ -39,19 +39,19 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Update Property File 
+      - name: Update Property File
         run: mv src/e2e/resources/test.ci-${{ matrix.browser }}.properties src/e2e/resources/test.properties
       - name: Run Solr search service + local Datastore emulator
         run: docker-compose up -d
       - name: Create Config Files
-        run: ./gradlew createConfigs testClasses generateTypes 
+        run: ./gradlew createConfigs testClasses generateTypes
       - name: Install Frontend Dependencies
-        run: npm ci 
-      - name: Build Frontend Bundle 
+        run: npm ci
+      - name: Build Frontend Bundle
         run: npm run build
       - name: Start Server
         run: |
           ./gradlew serverRun &
           ./wait-for-server.sh
-      - name: Start Tests 
-        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew e2eTests 
+      - name: Start Tests
+        run: xvfb-run --server-args="-screen 0 1024x768x24" ./gradlew e2eTests

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -5,7 +5,7 @@
   <button class="navbar-toggler d-lg-none" type="button" (click)="toggleCollapse()" [attr.aria-expanded]="!isCollapsed" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <div class="navbar-collapse" [ngStyle]="{display: isCollapsed ? 'none' : 'block'}">
+  <div class="navbar-collapse" [ngStyle]="{ display: isCollapsed ? 'none' : 'block' }">
     <ul class="nav navbar-nav flex-nowrap me-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>
@@ -44,15 +44,13 @@
 </nav>
 <tm-loader-bar></tm-loader-bar>
 <tm-toast [(toast)]="toast" aria-live="polite" aria-atomic="true"></tm-toast>
-<div id="main-content" class="container main-content">
-  <tm-notification-banner *ngIf="isStudent || isInstructor"
-                          [url]="getUrl()"
-                          [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
+<main id="main-content" class="container main-content">
+  <tm-notification-banner *ngIf="isStudent || isInstructor" [url]="getUrl()" [notificationTargetUser]="notificationTargetUser"></tm-notification-banner>
   <div *tmIsLoading="isFetchingAuthDetails">
     <div *ngIf="isUnsupportedBrowser">
       <div class="alert alert-danger" role="alert">
         <i class="fas fa-exclamation-circle"></i>&nbsp;You are currently using {{ browser }}. This web browser is not officially supported by TEAMMATES.
-        In case this web browser does not display the webpage correctly you may wish to view it in the following supported browsers:
+        In case this web browser does not display the webpage correctly, you may wish to view it in the following supported browsers:
         <ol>
           <li>Chrome {{ minimumVersions['Chrome'] }}+</li>
           <li>Edge {{ minimumVersions['Edge'] }}+</li>
@@ -116,21 +114,17 @@
     <h1 *ngIf="pageTitle && isValidUser">{{ pageTitle }}</h1>
     <router-outlet *ngIf="isValidUser"></router-outlet>
   </div>
-</div>
-<div>
-  <footer>
-    <div class="container footer">
-      <div class="row text-center">
-        <div class="col-sm-6 text-md-start">
-          <i class="fas fa-bolt"></i><a tmRouterLink="/web/front/home"> TEAMMATES</a> V{{ version }}
-        </div>
-        <div class="col-sm-6 text-md-end">
-          <i class="far fa-comments"></i> Send <a tmRouterLink="/web/front/contact" target="_blank">Feedback</a>
-        </div>
-        <div class="col-sm-12">
-          Sponsored by School of Computing, National University of Singapore. (<a tmRouterLink="/web/front/contact" target="_blank">Become a sponsor</a>)
-        </div>
-      </div>
+</main>
+<footer class="footer">
+  <div class="row text-center">
+    <div class="col-sm-6 text-md-start">
+      <i class="fas fa-bolt"></i><a tmRouterLink="/web/front/home">&nbsp;TEAMMATES</a> V{{ version }}
     </div>
-  </footer>
-</div>
+    <div class="col-sm-6 text-md-end">
+      <i class="far fa-comments"></i>&nbsp;Send <a tmRouterLink="/web/front/contact" target="_blank">Feedback</a>
+    </div>
+    <div class="col-sm-12">
+      Sponsored by School of Computing, National University of Singapore. <a tmRouterLink="/web/front/contact" target="_blank">Become a sponsor</a>
+    </div>
+  </div>
+</footer>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -76,7 +76,7 @@
             <img src="assets/images/angry.png" style="float: left; height: 90px; margin: 0 10px 10px 0;">
             <h5 style="padding: 30px 0 20px 0;">You are not authorized to view this page.</h5>
             <hr>
-            <p style="text-align: center;">Logout and return to main page.</p>
+            <p style="text-align: center;">Log out and return to main page.</p>
           </div>
         </div>
       </div>
@@ -90,10 +90,10 @@
               </p>
               <hr>
               <br>
-              If you 'joined' the course in TEAMMATES using a Google account before, but cannot login anymore, these are the possible reasons:
+              If you 'joined' the course in TEAMMATES using a Google account before, but cannot log in anymore, these are the possible reasons:
               <ol>
                 <li>
-                  You used a different Google account to access TEAMMATES in the past. In that case, you need to use the same Google account to access TEAMMATES again. Logout and re-login using the other Google account. If you don't remember which Google account you used previously, email us from the same email account to which you receive TEAMMATES emails.
+                  You used a different Google account to access TEAMMATES in the past. In that case, you need to use the same Google account to access TEAMMATES again. Log out and re-log in using the other Google account. If you don't remember which Google account you used previously, email us from the same email account to which you receive TEAMMATES emails.
                 </li>
                 <li>
                   You changed the primary email from a non-Gmail address to a Gmail address recently. In that case,

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -91,11 +91,6 @@ nav {
   .footer {
     padding: 5px 15px;
   }
-
-  // .footer .row {
-  //   margin-left: 0;
-  //   margin-right: 0;
-  // }
 }
 
 .navbar-toggler {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -147,7 +147,7 @@
                             headerText="Is it compulsory for students to use Google accounts?"
                             [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT]">
     <p>
-      Students can submit feedback and view results without having to login to TEAMMATES, unless they choose to link their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results.
+      Students can submit feedback and view results without having to log in to TEAMMATES, unless they choose to link their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results.
       However, the following non-essential features are available only to users who have joined a TEAMMATES course using a Google account:
     </p>
     <ol>

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
@@ -1,38 +1,36 @@
-<main>
-  <h1 class="color-orange">
-    Recovering Session Links for Students
-  </h1>
+<h1 class="color-orange">
+  Recovering Session Links for Students
+</h1>
 
-  <p>
-    If you cannot find your feedback session links, enter your course registered email below. Links to all your feedback sessions with start date within the past 90 days will be sent to the email address.
-  </p>
+<p>
+  If you cannot find your feedback session links, enter your course registered email below. Links to all your feedback sessions with start date within the past 90 days will be sent to the email address.
+</p>
 
-  <div class="card bg-light top-padded col-sm-9 col-md-6">
-    <form class="form form-horizontal" [formGroup]="formSessionLinksRecovery" (ngSubmit)="onSubmitFormSessionLinksRecovery(formSessionLinksRecovery)">
+<div class="card bg-light top-padded col-sm-9 col-md-6">
+  <form class="form form-horizontal" [formGroup]="formSessionLinksRecovery" (ngSubmit)="onSubmitFormSessionLinksRecovery(formSessionLinksRecovery)">
 
-      <div class="form-group form-row top-padded">
-        <label class="control-label">
-          <strong>Email:</strong>
-        </label>
-        <input class="form-control" type="email" formControlName="email" maxlength="254" email="true" spellcheck="false">
-      </div>
-      <div *ngIf="captchaSiteKey !== ''" class="form-row form-group top-padded">
-        <ngx-recaptcha2 #captchaElem
-                        [siteKey]="captchaSiteKey"
-                        (success)="handleSuccess($event)"
-                        [useGlobalDomain]="false"
-                        [size]="size"
-                        [hl]="lang"
-                        formControlName="recaptcha">
-        </ngx-recaptcha2>
-      </div>
+    <div class="form-group form-row top-padded">
+      <label class="control-label">
+        <strong>Email:</strong>
+      </label>
+      <input class="form-control" type="email" formControlName="email" maxlength="254" email="true" spellcheck="false">
+    </div>
+    <div *ngIf="captchaSiteKey !== ''" class="form-row form-group top-padded">
+      <ngx-recaptcha2 #captchaElem
+                      [siteKey]="captchaSiteKey"
+                      (success)="handleSuccess($event)"
+                      [useGlobalDomain]="false"
+                      [size]="size"
+                      [hl]="lang"
+                      formControlName="recaptcha">
+      </ngx-recaptcha2>
+    </div>
 
-      <div class="form-row top-padded">
-        <button class="btn btn-primary" type="submit">
-          <tm-ajax-loading *ngIf="isFormSubmitting"></tm-ajax-loading>Submit
-        </button>
-      </div>
+    <div class="form-row top-padded">
+      <button class="btn btn-primary" type="submit">
+        <tm-ajax-loading *ngIf="isFormSubmitting"></tm-ajax-loading>Submit
+      </button>
+    </div>
 
-    </form>
-  </div>
-</main>
+  </form>
+</div>

--- a/src/web/app/pages-help/student-help-page/student-help-page.component.html
+++ b/src/web/app/pages-help/student-help-page/student-help-page.component.html
@@ -40,7 +40,7 @@
         <li>
           You used a different Google account to access TEAMMATES in the past.
           In that case, you need to use the same Google account to access TEAMMATES again.
-          Logout and re-login using the other Google account.
+          Log out and re-log in using the other Google account.
         </li>
         <li>
           You changed the primary email from a non-Gmail address to a Gmail address recently.

--- a/src/web/app/pages-help/student-help-page/student-help-page.component.html
+++ b/src/web/app/pages-help/student-help-page/student-help-page.component.html
@@ -1,96 +1,93 @@
-<main>
-  <h1 class="color-orange">
-    Help for Students
-  </h1>
+<h1 class="color-orange">
+  Help for Students
+</h1>
 
-  <h4 class="color-blue">
-    Getting Started
-  </h4>
+<h4 class="color-blue">
+  Getting Started
+</h4>
 
-  <ol>
-    <li>
-      <b>Join the course</b> by clicking the link given in the email you received from TEAMMATES.<br>
-      Note that you need to join a course only once per course.<br>
-      Also note that joining a course is optional. If you do not join, you can still submit feedback and view feedback
-      responses using links sent to you by TEAMMATES. If you join, you get access to extra features such as the ability
-      to see all your feedback sessions in a single home page.<br>
-    </li>
-    <li>
-      <b>Do the pending submissions</b> (if any).<br>
-      You will need to <b>use the "Submit Feedback" button</b> in order to submit your responses
-      (including any intermediate/draft responses) as the system will not perform any kind of auto-save.
-    </li>
-    <li>You can <b>edit your submissions</b> up to the closing time of the respective session.</li>
-    <li>You can <b>view session results</b> after the instructor has published session results. The system will notify
-      you via email when results are available for viewing.
-    </li>
-  </ol>
+<ol>
+  <li>
+    <b>Join the course</b> by clicking the link given in the email you received from TEAMMATES.<br>
+    Note that you need to join a course only once per course.<br>
+    Also note that joining a course is optional. If you do not join, you can still submit feedback and view feedback
+    responses using links sent to you by TEAMMATES. If you join, you get access to extra features such as the ability
+    to see all your feedback sessions in a single home page.<br>
+  </li>
+  <li>
+    <b>Do the pending submissions</b> (if any).<br>
+    You will need to <b>use the "Submit Feedback" button</b> in order to submit your responses
+    (including any intermediate/draft responses) as the system will not perform any kind of auto-save.
+  </li>
+  <li>You can <b>edit your submissions</b> up to the closing time of the respective session.</li>
+  <li>You can <b>view session results</b> after the instructor has published session results. The system will notify
+    you via email when results are available for viewing.
+  </li>
+</ol>
 
-  <hr>
+<hr>
 
-  <h4 class="color-blue">
-    Frequently Asked Questions
-  </h4>
+<h4 class="color-blue">
+  Frequently Asked Questions
+</h4>
 
-  <ul>
-    <li>
-      <b>What should I do if I cannot see any/some of my courses I should be able to see in the system?</b>
-      <div>
-        These are the possible reasons:
-        <ol>
-          <li>
-            You used a different Google account to access TEAMMATES in the past.
-            In that case, you need to use the same Google account to access TEAMMATES again.
-            Logout and re-login using the other Google account.
-          </li>
-          <li>
-            You changed the primary email from a non-Gmail address to a Gmail address recently.
-            In that case, email <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a> so that we can
-            reconfigure your account to use the new Gmail address.
-          </li>
-        </ol>
-      </div>
-    </li>
-    <li>
-      <b>What should I do if I'm unable to submit my response?</b>
-      <div>
-        <a href="mailto:{{ supportEmail }}">Email us</a> so that we can assist you with your submission.
-        Note that we cannot do much if the submission deadline is over. It is not up to us (the TEAMMATES team) to
-        accept overdue submissions.
-      </div>
-    </li>
-    <li>
-      <b>What should I do if I didn't receive the link to submit responses or view results?</b>
-      <div>
-        These are some solutions:
-        <ol>
-          <li>
-            Check your spam/junk email folder.
-          </li>
-          <li>
-            Go to <a tmRouterLink="/web/front/help/session-links-recovery">the session links recovery page</a> and request TEAMMATES to resend the link.
-            You should specify the exact email address that was used by your instructor to enroll you in the course.
-            Usually, this should be your school email address. You can ask your instructor if you're unsure.
-          </li>
-          <li>
-            If none of the options above works, <a href="mailto:{{ supportEmail }}">email us</a> and we will resend the email using an alternate means.
-            For identification purpose, you should use the email address that was used to enroll you in the course.
-          </li>
-        </ol>
-      </div>
-    </li>
-    <li>
-      <b>What should I do if my team or my name is not displayed correctly?</b>
-      <div>
-        Your team and your name are set by your course instructor and you should contact the instructor to change accordingly.
-      </div>
-    </li>
-    <li>
-      <b>Why can't I see the feedback I receive after submitting my responses?</b>
-      <div>
-        You will only be able to see the feedback received after your instructor publishes the session results.
-      </div>
-    </li>
-  </ul>
-
-</main>
+<ul>
+  <li>
+    <b>What should I do if I cannot see any/some of my courses I should be able to see in the system?</b>
+    <div>
+      These are the possible reasons:
+      <ol>
+        <li>
+          You used a different Google account to access TEAMMATES in the past.
+          In that case, you need to use the same Google account to access TEAMMATES again.
+          Logout and re-login using the other Google account.
+        </li>
+        <li>
+          You changed the primary email from a non-Gmail address to a Gmail address recently.
+          In that case, email <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a> so that we can
+          reconfigure your account to use the new Gmail address.
+        </li>
+      </ol>
+    </div>
+  </li>
+  <li>
+    <b>What should I do if I'm unable to submit my response?</b>
+    <div>
+      <a href="mailto:{{ supportEmail }}">Email us</a> so that we can assist you with your submission.
+      Note that we cannot do much if the submission deadline is over. It is not up to us (the TEAMMATES team) to
+      accept overdue submissions.
+    </div>
+  </li>
+  <li>
+    <b>What should I do if I didn't receive the link to submit responses or view results?</b>
+    <div>
+      These are some solutions:
+      <ol>
+        <li>
+          Check your spam/junk email folder.
+        </li>
+        <li>
+          Go to <a tmRouterLink="/web/front/help/session-links-recovery">the session links recovery page</a> and request TEAMMATES to resend the link.
+          You should specify the exact email address that was used by your instructor to enroll you in the course.
+          Usually, this should be your school email address. You can ask your instructor if you're unsure.
+        </li>
+        <li>
+          If none of the options above works, <a href="mailto:{{ supportEmail }}">email us</a> and we will resend the email using an alternate means.
+          For identification purpose, you should use the email address that was used to enroll you in the course.
+        </li>
+      </ol>
+    </div>
+  </li>
+  <li>
+    <b>What should I do if my team or my name is not displayed correctly?</b>
+    <div>
+      Your team and your name are set by your course instructor and you should contact the instructor to change accordingly.
+    </div>
+  </li>
+  <li>
+    <b>Why can't I see the feedback I receive after submitting my responses?</b>
+    <div>
+      You will only be able to see the feedback received after your instructor publishes the session results.
+    </div>
+  </li>
+</ul>

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -55,7 +55,7 @@ exports[`SessionResultPageComponent should snap when session results failed to l
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>
@@ -204,7 +204,7 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>
@@ -350,7 +350,7 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>
@@ -496,7 +496,7 @@ exports[`SessionResultPageComponent should snap with session details and results
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>
@@ -591,7 +591,7 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>
@@ -884,7 +884,7 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (recommended). 
         </div>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -10,7 +10,7 @@
       </div>
       <div *ngIf="!loggedInUser">
         You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are currently open and view results without logging in.
-        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">login using a Google account</a> (recommended).
+        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">log in using a Google account</a> (recommended).
       </div>
     </div>
   </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -73,7 +73,7 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>
@@ -223,7 +223,7 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>
@@ -370,7 +370,7 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>
@@ -763,7 +763,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>
@@ -3229,7 +3229,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>
@@ -5870,7 +5870,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
           <a
             href="#"
           >
-            login using a Google account
+            log in using a Google account
           </a>
            (optional). 
         </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -36,7 +36,7 @@
       </div>
       <div *ngIf="!loggedInUser">
         You are submitting feedback as <mark><b>{{ personName }}</b></mark>. You may submit feedback for sessions that are currently open and view results without logging in.
-        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">login using a Google account</a> (optional).
+        To access other features you need to <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">log in using a Google account</a> (optional).
       </div>
     </div>
   </div>

--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -1,22 +1,20 @@
-<main>
-  <h1 class="color-orange">
-    Contact Us
-  </h1>
-  <img src="assets/images/contact.png">
-  <p>
-    <b>Email:</b> You can contact us at the following email address: <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a>.
-  </p>
-  <p>
-    <b>Blog:</b> Visit the <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer">TEAMMATES Blog</a> to see our latest updates and information.
-  </p>
-  <p>
-    <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
-  </p>
-  <p>
-    <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Developer Website</a>.
-  </p>
-  <p>
-    <b>Becoming a sponsor</b>:
-    If you are interested in sponsoring the TEAMMATES service for a period of time, please contact us at the above email address for details.
-  </p>
-</main>
+<h1 class="color-orange">
+  Contact Us
+</h1>
+<img src="assets/images/contact.png">
+<p>
+  <b>Email:</b> You can contact us at the following email address: <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a>.
+</p>
+<p>
+  <b>Blog:</b> Visit the <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer">TEAMMATES Blog</a> to see our latest updates and information.
+</p>
+<p>
+  <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
+</p>
+<p>
+  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Developer Website</a>.
+</p>
+<p>
+  <b>Becoming a sponsor</b>:
+  If you are interested in sponsoring the TEAMMATES service for a period of time, please contact us at the above email address for details.
+</p>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -131,13 +131,13 @@
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">No signup required for students</h2>
-      <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
+      <h2 class="color-orange col-xs-12">No sign up required for students</h2>
+      <img src="assets/images/feature-nosignuprequired.png" alt="No sign up required for students">
       <div class="col-xs-9 col-sm-9">
         <div>
-          Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to login or signup.
+          Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to log in or sign up.
           <br><br>
-          If they login to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
+          If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
         </div>
       </div>
     </div>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -131,8 +131,8 @@
 <section class="row">
   <div class="col-xs-12 col-sm-8 offset-sm-1">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">No sign up required for students</h2>
-      <img src="assets/images/feature-nosignuprequired.png" alt="No sign up required for students">
+      <h2 class="color-orange col-xs-12">No signup required for students</h2>
+      <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
       <div class="col-xs-9 col-sm-9">
         <div>
           Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to log in or sign up.

--- a/src/web/app/pages-static/index-page/index-page.component.html
+++ b/src/web/app/pages-static/index-page/index-page.component.html
@@ -1,19 +1,17 @@
-<main>
-  <p class="h2 color-orange text-center">
-    Student peer evaluations/feedback, shareable instructor comments, and more...
-  </p>
-  <div class="text-center">
-    <img class="mx-auto" alt="Overview of TEAMMATES - anonymous peer feedback and confidential peer evaluations" src="assets/images/overview.png">
+<p class="h2 color-orange text-center">
+  Student peer evaluations/feedback, shareable instructor comments, and more...
+</p>
+<div class="text-center">
+  <img class="mx-auto" alt="Overview of TEAMMATES - anonymous peer feedback and confidential peer evaluations" src="assets/images/overview.png">
+</div>
+<p class="h4 color-blue text-center">
+  <span class="color-orange">{{ submissionsNumber }}</span> feedback entries submitted so far ...
+</p>
+<div class="row">
+  <div class="margin-bottom-10px button-center col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3 d-grid">
+    <a class="btn btn-success" tmRouterLink="/web/front/request">Request a Free Instructor Account</a>
   </div>
-  <p class="h4 color-blue text-center">
-    <span class="color-orange">{{ submissionsNumber }}</span> feedback entries submitted so far ...
-  </p>
-  <div class="row">
-    <div class="margin-bottom-10px button-center col-xs-10 offset-xs-1 col-sm-5 offset-sm-0 col-md-4 col-lg-3 d-grid">
-      <a class="btn btn-success" tmRouterLink="/web/front/request">Request a Free Instructor Account</a>
-    </div>
-  </div>
-</main>
+</div>
 
 <div class="text-center">
   <img id="raisedEdge" src="assets/images/raised-edge.png" aria-hidden="true">

--- a/src/web/app/pages-static/request-page/request-page.component.html
+++ b/src/web/app/pages-static/request-page/request-page.component.html
@@ -1,16 +1,14 @@
-<main>
-  <h1 class="color-orange">
-    Request for an Account
-  </h1>
-  <div *ngIf="accountRequestFormUrl">
-    <p>
-      Cannot see the request form below? <a [href]="accountRequestFormUrl" target="_blank" rel="noopener noreferrer">Click here.</a>
-    </p>
-    <iframe [src]="accountRequestFormUrl" width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
-      Loading...
-    </iframe>
-  </div>
-  <div *ngIf="!accountRequestFormUrl">
-    The URL for the account request form is not set.
-  </div>
-</main>
+<h1 class="color-orange">
+  Request for an Account
+</h1>
+<div *ngIf="accountRequestFormUrl">
+  <p>
+    Cannot see the request form below? <a [href]="accountRequestFormUrl" target="_blank" rel="noopener noreferrer">Click here.</a>
+  </p>
+  <iframe [src]="accountRequestFormUrl" width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
+    Loading...
+  </iframe>
+</div>
+<div *ngIf="!accountRequestFormUrl">
+  The URL for the account request form is not set.
+</div>

--- a/src/web/app/pages-static/terms-page/terms-page.component.html
+++ b/src/web/app/pages-static/terms-page/terms-page.component.html
@@ -1,22 +1,20 @@
-<main>
-  <h1 class="color-orange">
-    Terms of Use
-  </h1>
-  <img src="assets/images/terms.png">
-  <p>
-    By using <b>TEAMMATES</b>, you agree to the following terms of use:
-  </p>
-  <p>
-    <b>Quality of service</b>: We take pride in our work and we shall do our best to provide good service to users. However, the service is provided "AS IS" and WITHOUT ANY WARRANTY.
-    You use TEAMMATES at your own discretion and risk and you will be solely responsible for any damages that may arise from such use.
-  </p>
-  <p>
-    <b>Changes to the service</b>: We strive to improve TEAMMATES continuously and provide its services free for as long as we can. However, TEAMMATES services may change or be terminated at our discretion.
-  </p>
-  <p>
-    <b>Security and privacy of data</b>: Our data are stored in Google servers and are protected by the same security mechanisms that protect Google data.
-    However, you are advised not to store in TEAMMATES any 'sensitive' data such as credit card numbers and passwords.<br>
-    We do not use TEAMMATES data for research or share TEAMMATES data with third parties.
-    While TEAMMATES maintainers (tenured developers) have some access to system data for performance monitoring and troubleshooting purposes, only TEAMMATES administrators have access to secured and identifiable data.
-  </p>
-</main>
+<h1 class="color-orange">
+  Terms of Use
+</h1>
+<img src="assets/images/terms.png">
+<p>
+  By using <b>TEAMMATES</b>, you agree to the following terms of use:
+</p>
+<p>
+  <b>Quality of service</b>: We take pride in our work and we shall do our best to provide good service to users. However, the service is provided "AS IS" and WITHOUT ANY WARRANTY.
+  You use TEAMMATES at your own discretion and risk and you will be solely responsible for any damages that may arise from such use.
+</p>
+<p>
+  <b>Changes to the service</b>: We strive to improve TEAMMATES continuously and provide its services free for as long as we can. However, TEAMMATES services may change or be terminated at our discretion.
+</p>
+<p>
+  <b>Security and privacy of data</b>: Our data are stored in Google servers and are protected by the same security mechanisms that protect Google data.
+  However, you are advised not to store in TEAMMATES any 'sensitive' data such as credit card numbers and passwords.<br>
+  We do not use TEAMMATES data for research or share TEAMMATES data with third parties.
+  While TEAMMATES maintainers (tenured developers) have some access to system data for performance monitoring and troubleshooting purposes, only TEAMMATES administrators have access to secured and identifiable data.
+</p>


### PR DESCRIPTION
Part of #12081.

Refactored `page.component.html` so that all page content is wrapped in `<main>` tag.

Other miscellaneous fixes include:
- Removing trailing spaces in github workflow files
- Removing unnecessary `<div>` tags in `page.component.html`
- Making minor changes to wording (e.g. `login` used as noun, `log in` used as verb)
