### PR TITLE
[#12048] Update entities to use UUID instead of Integer as ID

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/NotificationsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/NotificationsLogicIT.java
@@ -37,11 +37,11 @@ public class NotificationsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");
         notificationsLogic.createNotification(notification);
 
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
         Notification expectedNotification = notificationsLogic.updateNotification(notificationId, newStartTime, newEndTime,
                 newStyle, newTargetUser, newTitle, newMessage);
 
-        assertEquals(notificationId, expectedNotification.getNotificationId());
+        assertEquals(notificationId, expectedNotification.getId());
         assertEquals(newStartTime, expectedNotification.getStartTime());
         assertEquals(newEndTime, expectedNotification.getEndTime());
         assertEquals(newStyle, expectedNotification.getStyle());

--- a/src/it/java/teammates/it/storage/sqlapi/NotificationDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/NotificationDbIT.java
@@ -27,7 +27,7 @@ public class NotificationDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         notificationsDb.createNotification(newNotification);
 
-        UUID notificationId = newNotification.getNotificationId();
+        UUID notificationId = newNotification.getId();
         Notification actualNotification = notificationsDb.getNotification(notificationId);
         verifyEquals(newNotification, actualNotification);
     }
@@ -39,7 +39,7 @@ public class NotificationDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         notificationsDb.createNotification(newNotification);
 
-        UUID notificationId = newNotification.getNotificationId();
+        UUID notificationId = newNotification.getId();
         Notification actualNotification = notificationsDb.getNotification(notificationId);
         verifyEquals(newNotification, actualNotification);
 
@@ -55,7 +55,7 @@ public class NotificationDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         Notification notification = generateTypicalNotification();
 
         notificationsDb.createNotification(notification);
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
         assertNotNull(notificationsDb.getNotification(notificationId));
 
         notificationsDb.deleteNotification(notification);

