### PR TITLE
fix: add manual branch coverage (#49)

### DIFF
--- a/src/web/app/components/visibility-messages/visibility-capability.pipe.spec.ts
+++ b/src/web/app/components/visibility-messages/visibility-capability.pipe.spec.ts
@@ -4,5 +4,8 @@ describe('VisibilityCapabilityPipe', () => {
   it('create an instance', () => {
     const pipe: VisibilityCapabilityPipe = new VisibilityCapabilityPipe();
     expect(pipe).toBeTruthy();
+    pipe.transform({SHOW_RESPONSE: true, SHOW_GIVER_NAME: true, SHOW_RECIPIENT_NAME: true});
+
+    console.log(pipe.b);
   });
 });

--- a/src/web/app/components/visibility-messages/visibility-capability.pipe.ts
+++ b/src/web/app/components/visibility-messages/visibility-capability.pipe.ts
@@ -9,6 +9,7 @@ import { VisibilityControl } from '../../../types/visibility-control';
 })
 export class VisibilityCapabilityPipe implements PipeTransform {
 
+  b: Record<number, boolean> = Object.fromEntries([...new Array(5)].map((_, i) => [i, false]));
   /**
    * Transforms a map of VisibilityControl to a capability description.
    *
@@ -19,16 +20,21 @@ export class VisibilityCapabilityPipe implements PipeTransform {
     let message: string = 'can see your response';
 
     if (controls.SHOW_RECIPIENT_NAME) {
+      this.b[0] = true;
       message += ', the name of the recipient';
 
       if (controls.SHOW_GIVER_NAME) {
+        this.b[1] = true;
         message += ', and your name';
       } else {
+        this.b[2] = true;
         message += ', but not your name';
       }
     } else if (controls.SHOW_GIVER_NAME) {
+      this.b[3] = true;
       message += ', and your name, but not the name of the recipient';
     } else {
+      this.b[4] = true;
       message += ', but not the name of the recipient, or your name';
     }
 


### PR DESCRIPTION
DON'T MERGE!

Solves #49 as part of #4.

> 1. What is the quality of your own coverage measurement? Does it take into account ternary operators (condition ? yes : no) and exceptions, if available in your language?

It measures the branch coverage for this function only. It does not take ternary operators into account, but there are no ternary operators in this function.

> 2. What are the limitations of your tool? How would the instrumentation change if you modify the program?

It only works for this exact version of the function and would have to be remade if any changes are made to it.

> 3. If you have an automated tool, are your results consistent with the ones produced by existing tool(s)?

Yes.

Result of manual branch coverage:

```
console.log
      { '0': true, '1': true, '2': false, '3': false, '4': false }

      at src/web/app/components/visibility-messages/visibility-capability.pipe.spec.ts:9:13
```