### PR TITLE
[#12081] Modify header and footer colours

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -118,7 +118,7 @@
 <footer class="footer">
   <div class="row text-center">
     <div class="col-sm-6 text-md-start">
-      <i class="fas fa-bolt"></i><a tmRouterLink="/web/front/home">&nbsp;TEAMMATES</a> V{{ version }}
+      <i class="fas fa-bolt"></i>&nbsp;<a tmRouterLink="/web/front/home">TEAMMATES</a> V{{ version }}
     </div>
     <div class="col-sm-6 text-md-end">
       <i class="far fa-comments"></i>&nbsp;Send <a tmRouterLink="/web/front/contact" target="_blank">Feedback</a>

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -21,6 +21,12 @@ nav {
 .footer {
   padding: 5px 70px;
   color: rgba(255, 255, 255, .75);
+
+  a {
+    &:hover {
+      filter: brightness(150%);
+    }
+  }
 }
 
 .container {

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -20,7 +20,7 @@ nav {
 
 .footer {
   padding: 5px 70px;
-  color: rgba(255, 255, 255, .5);
+  color: rgba(255, 255, 255, .75);
 }
 
 .container {
@@ -28,12 +28,12 @@ nav {
 }
 
 .dropdown-item {
-  color: rgba(255, 255, 255, .5);
+  color: rgba(255, 255, 255, .75);
 
   &:hover,
   &:focus {
     background-color: inherit;
-    color: rgba(255, 255, 255, .75);
+    color: white;
   }
 }
 
@@ -108,7 +108,7 @@ nav {
 }
 
 .dropdown-divider {
-  border: 1px solid rgba(255, 255, 255, .3);
+  border: 1px solid rgba(255, 255, 255, .5);
   margin: .5rem 15px;
 }
 

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -279,7 +279,6 @@ h6,
 
 // new rules to adapt to Bootstrap 5 changes
 
-a,
 .btn-link {
   text-decoration: none;
 }
@@ -367,3 +366,9 @@ label {
 }
 
 // end of new rules to adapt to Bootstrap 5
+
+// overrides default bootstrap colours to increase contrast
+.navbar-dark {
+  --bs-navbar-color: rgba(255, 255, 255, .75);
+  --bs-navbar-hover-color: white;
+}


### PR DESCRIPTION
Part of #12081

For header, overrode default Bootstrap nav link colours to increase contrast, and modified text colour accordingly for dropdowns. For footer, made colour of text consistent with header.
Also removed the `text-decoration: none` style override on links given accessibility best practices.

Before change:
<img width="1426" alt="Screenshot 2023-03-05 at 17 34 08" src="https://user-images.githubusercontent.com/54243224/222952875-bcd9a97a-3a40-4768-8f4a-173441242fd2.png">

After change:
<img width="1427" alt="Screenshot 2023-03-05 at 17 43 21" src="https://user-images.githubusercontent.com/54243224/222953163-8381c825-b6a4-454c-ade0-39b3e8330a02.png">