### PR TITLE
User-friendliness: Add labels and change "more info" button for team contribution questions

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -82,9 +82,9 @@
           <div class="margin-top-20px" [ngClass]="isMCQDropDownEnabled ? 'col-12' : 'col'">
             <tm-contribution-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="model.questionDetails"
                                                       [responseDetails]="recipientSubmissionFormModel.responseDetails"
-                                                      [shouldShowHelpLink]="i === 0"
                                                       (responseDetailsChange)="triggerRecipientSubmissionFormChange(i, 'responseDetails', $event)"
                                                       [isDisabled]="isFormsDisabled"
+                                                      [recipient]="getRecipientName(recipientSubmissionFormModel.recipientIdentifier)"
             ></tm-contribution-question-edit-answer-form>
             <tm-text-question-edit-answer-form *ngIf="model.questionType === FeedbackQuestionType.TEXT" [questionDetails]="model.questionDetails"
                                               [responseDetails]="recipientSubmissionFormModel.responseDetails"

--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
@@ -5,7 +5,7 @@
               'color-negative': responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SURE && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED,
               'fw-bold': responseDetails.answer === 100,
               'color-black': responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE}"
-            [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled">
+            [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled" [attr.aria-label]="getAriaLabel()">
       <option [ngValue]="CONTRIBUTION_POINT_NOT_SUBMITTED"></option>
       <option *ngFor="let point of contributionQuestionPoints" [ngValue]="point"
               [ngClass]="{'color-positive': point >= 100,
@@ -14,13 +14,4 @@
       <option *ngIf="questionDetails.isNotSureAllowed" [ngValue]="CONTRIBUTION_POINT_NOT_SURE" class="color-black">Not Sure</option>
     </select>
   </div>
-  <div class="col-lg-7 col-md-12 col-sm-6 col-xs-12" *ngIf="shouldShowHelpLink">
-    <button type="button" class="btn btn-link" (click)="openHelpModal(equalShareHelp)"><i class="fas fa-exclamation-circle"></i> More info about the <code>Equal Share</code> scale</button>
-  </div>
-  <ng-template #equalShareHelp>
-    <p><code>Equal share</code> is a relative measure of individual contribution to a team task.</p>
-    <p>For example, in a 3-person team, <code>Equal share</code> means a third of the work done.</p>
-    <p><code>Equal share + 10%</code> means the person did about 10% <em>more</em> than an equal share,
-      <code>Equal share - 10%</code> means about 10% <em>less</em> than an equal share, and so on.</p>
-  </ng-template>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, TemplateRef } from '@angular/core';
-import { SimpleModalService } from '../../../../services/simple-modal.service';
+import { Component } from '@angular/core';
 import {
   FeedbackContributionQuestionDetails,
   FeedbackContributionResponseDetails,
@@ -12,7 +11,6 @@ import {
   CONTRIBUTION_POINT_NOT_SUBMITTED,
   CONTRIBUTION_POINT_NOT_SURE,
 } from '../../../../types/feedback-response-details';
-import { SimpleModalType } from '../../simple-modal/simple-modal-type';
 import { QuestionEditAnswerFormComponent } from './question-edit-answer-form';
 
 /**
@@ -27,13 +25,10 @@ export class ContributionQuestionEditAnswerFormComponent
     extends QuestionEditAnswerFormComponent
         <FeedbackContributionQuestionDetails, FeedbackContributionResponseDetails> {
 
-  @Input()
-  shouldShowHelpLink: boolean = true;
-
   CONTRIBUTION_POINT_NOT_SUBMITTED: number = CONTRIBUTION_POINT_NOT_SUBMITTED;
   CONTRIBUTION_POINT_NOT_SURE: number = CONTRIBUTION_POINT_NOT_SURE;
 
-  constructor(private simpleModalService: SimpleModalService) {
+  constructor() {
     super(DEFAULT_CONTRIBUTION_QUESTION_DETAILS(), DEFAULT_CONTRIBUTION_RESPONSE_DETAILS());
   }
 
@@ -52,10 +47,5 @@ export class ContributionQuestionEditAnswerFormComponent
     }
 
     return points;
-  }
-
-  openHelpModal(modal: TemplateRef<any>): void {
-    const modalHeader: string = 'More info about the <code>Equal Share</code> scale';
-    this.simpleModalService.openInformationModal(modalHeader, SimpleModalType.NEUTRAL, modal);
   }
 }

--- a/src/web/app/components/question-types/question-instruction/contribution-question-instruction.component.html
+++ b/src/web/app/components/question-types/question-instruction/contribution-question-instruction.component.html
@@ -1,7 +1,12 @@
-<div class="text-info" *ngIf="questionDetails.isZeroSum">
-  <p class="text-start fw-bold">Note:</p>
-  <p id="total-contributions-message">
-    <span class="fa fa-info-circle"></span>
-    Total contributions distributed should <strong>add up to <code>{{ numOfRecipients }} x Equal Share</code></strong>.
-  </p>
-</div>
+<p class="text-start fw-bold mt-3 mb-0">Note:</p>
+<p class="text-info mt-3 mb-0 ms-3" id="total-contributions-message" *ngIf="questionDetails.isZeroSum">
+  <span class="fa fa-info-circle"></span>
+  Total contributions distributed should <strong>add up to <code>{{ numOfRecipients }} x Equal Share</code></strong>.
+</p>
+<button type="button" class="btn btn-link mt-3 ms-3 p-0" (click)="openHelpModal(equalShareHelp)"><i class="fas fa-exclamation-circle"></i> More info about the <code>Equal Share</code> scale</button>
+<ng-template #equalShareHelp>
+  <p><code>Equal share</code> is a relative measure of individual contribution to a team task.</p>
+  <p>For example, in a 3-person team, <code>Equal share</code> means a third of the work done.</p>
+  <p><code>Equal share + 10%</code> means the person did about 10% <em>more</em> than an equal share,
+    <code>Equal share - 10%</code> means about 10% <em>less</em> than an equal share, and so on.</p>
+</ng-template>

--- a/src/web/app/components/question-types/question-instruction/contribution-question-instruction.component.ts
+++ b/src/web/app/components/question-types/question-instruction/contribution-question-instruction.component.ts
@@ -1,6 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
+import { SimpleModalService } from '../../../../services/simple-modal.service';
 import { FeedbackContributionQuestionDetails } from '../../../../types/api-output';
 import { DEFAULT_CONTRIBUTION_QUESTION_DETAILS } from '../../../../types/default-question-structs';
+import { SimpleModalType } from '../../simple-modal/simple-modal-type';
 
 /**
  * Instruction of contribution question.
@@ -18,4 +20,10 @@ export class ContributionQuestionInstructionComponent {
   @Input()
   numOfRecipients: number = 0;
 
+  constructor(private simpleModalService: SimpleModalService) {}
+
+  openHelpModal(modal: TemplateRef<any>): void {
+    const modalHeader: string = 'More info about the <code>Equal Share</code> scale';
+    this.simpleModalService.openInformationModal(modalHeader, SimpleModalType.NEUTRAL, modal);
+  }
 }

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -2216,6 +2216,24 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                 </ul>
               </div>
               <tm-contribution-question-instruction>
+                <p
+                  class="text-start fw-bold mt-3 mb-0"
+                >
+                  Note:
+                </p>
+                <button
+                  class="btn btn-link mt-3 ms-3 p-0"
+                  type="button"
+                >
+                  <i
+                    class="fas fa-exclamation-circle"
+                  />
+                   More info about the 
+                  <code>
+                    Equal Share
+                  </code>
+                   scale
+                </button>
               </tm-contribution-question-instruction>
               <div
                 class="row margin-top-30px margin-bottom-0px"
@@ -2264,6 +2282,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
                         >
                           <select
+                            aria-label="Response for Barry Harris"
                             class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
                           >
                             <option
@@ -2516,23 +2535,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                               0%
                             </option>
                           </select>
-                        </div>
-                        <div
-                          class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <button
-                            class="btn btn-link"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-exclamation-circle"
-                            />
-                             More info about the 
-                            <code>
-                              Equal Share
-                            </code>
-                             scale
-                          </button>
                         </div>
                       </div>
                     </tm-contribution-question-edit-answer-form>
@@ -4891,6 +4893,24 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                 </ul>
               </div>
               <tm-contribution-question-instruction>
+                <p
+                  class="text-start fw-bold mt-3 mb-0"
+                >
+                  Note:
+                </p>
+                <button
+                  class="btn btn-link mt-3 ms-3 p-0"
+                  type="button"
+                >
+                  <i
+                    class="fas fa-exclamation-circle"
+                  />
+                   More info about the 
+                  <code>
+                    Equal Share
+                  </code>
+                   scale
+                </button>
               </tm-contribution-question-instruction>
               <div
                 class="row margin-top-30px margin-bottom-0px"
@@ -4939,6 +4959,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           class="col-lg-5 col-md-12 col-sm-6 col-xs-12"
                         >
                           <select
+                            aria-label="Response for Barry Harris"
                             class="form-control form-select color-negative ng-untouched ng-pristine ng-valid"
                           >
                             <option
@@ -5191,23 +5212,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                               0%
                             </option>
                           </select>
-                        </div>
-                        <div
-                          class="col-lg-7 col-md-12 col-sm-6 col-xs-12"
-                        >
-                          <button
-                            class="btn btn-link"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-exclamation-circle"
-                            />
-                             More info about the 
-                            <code>
-                              Equal Share
-                            </code>
-                             scale
-                          </button>
                         </div>
                       </div>
                     </tm-contribution-question-edit-answer-form>


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Labels and "more info" button for team contribution question](https://github.com/TEAMMATES/teammates/projects/16#card-88052182)

**Outline of Solution**

Add labels similar to previous question types. Also changed the position of the "more info" button as I think that it makes more sense to come under question instructions. In addition, since `tabindex` is a global attribute, to allow for the button to come first while in its current position, there would be a need to add/change the `tabindex` of many elements on the page. Moving the "more info" button solves this problem.

I also altered the CSS a little to take into account the move. See below for a comparison.

Previously (v4):
![v4](https://user-images.githubusercontent.com/48304907/222457148-3bca81ab-5686-4092-a209-60ba01cb1707.png)

After the change:
![current](https://user-images.githubusercontent.com/48304907/222457193-18919caf-155e-4e95-a6ba-503cf566feb3.png)


