### PR TITLE
[#12132] Instructor home page: redundant padding

### DIFF
--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -34,9 +34,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
   <div
     class="row"
   >
-    <div
-      class="col-12"
-    >
+    <div>
       <table
         class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
         id="sessions-table"
@@ -510,9 +508,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
   <div
     class="row"
   >
-    <div
-      class="col-12"
-    >
+    <div>
       <table
         class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
         id="sessions-table"

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -1,5 +1,5 @@
 <div class="row" *ngIf="sessionsTableRowModels.length > 0; else noSessionMessage">
-  <div class="col-12">
+  <div>
     <table id="sessions-table" class="table table-responsive-lg table-striped table-bordered margin-bottom-0">
       <thead>
       <tr [ngClass]="{ 'bg-primary text-white': headerColorScheme === SessionsTableHeaderColorScheme.BLUE }">

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -534,9 +534,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                 <div
                   class="row"
                 >
-                  <div
-                    class="col-12"
-                  >
+                  <div>
                     <table
                       class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
                       id="sessions-table"
@@ -1036,9 +1034,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                 <div
                   class="row"
                 >
-                  <div
-                    class="col-12"
-                  >
+                  <div>
                     <table
                       class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
                       id="sessions-table"


### PR DESCRIPTION
Fixes #12132

**Outline of Solution**
Removed the `col-12` class from the sessions table component which seems to fix the padding issue.
![instructorhomepage](https://user-images.githubusercontent.com/123022263/223748227-ae4906fe-278b-4e4e-b9d6-49ee1f05880c.png)
