### PR TITLE
[#12081] Fix duplicate IDs in codebase

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -313,7 +313,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private String getQuestionText(int questionNum) {
-        return getQuestionResponsesSection(questionNum).findElement(By.id("question-text")).getText().trim();
+        return getQuestionResponsesSection(questionNum).findElement(By.className("question-text")).getText().trim();
     }
 
     private String getMcqAddInfo(FeedbackMcqQuestionDetails questionDetails) {
@@ -406,7 +406,8 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private void showAdditionalInfo(int qnNumber) {
-        WebElement additionalInfoLink = getQuestionResponsesSection(qnNumber).findElement(By.id("additional-info-button"));
+        WebElement additionalInfoLink =
+                getQuestionResponsesSection(qnNumber).findElement(By.className("additional-info-button"));
         if ("[more]".equals(additionalInfoLink.getText())) {
             click(additionalInfoLink);
             waitUntilAnimationFinish();
@@ -415,7 +416,7 @@ public class FeedbackResultsPage extends AppPage {
 
     private String getAdditionalInfo(int questionNum) {
         showAdditionalInfo(questionNum);
-        return getQuestionResponsesSection(questionNum).findElement(By.id("additional-info")).getText();
+        return getQuestionResponsesSection(questionNum).findElement(By.className("additional-info")).getText();
     }
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -550,7 +550,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private boolean isCommentByResponseGiver(WebElement commentField) {
-        return commentField.findElements(By.id("by-response-giver")).size() > 0;
+        return commentField.findElements(By.className("by-response-giver")).size() > 0;
     }
 
     private String getCommentGiver(WebElement commentField) {
@@ -570,7 +570,7 @@ public class FeedbackResultsPage extends AppPage {
     private WebElement getCommentField(int questionNum, String commentString) {
         List<WebElement> commentFields = getCommentFields(questionNum);
         for (WebElement comment : commentFields) {
-            if (comment.findElement(By.id("comment-text")).getText().equals(commentString)) {
+            if (comment.findElement(By.className("comment-text")).getText().equals(commentString)) {
                 return comment;
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -611,7 +611,7 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     private void verifyVisibilityStringPresent(int qnNumber, String expectedString) {
-        List<WebElement> visibilityStrings = getQuestionForm(qnNumber).findElement(By.id("visibility-list"))
+        List<WebElement> visibilityStrings = getQuestionForm(qnNumber).findElement(By.className("visibility-list"))
                 .findElements(By.tagName("li"));
         for (WebElement visibilityString : visibilityStrings) {
             if (visibilityString.getText().equals(expectedString)) {
@@ -716,7 +716,7 @@ public class FeedbackSubmitPage extends AppPage {
         WebElement questionForm = getQuestionForm(qnNumber);
         // For questions with flexible recipient.
         try {
-            List<WebElement> recipientDropdowns = questionForm.findElements(By.id("recipient-dropdown"));
+            List<WebElement> recipientDropdowns = questionForm.findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
             for (int i = 0; i < recipientDropdowns.size(); i++) {
                 String dropdownText = getSelectedDropdownOptionText(recipientDropdowns.get(i));
                 if (dropdownText.isEmpty()) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -594,7 +594,7 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     private String getQuestionBrief(int qnNumber) {
-        String questionDetails = getQuestionForm(qnNumber).findElement(By.id("question-details")).getText();
+        String questionDetails = getQuestionForm(qnNumber).findElement(By.className("question-details")).getText();
         return questionDetails.split(": ")[1];
     }
 
@@ -731,7 +731,8 @@ public class FeedbackSubmitPage extends AppPage {
         }
         int limit = 20; // we are not likely to set test data exceeding this number
         for (int i = 0; i < limit; i++) {
-            if (questionForm.findElement(By.id("recipient-name-qn-" + qnNumber + "-idx-" + i)).getText().contains(recipient)) {
+            if (questionForm.findElement(By.id("recipient-name-qn-" + qnNumber + "-idx-" + i))
+                    .getText().contains(recipient)) {
                 return i;
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -66,7 +66,7 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     public void verifyNumQuestions(int expected) {
-        assertEquals(browser.driver.findElements(By.id("question-submission-form")).size(), expected);
+        assertEquals(browser.driver.findElements(By.cssSelector("[id^='question-submission-form-qn-']")).size(), expected);
     }
 
     public void verifyQuestionDetails(int qnNumber, FeedbackQuestionAttributes questionAttributes) {
@@ -78,7 +78,7 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     public void verifyLimitedRecipients(int qnNumber, int numRecipients, List<String> recipientNames) {
-        List<WebElement> recipientDropdowns = getQuestionForm(qnNumber).findElements(By.id("recipient-dropdown"));
+        List<WebElement> recipientDropdowns = getQuestionForm(qnNumber).findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
         assertEquals(numRecipients, recipientDropdowns.size());
         List<WebElement> recipients = recipientDropdowns.get(0).findElements(By.tagName("option"));
         assertEquals(recipientNames.size(), recipients.size() - 1);
@@ -93,7 +93,7 @@ public class FeedbackSubmitPage extends AppPage {
         Collections.sort(recipientNames);
         for (int i = 0; i < recipientNames.size(); i++) {
             assertEquals(recipientNames.get(i) + " (" + role + ")",
-                    questionForm.findElement(By.id("recipient-name-" + i)).getText());
+                    questionForm.findElement(By.id("recipient-name-qn-" + qnNumber + "-idx-" + i)).getText());
         }
     }
 
@@ -118,28 +118,28 @@ public class FeedbackSubmitPage extends AppPage {
 
     public void addComment(int qnNumber, String recipient, String newComment) {
         WebElement commentSection = getCommentSection(qnNumber, recipient);
-        click(commentSection.findElement(By.id("btn-add-comment")));
+        click(commentSection.findElement(By.className("btn-add-comment")));
         writeToCommentEditor(commentSection, newComment);
     }
 
     public void editComment(int qnNumber, String recipient, String editedComment) {
         WebElement commentSection = getCommentSection(qnNumber, recipient);
-        click(commentSection.findElement(By.id("btn-edit-comment")));
+        click(commentSection.findElement(By.className("btn-edit-comment")));
         writeToCommentEditor(commentSection, editedComment);
     }
 
     public void deleteComment(int qnNumber, String recipient) {
-        clickAndConfirm(getCommentSection(qnNumber, recipient).findElement(By.id("btn-delete-comment")));
+        clickAndConfirm(getCommentSection(qnNumber, recipient).findElement(By.className("btn-delete-comment")));
     }
 
     public void verifyComment(int qnNumber, String recipient, String expectedComment) {
         WebElement commentSection = getCommentSection(qnNumber, recipient);
-        String actualComment = commentSection.findElement(By.id("comment-text")).getAttribute("innerHTML");
+        String actualComment = commentSection.findElement(By.className("comment-text")).getAttribute("innerHTML");
         assertEquals(expectedComment, actualComment);
     }
 
     public void verifyNoCommentPresent(int qnNumber, String recipient) {
-        int numComments = getCommentSection(qnNumber, recipient).findElements(By.id("comment-text")).size();
+        int numComments = getCommentSection(qnNumber, recipient).findElements(By.className("comment-text")).size();
         assertEquals(numComments, 0);
     }
 
@@ -583,9 +583,9 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     private WebElement getQuestionForm(int qnNumber) {
-        By questionFormId = By.id("question-submission-form");
+        By questionFormId = By.id("question-submission-form-qn-" + qnNumber);
         waitForElementPresence(questionFormId);
-        WebElement questionForm = browser.driver.findElements(questionFormId).get(qnNumber - 1);
+        WebElement questionForm = browser.driver.findElement(questionFormId);
         // Scroll to the question to ensure that the details are fully loaded
         scrollElementToCenter(questionForm);
         waitUntilAnimationFinish();

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -78,7 +78,8 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     public void verifyLimitedRecipients(int qnNumber, int numRecipients, List<String> recipientNames) {
-        List<WebElement> recipientDropdowns = getQuestionForm(qnNumber).findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
+        List<WebElement> recipientDropdowns = getQuestionForm(qnNumber)
+                .findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
         assertEquals(numRecipients, recipientDropdowns.size());
         List<WebElement> recipients = recipientDropdowns.get(0).findElements(By.tagName("option"));
         assertEquals(recipientNames.size(), recipients.size() - 1);
@@ -730,7 +731,7 @@ public class FeedbackSubmitPage extends AppPage {
         }
         int limit = 20; // we are not likely to set test data exceeding this number
         for (int i = 0; i < limit; i++) {
-            if (questionForm.findElement(By.id("recipient-name-" + i)).getText().contains(recipient)) {
+            if (questionForm.findElement(By.id("recipient-name-qn-" + qnNumber + "-idx-" + i)).getText().contains(recipient)) {
                 return i;
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -694,7 +694,7 @@ public class FeedbackSubmitPage extends AppPage {
     }
 
     private String getQuestionDescription(int qnNumber) {
-        return getQuestionForm(qnNumber).findElement(By.id("question-description")).getAttribute("innerHTML");
+        return getQuestionForm(qnNumber).findElement(By.className("question-description")).getAttribute("innerHTML");
     }
 
     private WebElement getCommentSection(int qnNumber, String recipient) {
@@ -716,7 +716,8 @@ public class FeedbackSubmitPage extends AppPage {
         WebElement questionForm = getQuestionForm(qnNumber);
         // For questions with flexible recipient.
         try {
-            List<WebElement> recipientDropdowns = questionForm.findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
+            List<WebElement> recipientDropdowns =
+                    questionForm.findElements(By.cssSelector("[id^='recipient-dropdown-qn-']"));
             for (int i = 0; i < recipientDropdowns.size(); i++) {
                 String dropdownText = getSelectedDropdownOptionText(recipientDropdowns.get(i));
                 if (dropdownText.isEmpty()) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -699,7 +699,7 @@ public class FeedbackSubmitPage extends AppPage {
 
     private WebElement getCommentSection(int qnNumber, String recipient) {
         int recipientIndex = getRecipientIndex(qnNumber, recipient);
-        return getQuestionForm(qnNumber).findElements(By.id("comment-section")).get(recipientIndex);
+        return getQuestionForm(qnNumber).findElement(By.id("comment-section-qn-" + qnNumber + "-idx-" + recipientIndex));
     }
 
     private void writeToCommentEditor(WebElement commentSection, String comment) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
@@ -83,12 +83,12 @@ public class InstructorCourseDetailsPage extends AppPage {
     }
 
     public void sortByName() {
-        click(browser.driver.findElement(By.id("sort-by-name")));
+        click(browser.driver.findElement(By.className("sort-by-name")));
         waitUntilAnimationFinish();
     }
 
     public void sortByStatus() {
-        click(browser.driver.findElement(By.id("sort-by-status")));
+        click(browser.driver.findElement(By.className("sort-by-status")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
@@ -125,12 +125,12 @@ public class InstructorCourseDetailsPage extends AppPage {
 
     private WebElement getSendInviteButton(StudentAttributes student) {
         WebElement studentRow = getStudentRow(student);
-        return studentRow.findElement(By.id("btn-send-invite"));
+        return studentRow.findElement(By.cssSelector("[id^='btn-send-invite-']"));
     }
 
     private WebElement getDeleteButton(StudentAttributes student) {
         WebElement studentRow = getStudentRow(student);
-        return studentRow.findElement(By.id("btn-delete"));
+        return studentRow.findElement(By.cssSelector("[id^='btn-delete-']"));
     }
 
     private List<WebElement> getAllStudentRows() {
@@ -158,7 +158,7 @@ public class InstructorCourseDetailsPage extends AppPage {
 
     public InstructorCourseStudentDetailsViewPage clickViewStudent(StudentAttributes student) {
         WebElement studentRow = getStudentRow(student);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -167,7 +167,7 @@ public class InstructorCourseDetailsPage extends AppPage {
 
     public InstructorCourseStudentDetailsEditPage clickEditStudent(StudentAttributes student) {
         WebElement studentRow = getStudentRow(student);
-        WebElement viewButton = studentRow.findElement(By.id("btn-edit-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -176,7 +176,7 @@ public class InstructorCourseDetailsPage extends AppPage {
 
     public InstructorStudentRecordsPage clickViewAllRecords(StudentAttributes student) {
         WebElement studentRow = getStudentRow(student);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-records"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1018,7 +1018,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     private WebElement getCommentField(WebElement commentSection, String commentString) {
         List<WebElement> commentFields = getCommentFields(commentSection);
         for (WebElement comment : commentFields) {
-            if (comment.findElement(By.id("comment-text")).getText().equals(commentString)) {
+            if (comment.findElement(By.className("comment-text")).getText().equals(commentString)) {
                 return comment;
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -918,14 +918,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     private void expandQuestionPanel(WebElement questionPanel) {
         if (!isQuestionPanelExpanded(questionPanel)) {
-            click(questionPanel.findElement(By.id("question-header")));
+            click(questionPanel.findElement(By.className("card-header")));
             waitUntilAnimationFinish();
         }
     }
 
     private void hideQuestionPanel(WebElement questionPanel) {
         if (isQuestionPanelExpanded(questionPanel)) {
-            click(questionPanel.findElement(By.id("question-header")));
+            click(questionPanel.findElement(By.className("card-header")));
             waitUntilAnimationFinish();
         }
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -936,7 +936,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     private String getQuestionText(WebElement questionPanel) {
-        return questionPanel.findElement(By.id("question-text")).getText().trim();
+        return questionPanel.findElement(By.className("question-text")).getText().trim();
     }
 
     private WebElement getResponseTable(WebElement questionPanel) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -846,9 +846,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
     private WebElement getQuestionPanel(WebElement parentPanel, int qnNum) {
         List<WebElement> questionPanels;
         if (parentPanel == null) {
-            questionPanels = browser.driver.findElements(By.id("question-panel"));
+            questionPanels = browser.driver.findElements(By.cssSelector("[id^='question-panel-']"));
         } else {
-            questionPanels = parentPanel.findElements(By.id("question-panel"));
+            questionPanels = parentPanel.findElements(By.cssSelector("[id^='question-panel-']"));
         }
 
         for (WebElement questionPanel : questionPanels) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
@@ -203,7 +203,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
 
     public void moveToRecycleBin(FeedbackSessionAttributes sessionToDelete) {
         int rowId = getFeedbackSessionRowId(sessionToDelete.getCourseId(), sessionToDelete.getFeedbackSessionName());
-        clickAndConfirm(browser.driver.findElement(By.id("btn-soft-delete-" + rowId)));
+        clickAndConfirm(browser.driver.findElement(By.className("btn-soft-delete-" + rowId)));
         waitUntilAnimationFinish();
     }
 
@@ -211,7 +211,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         showDeleteTable();
         int rowId = getSoftDeletedFeedbackSessionRowId(sessionToRestore.getCourseId(),
                 sessionToRestore.getFeedbackSessionName());
-        click(browser.driver.findElement(By.id("btn-restore-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-restore-" + rowId)));
         waitUntilAnimationFinish();
     }
 
@@ -219,7 +219,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         showDeleteTable();
         int rowId = getSoftDeletedFeedbackSessionRowId(sessionToRestore.getCourseId(),
                 sessionToRestore.getFeedbackSessionName());
-        clickAndConfirm(browser.driver.findElement(By.id("btn-delete-" + rowId)));
+        clickAndConfirm(browser.driver.findElement(By.className("btn-delete-" + rowId)));
         waitUntilAnimationFinish();
     }
 
@@ -243,8 +243,8 @@ public class InstructorFeedbackSessionsPage extends AppPage {
     public void sendReminderEmailToSelectedStudent(FeedbackSessionAttributes session, StudentAttributes student) {
         int rowId = getFeedbackSessionRowId(session.getCourseId(), session.getFeedbackSessionName());
 
-        click(browser.driver.findElement(By.id("btn-remind-" + rowId)));
-        click(waitForElementPresence(By.id("btn-remind-selected-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-remind-" + rowId)));
+        click(waitForElementPresence(By.className("btn-remind-selected-" + rowId)));
         selectStudentToEmail(student.getEmail());
         click(browser.driver.findElement(By.id("btn-confirm-send-reminder")));
     }
@@ -252,16 +252,16 @@ public class InstructorFeedbackSessionsPage extends AppPage {
     public void sendReminderEmailToNonSubmitters(FeedbackSessionAttributes session) {
         int rowId = getFeedbackSessionRowId(session.getCourseId(), session.getFeedbackSessionName());
 
-        click(browser.driver.findElement(By.id("btn-remind-" + rowId)));
-        click(waitForElementPresence(By.id("btn-remind-all-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-remind-" + rowId)));
+        click(waitForElementPresence(By.className("btn-remind-all-" + rowId)));
         click(waitForElementPresence(By.id("btn-confirm-send-reminder")));
     }
 
     public void resendResultsLink(FeedbackSessionAttributes session, StudentAttributes student) {
         int rowId = getFeedbackSessionRowId(session.getCourseId(), session.getFeedbackSessionName());
 
-        click(browser.driver.findElement(By.id("btn-results-" + rowId)));
-        click(waitForElementPresence(By.id("btn-resend-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-results-" + rowId)));
+        click(waitForElementPresence(By.className("btn-resend-" + rowId)));
         selectStudentToEmail(student.getEmail());
 
         click(browser.driver.findElement(By.id("btn-confirm-resend-results")));
@@ -269,20 +269,20 @@ public class InstructorFeedbackSessionsPage extends AppPage {
 
     public void publishSessionResults(FeedbackSessionAttributes sessionToPublish) {
         int rowId = getFeedbackSessionRowId(sessionToPublish.getCourseId(), sessionToPublish.getFeedbackSessionName());
-        click(browser.driver.findElement(By.id("btn-results-" + rowId)));
-        clickAndConfirm(waitForElementPresence(By.id("btn-publish-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-results-" + rowId)));
+        clickAndConfirm(waitForElementPresence(By.className("btn-publish-" + rowId)));
     }
 
     public void unpublishSessionResults(FeedbackSessionAttributes sessionToPublish) {
         int rowId = getFeedbackSessionRowId(sessionToPublish.getCourseId(), sessionToPublish.getFeedbackSessionName());
-        click(browser.driver.findElement(By.id("btn-results-" + rowId)));
-        clickAndConfirm(waitForElementPresence(By.id("btn-unpublish-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-results-" + rowId)));
+        clickAndConfirm(waitForElementPresence(By.className("btn-unpublish-" + rowId)));
     }
 
     public void downloadResults(FeedbackSessionAttributes session) {
         int rowId = getFeedbackSessionRowId(session.getCourseId(), session.getFeedbackSessionName());
-        click(browser.driver.findElement(By.id("btn-results-" + rowId)));
-        click(waitForElementPresence(By.id("btn-download-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-results-" + rowId)));
+        click(waitForElementPresence(By.className("btn-download-" + rowId)));
     }
 
     public void sortBySessionsName() {
@@ -330,11 +330,11 @@ public class InstructorFeedbackSessionsPage extends AppPage {
     }
 
     private String getResponseRate(int rowId) {
-        By showButtonId = By.id("show-response-rate-" + rowId);
+        By showButtonId = By.className("show-response-rate-" + rowId);
         if (isElementPresent(showButtonId)) {
             click(showButtonId);
         }
-        return waitForElementPresence(By.id("response-rate-" + rowId)).getText();
+        return waitForElementPresence(By.className("response-rate-" + rowId)).getText();
     }
 
     private void clickAddSessionButton() {
@@ -456,7 +456,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
 
     private WebElement clickCopyButtonInTable(String courseId, String sessionName) {
         int rowId = getFeedbackSessionRowId(courseId, sessionName);
-        click(browser.driver.findElement(By.id("btn-copy-" + rowId)));
+        click(browser.driver.findElement(By.className("btn-copy-" + rowId)));
         return waitForElementPresence(By.id("copy-course-modal"));
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
@@ -96,7 +96,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
     @FindBy(id = "btn-create-session")
     private WebElement createSessionButton;
 
-    @FindBy(id = "sessions-table")
+    @FindBy(className = "sessions-table")
     private WebElement sessionsTable;
 
     @FindBy(id = "deleted-sessions-heading")
@@ -286,11 +286,11 @@ public class InstructorFeedbackSessionsPage extends AppPage {
     }
 
     public void sortBySessionsName() {
-        click(waitForElementPresence(By.id("sort-session-name")));
+        click(waitForElementPresence(By.className("sort-session-name")));
     }
 
     public void sortByCourseId() {
-        click(waitForElementPresence(By.id("sort-course-id")));
+        click(waitForElementPresence(By.className("sort-course-id")));
     }
 
     private String[] getSessionDetails(FeedbackSessionAttributes session) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackSessionsPage.java
@@ -154,7 +154,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
 
     public void addFeedbackSession(FeedbackSessionAttributes newSession, boolean isUsingTemplate) {
         clickAddSessionButton();
-        waitForElementPresence(By.cssSelector("#instructions iframe"));
+        waitForElementPresence(By.id("session-edit-form"));
 
         if (isUsingTemplate) {
             selectDropdownOptionByText(sessionTypeDropdown,
@@ -211,7 +211,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         showDeleteTable();
         int rowId = getSoftDeletedFeedbackSessionRowId(sessionToRestore.getCourseId(),
                 sessionToRestore.getFeedbackSessionName());
-        click(browser.driver.findElement(By.className("btn-restore-" + rowId)));
+        click(browser.driver.findElement(By.id("btn-restore-" + rowId)));
         waitUntilAnimationFinish();
     }
 
@@ -219,7 +219,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         showDeleteTable();
         int rowId = getSoftDeletedFeedbackSessionRowId(sessionToRestore.getCourseId(),
                 sessionToRestore.getFeedbackSessionName());
-        clickAndConfirm(browser.driver.findElement(By.className("btn-delete-" + rowId)));
+        clickAndConfirm(browser.driver.findElement(By.id("btn-delete-" + rowId)));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -61,50 +61,50 @@ public class InstructorHomePage extends AppPage {
 
     public void publishSessionResults(int courseTabIndex, int sessionIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-results-" + sessionIndex)));
-        List<WebElement> publishButtons = browser.driver.findElements(By.id("btn-publish-" + sessionIndex));
+        click(courseTab.findElement(By.className("btn-results-" + sessionIndex)));
+        List<WebElement> publishButtons = browser.driver.findElements(By.className("btn-publish-" + sessionIndex));
         clickAndConfirm(publishButtons.get(publishButtons.size() - 1));
     }
 
     public void unpublishSessionResults(int courseTabIndex, int sessionIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-results-" + sessionIndex)));
-        List<WebElement> unpublishButtons = browser.driver.findElements(By.id("btn-unpublish-" + sessionIndex));
+        click(courseTab.findElement(By.className("btn-results-" + sessionIndex)));
+        List<WebElement> unpublishButtons = browser.driver.findElements(By.className("btn-unpublish-" + sessionIndex));
         clickAndConfirm(unpublishButtons.get(unpublishButtons.size() - 1));
     }
 
     public void sendReminderEmailToSelectedStudent(int courseTabIndex, int sessionIndex, StudentAttributes student) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-remind-" + sessionIndex)));
-        click(waitForElementPresence(By.id("btn-remind-selected-" + sessionIndex)));
+        click(courseTab.findElement(By.className("btn-remind-" + sessionIndex)));
+        click(waitForElementPresence(By.className("btn-remind-selected-" + sessionIndex)));
         selectStudentToEmail(student.getEmail());
         click(browser.driver.findElement(By.id("btn-confirm-send-reminder")));
     }
 
     public void sendReminderEmailToNonSubmitters(int courseTabIndex, int sessionIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-remind-" + sessionIndex)));
-        click(waitForElementPresence(By.id("btn-remind-all-" + sessionIndex)));
+        click(courseTab.findElement(By.className("btn-remind-" + sessionIndex)));
+        click(waitForElementPresence(By.className("btn-remind-all-" + sessionIndex)));
         click(waitForElementPresence(By.id("btn-confirm-send-reminder")));
     }
 
     public void resendResultsLink(int courseTabIndex, int sessionIndex, StudentAttributes student) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-results-" + sessionIndex)));
-        click(waitForElementPresence(By.id("btn-resend-" + sessionIndex)));
+        click(courseTab.findElement(By.className("btn-results-" + sessionIndex)));
+        click(waitForElementPresence(By.className("btn-resend-" + sessionIndex)));
         selectStudentToEmail(student.getEmail());
         click(browser.driver.findElement(By.id("btn-confirm-resend-results")));
     }
 
     public void downloadResults(int courseTabIndex, int sessionIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-results-" + sessionIndex)));
-        click(waitForElementPresence(By.id("btn-download-" + sessionIndex)));
+        click(courseTab.findElement(By.className("btn-results-" + sessionIndex)));
+        click(waitForElementPresence(By.className("btn-download-" + sessionIndex)));
     }
 
     public void deleteSession(int courseTabIndex, int sessionIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        clickAndConfirm(courseTab.findElement(By.id("btn-soft-delete-" + sessionIndex)));
+        clickAndConfirm(courseTab.findElement(By.className("btn-soft-delete-" + sessionIndex)));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -151,7 +151,7 @@ public class InstructorHomePage extends AppPage {
     }
 
     private WebElement getSessionsTable(int courseTabIndex) {
-        return getCourseTab(courseTabIndex).findElement(By.id("sessions-table"));
+        return getCourseTab(courseTabIndex).findElement(By.className("sessions-table"));
     }
 
     private String getDateString(Instant instant, String timeZone) {
@@ -189,7 +189,7 @@ public class InstructorHomePage extends AppPage {
     }
 
     private WebElement clickCopyButtonInTable(int courseTabIndex, int sessionIndex) {
-        click(getCourseTab(courseTabIndex).findElement(By.id("btn-copy-" + sessionIndex)));
+        click(getCourseTab(courseTabIndex).findElement(By.className("btn-copy-" + sessionIndex)));
         return waitForElementPresence(By.id("copy-course-modal"));
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -110,15 +110,15 @@ public class InstructorHomePage extends AppPage {
 
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.id("btn-archive-course")));
+        click(courseTab.findElement(By.className("btn-course")));
+        clickAndConfirm(courseTab.findElement(By.className("btn-archive-course")));
         waitUntilAnimationFinish();
     }
 
     public void deleteCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        click(courseTab.findElement(By.id("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.id("btn-delete-course")));
+        click(courseTab.findElement(By.className("btn-course")));
+        clickAndConfirm(courseTab.findElement(By.className("btn-delete-course")));
         waitUntilAnimationFinish();
     }
 
@@ -138,16 +138,16 @@ public class InstructorHomePage extends AppPage {
     }
 
     private int getNumCourses() {
-        return browser.driver.findElements(By.id("course-tab")).size();
+        return browser.driver.findElements(By.cssSelector("[id^='course-tab-']")).size();
     }
 
     private WebElement getCourseTab(int courseTabIndex) {
-        return browser.driver.findElements(By.id("course-tab")).get(courseTabIndex);
+        return browser.driver.findElement(By.id("course-tab-" + courseTabIndex));
     }
 
     private String getCourseDetails(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
-        return courseTab.findElement(By.id("course-details")).getText();
+        return courseTab.findElement(By.className("course-details")).getText();
     }
 
     private WebElement getSessionsTable(int courseTabIndex) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -178,14 +178,14 @@ public class InstructorHomePage extends AppPage {
     private String getResponseRate(int courseTabIndex, int sessionIndex) {
         WebElement showButton = null;
         try {
-            showButton = getCourseTab(courseTabIndex).findElement(By.id("show-response-rate-" + sessionIndex));
+            showButton = getCourseTab(courseTabIndex).findElement(By.className("show-response-rate-" + sessionIndex));
         } catch (NoSuchElementException e) {
             // continue
         }
         if (showButton != null) {
             click(showButton);
         }
-        return waitForElementPresence(By.id("response-rate-" + sessionIndex)).getText();
+        return waitForElementPresence(By.className("response-rate-" + sessionIndex)).getText();
     }
 
     private WebElement clickCopyButtonInTable(int courseTabIndex, int sessionIndex) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -132,7 +132,7 @@ public class InstructorSearchPage extends AppPage {
 
     public InstructorCourseStudentDetailsViewPage clickViewStudent(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -141,7 +141,7 @@ public class InstructorSearchPage extends AppPage {
 
     public InstructorCourseStudentDetailsEditPage clickEditStudent(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-edit-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -150,7 +150,7 @@ public class InstructorSearchPage extends AppPage {
 
     public InstructorStudentRecordsPage clickViewAllRecords(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-records"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -111,7 +111,7 @@ public class InstructorSearchPage extends AppPage {
 
     private WebElement getDeleteButton(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        return studentRow.findElement(By.id("btn-delete"));
+        return studentRow.findElement(By.cssSelector("[id^='btn-delete-']"));
     }
 
     private WebElement getStudentRow(CourseAttributes course, String studentEmail) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
@@ -142,7 +142,7 @@ public class InstructorStudentListPage extends AppPage {
 
     private WebElement getDeleteButton(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        return studentRow.findElement(By.id("btn-delete"));
+        return studentRow.findElement(By.cssSelector("[id^='btn-delete-']"));
     }
 
     private WebElement getStudentRow(CourseAttributes course, String studentEmail) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
@@ -171,7 +171,7 @@ public class InstructorStudentListPage extends AppPage {
 
     public InstructorCourseStudentDetailsViewPage clickViewStudent(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -180,7 +180,7 @@ public class InstructorStudentListPage extends AppPage {
 
     public InstructorCourseStudentDetailsEditPage clickEditStudent(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-edit-details"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();
@@ -189,7 +189,7 @@ public class InstructorStudentListPage extends AppPage {
 
     public InstructorStudentRecordsPage clickViewAllRecords(CourseAttributes course, String studentEmail) {
         WebElement studentRow = getStudentRow(course, studentEmail);
-        WebElement viewButton = studentRow.findElement(By.id("btn-view-records"));
+        WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
         ThreadHelper.waitFor(2000);
         switchToNewWindow();

--- a/src/e2e/java/teammates/e2e/pageobjects/UserNotificationsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/UserNotificationsPage.java
@@ -73,10 +73,10 @@ public class UserNotificationsPage extends AppPage {
         }
 
         // Check notification message
-        WebElement notifMessage = notificationTab.findElement(By.id("notification-message"));
+        WebElement notifMessage = notificationTab.findElement(By.className("notification-message"));
         assertEquals(notification.getMessage(), notifMessage.getAttribute("innerHTML"));
 
-        List<WebElement> markAsReadBtnList = notificationTab.findElements(By.id("btn-mark-as-read"));
+        List<WebElement> markAsReadBtnList = notificationTab.findElements(By.className("btn-mark-as-read"));
 
         if (isRead) {
             // Check that mark as read button cannot be found if notification is read
@@ -93,7 +93,7 @@ public class UserNotificationsPage extends AppPage {
 
     public void markNotificationAsRead(NotificationAttributes notification) {
         WebElement notificationTab = notificationTabs.findElement(By.id(notification.getNotificationId()));
-        click(notificationTab.findElement(By.id("btn-mark-as-read")));
+        click(notificationTab.findElement(By.className("btn-mark-as-read")));
         waitForPageToLoad(true);
     }
 

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -16,7 +16,7 @@
   <div class="card-body">
     <div class="row comment-row">
       <div class="col-12">
-        <span id="by-response-giver" class="text-secondary" *ngIf="isFeedbackParticipantComment">
+        <span class="by-response-giver text-secondary" *ngIf="isFeedbackParticipantComment">
           Comment by response giver.
         </span>
         <span class="text-secondary" *ngIf="!isFeedbackParticipantComment">
@@ -33,13 +33,13 @@
         <i class="fa fa-eye" aria-hidden="true" ngbTooltip="This response comment is visible to {{ visibilityStateMachine.getVisibilityTypesUnderVisibilityControl(CommentVisibilityControl.SHOW_COMMENT) | commentVisibilityTypesJointName }}"></i>
 
         <div class="float-end">
-          <button id="btn-edit-comment" type="button" class="btn btn-outline-primary btn-sm" *ngIf="!shouldHideEditButton" ngbTooltip='Edit this comment'
+          <button type="button" class="btn-edit-comment btn btn-outline-primary btn-sm" *ngIf="!shouldHideEditButton" ngbTooltip='Edit this comment'
                   (click)="triggerModelChange('isEditing', true)" [disabled]="isDisabled"><i class="fas fa-pencil-alt"></i></button>
-          <button id="btn-delete-comment" type="button" class="btn btn-outline-primary btn-sm btn-margin-left" *ngIf="!shouldHideDeleteButton" ngbTooltip='Delete this comment'
+          <button type="button" class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left" *ngIf="!shouldHideDeleteButton" ngbTooltip='Delete this comment'
                   (click)="triggerDeleteCommentEvent()" [disabled]="isDisabled"><i class="fas fa-trash"></i></button>
         </div>
       </div>
-      <div id="comment-text" class="col-12" [innerHTML]="model.originalComment.commentText | safeHtml"></div>
+      <div class="comment-text col-12" [innerHTML]="model.originalComment.commentText | safeHtml"></div>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -401,8 +401,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                                               </div>
                                             </div>
                                             <div
-                                              class="col-12"
-                                              id="comment-text"
+                                              class="comment-text col-12"
                                             >
                                               this is a text
                                             </div>

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
           class="card-body"
         >
           <tm-question-text-with-info
-            class="question-text"
+            class="question-text-with-info"
           >
             <span
               class="d-flex flex-column flex-sm-row align-items-sm-center"
@@ -125,7 +125,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
           class="card-body"
         >
           <tm-question-text-with-info
-            class="question-text"
+            class="question-text-with-info"
           >
             <span
               class="d-flex flex-column flex-sm-row align-items-sm-center"
@@ -273,7 +273,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
           class="card-body"
         >
           <tm-question-text-with-info
-            class="question-text"
+            class="question-text-with-info"
           >
             <span
               class="d-flex flex-column flex-sm-row align-items-sm-center"
@@ -453,7 +453,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
           class="card-body"
         >
           <tm-question-text-with-info
-            class="question-text"
+            class="question-text-with-info"
           >
             <span
               class="d-flex flex-column flex-sm-row align-items-sm-center"
@@ -643,7 +643,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
           class="card-body"
         >
           <tm-question-text-with-info
-            class="question-text"
+            class="question-text-with-info"
           >
             <span
               class="d-flex flex-column flex-sm-row align-items-sm-center"

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -35,14 +35,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                  Question 1: 
               </h2>
               <span
-                class="mx-sm-2"
-                id="question-text"
+                class="question-text mx-sm-2"
               >
                 How well did team member perform?
               </span>
               <button
-                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-                id="additional-info-button"
+                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
               >
                  [more] 
               </button>
@@ -138,14 +136,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                  Question 2: 
               </h2>
               <span
-                class="mx-sm-2"
-                id="question-text"
+                class="question-text mx-sm-2"
               >
                 Rate your teammates in contribution
               </span>
               <button
-                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-                id="additional-info-button"
+                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
               >
                  [more] 
               </button>
@@ -288,14 +284,12 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                  Question 3: 
               </h2>
               <span
-                class="mx-sm-2"
-                id="question-text"
+                class="question-text mx-sm-2"
               >
                 Rate your teammates proficiency
               </span>
               <button
-                class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-                id="additional-info-button"
+                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
               >
                  [more] 
               </button>
@@ -471,8 +465,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                  Question 1: 
               </h2>
               <span
-                class="mx-sm-2"
-                id="question-text"
+                class="question-text mx-sm-2"
               >
                 What comments do you have regarding each of your team members? (response is confidential and will only be shown to the instructor).
               </span>
@@ -662,8 +655,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                  Question 2: 
               </h2>
               <span
-                class="mx-sm-2"
-                id="question-text"
+                class="question-text mx-sm-2"
               >
                 How are the team dynamics thus far? (response is confidential and will only be shown to the instructor).
               </span>

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -8,7 +8,7 @@
     <div id="question-{{ question.feedbackQuestion.questionNumber }}-responses" class="card bg-light mt-4" *ngIf="question.hasResponse">
       <div class="card-body">
         <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" class="question-text"></tm-question-text-with-info>
-        <div id="other-responses" *ngIf="canUserSeeResponses(question), else nonViewableResponse">
+        <div class="other-responses" *ngIf="canUserSeeResponses(question), else nonViewableResponse">
           <tm-single-statistics [question]="question.feedbackQuestion.questionDetails"
                                 [responses]="question.allResponses"
                                 [statistics]="question.questionStatistics"

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -7,7 +7,7 @@
   >
     <div id="question-{{ question.feedbackQuestion.questionNumber }}-responses" class="card bg-light mt-4" *ngIf="question.hasResponse">
       <div class="card-body">
-        <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" class="question-text"></tm-question-text-with-info>
+        <tm-question-text-with-info [questionNumber]="question.feedbackQuestion.questionNumber" [questionDetails]="question.feedbackQuestion.questionDetails" class="question-text-with-info"></tm-question-text-with-info>
         <div class="other-responses" *ngIf="canUserSeeResponses(question), else nonViewableResponse">
           <tm-single-statistics [question]="question.feedbackQuestion.questionDetails"
                                 [responses]="question.allResponses"

--- a/src/web/app/components/question-response-panel/question-response-panel.component.scss
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.scss
@@ -1,4 +1,4 @@
-.question-text {
+.question-text-with-info {
   font-size: .9375rem;
 }
 

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -70,8 +70,8 @@
     </div>
     <div *ngIf="userExpanded[userInfo]" @collapseAnim>
       <div class="card-body top-padded-0">
-        <div id="question-panel" class="card top-padded alert-primary-border" *ngFor="let question of responsesToShow[userInfo]">
-          <div id="question-header" class="card-header alert alert-primary alert-no-bottom cursor-pointer" (click)="question.isTabExpanded = !question.isTabExpanded">
+        <div id="question-panel-{{ question.questionOutput.feedbackQuestion.questionNumber }}" class="card top-padded alert-primary-border" *ngFor="let question of responsesToShow[userInfo]">
+          <div class="card-header alert alert-primary alert-no-bottom cursor-pointer" (click)="question.isTabExpanded = !question.isTabExpanded">
             <tm-question-text-with-info [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
                                         [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
             ></tm-question-text-with-info>

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -18,7 +18,7 @@
     </div>
   </div>
   <div class="col-md-9">
-    <div id="question-panel" *ngFor="let response of responses">
+    <div id="question-panel-{{ response.feedbackQuestion.questionNumber }}" *ngFor="let response of responses">
       <div class="card bottom-padded alert-primary-border">
         <div class="card-header alert alert-primary alert-no-bottom">
           <tm-question-text-with-info [questionNumber]="response.feedbackQuestion.questionNumber" [questionDetails]="response.feedbackQuestion.questionDetails"></tm-question-text-with-info>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -50,8 +50,8 @@
           </p>
         </div>
         <div class="form-check" *ngIf="hasSectionTeam">
-            <input type="checkbox" class="showSectionTeam" name="showSectionTeam" value="sectionTeam" (change)="toggleSectionTeam($event)">
-            <label class="form-check-label ms-1" for="showSectionTeam">Show Section/Team</label>
+            <input type="checkbox" id="show-section-team-{{ model.questionNumber }}" name="show-section-team" value="sectionTeam" (change)="toggleSectionTeam($event)">
+            <label class="form-check-label ms-1" for="show-section-team-{{ model.questionNumber }}">Show Section/Team</label>
           </div>
       </div>
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,11 +1,11 @@
-<div id="question-submission-form" class="card">
+<div id="question-submission-form-qn-{{ model.questionNumber }}" class="card">
   <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="toggleQuestionTab();"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="model.isTabExpanded" aria-hidden="true"></tm-panel-chevron>
     </div>
     <i class="fas fa-check me-2" *ngIf="isSaved" aria-hidden="true"></i>
-    <h2 id="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h2>
+    <h2 class="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h2>
   </button>
 
   <div *ngIf="model.isTabExpanded" @collapseAnim>
@@ -14,12 +14,12 @@
         <div class="card-header">
           <b>More details</b>
         </div>
-        <div id="question-description" class="card-body" [innerHTML]="model.questionDescription | safeHtml"></div>
+        <div class="question-description card-body" [innerHTML]="model.questionDescription | safeHtml"></div>
       </div>
 
       <div class="card-body visibility-card">
         <p class="text-secondary">Only the following persons can see your responses: </p>
-        <ul id="visibility-list" class="text-secondary">
+        <ul class="visibility-list text-secondary">
           <li *ngIf="model.recipientType === FeedbackParticipantType.SELF">You can see your own feedback in the results page later on.</li>
           <ng-container *ngFor="let visibilityType of FeedbackVisibilityType | enumToArray">
             <li *ngIf="visibilityStateMachine.isVisibilityTypeApplicable(visibilityType) && visibilityStateMachine.hasAnyVisibilityControl(visibilityType)">
@@ -50,7 +50,7 @@
           </p>
         </div>
         <div class="form-check" *ngIf="hasSectionTeam">
-            <input type="checkbox" id="showSectionTeam" name="showSectionTeam" value="sectionTeam" (change)="toggleSectionTeam($event)">
+            <input type="checkbox" class="showSectionTeam" name="showSectionTeam" value="sectionTeam" (change)="toggleSectionTeam($event)">
             <label class="form-check-label ms-1" for="showSectionTeam">Show Section/Team</label>
           </div>
       </div>
@@ -62,11 +62,11 @@
       <div class="container">
         <div class="row" *ngFor="let recipientSubmissionFormModel of model.recipientSubmissionForms; let i = index; trackBy: trackRecipientSubmissionFormByFn">
           <div class="col-md-5 col-xs-12 margin-top-20px" *ngIf="model.recipientType !== FeedbackParticipantType.SELF && model.recipientType !== FeedbackParticipantType.NONE">
-            <div id="recipient-name-{{ i }}" *ngIf="formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT">
+            <div id="recipient-name-qn-{{ model.questionNumber }}-idx-{{ i }}" *ngIf="formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT">
               <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
             </div>
             <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
-              <select id="recipient-dropdown" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
+              <select id="recipient-dropdown-qn-{{ model.questionNumber }}-idx-{{ i }}" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
                       (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
                       [disabled]="isFormsDisabled">
                 <option value=""></option>
@@ -145,7 +145,7 @@
             </tm-constsum-recipients-question-edit-answer-form>
           </div>
 
-          <div id="comment-section" *ngIf="allowedToHaveParticipantComment" class="col-12 margin-bottom-20px margin-top-10px indent">
+          <div id="comment-section-qn-{{ model.questionNumber }}-idx-{{ i }}" *ngIf="allowedToHaveParticipantComment" class="col-12 margin-bottom-20px margin-top-10px indent">
             <div *ngIf="recipientSubmissionFormModel.commentByGiver && recipientSubmissionFormModel.commentByGiver.originalComment else newComment">
               <tm-comment-row [mode]="CommentRowMode.EDIT" [isVisibilityOptionEnabled]="false"
                               [model]="recipientSubmissionFormModel.commentByGiver"
@@ -162,7 +162,7 @@
             </div>
             <ng-template #newComment>
               <div style="display: inline-block;" [ngbTooltip]="isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails) ? 'Give a valid response in order to comment' : ''">
-                <button id="btn-add-comment" *ngIf="!recipientSubmissionFormModel.commentByGiver" class="btn btn-light btn-sm"
+                <button *ngIf="!recipientSubmissionFormModel.commentByGiver" class="btn-add-comment btn btn-light btn-sm"
                         (click)="addNewParticipantCommentToResponse(i)"
                         [disabled]="isFormsDisabled || isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)">
                   <i class="fas fa-comment"></i> [Optional] Comment on your response

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -44,7 +44,7 @@
   font-weight: bold;
 }
 
-#question-details {
+.question-details {
   font-size: .875rem;
   margin-bottom: 0;
   line-height: inherit;

--- a/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
+++ b/src/web/app/components/question-text-with-info/__snapshots__/question-text-with-info.component.spec.ts.snap
@@ -19,8 +19,7 @@ exports[`QuestionTextWithInfoComponent should not show control link and question
        Question 0: 
     </h2>
     <span
-      class="mx-sm-2"
-      id="question-text"
+      class="question-text mx-sm-2"
     >
       Text question details
     </span>
@@ -47,14 +46,12 @@ exports[`QuestionTextWithInfoComponent should show control link when question ty
        Question 0: 
     </h2>
     <span
-      class="mx-sm-2"
-      id="question-text"
+      class="question-text mx-sm-2"
     >
       MCQ question details
     </span>
     <button
-      class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-      id="additional-info-button"
+      class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
     >
        [more] 
     </button>
@@ -81,20 +78,17 @@ exports[`QuestionTextWithInfoComponent should show question detail when click co
        Question 0: 
     </h2>
     <span
-      class="mx-sm-2"
-      id="question-text"
+      class="question-text mx-sm-2"
     >
       MCQ question details
     </span>
     <button
-      class="info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-      id="additional-info-button"
+      class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
     >
        [less] 
     </button>
   </span><div
-    class="info-font-size"
-    id="additional-info"
+    class="additional-info info-font-size"
   >
     <tm-mcq-question-additional-info>
       Multiple-choice (single answer) question options:

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -7,13 +7,13 @@
   <h2 *ngIf="!shouldShowDownloadQuestionResult" class="question-number">
     Question {{ questionNumber }}:
   </h2>
-  <span id="question-text" class="mx-sm-2">{{ questionDetails.questionText }}</span>
-  <button id="additional-info-button" class="info-font-size me-auto border-0 p-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
+  <span class="question-text mx-sm-2">{{ questionDetails.questionText }}</span>
+  <button class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
   </button>
 </span>
 
-<div id="additional-info" class="info-font-size" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
+<div class="additional-info info-font-size" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">
   <tm-contribution-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.CONTRIB" [questionDetails]="questionDetails"></tm-contribution-question-additional-info>
   <tm-text-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.TEXT" [questionDetails]="questionDetails"></tm-text-question-additional-info>
   <tm-mcq-question-additional-info *ngIf="questionDetails.questionType === FeedbackQuestionType.MCQ" [questionDetails]="questionDetails"></tm-mcq-question-additional-info>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -1,4 +1,4 @@
-<div class="card card-plain">
+<div id="session-edit-form" class="card card-plain">
   <div class="close-header" *ngIf="formMode === SessionEditFormMode.ADD">
     <button type="button" class="btn-close" aria-label="Close" (click)="closeEditFormHandler()"></button>
   </div>

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -139,7 +139,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
           </td>
           <td>
             <div
-              id="response-rate-0"
+              class="response-rate-0"
             >
               8 / 9
             </div>
@@ -162,15 +162,13 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                 </button>
               </a>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-soft-delete-0"
+                class="btn btn-light btn-sm btn-soft-delete-0"
                 type="button"
               >
                 Delete
               </button>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-copy-0"
+                class="btn btn-copy-0 btn-light btn-sm"
                 ngbtooltip="Copy feedback session details"
                 type="button"
               >
@@ -195,8 +193,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-results-0"
+                  class="dropdown-toggle btn btn-light btn-results-0 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   Results
@@ -220,17 +217,15 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                     View Results (course-wide)
                   </a>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-publish-0 clickable dropdown-item"
                     container="body"
-                    id="btn-publish-0"
                     ngbtooltip="Make session responses available for viewing"
                     placement="left"
                   >
                     Publish Results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-download-0"
+                    class="btn btn-download-0 clickable dropdown-item"
                   >
                     Download Results
                   </button>
@@ -243,8 +238,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-remind-0"
+                  class="dropdown-toggle btn btn-light btn-remind-0 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   <div
@@ -264,14 +258,12 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   ngbdropdownmenu=""
                 >
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-all-0"
+                    class="btn btn-remind-all-0 clickable dropdown-item"
                   >
                     Remind all non-submitters
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-selected-0"
+                    class="btn btn-remind-selected-0 clickable dropdown-item"
                   >
                     Select non-submitters to remind
                   </button>
@@ -340,16 +332,14 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                  Edit 
               </button>
               <button
-                class="btn btn-light btn-sm"
+                class="btn btn-light btn-sm btn-soft-delete-1"
                 disabled=""
-                id="btn-soft-delete-1"
                 type="button"
               >
                 Delete
               </button>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-copy-1"
+                class="btn btn-copy-1 btn-light btn-sm"
                 ngbtooltip="Copy feedback session details"
                 type="button"
               >
@@ -370,8 +360,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-results-1"
+                  class="dropdown-toggle btn btn-light btn-results-1 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   Results
@@ -395,25 +384,22 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                     View Results (course-wide)
                   </a>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-unpublish-1 clickable dropdown-item"
                     container="body"
                     disabled=""
-                    id="btn-unpublish-1"
                     ngbtooltip="Make responses no longer visible"
                     placement="left"
                   >
                     Unpublish Results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-resend-1"
+                    class="btn btn-resend-1 clickable dropdown-item"
                   >
                     Resend link to view results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-download-1 clickable dropdown-item"
                     disabled=""
-                    id="btn-download-1"
                   >
                     Download Results
                   </button>
@@ -426,9 +412,8 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
+                  class="dropdown-toggle btn btn-light btn-remind-1 btn-sm"
                   disabled=""
-                  id="btn-remind-1"
                   ngbdropdowntoggle=""
                 >
                   <div
@@ -448,14 +433,12 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   ngbdropdownmenu=""
                 >
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-all-1"
+                    class="btn btn-remind-all-1 clickable dropdown-item"
                   >
                     Remind all non-submitters
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-selected-1"
+                    class="btn btn-remind-selected-1 clickable dropdown-item"
                   >
                     Select non-submitters to remind
                   </button>
@@ -589,7 +572,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
           </td>
           <td>
             <div
-              id="response-rate-0"
+              class="response-rate-0"
             >
               8 / 9
             </div>
@@ -612,15 +595,13 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                 </button>
               </a>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-soft-delete-0"
+                class="btn btn-light btn-sm btn-soft-delete-0"
                 type="button"
               >
                 Delete
               </button>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-copy-0"
+                class="btn btn-copy-0 btn-light btn-sm"
                 ngbtooltip="Copy feedback session details"
                 type="button"
               >
@@ -645,8 +626,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-results-0"
+                  class="dropdown-toggle btn btn-light btn-results-0 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   Results
@@ -670,17 +650,15 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                     View Results (course-wide)
                   </a>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-publish-0 clickable dropdown-item"
                     container="body"
-                    id="btn-publish-0"
                     ngbtooltip="Make session responses available for viewing"
                     placement="left"
                   >
                     Publish Results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-download-0"
+                    class="btn btn-download-0 clickable dropdown-item"
                   >
                     Download Results
                   </button>
@@ -693,8 +671,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-remind-0"
+                  class="dropdown-toggle btn btn-light btn-remind-0 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   <div
@@ -714,14 +691,12 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   ngbdropdownmenu=""
                 >
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-all-0"
+                    class="btn btn-remind-all-0 clickable dropdown-item"
                   >
                     Remind all non-submitters
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-selected-0"
+                    class="btn btn-remind-selected-0 clickable dropdown-item"
                   >
                     Select non-submitters to remind
                   </button>
@@ -781,16 +756,14 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                  Edit 
               </button>
               <button
-                class="btn btn-light btn-sm"
+                class="btn btn-light btn-sm btn-soft-delete-1"
                 disabled=""
-                id="btn-soft-delete-1"
                 type="button"
               >
                 Delete
               </button>
               <button
-                class="btn btn-light btn-sm"
-                id="btn-copy-1"
+                class="btn btn-copy-1 btn-light btn-sm"
                 ngbtooltip="Copy feedback session details"
                 type="button"
               >
@@ -811,8 +784,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
-                  id="btn-results-1"
+                  class="dropdown-toggle btn btn-light btn-results-1 btn-sm"
                   ngbdropdowntoggle=""
                 >
                   Results
@@ -836,25 +808,22 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                     View Results (course-wide)
                   </a>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-unpublish-1 clickable dropdown-item"
                     container="body"
                     disabled=""
-                    id="btn-unpublish-1"
                     ngbtooltip="Make responses no longer visible"
                     placement="left"
                   >
                     Unpublish Results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-resend-1"
+                    class="btn btn-resend-1 clickable dropdown-item"
                   >
                     Resend link to view results
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
+                    class="btn btn-download-1 clickable dropdown-item"
                     disabled=""
-                    id="btn-download-1"
                   >
                     Download Results
                   </button>
@@ -867,9 +836,8 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-light btn-sm"
+                  class="dropdown-toggle btn btn-light btn-remind-1 btn-sm"
                   disabled=""
-                  id="btn-remind-1"
                   ngbdropdowntoggle=""
                 >
                   <div
@@ -889,14 +857,12 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   ngbdropdownmenu=""
                 >
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-all-1"
+                    class="btn btn-remind-all-1 clickable dropdown-item"
                   >
                     Remind all non-submitters
                   </button>
                   <button
-                    class="btn dropdown-item clickable"
-                    id="btn-remind-selected-1"
+                    class="btn btn-remind-selected-1 clickable dropdown-item"
                   >
                     Select non-submitters to remind
                   </button>

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -33,16 +33,14 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
 >
   <div>
     <table
-      class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
-      id="sessions-table"
+      class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0"
     >
       <thead>
         <tr
           class="bg-primary text-white"
         >
           <th
-            class="sortable-header"
-            id="sort-session-name"
+            class="sort-session-name sortable-header"
           >
              Session Name 
             <span
@@ -486,16 +484,14 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
 >
   <div>
     <table
-      class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
-      id="sessions-table"
+      class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0"
     >
       <thead>
         <tr
           class="bg-primary text-white"
         >
           <th
-            class="sortable-header"
-            id="sort-course-id"
+            class="sort-course-id sortable-header"
           >
              Course ID 
             <span
@@ -507,8 +503,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-session-name"
+            class="sort-session-name sortable-header"
           >
              Session Name 
             <span

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -55,8 +55,8 @@
         <span class="ngb-tooltip-class" [ngbTooltip]="sessionsTableRowModel.feedbackSession.publishStatus | publishStatusTooltip">{{ sessionsTableRowModel.feedbackSession.publishStatus | publishStatusName }}</span>
       </td>
       <td>
-        <a id="show-response-rate-{{ idx }}" href="#" *ngIf="sessionsTableRowModel.responseRate.length === 0 && !sessionsTableRowModel.isLoadingResponseRate" (click)="loadResponseRateEvent.emit(idx); $event.preventDefault()">Show</a>
-        <div id="response-rate-{{ idx }}" *ngIf="sessionsTableRowModel.responseRate.length !== 0">{{ sessionsTableRowModel.responseRate }}</div>
+        <a class="show-response-rate-{{ idx }}" href="#" *ngIf="sessionsTableRowModel.responseRate.length === 0 && !sessionsTableRowModel.isLoadingResponseRate" (click)="loadResponseRateEvent.emit(idx); $event.preventDefault()">Show</a>
+        <div class="response-rate-{{ idx }}" *ngIf="sessionsTableRowModel.responseRate.length !== 0">{{ sessionsTableRowModel.responseRate }}</div>
         <tm-ajax-loading *ngIf="sessionsTableRowModel.isLoadingResponseRate" [useBlueSpinner]="true"></tm-ajax-loading>
       </td>
       <td class="actions-cell">
@@ -70,9 +70,9 @@
               Edit
             </button>
           </ng-template>
-          <button id="btn-soft-delete-{{ idx }}" type="button" class="btn btn-light btn-sm" (click)="moveSessionToRecycleBin(idx)"
+          <button type="button" class="btn-soft-delete-{{ idx }} btn btn-light btn-sm" (click)="moveSessionToRecycleBin(idx)"
                   [disabled]="!sessionsTableRowModel.instructorPrivilege.canModifySession">Delete</button>
-          <button id="btn-copy-{{ idx }}" type="button" class="btn btn-light btn-sm" ngbTooltip="Copy feedback session details" (click)="copySession(idx)">Copy</button>
+          <button type="button" class="btn-copy-{{ idx }} btn btn-light btn-sm" ngbTooltip="Copy feedback session details" (click)="copySession(idx)">Copy</button>
           <a *ngIf="sessionsTableRowModel.feedbackSession.submissionStatus === FeedbackSessionSubmissionStatus.OPEN && sessionsTableRowModel.instructorPrivilege.canSubmitSessionInSections; else submitBtn"
             tmRouterLink="/web/instructor/sessions/submission"
             [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">
@@ -84,7 +84,7 @@
                       || !sessionsTableRowModel.instructorPrivilege.canSubmitSessionInSections" (click)="submitSessionAsInstructorEvent.emit(idx)">Submit</button>
           </ng-template>
           <div ngbDropdown class="d-inline-block" container="body">
-            <button id="btn-results-{{ idx }}" class="btn btn-light btn-sm" ngbDropdownToggle>Results</button>
+            <button class="btn-results-{{ idx }} btn btn-light btn-sm" ngbDropdownToggle>Results</button>
             <div ngbDropdownMenu>
               <a class="btn dropdown-item clickable" [ngClass]="{disabled: !sessionsTableRowModel.instructorPrivilege.canViewSessionInSections}"
                       tmRouterLink="/web/instructor/sessions/result"
@@ -92,22 +92,22 @@
               <a class="btn dropdown-item clickable" [ngClass]="{disabled: !sessionsTableRowModel.instructorPrivilege.canViewSessionInSections}"
                       tmRouterLink="/web/instructor/sessions/report"
                       [queryParams]="{ courseid: sessionsTableRowModel.feedbackSession.courseId, fsname: sessionsTableRowModel.feedbackSession.feedbackSessionName }">View Results (course-wide)</a>
-              <button id="btn-unpublish-{{ idx }}" class="btn dropdown-item clickable" ngbTooltip="Make responses no longer visible" placement="left" container="body"
+              <button class="btn-unpublish-{{ idx }} btn dropdown-item clickable" ngbTooltip="Make responses no longer visible" placement="left" container="body"
                       *ngIf="![FeedbackSessionSubmissionStatus.NOT_VISIBLE, FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN].includes(sessionsTableRowModel.feedbackSession.submissionStatus)
                         && sessionsTableRowModel.feedbackSession.publishStatus === FeedbackSessionPublishStatus.PUBLISHED; else publishButton"
                       [disabled]="!sessionsTableRowModel.instructorPrivilege.canModifySession" (click)="unpublishSession(idx)">Unpublish Results</button>
               <ng-template #publishButton>
-                <button id="btn-publish-{{ idx }}" class="btn dropdown-item clickable" [disabled]="[FeedbackSessionSubmissionStatus.NOT_VISIBLE, FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN].includes(sessionsTableRowModel.feedbackSession.submissionStatus)
+                <button class="btn-publish-{{ idx }} btn dropdown-item clickable" [disabled]="[FeedbackSessionSubmissionStatus.NOT_VISIBLE, FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN].includes(sessionsTableRowModel.feedbackSession.submissionStatus)
                   || sessionsTableRowModel.feedbackSession.publishStatus === FeedbackSessionPublishStatus.PUBLISHED || !sessionsTableRowModel.instructorPrivilege.canModifySession"
                         ngbTooltip="Make session responses available for viewing" placement="left" container="body" (click)="publishSession(idx)">Publish Results</button>
               </ng-template>
-              <button id="btn-resend-{{ idx }}" class="btn dropdown-item clickable" *ngIf="sessionsTableRowModel.feedbackSession.publishStatus === FeedbackSessionPublishStatus.PUBLISHED" (click)="remindResultsLinkToStudent(idx)">Resend link to view results</button>
-              <button id="btn-download-{{ idx }}" class="btn dropdown-item clickable" (click)="downloadSessionResults(idx)"
+              <button class="btn-resend-{{ idx }} btn dropdown-item clickable" *ngIf="sessionsTableRowModel.feedbackSession.publishStatus === FeedbackSessionPublishStatus.PUBLISHED" (click)="remindResultsLinkToStudent(idx)">Resend link to view results</button>
+              <button class="btn-download-{{ idx }} btn dropdown-item clickable" (click)="downloadSessionResults(idx)"
                       [disabled]="!sessionsTableRowModel.instructorPrivilege.canViewSessionInSections">Download Results</button>
             </div>
           </div>
           <div ngbDropdown class="d-inline-block" ngbTooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so">
-            <button ngbDropdownToggle id="btn-remind-{{ idx }}" class="btn btn-light btn-sm"
+            <button ngbDropdownToggle class="btn-remind-{{ idx }} btn btn-light btn-sm"
                     [disabled]="sessionsTableRowModel.feedbackSession.submissionStatus !== FeedbackSessionSubmissionStatus.OPEN ||
                           !sessionsTableRowModel.instructorPrivilege.canModifySession">
               <div class="d-inline-flex">
@@ -118,8 +118,8 @@
               </div>
             </button>
             <div ngbDropdownMenu>
-              <button id="btn-remind-all-{{ idx }}" class="btn dropdown-item clickable" (click)="sendRemindersToAllNonSubmitters(idx); setRowClicked(idx)">Remind all non-submitters</button>
-              <button id="btn-remind-selected-{{ idx }}" class="btn dropdown-item clickable" (click)="sendRemindersToSelectedNonSubmitters(idx); setRowClicked(idx)" >Select non-submitters to remind</button>
+              <button class="btn-remind-all-{{ idx }} btn dropdown-item clickable" (click)="sendRemindersToAllNonSubmitters(idx); setRowClicked(idx)">Remind all non-submitters</button>
+              <button class="btn-remind-selected-{{ idx }} btn dropdown-item clickable" (click)="sendRemindersToSelectedNonSubmitters(idx); setRowClicked(idx)" >Select non-submitters to remind</button>
             </div>
           </div>
         </div>

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -1,8 +1,8 @@
 <div *ngIf="sessionsTableRowModels.length > 0; else noSessionMessage">
-  <table id="sessions-table" class="table table-responsive-lg table-striped table-bordered margin-bottom-0">
+  <table class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0">
     <thead>
     <tr [ngClass]="{ 'bg-primary text-white': headerColorScheme === SessionsTableHeaderColorScheme.BLUE }">
-      <th id="sort-course-id" class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.COURSE_ID)" *ngIf="columnsToShow.includes(SessionsTableColumn.COURSE_ID)">
+      <th class="sort-course-id sortable-header" (click)="sortSessionsTableRowModels(SortBy.COURSE_ID)" *ngIf="columnsToShow.includes(SessionsTableColumn.COURSE_ID)">
         Course ID
         <span class="fa-stack">
           <i class="fas fa-sort"></i>
@@ -10,7 +10,7 @@
           <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.COURSE_ID && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
         </span>
       </th>
-      <th id="sort-session-name" class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_NAME)">
+      <th class="sort-session-name sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_NAME)">
         Session Name
         <span class="fa-stack">
           <i class="fas fa-sort"></i>

--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -222,7 +222,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -231,7 +231,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -239,20 +239,20 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-send-invite"
+              id="btn-send-invite-0"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -284,7 +284,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -293,7 +293,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -301,20 +301,20 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-send-invite"
+              id="btn-send-invite-1"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -346,7 +346,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -355,7 +355,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -363,14 +363,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -402,7 +402,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -411,7 +411,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -419,14 +419,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -566,7 +566,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -575,7 +575,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -583,20 +583,20 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-send-invite"
+              id="btn-send-invite-0"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -628,7 +628,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -637,7 +637,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -645,14 +645,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -684,7 +684,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -693,7 +693,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -701,14 +701,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -740,7 +740,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -749,7 +749,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -757,14 +757,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -904,7 +904,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -913,7 +913,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -921,14 +921,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -960,7 +960,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -969,7 +969,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -977,14 +977,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1016,7 +1016,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1025,7 +1025,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1033,14 +1033,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1072,7 +1072,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1081,7 +1081,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1089,14 +1089,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1237,7 +1237,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1246,7 +1246,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1254,14 +1254,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1293,7 +1293,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1302,7 +1302,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1310,14 +1310,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1350,7 +1350,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1359,7 +1359,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1367,14 +1367,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1406,7 +1406,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1415,7 +1415,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1423,14 +1423,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1570,7 +1570,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1579,7 +1579,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1587,14 +1587,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1626,7 +1626,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1635,7 +1635,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1643,14 +1643,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete"
+              id="btn-delete-1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1682,7 +1682,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1691,7 +1691,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1699,14 +1699,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1738,7 +1738,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details"
+              id="btn-view-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1747,7 +1747,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details"
+              id="btn-edit-details-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1755,14 +1755,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records"
+              id="btn-view-records-3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1887,7 +1887,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details"
+              id="btn-view-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1896,7 +1896,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details"
+              id="btn-edit-details-0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1904,14 +1904,14 @@ exports[`StudentListComponent should snap with some student list data with no se
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete"
+              id="btn-delete-0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records"
+              id="btn-view-records-0"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -45,8 +45,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -58,8 +57,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -153,8 +151,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -166,8 +163,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -222,7 +218,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -231,7 +227,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -239,20 +235,20 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-send-invite-0"
+              id="btn-send-invite--0"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -284,7 +280,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details-1"
+              id="btn-view-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -293,7 +289,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details-1"
+              id="btn-edit-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -301,20 +297,20 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-send-invite-1"
+              id="btn-send-invite--1"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-1"
+              id="btn-delete--1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records-1"
+              id="btn-view-records--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -346,7 +342,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details-2"
+              id="btn-view-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -355,7 +351,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details-2"
+              id="btn-edit-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -363,14 +359,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-2"
+              id="btn-delete--2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records-2"
+              id="btn-view-records--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -402,7 +398,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details-3"
+              id="btn-view-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -411,7 +407,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details-3"
+              id="btn-edit-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -419,14 +415,14 @@ exports[`StudentListComponent should snap with enable remind button set to true 
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-3"
+              id="btn-delete--3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records-3"
+              id="btn-view-records--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -497,8 +493,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -510,8 +505,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -566,7 +560,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -575,7 +569,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -583,20 +577,20 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-send-invite-0"
+              id="btn-send-invite--0"
             >
               Send Invite
             </button>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -628,7 +622,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details-1"
+              id="btn-view-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -637,7 +631,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details-1"
+              id="btn-edit-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -645,14 +639,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-1"
+              id="btn-delete--1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records-1"
+              id="btn-view-records--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -684,7 +678,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details-2"
+              id="btn-view-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -693,7 +687,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details-2"
+              id="btn-edit-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -701,14 +695,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-2"
+              id="btn-delete--2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records-2"
+              id="btn-view-records--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -740,7 +734,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details-3"
+              id="btn-view-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -749,7 +743,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details-3"
+              id="btn-edit-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -757,14 +751,14 @@ exports[`StudentListComponent should snap with enable remind button set to true,
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-3"
+              id="btn-delete--3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records-3"
+              id="btn-view-records--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -835,8 +829,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -848,8 +841,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -904,7 +896,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -913,7 +905,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -921,14 +913,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -960,7 +952,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details-1"
+              id="btn-view-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -969,7 +961,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details-1"
+              id="btn-edit-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -977,14 +969,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-1"
+              id="btn-delete--1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records-1"
+              id="btn-view-records--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1016,7 +1008,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details-2"
+              id="btn-view-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1025,7 +1017,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details-2"
+              id="btn-edit-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1033,14 +1025,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-2"
+              id="btn-delete--2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records-2"
+              id="btn-view-records--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1072,7 +1064,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details-3"
+              id="btn-view-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1081,7 +1073,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details-3"
+              id="btn-edit-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1089,14 +1081,14 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-3"
+              id="btn-delete--3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records-3"
+              id="btn-view-records--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1167,8 +1159,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -1180,8 +1171,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -1237,7 +1227,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1246,7 +1236,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1254,14 +1244,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1293,7 +1283,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details-1"
+              id="btn-view-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1302,7 +1292,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details-1"
+              id="btn-edit-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1310,14 +1300,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-1"
+              id="btn-delete--1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records-1"
+              id="btn-view-records--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1350,7 +1340,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details-2"
+              id="btn-view-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1359,7 +1349,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details-2"
+              id="btn-edit-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1367,14 +1357,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-2"
+              id="btn-delete--2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records-2"
+              id="btn-view-records--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1406,7 +1396,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details-3"
+              id="btn-view-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1415,7 +1405,7 @@ exports[`StudentListComponent should snap with some student list data and some s
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details-3"
+              id="btn-edit-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1423,14 +1413,14 @@ exports[`StudentListComponent should snap with some student list data and some s
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-3"
+              id="btn-delete--3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records-3"
+              id="btn-view-records--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1501,8 +1491,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -1514,8 +1503,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -1570,7 +1558,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1579,7 +1567,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1587,14 +1575,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1626,7 +1614,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-details-1"
+              id="btn-view-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1635,7 +1623,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-edit-details-1"
+              id="btn-edit-details--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1643,14 +1631,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right disabled mouse-hover-only"
-              id="btn-delete-1"
+              id="btn-delete--1"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=benny.c.tmms@gmail.tmt"
-              id="btn-view-records-1"
+              id="btn-view-records--1"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1682,7 +1670,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-details-2"
+              id="btn-view-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1691,7 +1679,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-edit-details-2"
+              id="btn-edit-details--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1699,14 +1687,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-2"
+              id="btn-delete--2"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=alice.b.tmms@gmail.tmt"
-              id="btn-view-records-2"
+              id="btn-view-records--2"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1738,7 +1726,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-details-3"
+              id="btn-view-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1747,7 +1735,7 @@ exports[`StudentListComponent should snap with some student list data when not a
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-edit-details-3"
+              id="btn-edit-details--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1755,14 +1743,14 @@ exports[`StudentListComponent should snap with some student list data when not a
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-3"
+              id="btn-delete--3"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=danny.e.tmms@gmail.tmt"
-              id="btn-view-records-3"
+              id="btn-view-records--3"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1821,8 +1809,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -1834,8 +1821,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span
@@ -1887,7 +1873,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/details?courseid=&studentemail=tester@tester.com"
-              id="btn-view-details-0"
+              id="btn-view-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1896,7 +1882,7 @@ exports[`StudentListComponent should snap with some student list data with no se
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/courses/student/edit?courseid=&studentemail=tester@tester.com"
-              id="btn-edit-details-0"
+              id="btn-edit-details--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1904,14 +1890,14 @@ exports[`StudentListComponent should snap with some student list data with no se
             </a>
             <button
               class="btn btn-light btn-sm btn-margin-right"
-              id="btn-delete-0"
+              id="btn-delete--0"
             >
               Delete
             </button>
             <a
               class="btn btn-light btn-sm btn-margin-right"
               href="/web/instructor/students/records?courseid=&studentemail=tester@tester.com"
-              id="btn-view-records-0"
+              id="btn-view-records--0"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1971,8 +1957,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-name"
+            class="sort-by-name sortable-header"
           >
              Student Name 
             <span
@@ -1984,8 +1969,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
             </span>
           </th>
           <th
-            class="sortable-header"
-            id="sort-by-status"
+            class="sort-by-status sortable-header"
           >
              Status 
             <span

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -67,7 +67,7 @@
             {{name}}</a>
         </ng-template>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-          id: 'btn-view-details-' + idx,
+          id: 'btn-view-details-' + courseId + '-' + idx,
           isEnabled: studentModel.isAllowedToViewStudentInSection && isActionButtonsEnabled,
           tooltip: 'View the details of the student',
           name: 'View',
@@ -75,7 +75,7 @@
           queryParams: {courseid: courseId, studentemail: studentModel.student.email}
         }"></ng-container>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-          id: 'btn-edit-details-' + idx,
+          id: 'btn-edit-details-' + courseId + '-' + idx,
           isEnabled: studentModel.isAllowedToModifyStudent && isActionButtonsEnabled,
           tooltip: 'Use this to edit the details of this student. To edit multiple students'
             + ' in one go, you can use the enroll page: '
@@ -86,7 +86,7 @@
         }"></ng-container>
       <ng-container *ngIf="enableRemindButton">
         <ng-container *ngIf="studentModel.student.joinState === JoinState.NOT_JOINED">
-          <button id="btn-send-invite-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
+          <button id="btn-send-invite-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
             [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
             [disabled]=!isActionButtonsEnabled
             [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
@@ -97,7 +97,7 @@
             (click)="openRemindModal(studentModel)">Send Invite</button>
         </ng-container>
       </ng-container>
-      <button id="btn-delete-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
+      <button id="btn-delete-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
         [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
         [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
           ? 'Delete the student and the corresponding submissions from the course'
@@ -105,7 +105,7 @@
         [disabled]="!isActionButtonsEnabled"
         (click)="openDeleteModal(studentModel)">Delete</button>
       <ng-container *ngTemplateOutlet="actionButton; context: {
-        id: 'btn-view-records-' + idx,
+        id: 'btn-view-records-' + courseId + '-' + idx,
         isEnabled: isActionButtonsEnabled,
         tooltip: 'View all data about this student',
         name: 'All Records',

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -21,7 +21,7 @@
           <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
         </span>
       </th>
-      <th id="sort-by-name" class="sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_NAME)">
+      <th class="sort-by-name sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_NAME)">
         Student Name
         <span class="fa-stack">
           <i class="fas fa-sort"></i>
@@ -29,7 +29,7 @@
           <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
         </span>
       </th>
-      <th id="sort-by-status" class="sortable-header" (click)="sortStudentList(SortBy.JOIN_STATUS)">
+      <th class="sort-by-status sortable-header" (click)="sortStudentList(SortBy.JOIN_STATUS)">
         Status
         <span class="fa-stack">
           <i class="fas fa-sort"></i>

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -49,7 +49,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr *ngFor="let studentModel of students; trackBy: trackByFn" [hidden]="isStudentToHide(studentModel.student.email)" s>
+    <tr *ngFor="let studentModel of students; trackBy: trackByFn; let idx = index;" [hidden]="isStudentToHide(studentModel.student.email)" s>
       <td *ngIf="hasSection()" [innerHtml]="studentModel.student.sectionName | highlighter:searchString"></td>
       <td [innerHtml]="studentModel.student.teamName | highlighter:searchString"></td>
       <td [innerHtml]="studentModel.student.name | highlighter:searchString"></td>
@@ -67,26 +67,26 @@
             {{name}}</a>
         </ng-template>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-        id: 'btn-view-details',
-        isEnabled: studentModel.isAllowedToViewStudentInSection && isActionButtonsEnabled,
-        tooltip: 'View the details of the student',
-        name: 'View',
-        tmRouterLink: '/web/instructor/courses/student/details',
-        queryParams: {courseid: courseId, studentemail: studentModel.student.email}
-      }"></ng-container>
+          id: 'btn-view-details-' + idx,
+          isEnabled: studentModel.isAllowedToViewStudentInSection && isActionButtonsEnabled,
+          tooltip: 'View the details of the student',
+          name: 'View',
+          tmRouterLink: '/web/instructor/courses/student/details',
+          queryParams: {courseid: courseId, studentemail: studentModel.student.email}
+        }"></ng-container>
         <ng-container *ngTemplateOutlet="actionButton; context: {
-        id: 'btn-edit-details',
-        isEnabled: studentModel.isAllowedToModifyStudent && isActionButtonsEnabled,
-        tooltip: 'Use this to edit the details of this student. To edit multiple students'
-          + ' in one go, you can use the enroll page: '
-          + 'Simply enroll students using the updated data and existing data will be updated accordingly',
-        name: 'Edit',
-        tmRouterLink: '/web/instructor/courses/student/edit',
-        queryParams: {courseid: courseId, studentemail: studentModel.student.email}
-      }"></ng-container>
+          id: 'btn-edit-details-' + idx,
+          isEnabled: studentModel.isAllowedToModifyStudent && isActionButtonsEnabled,
+          tooltip: 'Use this to edit the details of this student. To edit multiple students'
+            + ' in one go, you can use the enroll page: '
+            + 'Simply enroll students using the updated data and existing data will be updated accordingly',
+          name: 'Edit',
+          tmRouterLink: '/web/instructor/courses/student/edit',
+          queryParams: {courseid: courseId, studentemail: studentModel.student.email}
+        }"></ng-container>
       <ng-container *ngIf="enableRemindButton">
         <ng-container *ngIf="studentModel.student.joinState === JoinState.NOT_JOINED">
-          <button id="btn-send-invite" class="btn btn-light btn-sm btn-margin-right"
+          <button id="btn-send-invite-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
             [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
             [disabled]=!isActionButtonsEnabled
             [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
@@ -97,7 +97,7 @@
             (click)="openRemindModal(studentModel)">Send Invite</button>
         </ng-container>
       </ng-container>
-      <button id="btn-delete" class="btn btn-light btn-sm btn-margin-right"
+      <button id="btn-delete-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
         [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
         [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
           ? 'Delete the student and the corresponding submissions from the course'
@@ -105,7 +105,7 @@
         [disabled]="!isActionButtonsEnabled"
         (click)="openDeleteModal(studentModel)">Delete</button>
       <ng-container *ngTemplateOutlet="actionButton; context: {
-        id: 'btn-view-records',
+        id: 'btn-view-records-' + idx,
         isEnabled: isActionButtonsEnabled,
         tooltip: 'View all data about this student',
         name: 'All Records',

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -271,7 +271,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 1
               </div>
@@ -281,8 +281,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               style=""
             >
               <button
-                class="btn btn-success"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-success"
                 type="button"
               >
                  Mark as Read 
@@ -326,7 +325,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 2
               </div>
@@ -336,8 +335,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               style=""
             >
               <button
-                class="btn btn-danger"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-danger"
                 type="button"
               >
                  Mark as Read 
@@ -450,7 +448,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 1
               </div>
@@ -460,8 +458,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               style=""
             >
               <button
-                class="btn btn-success"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-success"
                 type="button"
               >
                  Mark as Read 
@@ -505,7 +502,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 2
               </div>
@@ -515,8 +512,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               style=""
             >
               <button
-                class="btn btn-danger"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-danger"
                 type="button"
               >
                  Mark as Read 
@@ -629,7 +625,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 2
               </div>
@@ -639,8 +635,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               style=""
             >
               <button
-                class="btn btn-danger"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-danger"
                 type="button"
               >
                  Mark as Read 
@@ -684,7 +679,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-body pb-0"
             >
               <div
-                id="notification-message"
+                class="notification-message"
               >
                 valid message 1
               </div>
@@ -694,8 +689,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               style=""
             >
               <button
-                class="btn btn-success"
-                id="btn-mark-as-read"
+                class="btn-mark-as-read btn btn-success"
                 type="button"
               >
                  Mark as Read 

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -32,10 +32,10 @@
 
           <div class="mb-0" *ngIf="notificationTab.hasTabExpanded" @collapseAnim>
             <div [ngClass]="getBodyTextClass(notificationTab)">
-              <div id="notification-message" [innerHtml]="notificationTab.notification.message"></div>
+              <div class="notification-message" [innerHtml]="notificationTab.notification.message"></div>
             </div>
             <div class="d-flex flex-row-reverse me-4 mb-3" *ngIf="!notificationTab.isRead">
-              <button id="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
+              <button class="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
                 Mark as Read
               </button>
             </div>

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
@@ -130,7 +130,7 @@ describe('UserNotificationsListComponent', () => {
     component.notificationTabs = getNotificationTabs([testNotificationOne]);
     fixture.detectChanges();
     expect(component.notificationTabs[0].hasTabExpanded).toBeTruthy();
-    fixture.debugElement.query(By.css('#btn-mark-as-read')).nativeElement.click();
+    fixture.debugElement.query(By.css('.btn-mark-as-read')).nativeElement.click();
     expect(apiSpy).toHaveBeenCalledTimes(1);
     expect(messageSpy).toHaveBeenCalledTimes(1);
     // check that it is no longer expanded

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -498,7 +498,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/courses/student/details?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-view-details"
+                      id="btn-view-details-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -507,7 +507,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/courses/student/edit?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-edit-details"
+                      id="btn-edit-details-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -515,20 +515,20 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     </a>
                     <button
                       class="btn btn-light btn-sm btn-margin-right"
-                      id="btn-send-invite"
+                      id="btn-send-invite-0"
                     >
                       Send Invite
                     </button>
                     <button
                       class="btn btn-light btn-sm btn-margin-right"
-                      id="btn-delete"
+                      id="btn-delete-0"
                     >
                       Delete
                     </button>
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/students/records?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-view-records"
+                      id="btn-view-records-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -429,8 +429,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     </span>
                   </th>
                   <th
-                    class="sortable-header"
-                    id="sort-by-name"
+                    class="sort-by-name sortable-header"
                   >
                      Student Name 
                     <span
@@ -442,8 +441,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     </span>
                   </th>
                   <th
-                    class="sortable-header"
-                    id="sort-by-status"
+                    class="sort-by-status sortable-header"
                   >
                      Status 
                     <span
@@ -498,7 +496,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/courses/student/details?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-view-details-0"
+                      id="btn-view-details-CS101-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -507,7 +505,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/courses/student/edit?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-edit-details-0"
+                      id="btn-edit-details-CS101-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -515,20 +513,20 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                     </a>
                     <button
                       class="btn btn-light btn-sm btn-margin-right"
-                      id="btn-send-invite-0"
+                      id="btn-send-invite-CS101-0"
                     >
                       Send Invite
                     </button>
                     <button
                       class="btn btn-light btn-sm btn-margin-right"
-                      id="btn-delete-0"
+                      id="btn-delete-CS101-0"
                     >
                       Delete
                     </button>
                     <a
                       class="btn btn-light btn-sm btn-margin-right"
                       href="/web/instructor/students/records?courseid=CS101&studentemail=jamie@gmail.com"
-                      id="btn-view-records-0"
+                      id="btn-view-records-CS101-0"
                       rel="noopener noreferrer"
                       target="_blank"
                     >

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -526,14 +526,12 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               >
                 <div>
                   <table
-                    class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
-                    id="sessions-table"
+                    class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0"
                   >
                     <thead>
                       <tr>
                         <th
-                          class="sortable-header"
-                          id="sort-session-name"
+                          class="sort-session-name sortable-header"
                         >
                            Session Name 
                           <span
@@ -627,7 +625,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                         </td>
                         <td>
                           <div
-                            id="response-rate-0"
+                            class="response-rate-0"
                           >
                             0 / 6
                           </div>
@@ -650,15 +648,13 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                               </button>
                             </a>
                             <button
-                              class="btn btn-light btn-sm"
-                              id="btn-soft-delete-0"
+                              class="btn btn-light btn-sm btn-soft-delete-0"
                               type="button"
                             >
                               Delete
                             </button>
                             <button
-                              class="btn btn-light btn-sm"
-                              id="btn-copy-0"
+                              class="btn btn-copy-0 btn-light btn-sm"
                               ngbtooltip="Copy feedback session details"
                               type="button"
                             >
@@ -683,8 +679,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
-                                id="btn-results-0"
+                                class="dropdown-toggle btn btn-light btn-results-0 btn-sm"
                                 ngbdropdowntoggle=""
                               >
                                 Results
@@ -708,24 +703,21 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                   View Results (course-wide)
                                 </a>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-unpublish-0 clickable dropdown-item"
                                   container="body"
-                                  id="btn-unpublish-0"
                                   ngbtooltip="Make responses no longer visible"
                                   placement="left"
                                 >
                                   Unpublish Results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-resend-0"
+                                  class="btn btn-resend-0 clickable dropdown-item"
                                 >
                                   Resend link to view results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-download-0 clickable dropdown-item"
                                   disabled=""
-                                  id="btn-download-0"
                                 >
                                   Download Results
                                 </button>
@@ -738,8 +730,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
-                                id="btn-remind-0"
+                                class="dropdown-toggle btn btn-light btn-remind-0 btn-sm"
                                 ngbdropdowntoggle=""
                               >
                                 <div
@@ -759,14 +750,12 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                 ngbdropdownmenu=""
                               >
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-all-0"
+                                  class="btn btn-remind-all-0 clickable dropdown-item"
                                 >
                                   Remind all non-submitters
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-selected-0"
+                                  class="btn btn-remind-selected-0 clickable dropdown-item"
                                 >
                                   Select non-submitters to remind
                                 </button>
@@ -1018,14 +1007,12 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               >
                 <div>
                   <table
-                    class="table table-responsive-lg table-striped table-bordered margin-bottom-0"
-                    id="sessions-table"
+                    class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0"
                   >
                     <thead>
                       <tr>
                         <th
-                          class="sortable-header"
-                          id="sort-session-name"
+                          class="sort-session-name sortable-header"
                         >
                            Session Name 
                           <span
@@ -1119,7 +1106,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                         </td>
                         <td>
                           <div
-                            id="response-rate-0"
+                            class="response-rate-0"
                           >
                             0 / 6
                           </div>
@@ -1138,16 +1125,14 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                Edit 
                             </button>
                             <button
-                              class="btn btn-light btn-sm"
+                              class="btn btn-light btn-sm btn-soft-delete-0"
                               disabled=""
-                              id="btn-soft-delete-0"
                               type="button"
                             >
                               Delete
                             </button>
                             <button
-                              class="btn btn-light btn-sm"
-                              id="btn-copy-0"
+                              class="btn btn-copy-0 btn-light btn-sm"
                               ngbtooltip="Copy feedback session details"
                               type="button"
                             >
@@ -1168,8 +1153,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
-                                id="btn-results-0"
+                                class="dropdown-toggle btn btn-light btn-results-0 btn-sm"
                                 ngbdropdowntoggle=""
                               >
                                 Results
@@ -1193,25 +1177,22 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                   View Results (course-wide)
                                 </a>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-unpublish-0 clickable dropdown-item"
                                   container="body"
                                   disabled=""
-                                  id="btn-unpublish-0"
                                   ngbtooltip="Make responses no longer visible"
                                   placement="left"
                                 >
                                   Unpublish Results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-resend-0"
+                                  class="btn btn-resend-0 clickable dropdown-item"
                                 >
                                   Resend link to view results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-download-0 clickable dropdown-item"
                                   disabled=""
-                                  id="btn-download-0"
                                 >
                                   Download Results
                                 </button>
@@ -1224,9 +1205,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
+                                class="dropdown-toggle btn btn-light btn-remind-0 btn-sm"
                                 disabled=""
-                                id="btn-remind-0"
                                 ngbdropdowntoggle=""
                               >
                                 <div
@@ -1246,14 +1226,12 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 ngbdropdownmenu=""
                               >
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-all-0"
+                                  class="btn btn-remind-all-0 clickable dropdown-item"
                                 >
                                   Remind all non-submitters
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-selected-0"
+                                  class="btn btn-remind-selected-0 clickable dropdown-item"
                                 >
                                   Select non-submitters to remind
                                 </button>
@@ -1298,7 +1276,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                         </td>
                         <td>
                           <div
-                            id="response-rate-1"
+                            class="response-rate-1"
                           >
                             5 / 6
                           </div>
@@ -1317,16 +1295,14 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                Edit 
                             </button>
                             <button
-                              class="btn btn-light btn-sm"
+                              class="btn btn-light btn-sm btn-soft-delete-1"
                               disabled=""
-                              id="btn-soft-delete-1"
                               type="button"
                             >
                               Delete
                             </button>
                             <button
-                              class="btn btn-light btn-sm"
-                              id="btn-copy-1"
+                              class="btn btn-copy-1 btn-light btn-sm"
                               ngbtooltip="Copy feedback session details"
                               type="button"
                             >
@@ -1347,8 +1323,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
-                                id="btn-results-1"
+                                class="dropdown-toggle btn btn-light btn-results-1 btn-sm"
                                 ngbdropdowntoggle=""
                               >
                                 Results
@@ -1372,25 +1347,22 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                   View Results (course-wide)
                                 </a>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-unpublish-1 clickable dropdown-item"
                                   container="body"
                                   disabled=""
-                                  id="btn-unpublish-1"
                                   ngbtooltip="Make responses no longer visible"
                                   placement="left"
                                 >
                                   Unpublish Results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-resend-1"
+                                  class="btn btn-resend-1 clickable dropdown-item"
                                 >
                                   Resend link to view results
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
+                                  class="btn btn-download-1 clickable dropdown-item"
                                   disabled=""
-                                  id="btn-download-1"
                                 >
                                   Download Results
                                 </button>
@@ -1403,9 +1375,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                             >
                               <button
                                 aria-expanded="false"
-                                class="dropdown-toggle btn btn-light btn-sm"
+                                class="dropdown-toggle btn btn-light btn-remind-1 btn-sm"
                                 disabled=""
-                                id="btn-remind-1"
                                 ngbdropdowntoggle=""
                               >
                                 <div
@@ -1425,14 +1396,12 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 ngbdropdownmenu=""
                               >
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-all-1"
+                                  class="btn btn-remind-all-1 clickable dropdown-item"
                                 >
                                   Remind all non-submitters
                                 </button>
                                 <button
-                                  class="btn dropdown-item clickable"
-                                  id="btn-remind-selected-1"
+                                  class="btn btn-remind-selected-1 clickable dropdown-item"
                                 >
                                   Select non-submitters to remind
                                 </button>

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -232,15 +232,13 @@ exports[`InstructorHomePageComponent should snap with one course with error load
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
@@ -379,15 +377,13 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS1231]: Discrete Structures
             </b>
@@ -479,8 +475,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-primary btn-sm"
-                  id="btn-course"
+                  class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
                 >
                    Course 
@@ -490,8 +485,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   ngbdropdownmenu=""
                 >
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-archive-course"
+                    class="btn-archive-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   >
                      Archive 
@@ -504,8 +498,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                      View / Edit 
                   </a>
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-delete-course"
+                    class="btn-delete-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Delete the course and its corresponding students and sessions"
                   >
                      Delete 
@@ -889,15 +882,13 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
@@ -982,8 +973,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-primary btn-sm"
-                  id="btn-course"
+                  class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
                 >
                    Course 
@@ -993,8 +983,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   ngbdropdownmenu=""
                 >
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-archive-course"
+                    class="btn-archive-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   >
                      Archive 
@@ -1559,15 +1548,13 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
@@ -1659,8 +1646,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-primary btn-sm"
-                  id="btn-course"
+                  class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
                 >
                    Course 
@@ -1670,8 +1656,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   ngbdropdownmenu=""
                 >
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-archive-course"
+                    class="btn-archive-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   >
                      Archive 
@@ -1684,8 +1669,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                      View / Edit 
                   </a>
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-delete-course"
+                    class="btn-delete-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Delete the course and its corresponding students and sessions"
                   >
                      Delete 
@@ -1804,15 +1788,13 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
@@ -1904,8 +1886,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-primary btn-sm"
-                  id="btn-course"
+                  class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
                 >
                    Course 
@@ -1915,8 +1896,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   ngbdropdownmenu=""
                 >
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-archive-course"
+                    class="btn-archive-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   >
                      Archive 
@@ -1929,8 +1909,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                      View / Edit 
                   </a>
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-delete-course"
+                    class="btn-delete-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Delete the course and its corresponding students and sessions"
                   >
                      Delete 
@@ -2073,15 +2052,13 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
       <div>
         <div
           class="card"
-          id="course-tab"
+          id="course-tab-0"
         >
           <div
             class="card-header bg-primary text-white cursor-pointer"
-            id="course-tab-header"
           >
             <b
-              class="text-break"
-              id="course-details"
+              class="course-details text-break"
             >
               [CS1231]: Discrete Structures
             </b>
@@ -2173,8 +2150,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
               >
                 <button
                   aria-expanded="false"
-                  class="dropdown-toggle btn btn-primary btn-sm"
-                  id="btn-course"
+                  class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
                 >
                    Course 
@@ -2184,8 +2160,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   ngbdropdownmenu=""
                 >
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-archive-course"
+                    class="btn-archive-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   >
                      Archive 
@@ -2198,8 +2173,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                      View / Edit 
                   </a>
                   <a
-                    class="btn btn-light btn-sm dropdown-item"
-                    id="btn-delete-course"
+                    class="btn-delete-course btn btn-light btn-sm dropdown-item"
                     ngbtooltip="Delete the course and its corresponding students and sessions"
                   >
                      Delete 

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -28,9 +28,9 @@
 <tm-loading-retry [shouldShowRetry]="hasCoursesLoadingFailed" [message]="'Something went wrong'" (retryEvent)="loadCourses()">
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
-      <div id="course-tab" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div id="course-tab-header" class="card-header bg-primary text-white cursor-pointer" (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
-          <b id="course-details" class="text-break">[{{ courseTabModel.course.courseId }}]: {{ courseTabModel.course.courseName }}</b>
+      <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
+        <div class="card-header bg-primary text-white cursor-pointer" (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
+          <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{ courseTabModel.course.courseName }}</b>
           <div class="card-header-btn-toolbar flex-lg-shrink-0" *ngIf="courseTabModel.isAjaxSuccess">
             <span ngbDropdown>
               <button class="btn btn-primary btn-sm" ngbDropdownToggle> Students </button>
@@ -62,9 +62,9 @@
               </div>
             </span>
             <span ngbDropdown>
-              <button id="btn-course" class="btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
+              <button class="btn-course btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
               <div ngbDropdownMenu (click)="$event.stopPropagation()">
-                <a id="btn-archive-course" class="btn btn-light btn-sm dropdown-item"
+                <a class="btn-archive-course btn btn-light btn-sm dropdown-item"
                    ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                    (click)="archiveCourse(courseTabModel.course.courseId)"> Archive
                 </a>
@@ -75,7 +75,7 @@
 <!--                   tmRouterLink='/web/instructor/courses/student-activity-logs' [queryParams]="{courseid: courseTabModel.course.courseId}"> View Logs-->
 <!--                </a>-->
                 <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyCourse">
-                  <a id="btn-delete-course" class="btn btn-light btn-sm dropdown-item"
+                  <a class="btn-delete-course btn btn-light btn-sm dropdown-item"
                      ngbTooltip="Delete the course and its corresponding students and sessions"
                      (click)="deleteCourse(courseTabModel.course.courseId)"> Delete
                   </a>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -166,7 +166,7 @@ describe('InstructorHomePageComponent', () => {
     component.hasCoursesLoaded = true;
     fixture.detectChanges();
 
-    const button: any = fixture.debugElement.nativeElement.querySelector('#course-tab-header');
+    const button: any = fixture.debugElement.nativeElement.querySelector('.card-header');
     button.click();
     expect(component.courseTabModels[0].isTabExpanded).toBeFalsy();
     button.click();
@@ -194,9 +194,9 @@ describe('InstructorHomePageComponent', () => {
     );
     jest.spyOn(courseService, 'changeArchiveStatus').mockReturnValue(of(courseArchive));
 
-    const courseButton: any = fixture.debugElement.nativeElement.querySelector('#btn-course');
+    const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('#btn-archive-course');
+    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('.btn-archive-course');
     archiveButton.click();
 
     expect(component.courseTabModels.length).toEqual(1);
@@ -222,9 +222,9 @@ describe('InstructorHomePageComponent', () => {
     );
     jest.spyOn(courseService, 'binCourse').mockReturnValue(of(courseToDelete));
 
-    const courseButton: any = fixture.debugElement.nativeElement.querySelector('#btn-course');
+    const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('#btn-delete-course');
+    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('.btn-delete-course');
     archiveButton.click();
 
     expect(component.courseTabModels.length).toEqual(1);

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -183,8 +183,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </span>
                     </th>
                     <th
-                      class="sortable-header"
-                      id="sort-by-name"
+                      class="sort-by-name sortable-header"
                     >
                        Student Name 
                       <span
@@ -196,8 +195,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </span>
                     </th>
                     <th
-                      class="sortable-header"
-                      id="sort-by-status"
+                      class="sort-by-status sortable-header"
                     >
                        Status 
                       <span
@@ -252,7 +250,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-view-details-0"
+                        id="btn-view-details-test-exa.demo-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -261,7 +259,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-edit-details-0"
+                        id="btn-edit-details-test-exa.demo-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -269,14 +267,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete-0"
+                        id="btn-delete-test-exa.demo-0"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-view-records-0"
+                        id="btn-view-records-test-exa.demo-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -308,7 +306,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-view-details-1"
+                        id="btn-view-details-test-exa.demo-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -317,7 +315,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-edit-details-1"
+                        id="btn-edit-details-test-exa.demo-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -325,14 +323,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete-1"
+                        id="btn-delete-test-exa.demo-1"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-view-records-1"
+                        id="btn-view-records-test-exa.demo-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -364,7 +362,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-view-details-2"
+                        id="btn-view-details-test-exa.demo-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -373,7 +371,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-edit-details-2"
+                        id="btn-edit-details-test-exa.demo-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -381,14 +379,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete-2"
+                        id="btn-delete-test-exa.demo-2"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-view-records-2"
+                        id="btn-view-records-test-exa.demo-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -420,7 +418,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-view-details-3"
+                        id="btn-view-details-test-exa.demo-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -429,7 +427,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-edit-details-3"
+                        id="btn-edit-details-test-exa.demo-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -437,14 +435,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete-3"
+                        id="btn-delete-test-exa.demo-3"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-view-records-3"
+                        id="btn-view-records-test-exa.demo-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -252,7 +252,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-view-details"
+                        id="btn-view-details-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -261,7 +261,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-edit-details"
+                        id="btn-edit-details-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -269,14 +269,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete"
+                        id="btn-delete-0"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=tester@tester.com"
-                        id="btn-view-records"
+                        id="btn-view-records-0"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -308,7 +308,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-view-details"
+                        id="btn-view-details-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -317,7 +317,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-edit-details"
+                        id="btn-edit-details-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -325,14 +325,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete"
+                        id="btn-delete-1"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=benny.c.tmms@gmail.tmt"
-                        id="btn-view-records"
+                        id="btn-view-records-1"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -364,7 +364,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-view-details"
+                        id="btn-view-details-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -373,7 +373,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-edit-details"
+                        id="btn-edit-details-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -381,14 +381,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete"
+                        id="btn-delete-2"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=alice.b.tmms@gmail.tmt"
-                        id="btn-view-records"
+                        id="btn-view-records-2"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -420,7 +420,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/details?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-view-details"
+                        id="btn-view-details-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -429,7 +429,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/courses/student/edit?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-edit-details"
+                        id="btn-edit-details-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -437,14 +437,14 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                       </a>
                       <button
                         class="btn btn-light btn-sm btn-margin-right"
-                        id="btn-delete"
+                        id="btn-delete-3"
                       >
                         Delete
                       </button>
                       <a
                         class="btn btn-light btn-sm btn-margin-right"
                         href="/web/instructor/students/records?courseid=test-exa.demo&studentemail=danny.e.tmms@gmail.tmt"
-                        id="btn-view-records"
+                        id="btn-view-records-3"
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -514,6 +514,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
     <tm-session-edit-form>
       <div
         class="card card-plain"
+        id="session-edit-form"
       >
         <div
           class="card-body"
@@ -3116,6 +3117,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
     <tm-session-edit-form>
       <div
         class="card card-plain"
+        id="session-edit-form"
       >
         <div
           class="card-body"

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
@@ -56,7 +56,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -101,7 +101,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -115,7 +115,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -530,7 +530,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -575,7 +575,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -589,7 +589,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -1259,7 +1259,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -1304,7 +1304,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -1318,7 +1318,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -1682,7 +1682,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -1727,7 +1727,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -1741,7 +1741,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -2070,7 +2070,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -2115,7 +2115,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -2129,7 +2129,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -2546,7 +2546,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -2590,7 +2590,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -2604,7 +2604,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                5 Apr 2000 2:00:00 
             </div>
@@ -2815,7 +2815,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -2859,7 +2859,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -2873,7 +2873,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                5 Apr 2000 2:00:00 
             </div>
@@ -3588,7 +3588,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -3633,7 +3633,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -3647,7 +3647,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>
@@ -3949,7 +3949,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-3 text-md-start"
-              id="time-zone"
+              id="course-id"
             >
                exampleId 
             </div>
@@ -3994,7 +3994,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="session-name"
             >
             </div>
           </div>
@@ -4008,7 +4008,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             </div>
             <div
               class="col-md-10 text-md-start"
-              id="course-name"
+              id="original-deadline"
             >
                Fri, 14 Jul 2017, 02:40 AM UTC 
             </div>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.html
@@ -5,7 +5,7 @@
       <div class="card-body">
         <div class="row text-center">
           <div class="col-md-2 text-md-end font-bold">Course ID</div>
-          <div id="time-zone" class="col-md-3 text-md-start">
+          <div id="course-id" class="col-md-3 text-md-start">
             {{ courseId }}
           </div>
         </div>
@@ -23,13 +23,13 @@
         </div>
         <div class="row text-center">
           <div class="col-md-2 text-md-end font-bold">Session Name</div>
-          <div id="course-name" class="col-md-10 text-md-start">
+          <div id="session-name" class="col-md-10 text-md-start">
             {{ feedbackSessionName }}
           </div>
         </div>
         <div class="row text-center">
           <div class="col-md-2 text-md-end font-bold">Original Deadline</div>
-          <div id="course-name" class="col-md-10 text-md-start">
+          <div id="original-deadline" class="col-md-10 text-md-start">
             {{ feedbackSessionEndingTimestamp | formatDateDetail: feedbackSessionTimeZone }}
           </div>
         </div>
@@ -40,7 +40,6 @@
   </div>
 </tm-loading-retry>
 
-<!-- TODO: Use lazy loading toggleable dropdowns-->
 <tm-loading-retry [shouldShowRetry]="hasLoadedAllStudentsFailed" [message]="'Failed to load students'"
   (retryEvent)="loadFeedbackSessionAndIndividuals()">
   <div *tmIsLoading="isLoadingAllStudents">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -1,5 +1,5 @@
-<div id="question-panel" class="card margin-bottom-15px" *ngFor="let question of questionsOrder">
-  <div id="question-header" class="card-header bg-info cursor-pointer" (click)="toggleAndLoadTab.emit(question.question.feedbackQuestionId)">
+<div id="question-panel-{{ question.question.questionNumber }}" class="card margin-bottom-15px" *ngFor="let question of questionsOrder">
+  <div class="card-header bg-info cursor-pointer" (click)="toggleAndLoadTab.emit(question.question.feedbackQuestionId)">
     <tm-question-text-with-info [questionNumber]="question.question.questionNumber"
                                 [questionDetails]="question.question.questionDetails"
                                 [shouldShowDownloadQuestionResult]="true"

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -408,6 +408,7 @@ exports[`InstructorSessionsPageComponent should snap when new session form is ex
       >
         <div
           class="card card-plain"
+          id="session-edit-form"
         >
           <div
             class="close-header"

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -889,7 +889,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-1"
         >
           <button
             aria-expanded="true"
@@ -915,7 +915,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 1: 
@@ -942,8 +942,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -957,8 +956,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      Other students in the course can see your response, but not the name of the recipient, or your name 
@@ -994,7 +992,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-1-idx-0"
                     >
                       <b>
                         Unknown 
@@ -1077,7 +1075,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </div>
                   <div
                     class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
+                    id="comment-section-qn-1-idx-0"
                   >
                     <div>
                       <tm-comment-row>
@@ -1094,8 +1092,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 class="col-12"
                               >
                                 <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
+                                  class="by-response-giver text-secondary"
                                 >
                                    Comment by response giver. 
                                 </span>
@@ -1107,8 +1104,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                   class="float-end"
                                 >
                                   <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    id="btn-edit-comment"
+                                    class="btn-edit-comment btn btn-outline-primary btn-sm"
                                     ngbtooltip="Edit this comment"
                                     type="button"
                                   >
@@ -1117,8 +1113,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                     />
                                   </button>
                                   <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    id="btn-delete-comment"
+                                    class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left"
                                     ngbtooltip="Delete this comment"
                                     type="button"
                                   >
@@ -1129,8 +1124,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 </div>
                               </div>
                               <div
-                                class="col-12"
-                                id="comment-text"
+                                class="comment-text col-12"
                               >
                                 comment text
                               </div>
@@ -1161,7 +1155,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-3"
         >
           <button
             aria-expanded="true"
@@ -1187,7 +1181,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 3: 
@@ -1214,8 +1208,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -1229,8 +1222,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      Your team members can see your response, but not the name of the recipient, or your name 
@@ -1268,7 +1260,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-3-idx-0"
                     >
                       <b>
                         Unknown 
@@ -1317,7 +1309,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-2"
         >
           <button
             aria-expanded="true"
@@ -1339,7 +1331,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 2: 
@@ -1366,8 +1358,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -1381,8 +1372,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving teams can see your response, the name of the recipient, and your name 
@@ -1426,7 +1416,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-4"
         >
           <button
             aria-expanded="true"
@@ -1452,7 +1442,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 4: 
@@ -1479,8 +1469,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -1494,8 +1483,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -1566,7 +1554,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-4-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -1635,7 +1623,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </div>
                   <div
                     class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
+                    id="comment-section-qn-4-idx-0"
                   >
                     <div>
                       <tm-comment-row>
@@ -1652,8 +1640,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 class="col-12"
                               >
                                 <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
+                                  class="by-response-giver text-secondary"
                                 >
                                    Comment by response giver. 
                                 </span>
@@ -1665,8 +1652,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                   class="float-end"
                                 >
                                   <button
-                                    class="btn btn-outline-primary btn-sm"
-                                    id="btn-edit-comment"
+                                    class="btn-edit-comment btn btn-outline-primary btn-sm"
                                     ngbtooltip="Edit this comment"
                                     type="button"
                                   >
@@ -1675,8 +1661,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                     />
                                   </button>
                                   <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
-                                    id="btn-delete-comment"
+                                    class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left"
                                     ngbtooltip="Delete this comment"
                                     type="button"
                                   >
@@ -1687,8 +1672,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 </div>
                               </div>
                               <div
-                                class="col-12"
-                                id="comment-text"
+                                class="comment-text col-12"
                               >
                                 comment text
                               </div>
@@ -1732,7 +1716,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-5"
         >
           <button
             aria-expanded="true"
@@ -1758,7 +1742,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 5: 
@@ -1785,8 +1769,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -1800,8 +1783,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -1839,7 +1821,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-5-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -1927,7 +1909,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-6"
         >
           <button
             aria-expanded="true"
@@ -1953,7 +1935,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 6: 
@@ -1980,8 +1962,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -1995,8 +1976,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -2054,7 +2034,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-6-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -2136,7 +2116,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-7"
         >
           <button
             aria-expanded="true"
@@ -2162,7 +2142,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 7: 
@@ -2189,8 +2169,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -2204,8 +2183,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -2261,7 +2239,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-7-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -2575,7 +2553,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-8"
         >
           <button
             aria-expanded="true"
@@ -2601,7 +2579,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 8: 
@@ -2628,8 +2606,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -2643,8 +2620,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -2680,7 +2656,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-8-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -2899,7 +2875,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-9"
         >
           <button
             aria-expanded="true"
@@ -2925,7 +2901,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 9: 
@@ -2952,8 +2928,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -2967,8 +2942,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -3039,7 +3013,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-9-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -3161,7 +3135,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-10"
         >
           <button
             aria-expanded="true"
@@ -3187,7 +3161,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 10: 
@@ -3214,8 +3188,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -3229,8 +3202,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -3301,7 +3273,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-10-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -3586,7 +3558,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-1"
         >
           <button
             aria-expanded="true"
@@ -3612,7 +3584,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 1: 
@@ -3639,8 +3611,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -3654,8 +3625,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      Other students in the course can see your response, but not the name of the recipient, or your name 
@@ -3691,7 +3661,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-1-idx-0"
                     >
                       <b>
                         Unknown 
@@ -3777,7 +3747,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </div>
                   <div
                     class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
+                    id="comment-section-qn-1-idx-0"
                   >
                     <div>
                       <tm-comment-row>
@@ -3794,8 +3764,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 class="col-12"
                               >
                                 <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
+                                  class="by-response-giver text-secondary"
                                 >
                                    Comment by response giver. 
                                 </span>
@@ -3807,9 +3776,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                   class="float-end"
                                 >
                                   <button
-                                    class="btn btn-outline-primary btn-sm"
+                                    class="btn-edit-comment btn btn-outline-primary btn-sm"
                                     disabled=""
-                                    id="btn-edit-comment"
                                     ngbtooltip="Edit this comment"
                                     type="button"
                                   >
@@ -3818,9 +3786,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                     />
                                   </button>
                                   <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
+                                    class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left"
                                     disabled=""
-                                    id="btn-delete-comment"
                                     ngbtooltip="Delete this comment"
                                     type="button"
                                   >
@@ -3831,8 +3798,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 </div>
                               </div>
                               <div
-                                class="col-12"
-                                id="comment-text"
+                                class="comment-text col-12"
                               >
                                 comment text
                               </div>
@@ -3863,7 +3829,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-3"
         >
           <button
             aria-expanded="true"
@@ -3889,7 +3855,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 3: 
@@ -3916,8 +3882,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -3931,8 +3896,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      Your team members can see your response, but not the name of the recipient, or your name 
@@ -3970,7 +3934,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-3-idx-0"
                     >
                       <b>
                         Unknown 
@@ -4019,7 +3983,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-2"
         >
           <button
             aria-expanded="true"
@@ -4041,7 +4005,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-panel-chevron>
             </div>
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 2: 
@@ -4068,8 +4032,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -4083,8 +4046,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving teams can see your response, the name of the recipient, and your name 
@@ -4128,7 +4090,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-4"
         >
           <button
             aria-expanded="true"
@@ -4154,7 +4116,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 4: 
@@ -4181,8 +4143,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -4196,8 +4157,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -4268,7 +4228,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-4-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -4340,7 +4300,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </div>
                   <div
                     class="col-12 margin-bottom-20px margin-top-10px indent"
-                    id="comment-section"
+                    id="comment-section-qn-4-idx-0"
                   >
                     <div>
                       <tm-comment-row>
@@ -4357,8 +4317,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 class="col-12"
                               >
                                 <span
-                                  class="text-secondary"
-                                  id="by-response-giver"
+                                  class="by-response-giver text-secondary"
                                 >
                                    Comment by response giver. 
                                 </span>
@@ -4370,9 +4329,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                   class="float-end"
                                 >
                                   <button
-                                    class="btn btn-outline-primary btn-sm"
+                                    class="btn-edit-comment btn btn-outline-primary btn-sm"
                                     disabled=""
-                                    id="btn-edit-comment"
                                     ngbtooltip="Edit this comment"
                                     type="button"
                                   >
@@ -4381,9 +4339,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                     />
                                   </button>
                                   <button
-                                    class="btn btn-outline-primary btn-sm btn-margin-left"
+                                    class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left"
                                     disabled=""
-                                    id="btn-delete-comment"
                                     ngbtooltip="Delete this comment"
                                     type="button"
                                   >
@@ -4394,8 +4351,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                                 </div>
                               </div>
                               <div
-                                class="col-12"
-                                id="comment-text"
+                                class="comment-text col-12"
                               >
                                 comment text
                               </div>
@@ -4440,7 +4396,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-5"
         >
           <button
             aria-expanded="true"
@@ -4466,7 +4422,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 5: 
@@ -4493,8 +4449,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -4508,8 +4463,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -4547,7 +4501,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-5-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -4636,7 +4590,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-6"
         >
           <button
             aria-expanded="true"
@@ -4662,7 +4616,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 6: 
@@ -4689,8 +4643,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -4704,8 +4657,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -4763,7 +4715,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-6-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -4846,7 +4798,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-7"
         >
           <button
             aria-expanded="true"
@@ -4872,7 +4824,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 7: 
@@ -4899,8 +4851,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -4914,8 +4865,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -4971,7 +4921,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-7-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -5286,7 +5236,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-8"
         >
           <button
             aria-expanded="true"
@@ -5312,7 +5262,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 8: 
@@ -5339,8 +5289,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -5354,8 +5303,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -5391,7 +5339,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-8-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -5619,7 +5567,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-9"
         >
           <button
             aria-expanded="true"
@@ -5645,7 +5593,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 9: 
@@ -5672,8 +5620,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -5687,8 +5634,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -5759,7 +5705,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-9-idx-0"
                     >
                       <b>
                         Barry Harris 
@@ -5882,7 +5828,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       >
         <div
           class="card"
-          id="question-submission-form"
+          id="question-submission-form-qn-10"
         >
           <button
             aria-expanded="true"
@@ -5908,7 +5854,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               class="fas fa-check me-2"
             />
             <h2
-              id="question-details"
+              class="question-details"
             >
               <b>
                 Question 10: 
@@ -5935,8 +5881,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </b>
                 </div>
                 <div
-                  class="card-body"
-                  id="question-description"
+                  class="question-description card-body"
                 >
                   question description
                 </div>
@@ -5950,8 +5895,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   Only the following persons can see your responses: 
                 </p>
                 <ul
-                  class="text-secondary"
-                  id="visibility-list"
+                  class="visibility-list text-secondary"
                 >
                   <li>
                      The receiving students can see your response, the name of the recipient, and your name 
@@ -6022,7 +5966,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                     class="col-md-5 col-xs-12 margin-top-20px"
                   >
                     <div
-                      id="recipient-name-0"
+                      id="recipient-name-qn-10-idx-0"
                     >
                       <b>
                         Barry Harris 


### PR DESCRIPTION
Part of #12081 

Fixes all instances of duplicate IDs that were caught by accessibility tests. Fixes were implemented on a case by case basis:
- IDs were swapped to classes if uniquely identifying attributes (e.g. course ID) were not readily available to the component, or if a parent ID already exists.
- Indexes were added to IDs if they are deemed important (e.g. question submission forms), or if the components necessitate IDs (e.g. buttons using `ngTemplateOutlet` in `student-list`).

There may still be many other cases of duplicate IDs that were not identified due to the sheer size of the frontend codebase, but the more commonly used components should mostly be covered by this PR.

Snapshot and E2E tests were updated as necessary.