### PR TITLE
[#12081] User-friendliness: Display card header content in column format for mobile

### DIFF
--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -27,21 +27,21 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             class="question-text"
           >
             <span
-              class="d-inline-flex align-items-center"
+              class="d-flex flex-column flex-sm-row align-items-sm-center"
             >
               <h2
-                class="col-auto question-number"
+                class="question-number"
               >
-                 Question 1:  
+                 Question 1: 
               </h2>
               <span
-                class="col-auto"
+                class="mx-sm-2"
                 id="question-text"
               >
-                 How well did team member perform?
+                How well did team member perform?
               </span>
               <button
-                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
                 id="additional-info-button"
               >
                  [more] 
@@ -130,21 +130,21 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             class="question-text"
           >
             <span
-              class="d-inline-flex align-items-center"
+              class="d-flex flex-column flex-sm-row align-items-sm-center"
             >
               <h2
-                class="col-auto question-number"
+                class="question-number"
               >
-                 Question 2:  
+                 Question 2: 
               </h2>
               <span
-                class="col-auto"
+                class="mx-sm-2"
                 id="question-text"
               >
-                 Rate your teammates in contribution
+                Rate your teammates in contribution
               </span>
               <button
-                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
                 id="additional-info-button"
               >
                  [more] 
@@ -280,21 +280,21 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             class="question-text"
           >
             <span
-              class="d-inline-flex align-items-center"
+              class="d-flex flex-column flex-sm-row align-items-sm-center"
             >
               <h2
-                class="col-auto question-number"
+                class="question-number"
               >
-                 Question 3:  
+                 Question 3: 
               </h2>
               <span
-                class="col-auto"
+                class="mx-sm-2"
                 id="question-text"
               >
-                 Rate your teammates proficiency
+                Rate your teammates proficiency
               </span>
               <button
-                class="info-font-size ms-1 border-0 bg-transparent text-primary"
+                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
                 id="additional-info-button"
               >
                  [more] 
@@ -463,18 +463,18 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             class="question-text"
           >
             <span
-              class="d-inline-flex align-items-center"
+              class="d-flex flex-column flex-sm-row align-items-sm-center"
             >
               <h2
-                class="col-auto question-number"
+                class="question-number"
               >
-                 Question 1:  
+                 Question 1: 
               </h2>
               <span
-                class="col-auto"
+                class="mx-sm-2"
                 id="question-text"
               >
-                 What comments do you have regarding each of your team members? (response is confidential and will only be shown to the instructor).
+                What comments do you have regarding each of your team members? (response is confidential and will only be shown to the instructor).
               </span>
             </span>
           </tm-question-text-with-info>
@@ -654,18 +654,18 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             class="question-text"
           >
             <span
-              class="d-inline-flex align-items-center"
+              class="d-flex flex-column flex-sm-row align-items-sm-center"
             >
               <h2
-                class="col-auto question-number"
+                class="question-number"
               >
-                 Question 2:  
+                 Question 2: 
               </h2>
               <span
-                class="col-auto"
+                class="mx-sm-2"
                 id="question-text"
               >
-                 How are the team dynamics thus far? (response is confidential and will only be shown to the instructor).
+                How are the team dynamics thus far? (response is confidential and will only be shown to the instructor).
               </span>
             </span>
           </tm-question-text-with-info>

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -11,18 +11,18 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex align-items-center"
+    class="d-flex flex-column flex-sm-row align-items-sm-center"
   >
     <h2
-      class="col-auto question-number"
+      class="question-number"
     >
-       Question 0:  
+       Question 0: 
     </h2>
     <span
-      class="col-auto"
+      class="mx-sm-2"
       id="question-text"
     >
-       Text question details
+      Text question details
     </span>
   </span>
 </tm-question-text-with-info>
@@ -39,21 +39,21 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex align-items-center"
+    class="d-flex flex-column flex-sm-row align-items-sm-center"
   >
     <h2
-      class="col-auto question-number"
+      class="question-number"
     >
-       Question 0:  
+       Question 0: 
     </h2>
     <span
-      class="col-auto"
+      class="mx-sm-2"
       id="question-text"
     >
-       MCQ question details
+      MCQ question details
     </span>
     <button
-      class="info-font-size ms-1 border-0 bg-transparent text-primary"
+      class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
       id="additional-info-button"
     >
        [more] 
@@ -73,21 +73,21 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
   shouldShowDownloadQuestionResult="false"
 >
   <span
-    class="d-inline-flex align-items-center"
+    class="d-flex flex-column flex-sm-row align-items-sm-center"
   >
     <h2
-      class="col-auto question-number"
+      class="question-number"
     >
-       Question 0:  
+       Question 0: 
     </h2>
     <span
-      class="col-auto"
+      class="mx-sm-2"
       id="question-text"
     >
-       MCQ question details
+      MCQ question details
     </span>
     <button
-      class="info-font-size ms-1 border-0 bg-transparent text-primary"
+      class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
       id="additional-info-button"
     >
        [less] 

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,14 +1,14 @@
-<span class="d-inline-flex align-items-center">
-  <h2 *ngIf="shouldShowDownloadQuestionResult" class="col-auto question-number">
-    <button ngbTooltip="Download Question Results" type="button" class="btn btn-link padding-0" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
+<span class="d-flex flex-column flex-sm-row align-items-sm-center">
+  <h2 *ngIf="shouldShowDownloadQuestionResult" class="question-number">
+    <button ngbTooltip="Download Question Results" type="button" class="btn btn-link p-0" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
       Question {{ questionNumber }}:
     </button>
   </h2>
-  <h2 *ngIf="!shouldShowDownloadQuestionResult" class="col-auto question-number">
-    Question {{ questionNumber }}:&nbsp;
+  <h2 *ngIf="!shouldShowDownloadQuestionResult" class="question-number">
+    Question {{ questionNumber }}:
   </h2>
-  <span id="question-text" class="col-auto">&nbsp;{{ questionDetails.questionText }}</span>
-  <button id="additional-info-button" class="info-font-size ms-1 border-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
+  <span id="question-text" class="mx-sm-2">{{ questionDetails.questionText }}</span>
+  <button id="additional-info-button" class="info-font-size me-auto border-0 p-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
   </button>
 </span>

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -1,11 +1,3 @@
-.padding-0 {
-  padding: 0;
-}
-
-.col-auto {
-  flex: 0 1 auto;
-}
-
 .question-number {
   font-size: inherit;
   margin: 0;


### PR DESCRIPTION
Part of #12081 
Sub-issue [View responses page: Modify header of each card to display content in column instead of row format on mobile](https://github.com/TEAMMATES/teammates/projects/16#card-88348625)

**Outline of Solution**

- Use `flex-column` by default to make header display content in column (Mobile)
- Use `flex-sm-row` to make header display content in row (Desktop)