### PR TITLE
[#12081] User-friendliness: Fix dropdown caret overlap

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -66,7 +66,7 @@
               <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
             </div>
             <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
-              <select id="recipient-dropdown" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
+              <select id="recipient-dropdown" class="form-control form-select fw-bold select-flex" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
                       (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
                       [disabled]="isFormsDisabled">
                 <option value=""></option>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -54,3 +54,7 @@
 .collapse-caret {
   margin-right: 10px;
 }
+
+.select-flex {
+  flex: 1 0 0%;
+}


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Dropdown component text overlap with caret](https://github.com/TEAMMATES/teammates/projects/16#card-88331097)

**Outline of Solution**
Currently, the dropdown option text overlaps with the caret on the right if it's too long. `<select>` components in other pages mostly only have `.form-control` and `.form-select` classes and don't have the additional `.col` class. Hence, I removed the `.col` class which fixed the problem as it was overriding the padding, in particular the padding on the right. I also added a `.select-flex` class to add back the `flex` properties of the `.col` class so that the dropdown still looks the same as before. Example:
![Screenshot 2023-03-08 at 3 34 52 PM](https://user-images.githubusercontent.com/48304907/223653504-800a2d0c-72aa-4b45-931a-95a46c447650.png)
