### PR TITLE
Add pull request workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,15 +4,14 @@ on:
     types:
       - opened
       - reopened
+      - synchronize
     branches:
       - master
 
 jobs:
   check-pr:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+    permissions: write-all
     steps:
     - uses: actions/github-script@v6
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   check-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/github-script@v6
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,41 @@
+name: Pull Request Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+    branches:
+      - master
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          })
+          const isTitleValid = /^\[#\d\] /.test(pr.data.title)
+          const isDescriptionValid = /(Fixes|Part of) #\d/.test(pr.data.body)
+          if (isTitleValid && isDescriptionValid) {
+            return
+          }
+          let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
+            However, your PR does not appear to follow our [contribution guidelines](https://teammates.github.io/teammates/process.html#step-4-submit-a-pr):\n\n`
+          if (!isTitleValid) {
+            body += "- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n"
+          }
+          if (!isDescriptionValid) {
+            body += "- Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not addres the issue fully)\n"
+          }
+          body += "\nPlease address the above before we proceed to review your PR."
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body,
+          })


### PR DESCRIPTION
Fixes #(deliberately omitted to trigger workflow)

Adds simple Github Actions workflow using [actions/github-script](https://github.com/actions/github-script) to check PRs. The bot currently checks for the following:
- Title: starts with issue number in square brackets, followed by a space
- Description: contains either "Fixes" or "Part of", followed by the issue number. Only "Fixes" is checked since it is the keyword used in our PR template.

More checks can be added down the line as and when needed. The bot also only checks PRs that are newly opened/reopened, so as to avoid spam.