### PR TITLE
[#12116] Instructor viewing results of rubric questions: missing space after checkbox

### DIFF
--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -8,7 +8,7 @@
     </div>
     <div class="col-sm-8" style="text-align: right;">
       <label class="form-check-label">
-        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics" style="margin-left: 0.33rem;">Exclude self evaluation</span>
+        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics" style="margin-left: .33rem;">Exclude self evaluation</span>
       </label>
     </div>
   </div>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -6,12 +6,10 @@
       </strong>
       <span container="body" [ngbTooltip]="'Format: Response percentage (Response count)' + (hasWeights ? '[Weight of option]' : '') + ', e.g. 50% (2) ' + (hasWeights ? '[1.0]' : '')" class="fa fa-info-circle"></span>
     </div>
-    <div class="col-sm-8" style="text-align: right;">
-      <div class="form-check">
-        <label class="form-check-label">
-          <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
-        </label>
-      </div>
+    <div class="col-sm-8 form-check" style="text-align: right;">
+      <label class="form-check-label">
+        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+      </label>
     </div>
   </div>
   <div class="row">

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -8,7 +8,7 @@
     </div>
     <div class="col-sm-8" style="text-align: right;">
       <label class="form-check-label">
-        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics"> Exclude self evaluation</span>
+        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics" style="margin-left: 0.33rem;">Exclude self evaluation</span>
       </label>
     </div>
   </div>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -7,9 +7,11 @@
       <span container="body" [ngbTooltip]="'Format: Response percentage (Response count)' + (hasWeights ? '[Weight of option]' : '') + ', e.g. 50% (2) ' + (hasWeights ? '[1.0]' : '')" class="fa fa-info-circle"></span>
     </div>
     <div class="col-sm-8" style="text-align: right;">
-      <label class="form-check-label">
-        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics" style="margin-left: .33rem;">Exclude self evaluation</span>
-      </label>
+      <div class="form-check">
+        <label class="form-check-label">
+          <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+        </label>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -8,7 +8,7 @@
     </div>
     <div class="col-sm-8" style="text-align: right;">
       <label class="form-check-label">
-        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics">Exclude self evaluation</span>
+        <input id="exclude-self-checkbox" type="checkbox" [(ngModel)]="excludeSelf" (ngModelChange)="getTableData()" class="form-check-input"> <span container="body" class="ngb-tooltip-class" ngbTooltip="Excludes giver's responses to himself/herself from statistics"> Exclude self evaluation</span>
       </label>
     </div>
   </div>


### PR DESCRIPTION
Fixes #12116 

**Outline of Solution**
Added a space in the beginning of the _Exclude self evaluation_ text in `rubric-question-statistics.component.html`
![image](https://user-images.githubusercontent.com/60819181/222176653-87c57a50-af07-4545-980d-479eb83ff3db.png)

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
