### PR TITLE
[#12067] Inconsistent spacing in headings of rubric question statistics

### DIFF
--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-4 text-color-gray mt-2">
       <strong>
-        Response Summary <span *ngIf="isStudent">(of received responses)</span>
+        Response Summary <span *ngIf="isStudent">(of received responses) </span>
       </strong>
       <span container="body" [ngbTooltip]="'Format: Response percentage (Response count)' + (hasWeights ? '[Weight of option]' : '') + ', e.g. 50% (2) ' + (hasWeights ? '[1.0]' : '')" class="fa fa-info-circle"></span>
     </div>


### PR DESCRIPTION
Fixes #12067 

Added a space between the heading "Response Summary (of received responses)" and the info icon.

<img width="1287" alt="Screenshot 2023-03-09 at 8 49 52 PM" src="https://user-images.githubusercontent.com/115324898/224260895-9b4df586-401c-4221-9fc0-c73000da3dbb.png">
