### PR TITLE
[#12081] User-friendliness: Add labels and groups to distribute points (options) question

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -128,7 +128,8 @@
             <tm-constsum-options-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [questionDetails]="model.questionDetails"
                                                           [responseDetails]="recipientSubmissionFormModel.responseDetails"
                                                           (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                          [isDisabled]="isFormsDisabled">
+                                                          [isDisabled]="isFormsDisabled"
+                                                          [recipient]="getRecipientName(recipientSubmissionFormModel.recipientIdentifier)">
             </tm-constsum-options-question-edit-answer-form>
             <tm-constsum-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [questionDetails]="model.questionDetails"
                                                           [responseDetails]="recipientSubmissionFormModel.responseDetails"

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
@@ -1,51 +1,54 @@
-<div class="form-group row text-start" *ngFor="let option of questionDetails.constSumOptions; let i = index;">
-  <div class="col-md-5 col-xs-12 text-md-end col-form-label">
-    <strong>{{ option }}</strong>
+<div [attr.aria-label]="getAriaLabel()">
+  <div class="form-group row text-start" *ngFor="let option of questionDetails.constSumOptions; let i = index;">
+    <div class="col-md-5 col-xs-12 text-md-end col-form-label">
+      <strong>{{ option }}</strong>
+    </div>
+    <div class="col-md-7 col-xs-12 text-md-start">
+      <input type="number" class="form-control"
+            [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
+            (ngModelChange)="triggerResponse(i, $event)"
+            [disabled]="isDisabled"
+            [attr.aria-label]="getAriaLabelForOption(option)"
+            min="0" step="1"
+            tmDisableWheel>
+    </div>
   </div>
-  <div class="col-md-7 col-xs-12 text-md-start">
-    <input type="number" class="form-control"
-           [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
-           (ngModelChange)="triggerResponse(i, $event)"
-           [disabled]="isDisabled"
-           min="0" step="1"
-           tmDisableWheel>
+  <div class="form-group row" *ngIf="responseDetails.answers.length !== 0">
+    <div class="col-12 col-sm-5 offset-sm-2">
+      <button type="button" class="btn btn-light btn-sm" (click)="triggerResponseDetailsChange('answers', [])" [disabled]="isDisabled">Clear Points</button>
+    </div>
   </div>
-</div>
-<div class="form-group row" *ngIf="responseDetails.answers.length !== 0">
-  <div class="col-12 col-sm-5 offset-sm-2">
-    <button type="button" class="btn btn-light btn-sm" (click)="triggerResponseDetailsChange('answers', [])" [disabled]="isDisabled">Clear Points</button>
-  </div>
-</div>
-<div class="row" *ngIf="responseDetails.answers.length !== 0">
-  <div class="col-12">
-    <p *ngIf="totalAnsweredPoints < totalRequiredPoints" class="text-danger"><span class="fa fa-times"></span>
-      Actual total is {{ totalAnsweredPoints }}! Distribute the remaining {{ totalRequiredPoints - totalAnsweredPoints }} points.</p>
+  <div class="row" *ngIf="responseDetails.answers.length !== 0">
+    <div class="col-12">
+      <p *ngIf="totalAnsweredPoints < totalRequiredPoints" class="text-danger"><span class="fa fa-times"></span>
+        Actual total is {{ totalAnsweredPoints }}! Distribute the remaining {{ totalRequiredPoints - totalAnsweredPoints }} points.</p>
 
-    <p *ngIf="totalAnsweredPoints > totalRequiredPoints" class="text-danger"><span class="fa fa-times"></span>
-      Actual total is {{ totalAnsweredPoints }}! Remove the extra  {{ totalAnsweredPoints - totalRequiredPoints }} points allocated.</p>
+      <p *ngIf="totalAnsweredPoints > totalRequiredPoints" class="text-danger"><span class="fa fa-times"></span>
+        Actual total is {{ totalAnsweredPoints }}! Remove the extra  {{ totalAnsweredPoints - totalRequiredPoints }} points allocated.</p>
 
-    <p *ngIf="totalAnsweredPoints === totalRequiredPoints" class="text-success"><span class="fa fa-check"></span>
-      All points distributed!</p>
+      <p *ngIf="totalAnsweredPoints === totalRequiredPoints" class="text-success"><span class="fa fa-check"></span>
+        All points distributed!</p>
 
-    <p *ngIf="isAnyPointsNegative" class="text-danger"><span class="fa fa-times"></span>
-      Points cannot be negative!</p>
+      <p *ngIf="isAnyPointsNegative" class="text-danger"><span class="fa fa-times"></span>
+        Points cannot be negative!</p>
 
-    <p *ngIf="isAnyPointAboveMaximum" class="text-danger"><span class="fa fa-times"></span>
-      Points cannot be above: {{ questionDetails.maxPoint }}</p>
+      <p *ngIf="isAnyPointAboveMaximum" class="text-danger"><span class="fa fa-times"></span>
+        Points cannot be above: {{ questionDetails.maxPoint }}</p>
 
-    <p *ngIf="isAnyPointBelowMinimum" class="text-danger"><span class="fa fa-times"></span>
-      Points cannot be below: {{ questionDetails.minPoint }}</p>
+      <p *ngIf="isAnyPointBelowMinimum" class="text-danger"><span class="fa fa-times"></span>
+        Points cannot be below: {{ questionDetails.minPoint }}</p>
 
-    <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY && !isAllPointsUneven" class="text-danger"><span class="fa fa-times"></span>
-      Multiple options are given same points!</p>
+      <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY && !isAllPointsUneven" class="text-danger"><span class="fa fa-times"></span>
+        Multiple options are given same points!</p>
 
-    <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY && isAllPointsUneven" class="text-success"><span class="fa fa-check"></span>
-      All allocated points are different!</p>
+      <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY && isAllPointsUneven" class="text-success"><span class="fa fa-check"></span>
+        All allocated points are different!</p>
 
-    <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY && !isSomePointsUneven" class="text-danger"><span class="fa fa-times"></span>
-      All options are given {{ responseDetails.answers[0] }} points. Please allocate different points to at least one option.</p>
+      <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY && !isSomePointsUneven" class="text-danger"><span class="fa fa-times"></span>
+        All options are given {{ responseDetails.answers[0] }} points. Please allocate different points to at least one option.</p>
 
-    <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY && isSomePointsUneven" class="text-success"><span class="fa fa-check"></span>
-      At least one option has been allocated different number of points.</p>
+      <p *ngIf="questionDetails.distributePointsFor === FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY && isSomePointsUneven" class="text-success"><span class="fa fa-check"></span>
+        At least one option has been allocated different number of points.</p>
+    </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
@@ -29,6 +29,11 @@ export class ConstsumOptionsQuestionEditAnswerFormComponent
     super(DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS(), DEFAULT_CONSTSUM_RESPONSE_DETAILS());
   }
 
+  getAriaLabelForOption(option: String): String {
+    const baseAriaLabel: String = this.getAriaLabel();
+    return `${baseAriaLabel} for ${option} Option`;
+  }
+
   /**
    * Assigns a point to the option specified by index.
    */


### PR DESCRIPTION
Part of #12081 
Sub-issue [Add labels to distribute points (options) question](https://github.com/TEAMMATES/teammates/projects/16#card-88052106)

**Outline of Solution**

Similar to previous issues for adding labels, except I added an extra function to get the `aria-label` for each recipient's option. The function takes in the `option` and builds on the `aria-label` returned by the existing `getAriaLabel()` function.

Options are grouped by recipients, which requires a surrounding `div` around all the options (else they won't be grouped together).