### PR TITLE
[#12048] Update access visibility of HibernateUtils utility methods to private

### DIFF
--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -150,6 +150,7 @@ public final class HibernateUtil {
 
     /**
      * Returns a generic typed TypedQuery object.
+     * @see Session#createQuery(CriteriaQuery)
      */
     public static <T> TypedQuery<T> createQuery(CriteriaQuery<T> cr) {
         return getSessionFactory().getCurrentSession().createQuery(cr);

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -151,7 +151,7 @@ public final class HibernateUtil {
     /**
      * Returns a generic typed TypedQuery object.
      */
-    public static <T extends BaseEntity> TypedQuery<T> createQuery(CriteriaQuery<T> cr) {
+    public static <T> TypedQuery<T> createQuery(CriteriaQuery<T> cr) {
         return getSessionFactory().getCurrentSession().createQuery(cr);
     }
 

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -146,7 +146,7 @@ public final class HibernateUtil {
      * @see SessionFactory#getCriteriaBuilder()
      */
     public static CriteriaBuilder getCriteriaBuilder() {
-        return getSessionFactory().getCurrentSession().getCriteriaBuilder();
+        return getCurrentSession().getCriteriaBuilder();
     }
 
     /**
@@ -154,7 +154,7 @@ public final class HibernateUtil {
      * @see Session#createQuery(CriteriaQuery)
      */
     public static <T> TypedQuery<T> createQuery(CriteriaQuery<T> cr) {
-        return getSessionFactory().getCurrentSession().createQuery(cr);
+        return getCurrentSession().createQuery(cr);
     }
 
     public static void setSessionFactory(SessionFactory sessionFactory) {

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -9,9 +9,6 @@ import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
-import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.BaseEntity;
@@ -46,6 +43,10 @@ import teammates.storage.sqlentity.responses.FeedbackRankOptionsResponse;
 import teammates.storage.sqlentity.responses.FeedbackRankRecipientsResponse;
 import teammates.storage.sqlentity.responses.FeedbackRubricResponse;
 import teammates.storage.sqlentity.responses.FeedbackTextResponse;
+
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 
 /**
  * Utility class for Hibernate related methods.

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -9,6 +9,9 @@ import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.BaseEntity;
@@ -123,7 +126,7 @@ public final class HibernateUtil {
     /**
      * Returns the SessionFactory.
      */
-    public static SessionFactory getSessionFactory() {
+    private static SessionFactory getSessionFactory() {
         assert sessionFactory != null;
 
         return sessionFactory;
@@ -133,8 +136,23 @@ public final class HibernateUtil {
      * Returns the current hibernate session.
      * @see SessionFactory#getCurrentSession()
      */
-    public static Session getCurrentSession() {
+    private static Session getCurrentSession() {
         return HibernateUtil.getSessionFactory().getCurrentSession();
+    }
+
+    /**
+     * Returns a CriteriaBuilder object.
+     * @see SessionFactory#getCriteriaBuilder()
+     */
+    public static CriteriaBuilder getCriteriaBuilder() {
+        return getSessionFactory().getCurrentSession().getCriteriaBuilder();
+    }
+
+    /**
+     * Returns a generic typed TypedQuery object.
+     */
+    public static <T extends BaseEntity> TypedQuery<T> createQuery(CriteriaQuery<T> cr) {
+        return getSessionFactory().getCurrentSession().createQuery(cr);
     }
 
     public static void setSessionFactory(SessionFactory sessionFactory) {

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
@@ -6,8 +6,6 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 import java.time.Instant;
 import java.util.List;
 
-import org.hibernate.Session;
-
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -60,14 +58,13 @@ public final class AccountRequestsDb extends EntitiesDb<AccountRequest> {
      * Get AccountRequest by {@code email} and {@code institute} from database.
      */
     public AccountRequest getAccountRequest(String email, String institute) {
-        Session currentSession = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = currentSession.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<AccountRequest> cr = cb.createQuery(AccountRequest.class);
         Root<AccountRequest> root = cr.from(AccountRequest.class);
         cr.select(root).where(cb.and(cb.equal(
                 root.get("email"), email), cb.equal(root.get("institute"), institute)));
 
-        TypedQuery<AccountRequest> query = currentSession.createQuery(cr);
+        TypedQuery<AccountRequest> query = HibernateUtil.createQuery(cr);
         return query.getResultStream().findFirst().orElse(null);
     }
 
@@ -75,13 +72,12 @@ public final class AccountRequestsDb extends EntitiesDb<AccountRequest> {
      * Get AccountRequest by {@code registrationKey} from database.
      */
     public AccountRequest getAccountRequest(String registrationKey) {
-        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
-        CriteriaBuilder cb = currentSession.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<AccountRequest> cr = cb.createQuery(AccountRequest.class);
         Root<AccountRequest> root = cr.from(AccountRequest.class);
         cr.select(root).where(cb.equal(root.get("registrationKey"), registrationKey));
 
-        TypedQuery<AccountRequest> query = currentSession.createQuery(cr);
+        TypedQuery<AccountRequest> query = HibernateUtil.createQuery(cr);
         return query.getResultStream().findFirst().orElse(null);
     }
 
@@ -89,14 +85,13 @@ public final class AccountRequestsDb extends EntitiesDb<AccountRequest> {
      * Get AccountRequest with {@code createdTime} within the times {@code startTime} and {@code endTime}.
      */
     public List<AccountRequest> getAccountRequests(Instant startTime, Instant endTime) {
-        Session currentSession = HibernateUtil.getSessionFactory().getCurrentSession();
-        CriteriaBuilder cb = currentSession.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<AccountRequest> cr = cb.createQuery(AccountRequest.class);
         Root<AccountRequest> root = cr.from(AccountRequest.class);
         cr.select(root).where(cb.and(cb.greaterThanOrEqualTo(root.get("createdAt"), startTime),
                 cb.lessThanOrEqualTo(root.get("createdAt"), endTime)));
 
-        TypedQuery<AccountRequest> query = currentSession.createQuery(cr);
+        TypedQuery<AccountRequest> query = HibernateUtil.createQuery(cr);
         return query.getResultList();
     }
 

--- a/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
@@ -5,8 +5,6 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.UUID;
 
-import org.hibernate.Session;
-
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;

--- a/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
@@ -68,8 +68,7 @@ public final class DeadlineExtensionsDb extends EntitiesDb<DeadlineExtension> {
      * Get DeadlineExtension by {@code userId} and {@code feedbackSessionId}.
      */
     public DeadlineExtension getDeadlineExtension(UUID userId, UUID feedbackSessionId) {
-        Session currentSession = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = currentSession.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<DeadlineExtension> cr = cb.createQuery(DeadlineExtension.class);
         Root<DeadlineExtension> root = cr.from(DeadlineExtension.class);
 
@@ -77,7 +76,7 @@ public final class DeadlineExtensionsDb extends EntitiesDb<DeadlineExtension> {
                 cb.equal(root.get("sessionId"), feedbackSessionId),
                 cb.equal(root.get("userId"), userId)));
 
-        TypedQuery<DeadlineExtension> query = currentSession.createQuery(cr);
+        TypedQuery<DeadlineExtension> query = HibernateUtil.createQuery(cr);
         return query.getResultStream().findFirst().orElse(null);
     }
 

--- a/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
@@ -3,8 +3,6 @@ package teammates.storage.sqlapi;
 import java.time.Instant;
 import java.util.List;
 
-import org.hibernate.Session;
-
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.UsageStatistics;
 

--- a/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsageStatisticsDb.java
@@ -33,8 +33,7 @@ public final class UsageStatisticsDb extends EntitiesDb<UsageStatistics> {
      * Gets a list of statistics objects between start time and end time.
      */
     public List<UsageStatistics> getUsageStatisticsForTimeRange(Instant startTime, Instant endTime) {
-        Session session = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<UsageStatistics> cr = cb.createQuery(UsageStatistics.class);
         Root<UsageStatistics> root = cr.from(UsageStatistics.class);
 
@@ -42,7 +41,7 @@ public final class UsageStatisticsDb extends EntitiesDb<UsageStatistics> {
                 cb.greaterThanOrEqualTo(root.get("startTime"), startTime),
                 cb.lessThan(root.get("startTime"), endTime)));
 
-        return session.createQuery(cr).getResultList();
+        return HibernateUtil.createQuery(cr).getResultList();
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -3,8 +3,6 @@ package teammates.storage.sqlapi;
 import java.time.Instant;
 import java.util.UUID;
 
-import org.hibernate.Session;
-
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -76,8 +76,7 @@ public final class UsersDb extends EntitiesDb<User> {
      * Gets instructor exists by its {@code courseId} and {@code email}.
      */
     public Instructor getInstructor(String courseId, String email) {
-        Session session = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Instructor> cr = cb.createQuery(Instructor.class);
         Root<Instructor> instructorRoot = cr.from(Instructor.class);
 
@@ -85,7 +84,7 @@ public final class UsersDb extends EntitiesDb<User> {
                 cb.equal(instructorRoot.get("courseId"), courseId),
                 cb.equal(instructorRoot.get("email"), email)));
 
-        return session.createQuery(cr).getSingleResultOrNull();
+        return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
     }
 
     /**
@@ -101,8 +100,7 @@ public final class UsersDb extends EntitiesDb<User> {
      * Gets a student exists by its {@code courseId} and {@code email}.
      */
     public Student getStudent(String courseId, String email) {
-        Session session = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Student> cr = cb.createQuery(Student.class);
         Root<Student> studentRoot = cr.from(Student.class);
 
@@ -110,7 +108,7 @@ public final class UsersDb extends EntitiesDb<User> {
                 cb.equal(studentRoot.get("courseId"), courseId),
                 cb.equal(studentRoot.get("email"), email)));
 
-        return session.createQuery(cr).getSingleResultOrNull();
+        return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
     }
 
     /**
@@ -126,8 +124,7 @@ public final class UsersDb extends EntitiesDb<User> {
      * Gets the number of instructors created within a specified time range.
      */
     public long getNumInstructorsByTimeRange(Instant startTime, Instant endTime) {
-        Session session = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Long> cr = cb.createQuery(Long.class);
         Root<Instructor> root = cr.from(Instructor.class);
 
@@ -135,15 +132,14 @@ public final class UsersDb extends EntitiesDb<User> {
                 cb.greaterThanOrEqualTo(root.get("createdAt"), startTime),
                 cb.lessThan(root.get("createdAt"), endTime)));
 
-        return session.createQuery(cr).getSingleResult();
+        return HibernateUtil.createQuery(cr).getSingleResult();
     }
 
     /**
      * Gets the number of students created within a specified time range.
      */
     public long getNumStudentsByTimeRange(Instant startTime, Instant endTime) {
-        Session session = HibernateUtil.getCurrentSession();
-        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Long> cr = cb.createQuery(Long.class);
         Root<Student> root = cr.from(Student.class);
 
@@ -151,7 +147,7 @@ public final class UsersDb extends EntitiesDb<User> {
                 cb.greaterThanOrEqualTo(root.get("createdAt"), startTime),
                 cb.lessThan(root.get("createdAt"), endTime)));
 
-        return session.createQuery(cr).getSingleResult();
+        return HibernateUtil.createQuery(cr).getSingleResult();
     }
 
 }


### PR DESCRIPTION
Part of #12048.

**Outline of Solution**

This PR consists of the following changes:
- Updated access visibility for `getSessionFactory` and `getCurrentSession` in HibernateUtils to be `private`
- Introduce `getCriteriaBuilder` and `createQuery` to support files that previously used the above `public` methods