### PR TITLE
[#12081] User-friendliness: Fix numerical scale question table in view responses page

### DIFF
--- a/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/num-scale-question-statistics.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="responses.length">
   <div class="row">
-    <div class="col-sm-4 text-color-gray mt-2">
+    <div class="text-color-gray mt-2">
       <strong *ngIf="isStudent">Summary of responses received by you</strong>
       <strong *ngIf="!isStudent">Response Summary</strong>
     </div>

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)"  [attr.aria-sort]="getAriaSort(column.header)">
-        <button>
+        <button [attr.tabindex]="getTabIndex(column.sortBy)" [attr.role]="getRole(column.sortBy)">
           <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
           <span class="fa-stack" *ngIf="column.sortBy" aria-hidden="true">
             <i class="fas fa-sort"></i>

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -1,10 +1,10 @@
 <table class="table table-bordered table-striped margin-bottom-20px">
   <thead>
     <tr>
-      <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)">
-        <button [attr.aria-sort]="getAriaSort(sortOrder)">
+      <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)"  [attr.aria-sort]="getAriaSort(column.header)">
+        <button>
           <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
-          <span class="fa-stack" *ngIf="column.sortBy">
+          <span class="fa-stack" *ngIf="column.sortBy" aria-hidden="true">
             <i class="fas fa-sort"></i>
             <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -2,14 +2,16 @@
   <thead>
     <tr>
       <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)"  [attr.aria-sort]="getAriaSort(column.header)">
-        <button [attr.tabindex]="getTabIndex(column.sortBy)" [attr.role]="getRole(column.sortBy)">
+        <button *ngIf="column.sortBy">
           <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
-          <span class="fa-stack" *ngIf="column.sortBy" aria-hidden="true">
+          <span class="fa-stack" aria-hidden="true">
             <i class="fas fa-sort"></i>
             <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
         </button>
+
+        <span *ngIf="!column.sortBy" [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
       </th>
     </tr>
   </thead>

--- a/src/web/app/components/sortable-table/sortable-table.component.html
+++ b/src/web/app/components/sortable-table/sortable-table.component.html
@@ -2,12 +2,14 @@
   <thead>
     <tr>
       <th *ngFor="let column of columns" [ngClass]="{'sortable-header': column.sortBy}" (click)="column.sortBy && onClickHeader(column.header)">
-        <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
-        <span class="fa-stack" *ngIf="column.sortBy">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+        <button [attr.aria-sort]="getAriaSort(sortOrder)">
+          <span [ngbTooltip]=column.headerToolTip container="body">{{ column.header }}</span>
+          <span class="fa-stack" *ngIf="column.sortBy">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="column.sortBy && columnToSortBy === column.header && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
     </tr>
   </thead>

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -5,11 +5,13 @@
     margin-left: .3em;
   }
 
-  @media (max-width: 768px) {
-    .fa-stack {
-      width: 20%;
-    }
+  .fa-stack {
+    width: 20%;
   }
+}
+
+th {
+  vertical-align: middle;
 
   button {
     background: none;
@@ -19,7 +21,7 @@
     text-align: left;
     width: 100%;
     font: inherit;
-    cursor: pointer;
+    cursor: inherit;
   }
 }
 

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -4,6 +4,12 @@
   i {
     margin-left: .3em;
   }
+
+  @media (max-width: 768px) {
+    .fa-stack {
+      width: 20%;
+    }
+  }
 }
 
 .margin-bottom-20px {

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -8,10 +8,6 @@
   .fa-stack {
     width: 20%;
   }
-}
-
-th {
-  vertical-align: middle;
 
   button {
     background: none;
@@ -23,6 +19,10 @@ th {
     font: inherit;
     cursor: inherit;
   }
+}
+
+th {
+  vertical-align: middle;
 }
 
 .margin-bottom-20px {

--- a/src/web/app/components/sortable-table/sortable-table.component.scss
+++ b/src/web/app/components/sortable-table/sortable-table.component.scss
@@ -10,6 +10,17 @@
       width: 20%;
     }
   }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: pointer;
