### PR TITLE
[#12115] Instructor viewing results of rubric questions: some students not shown in the stats table

### DIFF
--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
@@ -98,25 +98,28 @@ export class RubricQuestionStatisticsCalculation
 
     // calculate per recipient stats
     for (const response of this.responses) {
-      this.perRecipientStatsMap[response.recipient] = this.perRecipientStatsMap[response.recipient] || {
-        recipientName: response.recipient,
-        recipientEmail: response.recipientEmail,
-        recipientTeam: response.recipientTeam,
-        answers: JSON.parse(JSON.stringify(emptyAnswers)),
-        answersSum: [],
-        percentages: [],
-        percentagesAverage: [],
-        weightsAverage: [],
-        subQuestionTotalChosenWeight: this.subQuestions.map(() => 0),
-        subQuestionWeightAverage: [],
-      };
+      this.perRecipientStatsMap[response.recipientEmail || response.recipient] =
+        this.perRecipientStatsMap[
+          response.recipientEmail || response.recipient
+        ] || {
+          recipientName: response.recipient,
+          recipientEmail: response.recipientEmail,
+          recipientTeam: response.recipientTeam,
+          answers: JSON.parse(JSON.stringify(emptyAnswers)),
+          answersSum: [],
+          percentages: [],
+          percentagesAverage: [],
+          weightsAverage: [],
+          subQuestionTotalChosenWeight: this.subQuestions.map(() => 0),
+          subQuestionWeightAverage: [],
+        };
       for (let i: number = 0; i < response.responseDetails.answer.length; i += 1) {
         const subAnswer: number = response.responseDetails.answer[i];
         if (subAnswer === RUBRIC_ANSWER_NOT_CHOSEN) {
           continue;
         }
-        this.perRecipientStatsMap[response.recipient].answers[i][subAnswer] += 1;
-        this.perRecipientStatsMap[response.recipient].subQuestionTotalChosenWeight[i] +=
+        this.perRecipientStatsMap[response.recipientEmail || response.recipient].answers[i][subAnswer] += 1;
+        this.perRecipientStatsMap[response.recipientEmail || response.recipient].subQuestionTotalChosenWeight[i] +=
             +this.weights[i][subAnswer].toFixed(5);
       }
     }

--- a/src/web/app/components/question-types/question-statistics/test-data/rubricQuestionResponses.json
+++ b/src/web/app/components/question-types/question-statistics/test-data/rubricQuestionResponses.json
@@ -58,7 +58,7 @@
     }
   ],
   "expectedStatsMap": {
-    "Alice": {
+    "alice@gmail.com": {
       "answers": [
         [1, 1], [1, 1], [2, 0]
       ],
@@ -76,7 +76,7 @@
       "overallWeightedSum": 2.8,
       "overallWeightAverage": 0.47
     },
-    "Bob": {
+    "bob@gmail.com": {
       "answers": [
         [2, 0], [1, 1], [2, 0]
       ],


### PR DESCRIPTION
Fixes #12115

**Outline of Solution**

- Issue (likely) caused by recipient (seems to be used interchangeably with recipient name) being identical.
- In this case, both recipients are counted as the same person for the purpose of displaying per recipient stats.
- Fix: Use email as key of perRecipientStats when available. When not available, default to using recipient.