### PR TITLE
[#12182][#12068] student viewing results: the spinner keeps going until the user clicks on the page

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -429,79 +429,57 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         String[][] expectedRubricStats = {
                 {
                         formattedSubQns[0],
-                        "33.33% (1) [1]",
-                        "33.33% (1) [2]",
-                        "0% (0) [3]",
-                        "0% (0) [4]",
-                        "33.33% (1) [5]",
-                        "2.67",
+                        "33.33% (1)",
+                        "33.33% (1)",
+                        "0% (0)",
+                        "0% (0)",
+                        "33.33% (1)",
                 },
                 {
                         formattedSubQns[1],
-                        "0% (0) [0.01]",
-                        "0% (0) [0.02]",
-                        "33.33% (1) [0.03]",
-                        "0% (0) [0.04]",
-                        "66.67% (2) [0.05]",
-                        "0.04",
+                        "0% (0)",
+                        "0% (0)",
+                        "33.33% (1)",
+                        "0% (0)",
+                        "66.67% (2)",
                 },
                 {
                         formattedSubQns[2],
-                        "0% (0) [2]",
-                        "0% (0) [1]",
-                        "0% (0) [0]",
-                        "66.67% (2) [-1]",
-                        "33.33% (1) [-2]",
-                        "-1.33",
+                        "0% (0)",
+                        "0% (0)",
+                        "0% (0)",
+                        "66.67% (2)",
+                        "33.33% (1)",
                 },
         };
 
         String[][] expectedRubricStatsExcludingSelf = {
                 {
                         formattedSubQns[0],
-                        "50% (1) [1]",
-                        "0% (0) [2]",
-                        "0% (0) [3]",
-                        "0% (0) [4]",
-                        "50% (1) [5]",
-                        "3",
+                        "50% (1)",
+                        "0% (0)",
+                        "0% (0)",
+                        "0% (0)",
+                        "50% (1)",
                 },
                 {
                         formattedSubQns[1],
-                        "0% (0) [0.01]",
-                        "0% (0) [0.02]",
-                        "0% (0) [0.03]",
-                        "0% (0) [0.04]",
-                        "100% (2) [0.05]",
-                        "0.05",
+                        "0% (0)",
+                        "0% (0)",
+                        "0% (0)",
+                        "0% (0)",
+                        "100% (2)",
                 },
                 {
                         formattedSubQns[2],
-                        "0% (0) [2]",
-                        "0% (0) [1]",
-                        "0% (0) [0]",
-                        "50% (1) [-1]",
-                        "50% (1) [-2]",
-                        "-1.5",
+                        "0% (0)",
+                        "0% (0)",
+                        "0% (0)",
+                        "50% (1)",
+                        "50% (1)",
                 },
         };
 
-        String[] studentNames = { "Anonymous student", "Benny Charles", "Charlie Davis", "You" };
-        String[] studentTeams = { "", "Team 1", "Team 1", "Team 1" };
-
-        String[][] expectedRubricStatsPerRecipient = new String[studentNames.length * formattedSubQns.length][3];
-        // The actual calculated stats are not verified for this table
-        // Checking the recipient presence in the table is sufficient for E2E purposes
-        for (int i = 0; i < studentNames.length; i++) {
-            for (int j = 0; j < formattedSubQns.length; j++) {
-                int index = i * formattedSubQns.length + j;
-                expectedRubricStatsPerRecipient[index][0] = studentTeams[i];
-                expectedRubricStatsPerRecipient[index][1] = studentNames[i];
-                expectedRubricStatsPerRecipient[index][2] = formattedSubQns[j];
-            }
-        }
-
-        resultsPage.verifyRubricStatistics(10, expectedRubricStats, expectedRubricStatsExcludingSelf,
-                expectedRubricStatsPerRecipient);
+        resultsPage.verifyRubricStatistics(10, expectedRubricStats, expectedRubricStatsExcludingSelf);
     }
 }

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -107,20 +107,14 @@ public class FeedbackResultsPage extends AppPage {
         verifyTableRowValues(getNumScaleStatistics(questionNum), expectedStats);
     }
 
