### PR TITLE
[#12081] User-friendliness: Add labels for distribute points by recipient questions

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,5 +1,5 @@
 <div id="question-submission-form" class="card">
-  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="handleClick();"
+  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="toggleQuestionTab();"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="model.isTabExpanded" aria-hidden="true"></tm-panel-chevron>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -133,7 +133,9 @@
             <tm-constsum-recipients-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [questionDetails]="model.questionDetails"
                                                           [responseDetails]="recipientSubmissionFormModel.responseDetails"
                                                           (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
-                                                          [isDisabled]="isFormsDisabled"></tm-constsum-recipients-question-edit-answer-form>
+                                                          [isDisabled]="isFormsDisabled"
+                                                          [recipient]="getRecipientName(recipientSubmissionFormModel.recipientIdentifier)">
+            </tm-constsum-recipients-question-edit-answer-form>
           </div>
 
           <div id="comment-section" *ngIf="allowedToHaveParticipantComment" class="col-12 margin-bottom-20px margin-top-10px indent">

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -167,7 +167,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     }
   }
 
-  handleClick(): void {
+  toggleQuestionTab(): void {
     this.model.isTabExpanded = !this.model.isTabExpanded;
     this.formModelChange.emit(this.model);
   }

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -169,6 +169,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   handleClick(): void {
     this.model.isTabExpanded = !this.model.isTabExpanded;
+    this.formModelChange.emit(this.model);
   }
 
   private compareByName(firstRecipient: FeedbackResponseRecipient,

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.html
@@ -5,6 +5,7 @@
              (ngModelChange)="triggerResponse($event)"
              [disabled]="isDisabled"
              min="0" step="1"
-             tmDisableWheel>
+             tmDisableWheel
+             [attr.aria-label]="getAriaLabel()">
   </div>
 </div>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -2073,6 +2073,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           class="form-group"
                         >
                           <input
+                            aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
                             min="0"
                             step="1"
@@ -4746,6 +4747,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           class="form-group"
                         >
                           <input
+                            aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
                             min="0"
                             step="1"


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Submit feedback page: distribute points (recipients) question](https://github.com/TEAMMATES/teammates/projects/16#card-88052150)

**Outline of Solution**

- Add labels for distribute points (recipients) question
    - Solution: Similar to #12144 
- Fix dropdown
    - Problem: 
        - I observed that the dropdown fails for all questions with constraints
        - I'm not entirely sure, but I suspect that the `QuestionSubmissionFormComponent::updateValidity` may be the issue here, since we always emit to the parent component a model with `isTabExpanded: true`? And due to the 2-way binding, the `@Input formModel` will always receive the model from the parent with `isTabExpanded: true`. 
        - However, with the 2-way binding, why don't the other questions without constraints face the same issue?
    - Solution: After updating `isTabExpanded`, emit the updated model to the parent component
        - This solution also fixes the collapsing issue mentioned in [Submit feedback page: team contribution question](https://github.com/TEAMMATES/teammates/projects/16#card-88052182) and [Submit feedback page: rank recipients question](https://github.com/TEAMMATES/teammates/projects/16#card-88052451) @weiquu 