### PR TITLE
[#12048] Update FeedbackSession entity and add methods for FeedbackQuestion use

### DIFF
--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
@@ -1,6 +1,10 @@
 package teammates.it.storage.sqlapi;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import org.testng.annotations.Test;
+
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
@@ -8,9 +12,6 @@ import teammates.storage.sqlapi.CoursesDb;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
-
-import java.time.Duration;
-import java.time.Instant;
 
 /**
  * SUT: {@link FeedbackSessionsDb}.

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
@@ -1,0 +1,42 @@
+package teammates.it.storage.sqlapi;
+
+import org.testng.annotations.Test;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
+import teammates.storage.sqlapi.CoursesDb;
+import teammates.storage.sqlapi.FeedbackSessionsDb;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * SUT: {@link FeedbackSessionsDb}.
+ */
+public class FeedbackSessionsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
+
+    private final CoursesDb coursesDb = CoursesDb.inst();
+    private final FeedbackSessionsDb fsDb = FeedbackSessionsDb.inst();
+
+    @Test
+    public void testGetFeedbackSessionByFeedbackSessionNameAndCourseId()
+            throws EntityAlreadyExistsException, InvalidParametersException {
+        ______TS("success: get feedback session that exists");
+        Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
+        coursesDb.createCourse(course1);
+        FeedbackSession fs1 = new FeedbackSession("name1", course1, "test1@test.com", "test-instruction",
+                Instant.now(), Instant.now().plus(Duration.ofDays(7)), Instant.now(), Instant.now().plus(Duration.ofDays(7)),
+                Duration.ofMinutes(10), true, true, true);
+        FeedbackSession fs2 = new FeedbackSession("name2", course1, "test1@test.com", "test-instruction",
+                Instant.now(), Instant.now().plus(Duration.ofDays(7)), Instant.now(), Instant.now().plus(Duration.ofDays(7)),
+                Duration.ofMinutes(10), true, true, true);
+        fsDb.createFeedbackSession(fs1);
+        fsDb.createFeedbackSession(fs2);
+
+        FeedbackSession actualFs = fsDb.getFeedbackSession(fs2.getName(), fs2.getCourse().getId());
+
+        verifyEquals(fs2, actualFs);
+    }
+}

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
@@ -27,11 +27,11 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
         coursesDb.createCourse(course1);
         FeedbackSession fs1 = new FeedbackSession("name1", course1, "test1@test.com", "test-instruction",
-                Instant.now(), Instant.now().plus(Duration.ofDays(7)), Instant.now(), Instant.now().plus(Duration.ofDays(7)),
-                Duration.ofMinutes(10), true, true, true);
+                Instant.now().plus(Duration.ofDays(1)), Instant.now().plus(Duration.ofDays(7)), Instant.now(),
+                Instant.now().plus(Duration.ofDays(7)), Duration.ofMinutes(10), true, true, true);
         FeedbackSession fs2 = new FeedbackSession("name2", course1, "test1@test.com", "test-instruction",
-                Instant.now(), Instant.now().plus(Duration.ofDays(7)), Instant.now(), Instant.now().plus(Duration.ofDays(7)),
-                Duration.ofMinutes(10), true, true, true);
+                Instant.now().plus(Duration.ofDays(1)), Instant.now().plus(Duration.ofDays(7)), Instant.now(),
+                Instant.now().plus(Duration.ofDays(7)), Duration.ofMinutes(10), true, true, true);
         fsDb.createFeedbackSession(fs1);
         fsDb.createFeedbackSession(fs2);
 

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -212,6 +212,15 @@ public class Logic {
     }
 
     /**
+     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
+     *
+     * @return null if not found.
+     */
+    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
+        return feedbackSessionsLogic.getFeedbackSession(feedbackSessionName, courseId);
+    }
+
+    /**
      * Creates a feedback session.
      *
      * @return created feedback session

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.NoResultException;
-import jakarta.persistence.NonUniqueResultException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackSessionsDb;

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
@@ -49,6 +51,18 @@ public final class FeedbackSessionsLogic {
     public FeedbackSession getFeedbackSession(UUID id) {
         assert id != null;
         return fsDb.getFeedbackSession(id);
+    }
+
+    /**
+     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
+     *
+     * @return null if not found.
+     */
+    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
+        assert feedbackSessionName != null;
+        assert courseId != null;
+
+        return fsDb.getFeedbackSession(feedbackSessionName, courseId);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.criteria.Join;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -17,6 +16,7 @@ import teammates.storage.sqlentity.FeedbackSession;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
 
 /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -7,10 +7,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.criteria.Join;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -43,6 +45,22 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
         assert fsId != null;
 
         return HibernateUtil.get(FeedbackSession.class, fsId);
+    }
+
+    /**
+     * Gets a feedback session.
+     *
+     * @return null if not found
+     */
+    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackSession> cq = cb.createQuery(FeedbackSession.class);
+        Root<FeedbackSession> fsRoot = cq.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> fsJoin = fsRoot.join("course");
+        cq.select(fsRoot).where(cb.and(
+                cb.equal(fsRoot.get("name"), feedbackSessionName),
+                cb.equal(fsJoin.get("id"), courseId)));
+        return HibernateUtil.createQuery(cq).getResultStream().findFirst().orElse(null);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -48,7 +48,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession> {
     }
 
     /**
-     * Gets a feedback session.
+     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
      *
      * @return null if not found
      */

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import jakarta.persistence.UniqueConstraint;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -23,6 +22,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 /**
  * Represents a course entity.

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import jakarta.persistence.UniqueConstraint;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -27,7 +28,7 @@ import jakarta.persistence.Table;
  * Represents a course entity.
  */
 @Entity
-@Table(name = "FeedbackSessions")
+@Table(name = "FeedbackSessions", uniqueConstraints = @UniqueConstraint(columnNames = {"courseId", "name"}))
 public class FeedbackSession extends BaseEntity {
     @Id
     private UUID id;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -27,6 +27,7 @@ import teammates.logic.api.RecaptchaVerifier;
 import teammates.logic.api.TaskQueuer;
 import teammates.logic.api.UserProvision;
 import teammates.sqllogic.api.Logic;
+import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Student;
 import teammates.ui.request.BasicRequest;
@@ -273,6 +274,15 @@ public abstract class Action {
 
     FeedbackSessionAttributes getNonNullFeedbackSession(String feedbackSessionName, String courseId) {
         FeedbackSessionAttributes feedbackSession = logic.getFeedbackSession(feedbackSessionName, courseId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
+        return feedbackSession;
+    }
+
+    // TODO: Remove Sql from method name after migration
+    FeedbackSession getNonNullSqlFeedbackSession(String feedbackSessionName, String courseId) {
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionName, courseId);
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }


### PR DESCRIPTION
Part of #12048 

- Make `(courseId, feedbackSessionName)` in `FeedbackSession` entity to be unique for existing APIs related to get feedback session by feedback session name and course id
- Create `FeedbackSession` methods for `FeedbackQuestion` use
