### PR TITLE
[#12081] User-friendliness: Landmark questions in feedback sessions results page

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -406,7 +406,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private void showAdditionalInfo(int qnNumber) {
-        WebElement additionalInfoLink = getQuestionResponsesSection(qnNumber).findElement(By.id("additional-info-link"));
+        WebElement additionalInfoLink = getQuestionResponsesSection(qnNumber).findElement(By.id("additional-info-button"));
         if ("[more]".equals(additionalInfoLink.getText())) {
             click(additionalInfoLink);
             waitUntilAnimationFinish();

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -40,14 +40,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               >
                  How well did team member perform?
               </span>
-              <a
-                class="info-font-size ms-1"
-                id="additional-info-link"
-                queryparamshandling="merge"
-                tabindex="0"
+              <button
+                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                id="additional-info-button"
               >
                  [more] 
-              </a>
+              </button>
             </span>
           </tm-question-text-with-info>
           <div
@@ -145,14 +143,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               >
                  Rate your teammates in contribution
               </span>
-              <a
-                class="info-font-size ms-1"
-                id="additional-info-link"
-                queryparamshandling="merge"
-                tabindex="0"
+              <button
+                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                id="additional-info-button"
               >
                  [more] 
-              </a>
+              </button>
             </span>
           </tm-question-text-with-info>
           <div
@@ -297,14 +293,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               >
                  Rate your teammates proficiency
               </span>
-              <a
-                class="info-font-size ms-1"
-                id="additional-info-link"
-                queryparamshandling="merge"
-                tabindex="0"
+              <button
+                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                id="additional-info-button"
               >
                  [more] 
-              </a>
+              </button>
             </span>
           </tm-question-text-with-info>
           <div

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -29,13 +29,11 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <h3
+              <h2
                 class="col-auto question-number"
               >
-                <b>
-                  Question 1: 
-                </b>
-              </h3>
+                 Question 1:  
+              </h2>
               <span
                 class="col-auto"
                 id="question-text"
@@ -136,13 +134,11 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <h3
+              <h2
                 class="col-auto question-number"
               >
-                <b>
-                  Question 2: 
-                </b>
-              </h3>
+                 Question 2:  
+              </h2>
               <span
                 class="col-auto"
                 id="question-text"
@@ -290,13 +286,11 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <h3
+              <h2
                 class="col-auto question-number"
               >
-                <b>
-                  Question 3: 
-                </b>
-              </h3>
+                 Question 3:  
+              </h2>
               <span
                 class="col-auto"
                 id="question-text"
@@ -477,13 +471,11 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <h3
+              <h2
                 class="col-auto question-number"
               >
-                <b>
-                  Question 1: 
-                </b>
-              </h3>
+                 Question 1:  
+              </h2>
               <span
                 class="col-auto"
                 id="question-text"
@@ -670,13 +662,11 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <h3
+              <h2
                 class="col-auto question-number"
               >
-                <b>
-                  Question 2: 
-                </b>
-              </h3>
+                 Question 2:  
+              </h2>
               <span
                 class="col-auto"
                 id="question-text"

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -29,13 +29,13 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <span
-                class="col-auto"
+              <h3
+                class="col-auto question-number"
               >
                 <b>
                   Question 1: 
                 </b>
-              </span>
+              </h3>
               <span
                 class="col-auto"
                 id="question-text"
@@ -46,6 +46,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                 class="info-font-size ms-1"
                 id="additional-info-link"
                 queryparamshandling="merge"
+                tabindex="0"
               >
                  [more] 
               </a>
@@ -135,13 +136,13 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <span
-                class="col-auto"
+              <h3
+                class="col-auto question-number"
               >
                 <b>
                   Question 2: 
                 </b>
-              </span>
+              </h3>
               <span
                 class="col-auto"
                 id="question-text"
@@ -152,6 +153,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                 class="info-font-size ms-1"
                 id="additional-info-link"
                 queryparamshandling="merge"
+                tabindex="0"
               >
                  [more] 
               </a>
@@ -288,13 +290,13 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <span
-                class="col-auto"
+              <h3
+                class="col-auto question-number"
               >
                 <b>
                   Question 3: 
                 </b>
-              </span>
+              </h3>
               <span
                 class="col-auto"
                 id="question-text"
@@ -305,6 +307,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                 class="info-font-size ms-1"
                 id="additional-info-link"
                 queryparamshandling="merge"
+                tabindex="0"
               >
                  [more] 
               </a>
@@ -474,13 +477,13 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <span
-                class="col-auto"
+              <h3
+                class="col-auto question-number"
               >
                 <b>
                   Question 1: 
                 </b>
-              </span>
+              </h3>
               <span
                 class="col-auto"
                 id="question-text"
@@ -667,13 +670,13 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             <span
               class="d-inline-flex align-items-center"
             >
-              <span
-                class="col-auto"
+              <h3
+                class="col-auto question-number"
               >
                 <b>
                   Question 2: 
                 </b>
-              </span>
+              </h3>
               <span
                 class="col-auto"
                 id="question-text"

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -13,13 +13,11 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
   <span
     class="d-inline-flex align-items-center"
   >
-    <h3
+    <h2
       class="col-auto question-number"
     >
-      <b>
-        Question 0: 
-      </b>
-    </h3>
+       Question 0:  
+    </h2>
     <span
       class="col-auto"
       id="question-text"
@@ -43,13 +41,11 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
   <span
     class="d-inline-flex align-items-center"
   >
-    <h3
+    <h2
       class="col-auto question-number"
     >
-      <b>
-        Question 0: 
-      </b>
-    </h3>
+       Question 0:  
+    </h2>
     <span
       class="col-auto"
       id="question-text"
@@ -81,13 +77,11 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
   <span
     class="d-inline-flex align-items-center"
   >
-    <h3
+    <h2
       class="col-auto question-number"
     >
-      <b>
-        Question 0: 
-      </b>
-    </h3>
+       Question 0:  
+    </h2>
     <span
       class="col-auto"
       id="question-text"

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -13,13 +13,13 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
   <span
     class="d-inline-flex align-items-center"
   >
-    <span
-      class="col-auto"
+    <h3
+      class="col-auto question-number"
     >
       <b>
         Question 0: 
       </b>
-    </span>
+    </h3>
     <span
       class="col-auto"
       id="question-text"
@@ -43,13 +43,13 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
   <span
     class="d-inline-flex align-items-center"
   >
-    <span
-      class="col-auto"
+    <h3
+      class="col-auto question-number"
     >
       <b>
         Question 0: 
       </b>
-    </span>
+    </h3>
     <span
       class="col-auto"
       id="question-text"
@@ -60,6 +60,7 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
       class="info-font-size ms-1"
       id="additional-info-link"
       queryparamshandling="merge"
+      tabindex="0"
     >
        [more] 
     </a>
@@ -80,13 +81,13 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
   <span
     class="d-inline-flex align-items-center"
   >
-    <span
-      class="col-auto"
+    <h3
+      class="col-auto question-number"
     >
       <b>
         Question 0: 
       </b>
-    </span>
+    </h3>
     <span
       class="col-auto"
       id="question-text"
@@ -97,6 +98,7 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
       class="info-font-size ms-1"
       id="additional-info-link"
       queryparamshandling="merge"
+      tabindex="0"
     >
        [less] 
     </a>

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -52,14 +52,12 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
     >
        MCQ question details
     </span>
-    <a
-      class="info-font-size ms-1"
-      id="additional-info-link"
-      queryparamshandling="merge"
-      tabindex="0"
+    <button
+      class="info-font-size ms-1 border-0 bg-transparent text-primary"
+      id="additional-info-button"
     >
        [more] 
-    </a>
+    </button>
   </span>
 </tm-question-text-with-info>
 `;
@@ -88,14 +86,12 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
     >
        MCQ question details
     </span>
-    <a
-      class="info-font-size ms-1"
-      id="additional-info-link"
-      queryparamshandling="merge"
-      tabindex="0"
+    <button
+      class="info-font-size ms-1 border-0 bg-transparent text-primary"
+      id="additional-info-button"
     >
        [less] 
-    </a>
+    </button>
   </span><div
     class="info-font-size"
     id="additional-info"

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,12 +1,12 @@
 <span class="d-inline-flex align-items-center">
-  <span *ngIf="shouldShowDownloadQuestionResult" class="col-auto">
+  <h3 *ngIf="shouldShowDownloadQuestionResult" class="col-auto question-number">
     <button ngbTooltip="Download Question Results" type="button" class="btn btn-link padding-0" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
       <b>Question {{ questionNumber }}:</b>
     </button>
-  </span>
-  <span *ngIf="!shouldShowDownloadQuestionResult" class="col-auto">
+  </h3>
+  <h3 *ngIf="!shouldShowDownloadQuestionResult" class="col-auto question-number">
     <b>Question {{ questionNumber }}:&nbsp;</b>
-  </span>
+  </h3>
   <span id="question-text" class="col-auto">&nbsp;{{ questionDetails.questionText }}</span>
   <a id="additional-info-link" class="info-font-size ms-1" tabindex="0" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [tmRouterLink]="" queryParamsHandling="merge">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -8,9 +8,9 @@
     Question {{ questionNumber }}:&nbsp;
   </h2>
   <span id="question-text" class="col-auto">&nbsp;{{ questionDetails.questionText }}</span>
-  <a id="additional-info-link" class="info-font-size ms-1" tabindex="0" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [tmRouterLink]="" queryParamsHandling="merge">
+  <button id="additional-info-button" class="info-font-size ms-1 border-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
-  </a>
+  </button>
 </span>
 
 <div id="additional-info" class="info-font-size" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,12 +1,12 @@
 <span class="d-inline-flex align-items-center">
-  <h3 *ngIf="shouldShowDownloadQuestionResult" class="col-auto question-number">
+  <h2 *ngIf="shouldShowDownloadQuestionResult" class="col-auto question-number">
     <button ngbTooltip="Download Question Results" type="button" class="btn btn-link padding-0" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
-      <b>Question {{ questionNumber }}:</b>
+      Question {{ questionNumber }}:
     </button>
-  </h3>
-  <h3 *ngIf="!shouldShowDownloadQuestionResult" class="col-auto question-number">
-    <b>Question {{ questionNumber }}:&nbsp;</b>
-  </h3>
+  </h2>
+  <h2 *ngIf="!shouldShowDownloadQuestionResult" class="col-auto question-number">
+    Question {{ questionNumber }}:&nbsp;
+  </h2>
   <span id="question-text" class="col-auto">&nbsp;{{ questionDetails.questionText }}</span>
   <a id="additional-info-link" class="info-font-size ms-1" tabindex="0" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [tmRouterLink]="" queryParamsHandling="merge">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -8,7 +8,7 @@
     <b>Question {{ questionNumber }}:&nbsp;</b>
   </span>
   <span id="question-text" class="col-auto">&nbsp;{{ questionDetails.questionText }}</span>
-  <a id="additional-info-link" class="info-font-size ms-1" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [tmRouterLink]="" queryParamsHandling="merge">
+  <a id="additional-info-link" class="info-font-size ms-1" tabindex="0" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)" [tmRouterLink]="" queryParamsHandling="merge">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
   </a>
 </span>

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -5,3 +5,8 @@
 .col-auto {
   flex: 0 1 auto;
 }
+
+.question-number {
+  font-size: inherit;
+  margin: 0;
+}

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -9,4 +9,5 @@
 .question-number {
   font-size: inherit;
   margin: 0;
+  font-weight: bold;
 }

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.spec.ts
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.spec.ts
@@ -83,7 +83,7 @@ describe('QuestionTextWithInfoComponent', () => {
     component.questionDetails = mcqQuestionDetails;
     fixture.detectChanges();
 
-    const questionDetailControlLink: any = fixture.debugElement.query(By.css('a'));
+    const questionDetailControlLink: any = fixture.debugElement.query(By.css('button'));
 
     questionDetailControlLink.nativeElement.click();
     fixture.detectChanges();


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Feedback sessions results page: Landmark questions](https://github.com/TEAMMATES/teammates/projects/16#card-88047383)

**Outline of Solution**

1. Landmark questions
    - Turn `span` element into `h3` element, so that screen reader can pick them up for more accessible navigation. 
    - Add CSS `.question-number` to make `h3` element look the same as before.
3. Make [more] button focusable
    - Add `tabindex="0"` tag