-    public void verifyRubricStatistics(int questionNum, String[][] expectedStats, String[][] expectedStatsExcludingSelf,
-                                       String[][] expectedStatsPerRecipient) {
+    public void verifyRubricStatistics(int questionNum, String[][] expectedStats,
+                                       String[][] expectedStatsExcludingSelf) {
         WebElement excludeSelfCheckbox = getRubricExcludeSelfCheckbox(questionNum);
         markOptionAsUnselected(excludeSelfCheckbox);
         verifyTableBodyValues(getRubricStatistics(questionNum), expectedStats);
 
         markOptionAsSelected(excludeSelfCheckbox);
         verifyTableBodyValues(getRubricStatistics(questionNum), expectedStatsExcludingSelf);
-
-        sortRubricPerRecipientStatsPerCriterion(questionNum, 2);
-        verifyTableBodyValues(getRubricPerRecipientStatsPerCriterion(questionNum), expectedStatsPerRecipient);
-
-        sortRubricPerRecipientStatsOverall(questionNum, 2);
-        verifyTableBodyValues(getRubricPerRecipientStatsPerCriterion(questionNum), expectedStatsPerRecipient);
     }
 
     public void verifyContributionStatistics(int questionNum, String[] expectedStats) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -526,22 +526,6 @@ public class FeedbackResultsPage extends AppPage {
         return getQuestionResponsesSection(questionNum).findElement(By.id("rubric-statistics"));
     }
 
-    private WebElement getRubricPerRecipientStatsPerCriterion(int questionNum) {
-        return getQuestionResponsesSection(questionNum).findElement(By.id("rubric-recipient-statistics-per-criterion"));
-    }
-
-    private void sortRubricPerRecipientStatsPerCriterion(int questionNum, int colNum) {
-        click(getRubricPerRecipientStatsPerCriterion(questionNum).findElements(By.tagName("th")).get(colNum - 1));
-    }
-
-    private WebElement getRubricPerRecipientStatsOverall(int questionNum) {
-        return getQuestionResponsesSection(questionNum).findElement(By.id("rubric-recipient-statistics-overall"));
-    }
-
-    private void sortRubricPerRecipientStatsOverall(int questionNum, int colNum) {
-        click(getRubricPerRecipientStatsOverall(questionNum).findElements(By.tagName("th")).get(colNum - 1));
-    }
-
     private boolean isCommentByResponseGiver(WebElement commentField) {
         return commentField.findElements(By.id("by-response-giver")).size() > 0;
     }

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -80,6 +80,8 @@ public class SessionResultsData extends ApiOutput {
                     questionDetails.getQuestionResultStatisticsJson(question, student.getEmail(), bundle));
             Map<String, List<ResponseOutput>> otherResponsesMap = new HashMap<>();
 
+            qnOutput.getFeedbackQuestion().hideInformationForStudent();
+
             if (questionDetails.isIndividualResponsesShownToStudents()) {
                 for (FeedbackResponseAttributes response : responses) {
                     boolean isUserInstructor = Const.USER_TEAM_FOR_INSTRUCTOR.equals(student.getTeam());

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/rubric-question-statistics-calculation.ts
@@ -37,6 +37,7 @@ export class RubricQuestionStatisticsCalculation
   hasWeights: boolean = false;
   weights: number[][] = [];
   answers: number[][] = [];
+  isWeightStatsVisible: boolean = false;
 
   percentages: number[][] = [];
   subQuestionWeightAverage: number[] = [];
@@ -59,6 +60,8 @@ export class RubricQuestionStatisticsCalculation
     this.choices = this.question.rubricChoices;
     this.hasWeights = this.question.hasAssignedWeights;
     this.weights = this.question.rubricWeightsForEachCell;
+    this.isWeightStatsVisible =
+      this.hasWeights && this.weights.length > 0 && this.weights[0].length > 0;
 
     const emptyAnswers: number[][] = [];
     for (let i = 0; i < this.question.rubricSubQuestions.length; i += 1) {
@@ -89,7 +92,7 @@ export class RubricQuestionStatisticsCalculation
     this.percentagesExcludeSelf = this.calculatePercentages(this.answersExcludeSelf);
 
     // only apply weights average if applicable
-    if (!this.hasWeights) {
+    if (!this.isWeightStatsVisible) {
       return;
     }
 

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -19,7 +19,7 @@
       ></tm-sortable-table>
     </div>
   </div>
-  <ng-container *ngIf="hasWeights">
+  <ng-container *ngIf="isWeightStatsVisible">
     <div class="row">
       <div class="col-sm-4 text-color-gray">
         <strong>

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit } from '@angular/core';
+import { Component, OnChanges } from '@angular/core';
 import { StringHelper } from '../../../../services/string-helper';
 import { DEFAULT_RUBRIC_QUESTION_DETAILS } from '../../../../types/default-question-structs';
 import { SortBy } from '../../../../types/sort-properties';
@@ -17,7 +17,7 @@ import {
   styleUrls: ['./rubric-question-statistics.component.scss'],
 })
 export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsCalculation
-    implements OnInit, OnChanges {
+    implements OnChanges {
 
   excludeSelf: boolean = false;
 
@@ -32,11 +32,6 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
     super(DEFAULT_RUBRIC_QUESTION_DETAILS());
   }
 
-  ngOnInit(): void {
-    this.calculateStatistics();
-    this.getTableData();
-  }
-
   ngOnChanges(): void {
     this.calculateStatistics();
     this.getTableData();
@@ -47,7 +42,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
         { header: 'Question', sortBy: SortBy.RUBRIC_SUBQUESTION },
       ...this.choices.map((choice: string) => ({ header: choice, sortBy: SortBy.RUBRIC_CHOICE })),
     ];
-    if (this.hasWeights) {
+    if (this.isWeightStatsVisible) {
       this.summaryColumnsData.push({ header: 'Average', sortBy: SortBy.RUBRIC_WEIGHT_AVERAGE });
     }
 
@@ -59,17 +54,17 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
             return {
               value: `${this.percentagesExcludeSelf[questionIndex][choiceIndex]}%`
                   + ` (${this.answersExcludeSelf[questionIndex][choiceIndex]})`
-                  + `${this.hasWeights ? ` [${this.weights[questionIndex][choiceIndex]}]` : ''}`,
+                  + `${this.isWeightStatsVisible ? ` [${this.weights[questionIndex][choiceIndex]}]` : ''}`,
             };
           }
           return {
             value: `${this.percentages[questionIndex][choiceIndex]}%`
                 + ` (${this.answers[questionIndex][choiceIndex]})`
-                + `${this.hasWeights ? ` [${this.weights[questionIndex][choiceIndex]}]` : ''}`,
+                + `${this.isWeightStatsVisible ? ` [${this.weights[questionIndex][choiceIndex]}]` : ''}`,
           };
         }),
       ];
-      if (this.hasWeights) {
+      if (this.isWeightStatsVisible) {
         if (this.excludeSelf) {
           currRow.push({ value: this.subQuestionWeightAverageExcludeSelf[questionIndex] });
         } else {
@@ -80,7 +75,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
       return currRow;
     });
 
-    if (!this.hasWeights) {
+    if (!this.isWeightStatsVisible) {
       return;
     }
 


### PR DESCRIPTION
Fixes #12182
Fixes #12068

See https://github.com/TEAMMATES/teammates/issues/12182#issuecomment-1462227482 for details of fix. The results for weighted rubric questions is now identical to that of non-weighted rubric questions for students (see below screenshot). Instructors are still able to see the detailed per recipient stats.

<img width="1225" alt="Screenshot 2023-03-10 at 00 13 32" src="https://user-images.githubusercontent.com/54243224/224084712-b7272676-3b3f-4c8f-8ce3-8da2c5a0ed45.png">