+  }
 }
 
 .margin-bottom-20px {

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -83,27 +83,6 @@ export class SortableTableComponent implements OnInit, OnChanges {
     return this.sortOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
-  getRole(sortBy: SortBy): String {
-    if (!sortBy) {
-      return 'columnheader';
-    }
-    return 'button';
-  }
-
-  getTabIndex(sortBy: SortBy): String {
-    if (!sortBy) {
-      return '-1';
-    }
-    return '0';
-  }
-
-  getAriaLabel(column: ColumnData): String {
-    if (!column.sortBy) {
-      return column.header;
-    }
-    return '';
-  }
-
   sortRows(): void {
     if (!this.columnToSortBy) {
       return;

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -83,6 +83,27 @@ export class SortableTableComponent implements OnInit, OnChanges {
     return this.sortOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
+  getRole(sortBy: SortBy): String {
+    if (!sortBy) {
+      return 'columnheader';
+    }
+    return 'button';
+  }
+
+  getTabIndex(sortBy: SortBy): String {
+    if (!sortBy) {
+      return '-1';
+    }
+    return '0';
+  }
+
+  getAriaLabel(column: ColumnData): String {
+    if (!column.sortBy) {
+      return column.header;
+    }
+    return '';
+  }
+
   sortRows(): void {
     if (!this.columnToSortBy) {
       return;

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -76,6 +76,10 @@ export class SortableTableComponent implements OnInit, OnChanges {
     this.sortRows();
   }
 
+  getAriaSort(sortOrder: SortOrder): String {
+    return sortOrder.toString();
+  }
+
   sortRows(): void {
     if (!this.columnToSortBy) {
       return;

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -77,7 +77,7 @@ export class SortableTableComponent implements OnInit, OnChanges {
   }
 
   getAriaSort(column: String): String {
-    if (column != this.columnToSortBy) {
+    if (column !== this.columnToSortBy) {
       return 'none';
     }
     return this.sortOrder === SortOrder.ASC ? 'ascending' : 'descending';

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -76,8 +76,11 @@ export class SortableTableComponent implements OnInit, OnChanges {
     this.sortRows();
   }
 
-  getAriaSort(sortOrder: SortOrder): String {
-    return sortOrder.toString();
+  getAriaSort(column: String): String {
+    if (column != this.columnToSortBy) {
+      return 'none';
+    }
+    return this.sortOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
   sortRows(): void {

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
@@ -1258,87 +1258,107 @@ exports[`InstructorStudentActivityLogsComponent should snap with results of a se
                   <thead>
                     <tr>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                        <span
-                          container="body"
-                        >
-                          Status
-                        </span>
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                          <span
+                            container="body"
+                          >
+                            Status
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="ascending"
                         class="sortable-header"
                       >
-                        <span
-                          container="body"
-                        >
-                          Name
-                        </span>
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                          <i
-                            class="fas fa-sort-up"
-                          />
-                        </span>
+                        <button>
+                          <span
+                            container="body"
+                          >
+                            Name
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                            <i
+                              class="fas fa-sort-up"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                        <span
-                          container="body"
-                        >
-                          Email
-                        </span>
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                          <span
+                            container="body"
+                          >
+                            Email
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                        <span
-                          container="body"
-                        >
-                          Section
-                        </span>
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                          <span
+                            container="body"
+                          >
+                            Section
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                        <span
-                          container="body"
-                        >
-                          Team
-                        </span>
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                          <span
+                            container="body"
+                          >
+                            Team
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                     </tr>
                   </thead>


### PR DESCRIPTION
Part of #12081 
Sub-issue: [View responses page: numerical scale question](https://github.com/TEAMMATES/teammates/projects/16#card-88067825)

**Outline of Solution**
Added a 20% width to the sort image so that it doesn't overflow into the next table cell on mobile. For the table headers, added an `aria-sort` attribute to the header so that the screen reader picks up on whether or not it is sorted. Further enclosed the text and sort image in a button so users can tab to it and know that it is clickable.

Also removed a class so that the text above the table doesn't break into 2 lines if there's no need for it.

**Notes**
The screen reader does not convey changes to the `aria-sort` value if it changes while the element is in focus. It also does not convey the `none` `aria-sort` value by indicating that the header is unsorted but sortable. These are known issues with screen readers, as per [this website](https://a11ysupport.io/tests/tech__aria__aria-sort) on accessibility tests.
