### PR TITLE
[#12131] Instructor edit session times: timing restrictions are not as expected

### DIFF
--- a/src/web/app/components/timepicker/timepicker.component.ts
+++ b/src/web/app/components/timepicker/timepicker.component.ts
@@ -10,7 +10,6 @@ import { DateFormat, TimeFormat, getDefaultTimeFormat, getDefaultDateFormat } fr
   styleUrls: ['./timepicker.component.scss'],
 })
 export class TimepickerComponent {
-
   @Input()
   isDisabled: boolean = false;
 
@@ -70,21 +69,33 @@ export class TimepickerComponent {
    * datetime.
    */
   isOptionDisabled(t: TimeFormat): boolean {
-    if (this.minDate && this.minTime
-        && this.date.year === this.minDate?.year && this.date.month === this.minDate?.month
-        && this.date.day === this.minDate?.day
-        && (t.hour < this.minTime?.hour || t.minute < this.minTime?.minute)) {
-      return true;
+    const date = this.toJsDate(this.date, t);
+
+    if (this.minDate && this.minTime) {
+      const minDate = this.toJsDate(this.minDate, this.minTime);
+      if (date < minDate) {
+        return true;
+      }
     }
 
-    if (this.maxDate && this.maxTime
-        && this.date.year === this.maxDate?.year && this.date.month === this.maxDate?.month
-        && this.date.day === this.maxDate?.day
-        && (t.hour > this.maxTime?.hour || t.minute > this.maxTime?.minute)) {
-      return true;
+    if (this.maxDate && this.maxTime) {
+      const maxDate = this.toJsDate(this.maxDate, this.maxTime);
+      if (date > maxDate) {
+        return true;
+      }
     }
 
     return false;
+  }
+
+  private toJsDate(date: DateFormat, time: TimeFormat): Date {
+    return new Date(
+      date.year,
+      date.month - 1,
+      date.day,
+      time.hour,
+      time.minute,
+    );
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -764,121 +764,145 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="form-control form-select ng-untouched ng-pristine ng-valid"
                         >
                           <option
+                            disabled=""
                             value="1: Object"
                           >
                              01:00H 
                           </option>
                           <option
+                            disabled=""
                             value="2: Object"
                           >
                              02:00H 
                           </option>
                           <option
+                            disabled=""
                             value="3: Object"
                           >
                              03:00H 
                           </option>
                           <option
+                            disabled=""
                             value="4: Object"
                           >
                              04:00H 
                           </option>
                           <option
+                            disabled=""
                             value="5: Object"
                           >
                              05:00H 
                           </option>
                           <option
+                            disabled=""
                             value="6: Object"
                           >
                              06:00H 
                           </option>
                           <option
+                            disabled=""
                             value="7: Object"
                           >
                              07:00H 
                           </option>
                           <option
+                            disabled=""
                             value="8: Object"
                           >
                              08:00H 
                           </option>
                           <option
+                            disabled=""
                             value="9: Object"
                           >
                              09:00H 
                           </option>
                           <option
+                            disabled=""
                             value="10: Object"
                           >
                              10:00H 
                           </option>
                           <option
+                            disabled=""
                             value="11: Object"
                           >
                              11:00H 
                           </option>
                           <option
+                            disabled=""
                             value="12: Object"
                           >
                              12:00H 
                           </option>
                           <option
+                            disabled=""
                             value="13: Object"
                           >
                              13:00H 
                           </option>
                           <option
+                            disabled=""
                             value="14: Object"
                           >
                              14:00H 
                           </option>
                           <option
+                            disabled=""
                             value="15: Object"
                           >
                              15:00H 
                           </option>
                           <option
+                            disabled=""
                             value="16: Object"
                           >
                              16:00H 
                           </option>
                           <option
+                            disabled=""
                             value="17: Object"
                           >
                              17:00H 
                           </option>
                           <option
+                            disabled=""
                             value="18: Object"
                           >
                              18:00H 
                           </option>
                           <option
+                            disabled=""
                             value="19: Object"
                           >
                              19:00H 
                           </option>
                           <option
+                            disabled=""
                             value="20: Object"
                           >
                              20:00H 
                           </option>
                           <option
+                            disabled=""
                             value="21: Object"
                           >
                              21:00H 
                           </option>
                           <option
+                            disabled=""
                             value="22: Object"
                           >
                              22:00H 
                           </option>
                           <option
+                            disabled=""
                             value="23: Object"
                           >
                              23:00H 
                           </option>
                           <option
+                            disabled=""
                             value="0: Object"
                           >
                             23:59H
@@ -944,121 +968,145 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="form-control form-select ng-untouched ng-pristine ng-valid"
                         >
                           <option
+                            disabled=""
                             value="1: Object"
                           >
                              01:00H 
                           </option>
                           <option
+                            disabled=""
                             value="2: Object"
                           >
                              02:00H 
                           </option>
                           <option
+                            disabled=""
                             value="3: Object"
                           >
                              03:00H 
                           </option>
                           <option
+                            disabled=""
                             value="4: Object"
                           >
                              04:00H 
                           </option>
                           <option
+                            disabled=""
                             value="5: Object"
                           >
                              05:00H 
                           </option>
                           <option
+                            disabled=""
                             value="6: Object"
                           >
                              06:00H 
                           </option>
                           <option
+                            disabled=""
                             value="7: Object"
                           >
                              07:00H 
                           </option>
                           <option
+                            disabled=""
                             value="8: Object"
                           >
                              08:00H 
                           </option>
                           <option
+                            disabled=""
                             value="9: Object"
                           >
                              09:00H 
                           </option>
                           <option
+                            disabled=""
                             value="10: Object"
                           >
                              10:00H 
                           </option>
                           <option
+                            disabled=""
                             value="11: Object"
                           >
                              11:00H 
                           </option>
                           <option
+                            disabled=""
                             value="12: Object"
                           >
                              12:00H 
                           </option>
                           <option
+                            disabled=""
                             value="13: Object"
                           >
                              13:00H 
                           </option>
                           <option
+                            disabled=""
                             value="14: Object"
                           >
                              14:00H 
                           </option>
                           <option
+                            disabled=""
                             value="15: Object"
                           >
                              15:00H 
                           </option>
                           <option
+                            disabled=""
                             value="16: Object"
                           >
                              16:00H 
                           </option>
                           <option
+                            disabled=""
                             value="17: Object"
                           >
                              17:00H 
                           </option>
                           <option
+                            disabled=""
                             value="18: Object"
                           >
                              18:00H 
                           </option>
                           <option
+                            disabled=""
                             value="19: Object"
                           >
                              19:00H 
                           </option>
                           <option
+                            disabled=""
                             value="20: Object"
                           >
                              20:00H 
                           </option>
                           <option
+                            disabled=""
                             value="21: Object"
                           >
                              21:00H 
                           </option>
                           <option
+                            disabled=""
                             value="22: Object"
                           >
                              22:00H 
                           </option>
                           <option
+                            disabled=""
                             value="23: Object"
                           >
                              23:00H 
                           </option>
                           <option
+                            disabled=""
                             value="0: Object"
                           >
                             23:59H
@@ -3363,121 +3411,145 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                           class="form-control form-select ng-untouched ng-pristine ng-valid"
                         >
                           <option
+                            disabled=""
                             value="1: Object"
                           >
                              01:00H 
                           </option>
                           <option
+                            disabled=""
                             value="2: Object"
                           >
                              02:00H 
                           </option>
                           <option
+                            disabled=""
                             value="3: Object"
                           >
                              03:00H 
                           </option>
                           <option
+                            disabled=""
                             value="4: Object"
                           >
                              04:00H 
                           </option>
                           <option
+                            disabled=""
                             value="5: Object"
                           >
                              05:00H 
                           </option>
                           <option
+                            disabled=""
                             value="6: Object"
                           >
                              06:00H 
                           </option>
                           <option
+                            disabled=""
                             value="7: Object"
                           >
                              07:00H 
                           </option>
                           <option
+                            disabled=""
                             value="8: Object"
                           >
                              08:00H 
                           </option>
                           <option
+                            disabled=""
                             value="9: Object"
                           >
                              09:00H 
                           </option>
                           <option
+                            disabled=""
                             value="10: Object"
                           >
                              10:00H 
                           </option>
                           <option
+                            disabled=""
                             value="11: Object"
                           >
                              11:00H 
                           </option>
                           <option
+                            disabled=""
                             value="12: Object"
                           >
                              12:00H 
                           </option>
                           <option
+                            disabled=""
                             value="13: Object"
                           >
                              13:00H 
                           </option>
                           <option
+                            disabled=""
                             value="14: Object"
                           >
                              14:00H 
                           </option>
                           <option
+                            disabled=""
                             value="15: Object"
                           >
                              15:00H 
                           </option>
                           <option
+                            disabled=""
                             value="16: Object"
                           >
                              16:00H 
                           </option>
                           <option
+                            disabled=""
                             value="17: Object"
                           >
                              17:00H 
                           </option>
                           <option
+                            disabled=""
                             value="18: Object"
                           >
                              18:00H 
                           </option>
                           <option
+                            disabled=""
                             value="19: Object"
                           >
                              19:00H 
                           </option>
                           <option
+                            disabled=""
                             value="20: Object"
                           >
                              20:00H 
                           </option>
                           <option
+                            disabled=""
                             value="21: Object"
                           >
                              21:00H 
                           </option>
                           <option
+                            disabled=""
                             value="22: Object"
                           >
                              22:00H 
                           </option>
                           <option
+                            disabled=""
                             value="23: Object"
                           >
                              23:00H 
                           </option>
                           <option
+                            disabled=""
                             value="0: Object"
                           >
                             23:59H
@@ -3543,121 +3615,145 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                           class="form-control form-select ng-untouched ng-pristine ng-valid"
                         >
                           <option
+                            disabled=""
                             value="1: Object"
                           >
                              01:00H 
                           </option>
                           <option
+                            disabled=""
                             value="2: Object"
                           >
                              02:00H 
                           </option>
                           <option
+                            disabled=""
                             value="3: Object"
                           >
                              03:00H 
                           </option>
                           <option
+                            disabled=""
                             value="4: Object"
                           >
                              04:00H 
                           </option>
                           <option
+                            disabled=""
                             value="5: Object"
                           >
                              05:00H 
                           </option>
                           <option
+                            disabled=""
                             value="6: Object"
                           >
                              06:00H 
                           </option>
                           <option
+                            disabled=""
                             value="7: Object"
                           >
                              07:00H 
                           </option>
                           <option
+                            disabled=""
                             value="8: Object"
                           >
                              08:00H 
                           </option>
                           <option
+                            disabled=""
                             value="9: Object"
                           >
                              09:00H 
                           </option>
                           <option
+                            disabled=""
                             value="10: Object"
                           >
                              10:00H 
                           </option>
                           <option
+                            disabled=""
                             value="11: Object"
                           >
                              11:00H 
                           </option>
                           <option
+                            disabled=""
                             value="12: Object"
                           >
                              12:00H 
                           </option>
                           <option
+                            disabled=""
                             value="13: Object"
                           >
                              13:00H 
                           </option>
                           <option
+                            disabled=""
                             value="14: Object"
                           >
                              14:00H 
                           </option>
                           <option
+                            disabled=""
                             value="15: Object"
                           >
                              15:00H 
                           </option>
                           <option
+                            disabled=""
                             value="16: Object"
                           >
                              16:00H 
                           </option>
                           <option
+                            disabled=""
                             value="17: Object"
                           >
                              17:00H 
                           </option>
                           <option
+                            disabled=""
                             value="18: Object"
                           >
                              18:00H 
                           </option>
                           <option
+                            disabled=""
                             value="19: Object"
                           >
                              19:00H 
                           </option>
                           <option
+                            disabled=""
                             value="20: Object"
                           >
                              20:00H 
                           </option>
                           <option
+                            disabled=""
                             value="21: Object"
                           >
                              21:00H 
                           </option>
                           <option
+                            disabled=""
                             value="22: Object"
                           >
                              22:00H 
                           </option>
                           <option
+                            disabled=""
                             value="23: Object"
                           >
                              23:00H 
                           </option>
                           <option
+                            disabled=""
                             value="0: Object"
                           >
                             23:59H

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -710,121 +710,145 @@ exports[`InstructorSessionsPageComponent should snap when new session form is ex
                             class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
                             <option
+                              disabled=""
                               value="1: Object"
                             >
                                01:00H 
                             </option>
                             <option
+                              disabled=""
                               value="2: Object"
                             >
                                02:00H 
                             </option>
                             <option
+                              disabled=""
                               value="3: Object"
                             >
                                03:00H 
                             </option>
                             <option
+                              disabled=""
                               value="4: Object"
                             >
                                04:00H 
                             </option>
                             <option
+                              disabled=""
                               value="5: Object"
                             >
                                05:00H 
                             </option>
                             <option
+                              disabled=""
                               value="6: Object"
                             >
                                06:00H 
                             </option>
                             <option
+                              disabled=""
                               value="7: Object"
                             >
                                07:00H 
                             </option>
                             <option
+                              disabled=""
                               value="8: Object"
                             >
                                08:00H 
                             </option>
                             <option
+                              disabled=""
                               value="9: Object"
                             >
                                09:00H 
                             </option>
                             <option
+                              disabled=""
                               value="10: Object"
                             >
                                10:00H 
                             </option>
                             <option
+                              disabled=""
                               value="11: Object"
                             >
                                11:00H 
                             </option>
                             <option
+                              disabled=""
                               value="12: Object"
                             >
                                12:00H 
                             </option>
                             <option
+                              disabled=""
                               value="13: Object"
                             >
                                13:00H 
                             </option>
                             <option
+                              disabled=""
                               value="14: Object"
                             >
                                14:00H 
                             </option>
                             <option
+                              disabled=""
                               value="15: Object"
                             >
                                15:00H 
                             </option>
                             <option
+                              disabled=""
                               value="16: Object"
                             >
                                16:00H 
                             </option>
                             <option
+                              disabled=""
                               value="17: Object"
                             >
                                17:00H 
                             </option>
                             <option
+                              disabled=""
                               value="18: Object"
                             >
                                18:00H 
                             </option>
                             <option
+                              disabled=""
                               value="19: Object"
                             >
                                19:00H 
                             </option>
                             <option
+                              disabled=""
                               value="20: Object"
                             >
                                20:00H 
                             </option>
                             <option
+                              disabled=""
                               value="21: Object"
                             >
                                21:00H 
                             </option>
                             <option
+                              disabled=""
                               value="22: Object"
                             >
                                22:00H 
                             </option>
                             <option
+                              disabled=""
                               value="23: Object"
                             >
                                23:00H 
                             </option>
                             <option
+                              disabled=""
                               value="0: Object"
                             >
                               23:59H
@@ -889,121 +913,145 @@ exports[`InstructorSessionsPageComponent should snap when new session form is ex
                             class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
                             <option
+                              disabled=""
                               value="1: Object"
                             >
                                01:00H 
                             </option>
                             <option
+                              disabled=""
                               value="2: Object"
                             >
                                02:00H 
                             </option>
                             <option
+                              disabled=""
                               value="3: Object"
                             >
                                03:00H 
                             </option>
                             <option
+                              disabled=""
                               value="4: Object"
                             >
                                04:00H 
                             </option>
                             <option
+                              disabled=""
                               value="5: Object"
                             >
                                05:00H 
                             </option>
                             <option
+                              disabled=""
                               value="6: Object"
                             >
                                06:00H 
                             </option>
                             <option
+                              disabled=""
                               value="7: Object"
                             >
                                07:00H 
                             </option>
                             <option
+                              disabled=""
                               value="8: Object"
                             >
                                08:00H 
                             </option>
                             <option
+                              disabled=""
                               value="9: Object"
                             >
                                09:00H 
                             </option>
                             <option
+                              disabled=""
                               value="10: Object"
                             >
                                10:00H 
                             </option>
                             <option
+                              disabled=""
                               value="11: Object"
                             >
                                11:00H 
                             </option>
                             <option
+                              disabled=""
                               value="12: Object"
                             >
                                12:00H 
                             </option>
                             <option
+                              disabled=""
                               value="13: Object"
                             >
                                13:00H 
                             </option>
                             <option
+                              disabled=""
                               value="14: Object"
                             >
                                14:00H 
                             </option>
                             <option
+                              disabled=""
                               value="15: Object"
                             >
                                15:00H 
                             </option>
                             <option
+                              disabled=""
                               value="16: Object"
                             >
                                16:00H 
                             </option>
                             <option
+                              disabled=""
                               value="17: Object"
                             >
                                17:00H 
                             </option>
                             <option
+                              disabled=""
                               value="18: Object"
                             >
                                18:00H 
                             </option>
                             <option
+                              disabled=""
                               value="19: Object"
                             >
                                19:00H 
                             </option>
                             <option
+                              disabled=""
                               value="20: Object"
                             >
                                20:00H 
                             </option>
                             <option
+                              disabled=""
                               value="21: Object"
                             >
                                21:00H 
                             </option>
                             <option
+                              disabled=""
                               value="22: Object"
                             >
                                22:00H 
                             </option>
                             <option
+                              disabled=""
                               value="23: Object"
                             >
                                23:00H 
                             </option>
                             <option
+                              disabled=""
                               value="0: Object"
                             >
                               23:59H


### PR DESCRIPTION
Fixes #12131

**Outline of Solution**

Error in logic here:
```
(t.hour < this.minTime?.hour || t.minute < this.minTime?.minute)
```

This does not correctly check that `currentTime` is before `minTime`.