### PR TITLE
[#12048] Refactor v9 unit tests

### DIFF
--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestDbIT.java
@@ -62,7 +62,7 @@ public class AccountRequestDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("Delete account request that was created");
 
-        accountRequestDb.deleteAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+        accountRequestDb.deleteAccountRequest(accountRequest);
 
         AccountRequest actualAccountRequest =
                 accountRequestDb.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -47,12 +47,12 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().begin();
+        HibernateUtil.beginTransaction();
     }
 
     @AfterMethod
     public void tearDown() {
-        HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().rollback();
+        HibernateUtil.rollbackTransaction();
     }
 
     /**

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -141,7 +141,7 @@ public final class HibernateUtil {
      * or null if there is no such persistent instance.
      * @see Session#get(Class, Object)
      */
-    public static <T> T get(Class<T> entityType, Object id) {
+    public static <T extends BaseEntity> T get(Class<T> entityType, Object id) {
         return HibernateUtil.getCurrentSession().get(entityType, id);
     }
 

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -24,7 +24,7 @@ import teammates.storage.sqlentity.UsageStatistics;
 import teammates.storage.sqlentity.User;
 
 /**
- * Utility class for Hibernate.
+ * Utility class for Hibernate related methods.
  */
 public final class HibernateUtil {
     private static SessionFactory sessionFactory;

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
@@ -118,7 +118,7 @@ public final class AccountRequestDb extends EntitiesDb<AccountRequest> {
     }
 
     /**
-     * Delete an AccountRequest.
+     * Deletes an AccountRequest.
      */
     public void deleteAccountRequest(AccountRequest accountRequest) {
         if (accountRequest != null) {

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
@@ -118,14 +118,11 @@ public final class AccountRequestDb extends EntitiesDb<AccountRequest> {
     }
 
     /**
-     * Delete the AccountRequest with the given email and institute from the database.
+     * Delete an AccountRequest.
      */
-    public void deleteAccountRequest(String email, String institute) {
-        assert email != null && institute != null;
-
-        AccountRequest accountRequestToDelete = getAccountRequest(email, institute);
-        if (accountRequestToDelete != null) {
-            delete(accountRequestToDelete);
+    public void deleteAccountRequest(AccountRequest accountRequest) {
+        if (accountRequest != null) {
+            delete(accountRequest);
         }
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestDb.java
@@ -57,7 +57,7 @@ public final class AccountRequestDb extends EntitiesDb<AccountRequest> {
      * Get AccountRequest by {@code email} and {@code institute} from database.
      */
     public AccountRequest getAccountRequest(String email, String institute) {
-        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
+        Session currentSession = HibernateUtil.getCurrentSession();
         CriteriaBuilder cb = currentSession.getCriteriaBuilder();
         CriteriaQuery<AccountRequest> cr = cb.createQuery(AccountRequest.class);
         Root<AccountRequest> root = cr.from(AccountRequest.class);

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -1,7 +1,5 @@
 package teammates.storage.sqlapi;
 
-import java.time.Instant;
-
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -72,45 +70,10 @@ public final class CoursesDb extends EntitiesDb<Course> {
     /**
      * Deletes a course.
      */
-    public void deleteCourse(String courseId) {
-        assert courseId != null;
-
-        Course course = getCourse(courseId);
+    public void deleteCourse(Course course) {
         if (course != null) {
             delete(course);
         }
     }
 
-    /**
-     * Soft-deletes a course by its given corresponding ID.
-     *
-     * @return Soft-deletion time of the course.
-     */
-    public Instant softDeleteCourse(String courseId) throws EntityDoesNotExistException {
-        assert courseId != null;
-
-        Course course = getCourse(courseId);
-        if (course == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        course.setDeletedAt(Instant.now());
-
-        return course.getDeletedAt();
-    }
-
-    /**
-     * Restores a soft-deleted course by its given corresponding ID.
-     */
-    public void restoreDeletedCourse(String courseId) throws EntityDoesNotExistException {
-        assert courseId != null;
-
-        Course course = getCourse(courseId);
-
-        if (course == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        course.setDeletedAt(null);
-    }
 }

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -31,7 +31,7 @@ public final class CoursesDb extends EntitiesDb<Course> {
     public Course getCourse(String courseId) {
         assert courseId != null;
 
-        return HibernateUtil.getSessionFactory().getCurrentSession().get(Course.class, courseId);
+        return HibernateUtil.get(Course.class, courseId);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/EntitiesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/EntitiesDb.java
@@ -25,7 +25,7 @@ class EntitiesDb<E extends BaseEntity> {
     E merge(E entity) {
         assert entity != null;
 
-        E newEntity = HibernateUtil.getSessionFactory().getCurrentSession().merge(entity);
+        E newEntity = HibernateUtil.merge(entity);
         log.info("Entity saves: " + JsonUtils.toJson(entity));
         return newEntity;
     }
@@ -36,7 +36,7 @@ class EntitiesDb<E extends BaseEntity> {
     void persist(E entity) {
         assert entity != null;
 
-        HibernateUtil.getSessionFactory().getCurrentSession().persist(entity);
+        HibernateUtil.persist(entity);
         log.info("Entity persisted: " + JsonUtils.toJson(entity));
     }
 
@@ -46,7 +46,7 @@ class EntitiesDb<E extends BaseEntity> {
     void delete(E entity) {
         assert entity != null;
 
-        HibernateUtil.getSessionFactory().getCurrentSession().remove(entity);
+        HibernateUtil.remove(entity);
         log.info("Entity deleted: " + JsonUtils.toJson(entity));
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -1,7 +1,5 @@
 package teammates.storage.sqlapi;
 
-import java.time.Instant;
-
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
@@ -25,39 +23,14 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
     }
 
     /**
-     * Gets a feedback session that is not soft-deleted.
+     * Gets a feedback session.
      *
-     * @return null if not found or soft-deleted.
+     * @return null if not found
      */
     public FeedbackSession getFeedbackSession(Integer fsId) {
         assert fsId != null;
 
-        FeedbackSession fs = HibernateUtil.get(FeedbackSession.class, fsId);
-
-        if (fs != null && fs.getDeletedAt() != null) {
-            log.info("Trying to access soft-deleted session: " + fs.getName() + "/" + fs.getCourse().getId());
-            return null;
-        }
-
-        return fs;
-    }
-
-    /**
-     * Gets a soft-deleted feedback session.
-     *
-     * @return null if not found or not soft-deleted.
-     */
-    public FeedbackSession getSoftDeletedFeedbackSession(Integer fsId) {
-        assert fsId != null;
-
-        FeedbackSession fs = HibernateUtil.get(FeedbackSession.class, fsId);
-
-        if (fs != null && fs.getDeletedAt() != null) {
-            log.info(fs.getName() + "/" + fs.getCourse().getId() + " is not soft-deleted");
-            return null;
-        }
-
-        return fs;
+        return HibernateUtil.get(FeedbackSession.class, fsId);
     }
 
     /**
@@ -80,41 +53,6 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
         }
 
         return merge(feedbackSession);
-    }
-
-    /**
-     * Soft-deletes a feedback session.
-     *
-     * @return Soft-deletion time of the feedback session.
-     */
-    public Instant softDeleteFeedbackSession(Integer fsId)
-            throws EntityDoesNotExistException {
-        assert fsId != null;
-
-        FeedbackSession fs = getFeedbackSession(fsId);
-        if (fs == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        fs.setDeletedAt(Instant.now());
-
-        return fs.getDeletedAt();
-    }
-
-    /**
-     * Restores a specific soft deleted feedback session.
-     */
-    public void restoreDeletedFeedbackSession(Integer fsId)
-            throws EntityDoesNotExistException {
-        assert fsId != null;
-
-        FeedbackSession fs = getFeedbackSession(fsId);
-
-        if (fs == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        fs.setDeletedAt(null);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -32,7 +32,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
     public FeedbackSession getFeedbackSession(Integer fsId) {
         assert fsId != null;
 
-        FeedbackSession fs = HibernateUtil.getSessionFactory().getCurrentSession().get(FeedbackSession.class, fsId);
+        FeedbackSession fs = HibernateUtil.get(FeedbackSession.class, fsId);
 
         if (fs != null && fs.getDeletedAt() != null) {
             log.info("Trying to access soft-deleted session: " + fs.getName() + "/" + fs.getCourse().getId());
@@ -50,7 +50,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
     public FeedbackSession getSoftDeletedFeedbackSession(Integer fsId) {
         assert fsId != null;
 
-        FeedbackSession fs = HibernateUtil.getSessionFactory().getCurrentSession().get(FeedbackSession.class, fsId);
+        FeedbackSession fs = HibernateUtil.get(FeedbackSession.class, fsId);
 
         if (fs != null && fs.getDeletedAt() != null) {
             log.info(fs.getName() + "/" + fs.getCourse().getId() + " is not soft-deleted");

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -68,14 +68,11 @@ public final class NotificationsDb extends EntitiesDb<Notification> {
     }
 
     /**
-     * Deletes a notification by its unique ID.
+     * Deletes a notification.
      *
-     * <p>Fails silently if there is no such notification.
+     * <p>Fails silently if notification is null.
      */
-    public void deleteNotification(UUID notificationId) {
-        assert notificationId != null;
-
-        Notification notification = getNotification(notificationId);
+    public void deleteNotification(Notification notification) {
         if (notification != null) {
             delete(notification);
         }

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -46,7 +46,7 @@ public final class NotificationsDb extends EntitiesDb<Notification> {
     public Notification getNotification(UUID notificationId) {
         assert notificationId != null;
 
-        return HibernateUtil.getSessionFactory().getCurrentSession().get(Notification.class, notificationId);
+        return HibernateUtil.get(Notification.class, notificationId);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
@@ -33,7 +33,7 @@ public final class UsageStatisticsDb extends EntitiesDb<UsageStatistics> {
      * Gets a list of statistics objects between start time and end time.
      */
     public List<UsageStatistics> getUsageStatisticsForTimeRange(Instant startTime, Instant endTime) {
-        Session session = HibernateUtil.getSessionFactory().getCurrentSession();
+        Session session = HibernateUtil.getCurrentSession();
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaQuery<UsageStatistics> cr = cb.createQuery(UsageStatistics.class);
         Root<UsageStatistics> root = cr.from(UsageStatistics.class);

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -8,8 +8,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
 import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import com.google.cloud.datastore.DatastoreException;
 
@@ -116,19 +114,15 @@ public class WebApiServlet extends HttpServlet {
     private ActionResult executeWithTransaction(Action action, HttpServletRequest req)
             throws InvalidOperationException, InvalidHttpRequestBodyException, UnauthorizedAccessException {
         try {
-            HibernateUtil.getSessionFactory().getCurrentSession().beginTransaction();
+            HibernateUtil.beginTransaction();
             action.init(req);
             action.checkAccessControl();
 
             ActionResult result = action.execute();
-            HibernateUtil.getSessionFactory().getCurrentSession().getTransaction().commit();
+            HibernateUtil.commitTransaction();
             return result;
         } catch (Exception e) {
-            Session session = HibernateUtil.getSessionFactory().getCurrentSession();
-            if (session.getTransaction().getStatus() == TransactionStatus.ACTIVE
-                    || session.getTransaction().getStatus() == TransactionStatus.MARKED_ROLLBACK) {
-                session.getTransaction().rollback();
-            }
+            HibernateUtil.rollbackTransaction();
             throw e;
         }
     }

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -79,7 +79,7 @@ class CreateCourseAction extends Action {
             throw new InvalidHttpRequestBodyException(e);
         }
 
-        HibernateUtil.getSessionFactory().getCurrentSession().flush();
+        HibernateUtil.flushSession();
         CourseData courseData = new CourseData(course);
         return new JsonResult(courseData);
     }

--- a/src/test/java/teammates/storage/sqlapi/AccountRequestDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountRequestDbTest.java
@@ -66,7 +66,7 @@ public class AccountRequestDbTest extends BaseTestCase {
         AccountRequest returnedAccountRequest = new AccountRequest("test@gmail.com", "name", "institute");
         doReturn(returnedAccountRequest).when(accountRequestDb).getAccountRequest(anyString(), anyString());
 
-        accountRequestDb.deleteAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+        accountRequestDb.deleteAccountRequest(accountRequest);
 
         verify(session, times(1)).remove(returnedAccountRequest);
     }

--- a/src/test/java/teammates/storage/sqlapi/AccountRequestDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountRequestDbTest.java
@@ -2,14 +2,12 @@ package teammates.storage.sqlapi;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -26,26 +24,27 @@ public class AccountRequestDbTest extends BaseTestCase {
 
     private AccountRequestDb accountRequestDb;
 
-    private Session session;
+    private MockedStatic<HibernateUtil> mockHibernateUtil;
 
     @BeforeMethod
-    public void setUp() {
+    public void setUpMethod() {
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
         accountRequestDb = spy(AccountRequestDb.class);
-        session = spy(Session.class);
-        SessionFactory sessionFactory = spy(SessionFactory.class);
+    }
 
-        HibernateUtil.setSessionFactory(sessionFactory);
-
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
+    @AfterMethod
+    public void teardownMethod() {
+        mockHibernateUtil.close();
     }
 
     @Test
     public void createAccountRequestDoesNotExist() throws InvalidParametersException, EntityAlreadyExistsException {
         AccountRequest accountRequest = new AccountRequest("test@gmail.com", "name", "institute");
         doReturn(null).when(accountRequestDb).getAccountRequest(anyString(), anyString());
+
         accountRequestDb.createAccountRequest(accountRequest);
 
-        verify(session, times(1)).persist(accountRequest);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest));
     }
 
     @Test
@@ -56,18 +55,17 @@ public class AccountRequestDbTest extends BaseTestCase {
 
         EntityAlreadyExistsException ex = assertThrows(EntityAlreadyExistsException.class,
                 () -> accountRequestDb.createAccountRequest(accountRequest));
+
         assertEquals(ex.getMessage(), "Trying to create an entity that exists: " + accountRequest.toString());
-        verify(session, never()).persist(accountRequest);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest), never());
     }
 
     @Test
     public void deleteAccountRequest() {
         AccountRequest accountRequest = new AccountRequest("test@gmail.com", "name", "institute");
-        AccountRequest returnedAccountRequest = new AccountRequest("test@gmail.com", "name", "institute");
-        doReturn(returnedAccountRequest).when(accountRequestDb).getAccountRequest(anyString(), anyString());
 
         accountRequestDb.deleteAccountRequest(accountRequest);
 
-        verify(session, times(1)).remove(returnedAccountRequest);
+        mockHibernateUtil.verify(() -> HibernateUtil.remove(accountRequest));
     }
 }

--- a/src/test/java/teammates/storage/sqlapi/CoursesDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/CoursesDbTest.java
@@ -1,13 +1,10 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -24,14 +21,16 @@ public class CoursesDbTest extends BaseTestCase {
 
     private CoursesDb coursesDb = CoursesDb.inst();
 
-    private Session session;
+    private MockedStatic<HibernateUtil> mockHibernateUtil;
 
     @BeforeMethod
-    public void setUp() {
-        session = mock(Session.class);
-        SessionFactory sessionFactory = mock(SessionFactory.class);
-        HibernateUtil.setSessionFactory(sessionFactory);
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
+    public void setUpMethod() {
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
+    }
+
+    @AfterMethod
+    public void teardownMethod() {
+        mockHibernateUtil.close();
     }
 
     @Test
@@ -39,22 +38,20 @@ public class CoursesDbTest extends BaseTestCase {
             throws InvalidParametersException, EntityAlreadyExistsException {
         Course c = new Course("course-id", "course-name", null, "institute");
 
-        when(session.get(Course.class, "course-id")).thenReturn(null);
-
         coursesDb.createCourse(c);
 
-        verify(session, times(1)).persist(c);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(c));
     }
 
     @Test
     public void testCreateCourse_courseAlreadyExists_throwsEntityAlreadyExistsException() {
         Course c = new Course("course-id", "course-name", null, "institute");
-
-        when(session.get(Course.class, "course-id")).thenReturn(c);
+        mockHibernateUtil.when(() -> HibernateUtil.get(Course.class, "course-id")).thenReturn(c);
 
         EntityAlreadyExistsException ex = assertThrows(EntityAlreadyExistsException.class,
                 () -> coursesDb.createCourse(c));
+
         assertEquals(ex.getMessage(), "Trying to create an entity that exists: " + c.toString());
-        verify(session, never()).persist(c);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(c), never());
     }
 }

--- a/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
@@ -1,16 +1,13 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.UUID;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -29,14 +26,16 @@ public class NotificationsDbTest extends BaseTestCase {
 
     private NotificationsDb notificationsDb = NotificationsDb.inst();
 
-    private Session session;
+    private MockedStatic<HibernateUtil> mockHibernateUtil;
 
     @BeforeMethod
-    public void setUp() {
-        session = mock(Session.class);
-        SessionFactory sessionFactory = mock(SessionFactory.class);
-        HibernateUtil.setSessionFactory(sessionFactory);
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
+    public void setUpMethod() {
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
+    }
+
+    @AfterMethod
+    public void teardownMethod() {
+        mockHibernateUtil.close();
     }
 
     @Test
@@ -48,7 +47,7 @@ public class NotificationsDbTest extends BaseTestCase {
 
         notificationsDb.createNotification(newNotification);
 
-        verify(session, times(1)).persist(newNotification);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(newNotification));
     }
 
     @Test
@@ -58,7 +57,7 @@ public class NotificationsDbTest extends BaseTestCase {
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");
 
         assertThrows(InvalidParametersException.class, () -> notificationsDb.createNotification(invalidNotification));
-        verify(session, never()).persist(invalidNotification);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(invalidNotification), never());
     }
 
     @Test
@@ -68,7 +67,7 @@ public class NotificationsDbTest extends BaseTestCase {
                 "", "<p>Deprecation happens in three minutes</p>");
 
         assertThrows(InvalidParametersException.class, () -> notificationsDb.createNotification(invalidNotification));
-        verify(session, never()).persist(invalidNotification);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(invalidNotification), never());
     }
 
     @Test
@@ -78,7 +77,7 @@ public class NotificationsDbTest extends BaseTestCase {
                 "A deprecation note", "");
 
         assertThrows(InvalidParametersException.class, () -> notificationsDb.createNotification(invalidNotification));
-        verify(session, never()).persist(invalidNotification);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(invalidNotification), never());
     }
 
     @Test
@@ -87,10 +86,9 @@ public class NotificationsDbTest extends BaseTestCase {
                 Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");
         notification.setNotificationId(UUID.randomUUID());
-        notificationsDb.createNotification(notification);
-        verify(session, times(1)).persist(notification);
+        mockHibernateUtil.when(() ->
+                HibernateUtil.get(Notification.class, notification.getNotificationId())).thenReturn(notification);
 
-        when(session.get(Notification.class, notification.getNotificationId())).thenReturn(notification);
         Notification actualNotification = notificationsDb.getNotification(notification.getNotificationId());
 
         assertEquals(notification, actualNotification);
@@ -98,16 +96,9 @@ public class NotificationsDbTest extends BaseTestCase {
 
     @Test
     public void testGetNotification_entityDoesNotExist() throws EntityAlreadyExistsException, InvalidParametersException {
-        Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
-                Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
-                "A deprecation note", "<p>Deprecation happens in three minutes</p>");
-        notification.setNotificationId(UUID.randomUUID());
-        notificationsDb.createNotification(notification);
-        verify(session, times(1)).persist(notification);
-
         UUID nonExistentId = UUID.fromString("00000000-0000-1000-0000-000000000000");
+        mockHibernateUtil.when(() -> HibernateUtil.get(Notification.class, nonExistentId)).thenReturn(null);
 
-        when(session.get(Notification.class, nonExistentId)).thenReturn(null);
         Notification actualNotification = notificationsDb.getNotification(nonExistentId);
 
         assertNull(actualNotification);

--- a/src/test/java/teammates/storage/sqlapi/UsageStatisticsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/UsageStatisticsDbTest.java
@@ -1,14 +1,11 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 import java.time.Instant;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -23,14 +20,16 @@ public class UsageStatisticsDbTest extends BaseTestCase {
 
     private UsageStatisticsDb usageStatisticsDb = UsageStatisticsDb.inst();
 
-    private Session session;
+    private MockedStatic<HibernateUtil> mockHibernateUtil;
 
     @BeforeMethod
-    public void setUp() {
-        session = mock(Session.class);
-        SessionFactory sessionFactory = mock(SessionFactory.class);
-        HibernateUtil.setSessionFactory(sessionFactory);
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
+    public void setUpMethod() {
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
+    }
+
+    @AfterMethod
+    public void teardownMethod() {
+        mockHibernateUtil.close();
     }
 
     @Test
@@ -40,7 +39,7 @@ public class UsageStatisticsDbTest extends BaseTestCase {
 
         usageStatisticsDb.createUsageStatistics(newUsageStatistics);
 
-        verify(session, times(1)).persist(newUsageStatistics);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(newUsageStatistics));
     }
 
 }

--- a/src/test/java/teammates/ui/servlets/WebApiServletTest.java
+++ b/src/test/java/teammates/ui/servlets/WebApiServletTest.java
@@ -1,7 +1,6 @@
 package teammates.ui.servlets;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -11,9 +10,8 @@ import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,17 +33,19 @@ public class WebApiServletTest extends BaseTestCase {
 
     private static final WebApiServlet SERVLET = new WebApiServlet();
 
+    private static MockedStatic<HibernateUtil> mockHibernateUtil;
+
     private MockHttpServletRequest mockRequest;
     private MockHttpServletResponse mockResponse;
 
     @BeforeClass
     public static void classSetup() {
-        SessionFactory sessionFactory = mock(SessionFactory.class);
-        Session session = mock(Session.class);
-        Transaction transaction = mock(Transaction.class);
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
-        when(session.getTransaction()).thenReturn(transaction);
-        HibernateUtil.setSessionFactory(sessionFactory);
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
+    }
+
+    @AfterClass
+    public static void classTeardown() {
+        mockHibernateUtil.close();
     }
 
     private void setupMocks(String method, String requestUrl) {


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

- Move hibernate related methods to HibernateUtil. Extra level of indirection to facilitate testing, see "Don't mock what you don't own" heuristic.
- Change parameters of remove in db layer from the entities id/natural key to the entity itself.
- Updated tests to use new mocks.
- Remove unnecessary methods in db layer.