### PR TITLE
[#12194] Add simple workflow to vet pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
             pull_number: context.issue.number
           })
           const isTitleValid = /^\[#\d\] /.test(pr.data.title)
-          const isDescriptionValid = /(Fixes|Part of) #\d/.test(pr.data.body)
+          const isDescriptionValid = /([Ff]ix(es|ed)?|[Cc]lose(s|d)?|[Rr]esolve(s|d)?|[Pp]art [Oo]f) #\d/.test(pr.data.body)
           if (isTitleValid && isDescriptionValid) {
             return
           }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,8 +19,8 @@ jobs:
             repo: context.repo.repo,
             pull_number: context.issue.number
           })
-          const isTitleValid = /^\[#\d\] /.test(pr.data.title)
-          const isDescriptionValid = /([Ff]ix(es|ed)?|[Cc]lose(s|d)?|[Rr]esolve(s|d)?|[Pp]art [Oo]f) #\d/.test(pr.data.body)
+          const isTitleValid = /^\[#\d+\] /.test(pr.data.title)
+          const isDescriptionValid = /([Ff]ix(es|ed)?|[Cc]lose(s|d)?|[Rr]esolve(s|d)?|[Pp]art [Oo]f) #\d+/.test(pr.data.body)
           if (isTitleValid && isDescriptionValid) {
             return
           }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
             body += "- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n"
           }
           if (!isDescriptionValid) {
-            body += "- Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not addres the issue fully)\n"
+            body += "- Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not address the issue fully)\n"
           }
           body += "\nPlease address the above before we proceed to review your PR."
           await github.rest.issues.createComment({

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,41 @@
+name: Pull Request Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+    branches:
+      - master
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          })
+          const isTitleValid = /^\[#\d\] /.test(pr.data.title)
+          const isDescriptionValid = /(Fixes|Part of) #\d/.test(pr.data.body)
+          if (isTitleValid && isDescriptionValid) {
+            return
+          }
+          let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
+            However, your PR does not appear to follow our [contribution guidelines](https://teammates.github.io/teammates/process.html#step-4-submit-a-pr):\n\n`
+          if (!isTitleValid) {
+            body += "- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n"
+          }
+          if (!isDescriptionValid) {
+            body += "- Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not addres the issue fully)\n"
+          }
+          body += "\nPlease address the above before we proceed to review your PR."
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body,
+          })


### PR DESCRIPTION
Fixes #12194
Part of #11383

Adds simple Github Actions workflow using [actions/github-script](https://github.com/actions/github-script) to check PRs. The bot currently checks for the following:
- Title: starts with issue number in square brackets, followed by a space
- Description: contains either "Fixes" or "Part of", followed by the issue number. Only "Fixes" is checked since it is the keyword used in our PR template.

More checks can be added down the line as and when needed. The bot also only checks PRs that are newly opened/reopened, so as to avoid spam.