--- a/src/main/java/teammates/storage/sqlapi/AccountsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountsDb.java
@@ -3,6 +3,8 @@ package teammates.storage.sqlapi;
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.UUID;
+
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -29,7 +31,7 @@ public final class AccountsDb extends EntitiesDb<Account> {
     /**
      * Returns an Account with the {@code id} or null if it does not exist.
      */
-    public Account getAccount(Integer id) {
+    public Account getAccount(UUID id) {
         assert id != null;
 
         return HibernateUtil.get(Account.class, id);

--- a/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
@@ -3,6 +3,8 @@ package teammates.storage.sqlapi;
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.UUID;
+
 import org.hibernate.Session;
 
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -44,8 +46,7 @@ public final class DeadlineExtensionsDb extends EntitiesDb<DeadlineExtension> {
             throw new InvalidParametersException(de.getInvalidityInfo());
         }
 
-        if (getDeadlineExtension(de.getId()) != null
-                || getDeadlineExtension(de.getUser().getId(), de.getFeedbackSession().getId()) != null) {
+        if (getDeadlineExtension(de.getId()) != null) {
             throw new EntityAlreadyExistsException(
                     String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, de.toString()));
         }
@@ -57,17 +58,16 @@ public final class DeadlineExtensionsDb extends EntitiesDb<DeadlineExtension> {
     /**
      * Gets a deadline extension by {@code id}.
      */
-    public DeadlineExtension getDeadlineExtension(Integer id) {
+    public DeadlineExtension getDeadlineExtension(UUID id) {
         assert id != null;
 
-        return HibernateUtil.getCurrentSession()
-                .get(DeadlineExtension.class, id);
+        return HibernateUtil.get(DeadlineExtension.class, id);
     }
 
     /**
      * Get DeadlineExtension by {@code userId} and {@code feedbackSessionId}.
      */
-    public DeadlineExtension getDeadlineExtension(Integer userId, Integer feedbackSessionId) {
+    public DeadlineExtension getDeadlineExtension(UUID userId, UUID feedbackSessionId) {
         Session currentSession = HibernateUtil.getCurrentSession();
         CriteriaBuilder cb = currentSession.getCriteriaBuilder();
         CriteriaQuery<DeadlineExtension> cr = cb.createQuery(DeadlineExtension.class);

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -2,6 +2,8 @@ package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.UUID;
+
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
@@ -29,7 +31,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
      *
      * @return null if not found
      */
-    public FeedbackSession getFeedbackSession(Integer fsId) {
+    public FeedbackSession getFeedbackSession(UUID fsId) {
         assert fsId != null;
 
         return HibernateUtil.get(FeedbackSession.class, fsId);
@@ -60,12 +62,9 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
     /**
      * Deletes a feedback session.
      */
-    public void deleteFeedbackSession(Integer fsId) {
-        assert fsId != null;
-
-        FeedbackSession fs = getFeedbackSession(fsId);
-        if (fs != null) {
-            delete(fs);
+    public void deleteFeedbackSession(FeedbackSession feedbackSession) {
+        if (feedbackSession != null) {
+            delete(feedbackSession);
         }
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -4,6 +4,7 @@ import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import org.hibernate.Session;
 
@@ -193,7 +194,7 @@ public final class UsersDb extends EntitiesDb<User> {
     /**
      * Checks if a user exists by its {@code id}.
      */
-    private boolean hasExistingUser(Integer id) {
+    private boolean hasExistingUser(UUID id) {
         assert id != null;
 
         return HibernateUtil.getCurrentSession().get(User.class, id) != null;

--- a/src/main/java/teammates/storage/sqlentity/Account.java
+++ b/src/main/java/teammates/storage/sqlentity/Account.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -13,7 +14,6 @@ import teammates.common.util.SanitizationHelper;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -25,8 +25,7 @@ import jakarta.persistence.Table;
 @Table(name = "Accounts")
 public class Account extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Integer id;
+    private UUID id;
 
     @NaturalId
     private String googleId;
@@ -48,17 +47,18 @@ public class Account extends BaseEntity {
     }
 
     public Account(String googleId, String name, String email) {
+        this.setId(UUID.randomUUID());
         this.setGoogleId(googleId);
         this.setName(name);
         this.setEmail(email);
         this.readNotifications = new ArrayList<>();
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -121,7 +121,7 @@ public class Account extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             Account otherAccount = (Account) other;
-            return Objects.equals(this.googleId, otherAccount.googleId);
+            return Objects.equals(this.getId(), otherAccount.getId());
         } else {
             return false;
         }
@@ -129,7 +129,7 @@ public class Account extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return this.getGoogleId().hashCode();
+        return this.getId().hashCode();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/AccountRequest.java
+++ b/src/main/java/teammates/storage/sqlentity/AccountRequest.java
@@ -4,6 +4,8 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,8 +14,6 @@ import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -29,8 +29,7 @@ import jakarta.persistence.UniqueConstraint;
         })
 public class AccountRequest extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private int id;
+    private UUID id;
 
     private String registrationKey;
 
@@ -50,6 +49,7 @@ public class AccountRequest extends BaseEntity {
     }
 
     public AccountRequest(String email, String name, String institute) {
+        this.setId(UUID.randomUUID());
         this.setEmail(email);
         this.setName(name);
         this.setInstitute(institute);
@@ -80,11 +80,11 @@ public class AccountRequest extends BaseEntity {
         return StringHelper.encrypt(uniqueId + prng.nextInt());
     }
 
-    public int getId() {
+    public UUID getId() {
         return this.id;
     }
 
-    public void setId(int id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -134,6 +134,25 @@ public class AccountRequest extends BaseEntity {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        } else if (this == other) {
+            return true;
+        } else if (this.getClass() == other.getClass()) {
+            AccountRequest otherAccountRequest = (AccountRequest) other;
+            return Objects.equals(this.getId(), otherAccountRequest.getId());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/DeadlineExtension.java
+++ b/src/main/java/teammates/storage/sqlentity/DeadlineExtension.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -11,7 +12,6 @@ import teammates.common.util.FieldValidator;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -24,8 +24,7 @@ import jakarta.persistence.Table;
 @Table(name = "DeadlineExtensions")
 public class DeadlineExtension extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "userId", nullable = false)
@@ -47,16 +46,17 @@ public class DeadlineExtension extends BaseEntity {
     }
 
     public DeadlineExtension(User user, FeedbackSession feedbackSession, Instant endTime) {
+        this.setId(UUID.randomUUID());
         this.setUser(user);
         this.setFeedbackSession(feedbackSession);
         this.setEndTime(endTime);
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -100,7 +100,7 @@ public class DeadlineExtension extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.user, this.feedbackSession);
+        return this.getId().hashCode();
     }
 
     @Override
@@ -111,8 +111,7 @@ public class DeadlineExtension extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             DeadlineExtension otherDe = (DeadlineExtension) other;
-            return Objects.equals(this.user, otherDe.user)
-                    && Objects.equals(this.feedbackSession, otherDe.feedbackSession);
+            return Objects.equals(this.getId(), otherDe.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
@@ -98,6 +98,7 @@ public abstract class FeedbackQuestion extends BaseEntity {
             Integer numOfEntitiesToGiveFeedbackTo, List<FeedbackParticipantType> showResponsesTo,
             List<FeedbackParticipantType> showGiverNameTo, List<FeedbackParticipantType> showRecipientNameTo
     ) {
+        this.setId(UUID.randomUUID());
         this.setFeedbackSession(feedbackSession);
         this.setQuestionNumber(questionNumber);
         this.setDescription(description);
@@ -261,7 +262,7 @@ public abstract class FeedbackQuestion extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             FeedbackQuestion otherQuestion = (FeedbackQuestion) other;
-            return Objects.equals(this.id, otherQuestion.id);
+            return Objects.equals(this.getId(), otherQuestion.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -67,6 +67,7 @@ public abstract class FeedbackResponse extends BaseEntity {
             FeedbackQuestion feedbackQuestion, FeedbackQuestionType type, String giver,
             Section giverSection, String receiver, Section receiverSection
     ) {
+        this.setId(UUID.randomUUID());
         this.setFeedbackQuestion(feedbackQuestion);
         this.setFeedbackQuestionType(type);
         this.setGiver(giver);
@@ -171,7 +172,7 @@ public abstract class FeedbackResponse extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             FeedbackResponse otherResponse = (FeedbackResponse) other;
-            return Objects.equals(this.id, otherResponse.id);
+            return Objects.equals(this.getId(), otherResponse.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -81,6 +81,7 @@ public class FeedbackResponseComment extends BaseEntity {
             List<FeedbackParticipantType> showCommentTo, List<FeedbackParticipantType> showGiverNameTo,
             String lastEditorEmail
     ) {
+        this.setId(UUID.randomUUID());
         this.setFeedbackResponse(feedbackResponse);
         this.setGiver(giver);
         this.setGiverType(giverType);
@@ -232,7 +233,7 @@ public class FeedbackResponseComment extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             FeedbackResponseComment otherResponse = (FeedbackResponseComment) other;
-            return Objects.equals(this.id, otherResponse.id);
+            return Objects.equals(this.getId(), otherResponse.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -16,7 +17,6 @@ import teammates.common.util.SanitizationHelper;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -30,8 +30,7 @@ import jakarta.persistence.Table;
 @Table(name = "FeedbackSessions")
 public class FeedbackSession extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "courseId")
@@ -86,6 +85,7 @@ public class FeedbackSession extends BaseEntity {
     public FeedbackSession(String name, Course course, String creatorEmail, String instructions, Instant startTime,
             Instant endTime, Instant sessionVisibleFromTime, Instant resultsVisibleFromTime, Duration gracePeriod,
             boolean isOpeningEmailEnabled, boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled) {
+        this.setId(UUID.randomUUID());
         this.setName(name);
         this.setCourse(course);
         this.setCreatorEmail(creatorEmail);
@@ -162,11 +162,11 @@ public class FeedbackSession extends BaseEntity {
         return errors;
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -303,7 +303,7 @@ public class FeedbackSession extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.course, this.name);
+        return this.getId().hashCode();
     }
 
     @Override
@@ -314,8 +314,7 @@ public class FeedbackSession extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             FeedbackSession otherFs = (FeedbackSession) other;
-            return Objects.equals(this.name, otherFs.name)
-                    && Objects.equals(this.course, otherFs.course);
+            return Objects.equals(this.getId(), otherFs.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/Notification.java
+++ b/src/main/java/teammates/storage/sqlentity/Notification.java
@@ -17,7 +17,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -30,8 +29,7 @@ import jakarta.persistence.Table;
 public class Notification extends BaseEntity {
 
     @Id
-    @GeneratedValue
-    private UUID notificationId;
+    private UUID id;
 
     @Column(nullable = false)
     private Instant startTime;
@@ -73,6 +71,7 @@ public class Notification extends BaseEntity {
         this.setTargetUser(targetUser);
         this.setTitle(title);
         this.setMessage(message);
+        this.setId(UUID.randomUUID());
     }
 
     protected Notification() {
@@ -94,12 +93,12 @@ public class Notification extends BaseEntity {
         return errors;
     }
 
-    public UUID getNotificationId() {
-        return notificationId;
+    public UUID getId() {
+        return id;
     }
 
-    public void setNotificationId(UUID notificationId) {
-        this.notificationId = notificationId;
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public Instant getStartTime() {
@@ -180,7 +179,7 @@ public class Notification extends BaseEntity {
 
     @Override
     public String toString() {
-        return "Notification [notificationId=" + notificationId + ", startTime=" + startTime + ", endTime=" + endTime
+        return "Notification [notificationId=" + id + ", startTime=" + startTime + ", endTime=" + endTime
                 + ", style=" + style + ", targetUser=" + targetUser + ", title=" + title + ", message=" + message
                 + ", shown=" + shown + ", readNotifications=" + readNotifications + ", createdAt=" + getCreatedAt()
                 + ", updatedAt=" + updatedAt + "]";
@@ -188,8 +187,7 @@ public class Notification extends BaseEntity {
 
     @Override
     public int hashCode() {
-        // Notification ID uniquely identifies a notification.
-        return this.getNotificationId().hashCode();
+        return this.getId().hashCode();
     }
 
     @Override
@@ -200,15 +198,7 @@ public class Notification extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             Notification otherNotification = (Notification) other;
-            return Objects.equals(this.notificationId, otherNotification.getNotificationId())
-                    && Objects.equals(this.startTime, otherNotification.startTime)
-                    && Objects.equals(this.endTime, otherNotification.endTime)
-                    && Objects.equals(this.style, otherNotification.style)
-                    && Objects.equals(this.targetUser, otherNotification.targetUser)
-                    && Objects.equals(this.title, otherNotification.title)
-                    && Objects.equals(this.message, otherNotification.message)
-                    && Objects.equals(this.shown, otherNotification.shown)
-                    && Objects.equals(this.readNotifications, otherNotification.readNotifications);
+            return Objects.equals(this.getId(), otherNotification.getId());
         } else {
             return false;
         }

--- a/src/main/java/teammates/storage/sqlentity/ReadNotification.java
+++ b/src/main/java/teammates/storage/sqlentity/ReadNotification.java
@@ -1,13 +1,11 @@
 package teammates.storage.sqlentity;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,8 +18,7 @@ import jakarta.persistence.Table;
 @Table(name = "ReadNotifications")
 public class ReadNotification extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     private Account account;
@@ -29,27 +26,22 @@ public class ReadNotification extends BaseEntity {
     @ManyToOne
     private Notification notification;
 
-    @Column(nullable = false)
-    private Instant readAt;
-
     protected ReadNotification() {
         // required by Hibernate
     }
 
-    public Integer getId() {
+    public ReadNotification(Account account, Notification notification) {
+        this.setId(UUID.randomUUID());
+        this.setAccount(account);
+        this.setNotification(notification);
+    }
+
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
-    }
-
-    public Instant getReadAt() {
-        return readAt;
-    }
-
-    public void setReadAt(Instant readAt) {
-        this.readAt = readAt;
     }
 
     public Account getAccount() {
@@ -80,11 +72,8 @@ public class ReadNotification extends BaseEntity {
         } else if (this == other) {
             return true;
         } else if (this.getClass() == other.getClass()) {
-            ReadNotification otherReadNotifiation = (ReadNotification) other;
-            return Objects.equals(this.account, otherReadNotifiation.account)
-                    && Objects.equals(this.notification, otherReadNotifiation.notification)
-                    && Objects.equals(this.readAt, otherReadNotifiation.readAt)
-                    && Objects.equals(this.id, otherReadNotifiation.id);
+            ReadNotification otherReadNotification = (ReadNotification) other;
+            return Objects.equals(this.getId(), otherReadNotification.getId());
         } else {
             return false;
         }
@@ -97,7 +86,6 @@ public class ReadNotification extends BaseEntity {
 
     @Override
     public String toString() {
-        return "ReadNotification [id=" + id + ", account=" + account + ", notification=" + notification + ", readAt="
-                + readAt + "]";
+        return "ReadNotification [id=" + id + ", account=" + account + ", notification=" + notification + "]";
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/Section.java
+++ b/src/main/java/teammates/storage/sqlentity/Section.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,8 +13,6 @@ import teammates.common.util.SanitizationHelper;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -27,8 +26,7 @@ import jakarta.persistence.Table;
 @Table(name = "Sections")
 public class Section extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "courseId")
@@ -48,6 +46,7 @@ public class Section extends BaseEntity {
     }
 
     public Section(Course course, String name) {
+        this.setId(UUID.randomUUID());
         this.setCourse(course);
         this.setName(name);
         this.setTeams(new ArrayList<>());
@@ -55,7 +54,7 @@ public class Section extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.course, this.name);
+        return this.getId().hashCode();
     }
 
     @Override
@@ -66,8 +65,7 @@ public class Section extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             Section otherSection = (Section) other;
-            return Objects.equals(this.name, otherSection.name)
-                    && Objects.equals(this.course, otherSection.course);
+            return Objects.equals(this.getId(), otherSection.getId());
         } else {
             return false;
         }
@@ -82,11 +80,11 @@ public class Section extends BaseEntity {
         return errors;
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/Team.java
+++ b/src/main/java/teammates/storage/sqlentity/Team.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -11,8 +12,6 @@ import teammates.common.util.FieldValidator;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,8 +25,7 @@ import jakarta.persistence.Table;
 @Table(name = "Teams")
 public class Team extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "sectionId")
@@ -47,6 +45,7 @@ public class Team extends BaseEntity {
     }
 
     public Team(Section section, String name) {
+        this.setId(UUID.randomUUID());
         this.setSection(section);
         this.setName(name);
         this.setUsers(new ArrayList<>());
@@ -54,7 +53,7 @@ public class Team extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.section, this.name);
+        return this.getId().hashCode();
     }
 
     @Override
@@ -65,8 +64,7 @@ public class Team extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             Team otherTeam = (Team) other;
-            return Objects.equals(this.name, otherTeam.name)
-                    && Objects.equals(this.section, otherTeam.section);
+            return Objects.equals(this.getId(), otherTeam.getId());
         } else {
             return false;
         }
@@ -81,11 +79,11 @@ public class Team extends BaseEntity {
         return errors;
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/UsageStatistics.java
+++ b/src/main/java/teammates/storage/sqlentity/UsageStatistics.java
@@ -4,10 +4,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
@@ -21,26 +21,32 @@ import jakarta.persistence.Table;
 @Table(name = "UsageStatistics")
 public class UsageStatistics extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Integer id;
+    private UUID id;
 
     @Column(nullable = false)
     private Instant startTime;
 
     @Column(nullable = false)
     private int timePeriod;
+
     @Column(nullable = false)
     private int numResponses;
+
     @Column(nullable = false)
     private int numCourses;
+
     @Column(nullable = false)
     private int numStudents;
+
     @Column(nullable = false)
     private int numInstructors;
+
     @Column(nullable = false)
     private int numAccountRequests;
+
     @Column(nullable = false)
     private int numEmails;
+
     @Column(nullable = false)
     private int numSubmissions;
 
@@ -51,6 +57,7 @@ public class UsageStatistics extends BaseEntity {
     public UsageStatistics(
             Instant startTime, int timePeriod, int numResponses, int numCourses,
             int numStudents, int numInstructors, int numAccountRequests, int numEmails, int numSubmissions) {
+        this.setId(UUID.randomUUID());
         this.startTime = startTime;
         this.timePeriod = timePeriod;
         this.numResponses = numResponses;
@@ -62,8 +69,12 @@ public class UsageStatistics extends BaseEntity {
         this.numSubmissions = numSubmissions;
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public Instant getStartTime() {
@@ -110,8 +121,7 @@ public class UsageStatistics extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             UsageStatistics otherUsageStatistics = (UsageStatistics) other;
-            return Objects.equals(this.startTime, otherUsageStatistics.startTime)
-                    && Objects.equals(this.timePeriod, otherUsageStatistics.timePeriod);
+            return Objects.equals(this.getId(), otherUsageStatistics.getId());
         } else {
             return false;
         }
@@ -119,7 +129,7 @@ public class UsageStatistics extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.startTime, this.timePeriod);
+        return this.getId().hashCode();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -3,6 +3,7 @@ package teammates.storage.sqlentity;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -11,8 +12,6 @@ import teammates.common.util.StringHelper;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
@@ -28,8 +27,7 @@ import jakarta.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 public abstract class User extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private Integer id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "accountId")
@@ -60,6 +58,7 @@ public abstract class User extends BaseEntity {
     }
 
     public User(Course course, Team team, String name, String email) {
+        this.setId(UUID.randomUUID());
         this.setCourse(course);
         this.setTeam(team);
         this.setName(name);
@@ -67,11 +66,11 @@ public abstract class User extends BaseEntity {
         this.setRegKey(generateRegistrationKey());
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -150,9 +149,7 @@ public abstract class User extends BaseEntity {
             return true;
         } else if (this.getClass() == other.getClass()) {
             User otherUser = (User) other;
-            return Objects.equals(this.course, otherUser.course)
-                    && Objects.equals(this.name, otherUser.name)
-                    && Objects.equals(this.email, otherUser.email);
+            return Objects.equals(this.getId(), otherUser.getId());
         } else {
             return false;
         }
@@ -160,6 +157,6 @@ public abstract class User extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.course, this.name, this.email);
+        return this.getId().hashCode();
     }
 }

--- a/src/main/java/teammates/ui/output/NotificationData.java
+++ b/src/main/java/teammates/ui/output/NotificationData.java
@@ -33,7 +33,7 @@ public class NotificationData extends ApiOutput {
     }
 
     public NotificationData(Notification notification) {
-        this.notificationId = notification.getNotificationId().toString();
+        this.notificationId = notification.getId().toString();
         this.startTimestamp = notification.getStartTime().toEpochMilli();
         this.endTimestamp = notification.getEndTime().toEpochMilli();
         this.createdAt = notification.getCreatedAt().toEpochMilli();

--- a/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
@@ -38,7 +38,7 @@ public class NotificationsLogicTest extends BaseTestCase {
     public void testUpdateNotification_entityAlreadyExists_success()
             throws InvalidParametersException, EntityDoesNotExistException {
         Notification notification = getTypicalNotificationWithId();
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
 
         when(notificationsDb.getNotification(notificationId)).thenReturn(notification);
 
@@ -54,7 +54,7 @@ public class NotificationsLogicTest extends BaseTestCase {
 
         verify(notificationsDb, times(1)).getNotification(notificationId);
 
-        assertEquals(notificationId, updatedNotification.getNotificationId());
+        assertEquals(notificationId, updatedNotification.getId());
         assertEquals(newStartTime, updatedNotification.getStartTime());
         assertEquals(newEndTime, updatedNotification.getEndTime());
         assertEquals(newStyle, updatedNotification.getStyle());
@@ -66,7 +66,7 @@ public class NotificationsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateNotification_invalidNonNullParameter_endTimeBeforeStartTime() {
         Notification notification = getTypicalNotificationWithId();
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
 
         when(notificationsDb.getNotification(notificationId)).thenReturn(notification);
 
@@ -82,7 +82,7 @@ public class NotificationsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateNotification_invalidNonNullParameter_emptyTitle() {
         Notification notification = getTypicalNotificationWithId();
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
 
         when(notificationsDb.getNotification(notificationId)).thenReturn(notification);
 
@@ -97,7 +97,7 @@ public class NotificationsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateNotification_invalidNonNullParameter_emptyMessage() {
         Notification notification = getTypicalNotificationWithId();
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
 
         when(notificationsDb.getNotification(notificationId)).thenReturn(notification);
 
@@ -112,7 +112,7 @@ public class NotificationsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateNotification_entityDoesNotExist() {
         Notification notification = getTypicalNotificationWithId();
-        UUID notificationId = notification.getNotificationId();
+        UUID notificationId = notification.getId();
 
         when(notificationsDb.getNotification(notificationId)).thenReturn(notification);
 
@@ -135,7 +135,7 @@ public class NotificationsLogicTest extends BaseTestCase {
                 NotificationTargetUser.GENERAL,
                 "A deprecation note",
                 "<p>Deprecation happens in three minutes</p>");
-        notification.setNotificationId(UUID.fromString("00000001-0000-1000-0000-000000000000"));
+        notification.setId(UUID.fromString("00000001-0000-1000-0000-000000000000"));
         return notification;
     }
 }

--- a/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
@@ -46,7 +46,7 @@ public class AccountsDbTest extends BaseTestCase {
 
     @Test
     public void testCreateAccount_accountAlreadyExists_throwsEntityAlreadyExistsException() {
-        Account existingAccount = getAccountWithId();
+        Account existingAccount = getTypicalAccount();
         mockHibernateUtil.when(() -> HibernateUtil.getBySimpleNaturalId(Account.class, "google-id"))
                 .thenReturn(existingAccount);
         Account account = new Account("google-id", "different name", "email@teammates.com");
@@ -78,7 +78,7 @@ public class AccountsDbTest extends BaseTestCase {
     @Test
     public void testUpdateAccount_accountAlreadyExists_success()
             throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = getAccountWithId();
+        Account account = getTypicalAccount();
         mockHibernateUtil.when(() -> HibernateUtil.get(Account.class, account.getId()))
                 .thenReturn(account);
         account.setName("new name");
@@ -91,7 +91,7 @@ public class AccountsDbTest extends BaseTestCase {
     @Test
     public void testUpdateAccount_accountDoesNotExist_throwsEntityDoesNotExistException()
             throws InvalidParametersException, EntityAlreadyExistsException {
-        Account account = getAccountWithId();
+        Account account = getTypicalAccount();
 
         EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
                 () -> accountsDb.updateAccount(account));
@@ -102,7 +102,7 @@ public class AccountsDbTest extends BaseTestCase {
 
     @Test
     public void testUpdateAccount_invalidEmail_throwsInvalidParametersException() {
-        Account account = getAccountWithId();
+        Account account = getTypicalAccount();
         account.setEmail("invalid");
 
         InvalidParametersException ex = assertThrows(InvalidParametersException.class,
@@ -127,9 +127,7 @@ public class AccountsDbTest extends BaseTestCase {
         mockHibernateUtil.verify(() -> HibernateUtil.remove(account));
     }
 
-    private Account getAccountWithId() {
-        Account account = new Account("google-id", "name", "email@teammates.com");
-        account.setId(1);
-        return account;
+    private Account getTypicalAccount() {
+        return new Account("google-id", "name", "email@teammates.com");
     }
 }

--- a/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
@@ -85,11 +85,11 @@ public class NotificationsDbTest extends BaseTestCase {
     public void testGetNotification_success() {
         Notification notification = generateTypicalNotificationWithId();
         mockHibernateUtil.when(() ->
-                HibernateUtil.get(Notification.class, notification.getNotificationId())).thenReturn(notification);
+                HibernateUtil.get(Notification.class, notification.getId())).thenReturn(notification);
 
-        Notification actualNotification = notificationsDb.getNotification(notification.getNotificationId());
+        Notification actualNotification = notificationsDb.getNotification(notification.getId());
 
-        mockHibernateUtil.verify(() -> HibernateUtil.get(Notification.class, notification.getNotificationId()));
+        mockHibernateUtil.verify(() -> HibernateUtil.get(Notification.class, notification.getId()));
         assertEquals(notification, actualNotification);
     }
 
@@ -121,7 +121,7 @@ public class NotificationsDbTest extends BaseTestCase {
         Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
                 Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");
-        notification.setNotificationId(UUID.randomUUID());
+        notification.setId(UUID.randomUUID());
         return notification;
     }
 


### PR DESCRIPTION
Part of #12048

**Rationale**

1) Consistency, some entities are using ID, some UUID.
2) Integer IDs are generated only when entity is persisted into db. This means that entity can be in two states, one where ID is null, another where ID is present. This leads to the following issues.
- Could lead to subtle bugs that might not be easily caught if ID field is used before ID is generated.
- Higher friction for new developers. This way, developers do not need to fully understand intricacies of Hibernate before they can start modifying entities. From our experience, the main issues so far have been to do with this. e.g. need to flush because ID is null, entity in detached rather than transient state because ID was set manually etc. Moving completely to UUID removes all these issues (and their associated support requests in the future).
- Slightly easier to write changelogs in the future. Do not have to handle generation of IDs.