### PR TITLE
[#12081] User-friendliness: Fix feedback path dropdown

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1079,11 +1079,10 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement feedbackPathPanel = questionForm.findElement(By.tagName("tm-feedback-path-panel"));
         click(feedbackPathPanel.findElement(By.id("btn-feedback-path")));
         WebElement dropdown = feedbackPathPanel.findElement(By.id("feedback-path-dropdown"));
-        List<WebElement> options = dropdown.findElements(By.className("dropdown-item"));
+        List<WebElement> options = dropdown.findElements(By.className("dropdown-button"));
         for (WebElement option : options) {
-            WebElement dropdownButton = option.findElement(By.className("dropdown-button"));
-            if (dropdownButton.getText().equals(text)) {
-                click(dropdownButton);
+            if (option.getText().equals(text)) {
+                click(option);
                 return;
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1081,7 +1081,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement dropdown = feedbackPathPanel.findElement(By.id("feedback-path-dropdown"));
         List<WebElement> options = dropdown.findElements(By.className("dropdown-item"));
         for (WebElement option : options) {
-            if (option.getText().equals(text)) {
+            if (option.findElement(By.className("dropdown-button")).getText().equals(text)) {
                 click(option);
                 return;
             }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1081,8 +1081,9 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement dropdown = feedbackPathPanel.findElement(By.id("feedback-path-dropdown"));
         List<WebElement> options = dropdown.findElements(By.className("dropdown-item"));
         for (WebElement option : options) {
-            if (option.findElement(By.className("dropdown-button")).getText().equals(text)) {
-                click(option);
+            WebElement dropdownButton = option.findElement(By.className("dropdown-button"));
+            if (dropdownButton.getText().equals(text)) {
+                click(dropdownButton);
                 return;
             }
         }

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -4,7 +4,7 @@
   </div>
   <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
     <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle
-            [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()" aria-label="Feedback Path Dropdown">
+            [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()">
       <span *ngIf="!model.isUsingOtherFeedbackPath" class="text-wrap">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}
       </span>

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -3,7 +3,8 @@
     <b class="feedback-path-title">Feedback Path</b> (Who is giving feedback about whom?)
   </div>
   <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
-    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()">
+    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle 
+            [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()" aria-label="Feedback Path Dropdown">
       <span *ngIf="!model.isUsingOtherFeedbackPath" class="text-wrap">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}
       </span>
@@ -12,13 +13,16 @@
     <ul id="feedback-path-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common feedback path combinations</li>
       <li *ngFor="let path of commonFeedbackPaths | keyvalue">
-        <div ngbDropdown #subMenu="ngbDropdown" (click)="toggleSubMenu(path.key)">
-          <div class="text-wrap dropdown-item"> {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-right"></i> </div>
+        <button class="dropdown-button" ngbDropdown #subMenu="ngbDropdown" (click)="toggleSubMenu(path.key)">
+          <div class="text-wrap dropdown-item"> {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-{{ isSubMenuOpen(path.key) ? 'down' : 'right' }}"></i> </div>
           <ul *ngIf="isSubMenuOpen(path.key)">
-            <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value"
-                (click)="changeGiverRecipientType(path.key, recipient); mainMenu.close()">{{ recipient | recipientTypeDescription }}</li>
+            <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value">
+              <button class="dropdown-button" (click)="changeGiverRecipientType(path.key, recipient); mainMenu.close()">
+                {{ recipient | recipientTypeDescription }}
+              </button>
+            </li>
           </ul>
-        </div>
+        </button>
       </li>
       <li class="dropdown-divider"></li>
       <li class="text-wrap dropdown-item" (click)="triggerCustomFeedbackPath(); mainMenu.close()">Custom feedback path...</li>

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -3,7 +3,7 @@
     <b class="feedback-path-title">Feedback Path</b> (Who is giving feedback about whom?)
   </div>
   <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
-    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle 
+    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle
             [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()" aria-label="Feedback Path Dropdown">
       <span *ngIf="!model.isUsingOtherFeedbackPath" class="text-wrap">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -28,9 +28,7 @@
       </li>
       <li class="dropdown-divider"></li>
       <li class="text-wrap dropdown-item">
-        <button class="dropdown-button" (click)="triggerCustomFeedbackPath(); mainMenu.close()">
-          Custom feedback path...
-        </button>
+        <button class="dropdown-button" (click)="triggerCustomFeedbackPath(); mainMenu.close()">Custom feedback path...</button>
       </li>
     </ul>
   </div>

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -13,7 +13,7 @@
     <ul id="feedback-path-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common feedback path combinations</li>
       <li *ngFor="let path of commonFeedbackPaths | keyvalue" ngbDropdown #subMenu="ngbDropdown">
-        <div class="dropdown-item">
+        <div class="text-wrap dropdown-item">
           <button class="dropdown-button" (click)="toggleSubMenu(path.key)">
             {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-{{ isSubMenuOpen(path.key) ? 'down' : 'right' }}"></i>
           </button>

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -3,26 +3,26 @@
     <b class="feedback-path-title">Feedback Path</b> (Who is giving feedback about whom?)
   </div>
   <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
-    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle [disabled]="!model.isEditable || commonFeedbackPaths.size === 1">
-      <span *ngIf="!model.isUsingOtherFeedbackPath">
+    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()">
+      <span *ngIf="!model.isUsingOtherFeedbackPath" class="text-wrap">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}
       </span>
       <span *ngIf="model.isUsingOtherFeedbackPath">Custom feedback path</span>
     </button>
     <ul id="feedback-path-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common feedback path combinations</li>
-      <li class="dropdown-item" *ngFor="let path of commonFeedbackPaths | keyvalue">
-        <div ngbDropdown #subMenu="ngbDropdown" placement="right" (mouseenter)="subMenu.open()" (mouseleave)="subMenu.close()">
-          <span ngbDropdownAnchor class="float-end invisible"></span>
-          {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-right"></i>
-          <ul ngbDropdownMenu>
-            <li class="dropdown-item" *ngFor="let recipient of path.value"
+      <li *ngFor="let path of commonFeedbackPaths | keyvalue">
+        <div ngbDropdown #subMenu="ngbDropdown" (click)="toggleSubMenu(path.key)">
+          <!-- <span ngbDropdownAnchor class="float-end invisible"></span> -->
+          <div class="text-wrap dropdown-item"> {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-right"></i> </div>
+          <ul *ngIf="isSubMenuOpen(path.key)">
+            <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value"
                 (click)="changeGiverRecipientType(path.key, recipient); mainMenu.close()">{{ recipient | recipientTypeDescription }}</li>
           </ul>
         </div>
       </li>
       <li class="dropdown-divider"></li>
-      <li class="dropdown-item" (click)="triggerCustomFeedbackPath(); mainMenu.close()">Custom feedback path...</li>
+      <li class="text-wrap dropdown-item" (click)="triggerCustomFeedbackPath(); mainMenu.close()">Custom feedback path...</li>
     </ul>
   </div>
   <div class="row margin-top-15px" *ngIf="model.isUsingOtherFeedbackPath">

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -13,7 +13,6 @@
       <li class="dropdown-header">Common feedback path combinations</li>
       <li *ngFor="let path of commonFeedbackPaths | keyvalue">
         <div ngbDropdown #subMenu="ngbDropdown" (click)="toggleSubMenu(path.key)">
-          <!-- <span ngbDropdownAnchor class="float-end invisible"></span> -->
           <div class="text-wrap dropdown-item"> {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-right"></i> </div>
           <ul *ngIf="isSubMenuOpen(path.key)">
             <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value"

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -12,20 +12,26 @@
     </button>
     <ul id="feedback-path-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common feedback path combinations</li>
-      <li *ngFor="let path of commonFeedbackPaths | keyvalue">
-        <button class="dropdown-button" ngbDropdown #subMenu="ngbDropdown" (click)="toggleSubMenu(path.key)">
-          <div class="text-wrap dropdown-item"> {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-{{ isSubMenuOpen(path.key) ? 'down' : 'right' }}"></i> </div>
-          <ul *ngIf="isSubMenuOpen(path.key)">
-            <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value">
-              <button class="dropdown-button" (click)="changeGiverRecipientType(path.key, recipient); mainMenu.close()">
-                {{ recipient | recipientTypeDescription }}
-              </button>
-            </li>
-          </ul>
-        </button>
+      <li *ngFor="let path of commonFeedbackPaths | keyvalue" ngbDropdown #subMenu="ngbDropdown">
+        <div class="dropdown-item">
+          <button class="dropdown-button" (click)="toggleSubMenu(path.key)">
+            {{ path.key | giverTypeDescription }} will give feedback on ... <i class="fas fa-caret-{{ isSubMenuOpen(path.key) ? 'down' : 'right' }}"></i>
+          </button>
+        </div>
+        <ul *ngIf="isSubMenuOpen(path.key)">
+          <li class="text-wrap dropdown-item" *ngFor="let recipient of path.value">
+            <button class="dropdown-button" (click)="changeGiverRecipientType(path.key, recipient); mainMenu.close()">
+              {{ recipient | recipientTypeDescription }}
+            </button>
+          </li>
+        </ul>
       </li>
       <li class="dropdown-divider"></li>
-      <li class="text-wrap dropdown-item" (click)="triggerCustomFeedbackPath(); mainMenu.close()">Custom feedback path...</li>
+      <li class="text-wrap dropdown-item">
+        <button class="dropdown-button" (click)="triggerCustomFeedbackPath(); mainMenu.close()">
+          Custom feedback path...
+        </button>
+      </li>
     </ul>
   </div>
   <div class="row margin-top-15px" *ngIf="model.isUsingOtherFeedbackPath">

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.scss
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.scss
@@ -21,7 +21,6 @@
 .dropdown-button {
   border: none;
   background: none;
-  cursor: inherit;
   width: 100%;
   text-align: left;
 }

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.scss
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.scss
@@ -17,3 +17,11 @@
 .dropdown-item {
   cursor: pointer;
 }
+
+.dropdown-button {
+  border: none;
+  background: none;
+  cursor: inherit;
+  width: 100%;
+  text-align: left;
+}

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -70,7 +70,7 @@ export class FeedbackPathPanelComponent {
   allowedFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
   @Input()
-  testMap: Map<FeedbackParticipantType, boolean> = new Map();
+  subMenuStatuses: Map<FeedbackParticipantType, boolean> = new Map();
 
   @Output()
   customFeedbackPath: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -99,35 +99,19 @@ export class FeedbackPathPanelComponent {
   }
 
   toggleSubMenu(menu: FeedbackParticipantType): void {
-    this.testMap.set(menu, !this.testMap.get(menu));
+    this.subMenuStatuses.set(menu, !this.subMenuStatuses.get(menu));
   }
 
   resetMenu(): void {
-    this.testMap.forEach((_, k) => this.testMap.set(k, false));
+    this.subMenuStatuses.forEach((_, key) => this.subMenuStatuses.set(key, false));
   }
 
-  // showSubMenu(menuToShow: FeedbackParticipantType): void {
-  //   this.testMap.set(menuToShow, true);
-  // }
-
-  // hideSubMenu(menuToHide: FeedbackParticipantType): void {
-  //   this.testMap.set(menuToHide, false);
-  // }
-
   isSubMenuOpen(menu: FeedbackParticipantType): boolean {
-    let subMenuState: boolean | undefined = this.testMap.get(menu);
+    let subMenuState: boolean | undefined = this.subMenuStatuses.get(menu);
     if (subMenuState === undefined) {
       subMenuState = false;
     }
     return subMenuState;
-    // const boolThing: boolean = this.testMap.get(menu);
-    // return boolThing;
-    // if (this.testMap.get(menu) == undefined) {
-    //   return false;
-    // } else {
-    //   return this.testMap.get(menu);
-    // }
-    //return this.testMap.get(menu);
   }
 
   /**

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -84,7 +84,7 @@ export class FeedbackPathPanelComponent {
     new EventEmitter<Partial<QuestionEditFormModel>>();
 
   subMenuStatuses: Map<FeedbackParticipantType, boolean> = new Map();
-  
+
   triggerCustomNumberOfEntities(data: number): void {
     this.customNumberOfEntitiesToGiveFeedbackTo.emit(data);
   }

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -69,6 +69,9 @@ export class FeedbackPathPanelComponent {
   @Input()
   allowedFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
+  @Input()
+  testMap: Map<FeedbackParticipantType, boolean> = new Map();
+
   @Output()
   customFeedbackPath: EventEmitter<boolean> = new EventEmitter<boolean>();
 
@@ -93,6 +96,38 @@ export class FeedbackPathPanelComponent {
 
   triggerCustomFeedbackPath(): void {
     this.customFeedbackPath.emit(true);
+  }
+
+  toggleSubMenu(menu: FeedbackParticipantType): void {
+    this.testMap.set(menu, !this.testMap.get(menu));
+  }
+
+  resetMenu(): void {
+    this.testMap.forEach((_, k) => this.testMap.set(k, false));
+  }
+
+  // showSubMenu(menuToShow: FeedbackParticipantType): void {
+  //   this.testMap.set(menuToShow, true);
+  // }
+
+  // hideSubMenu(menuToHide: FeedbackParticipantType): void {
+  //   this.testMap.set(menuToHide, false);
+  // }
+
+  isSubMenuOpen(menu: FeedbackParticipantType): boolean {
+    let subMenuState: boolean | undefined = this.testMap.get(menu);
+    if (subMenuState === undefined) {
+      subMenuState = false;
+    }
+    return subMenuState;
+    // const boolThing: boolean = this.testMap.get(menu);
+    // return boolThing;
+    // if (this.testMap.get(menu) == undefined) {
+    //   return false;
+    // } else {
+    //   return this.testMap.get(menu);
+    // }
+    //return this.testMap.get(menu);
   }
 
   /**

--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -69,9 +69,6 @@ export class FeedbackPathPanelComponent {
   @Input()
   allowedFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
-  @Input()
-  subMenuStatuses: Map<FeedbackParticipantType, boolean> = new Map();
-
   @Output()
   customFeedbackPath: EventEmitter<boolean> = new EventEmitter<boolean>();
 
@@ -86,6 +83,8 @@ export class FeedbackPathPanelComponent {
   triggerModelChangeBatch: EventEmitter<Partial<QuestionEditFormModel>> =
     new EventEmitter<Partial<QuestionEditFormModel>>();
 
+  subMenuStatuses: Map<FeedbackParticipantType, boolean> = new Map();
+  
   triggerCustomNumberOfEntities(data: number): void {
     this.customNumberOfEntitiesToGiveFeedbackTo.emit(data);
   }

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -239,12 +239,14 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Feedback Path Dropdown"
                 class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                 disabled=""
                 id="btn-feedback-path"
                 ngbdropdowntoggle=""
               >
                 <span
+                  class="text-wrap"
                   style=""
                 >
                    Students in this course will give feedback on 
@@ -268,9 +270,13 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                   class="dropdown-divider"
                 />
                 <li
-                  class="dropdown-item"
+                  class="text-wrap dropdown-item"
                 >
-                  Custom feedback path...
+                  <button
+                    class="dropdown-button"
+                  >
+                     Custom feedback path... 
+                  </button>
                 </li>
               </ul>
             </div>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -274,7 +274,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                   <button
                     class="dropdown-button"
                   >
-                     Custom feedback path... 
+                    Custom feedback path...
                   </button>
                 </li>
               </ul>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -239,7 +239,6 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             >
               <button
                 aria-expanded="false"
-                aria-label="Feedback Path Dropdown"
                 class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                 disabled=""
                 id="btn-feedback-path"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1447,11 +1447,13 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
+                        aria-label="Feedback Path Dropdown"
                         class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
                         <span
+                          class="text-wrap"
                           style=""
                         >
                            Students in this course will give feedback on 
@@ -1472,139 +1474,67 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           Common feedback path combinations
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Instructors in this course will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                            </ul>
+                               Instructors in this course will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Feedback session creator (i.e., me) will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                            </ul>
+                               Feedback session creator (i.e., me) will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Students in this course will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver's team members
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver's team members and Giver
-                              </li>
-                            </ul>
+                               Students in this course will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
                           class="dropdown-divider"
                         />
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                         >
-                          Custom feedback path...
+                          <button
+                            class="dropdown-button"
+                          >
+                             Custom feedback path... 
+                          </button>
                         </li>
                       </ul>
                     </div>
@@ -2186,11 +2116,13 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
+                        aria-label="Feedback Path Dropdown"
                         class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
                         <span
+                          class="text-wrap"
                           style=""
                         >
                            Students in this course will give feedback on 
@@ -2211,139 +2143,67 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           Common feedback path combinations
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Instructors in this course will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                            </ul>
+                               Instructors in this course will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Feedback session creator (i.e., me) will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                            </ul>
+                               Feedback session creator (i.e., me) will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
-                          class="dropdown-item"
+                          ngbdropdown=""
                           style=""
                         >
                           <div
-                            ngbdropdown=""
-                            placement="right"
+                            class="dropdown-item"
                           >
-                            <span
-                              aria-expanded="false"
-                              class="dropdown-toggle float-end invisible"
-                              ngbdropdownanchor=""
-                            />
-                             Students in this course will give feedback on ... 
-                            <i
-                              class="fas fa-caret-right"
-                            />
-                            <ul
-                              class="dropdown-menu"
-                              ngbdropdownmenu=""
+                            <button
+                              class="dropdown-button"
                             >
-                              <li
-                                class="dropdown-item"
-                              >
-                                Nobody specific (For general class feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver (Self feedback)
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Instructors in the course
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver's team members
-                              </li>
-                              <li
-                                class="dropdown-item"
-                              >
-                                Giver's team members and Giver
-                              </li>
-                            </ul>
+                               Students in this course will give feedback on ... 
+                              <i
+                                class="fa-caret-right fas"
+                              />
+                            </button>
                           </div>
                         </li>
                         <li
                           class="dropdown-divider"
                         />
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                         >
-                          Custom feedback path...
+                          <button
+                            class="dropdown-button"
+                          >
+                             Custom feedback path... 
+                          </button>
                         </li>
                       </ul>
                     </div>
@@ -4009,6 +3869,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                 >
                   <button
                     aria-expanded="false"
+                    aria-label="Feedback Path Dropdown"
                     class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                     id="btn-feedback-path"
                     ngbdropdowntoggle=""
@@ -4030,139 +3891,67 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       Common feedback path combinations
                     </li>
                     <li
-                      class="dropdown-item"
+                      ngbdropdown=""
                       style=""
                     >
                       <div
-                        ngbdropdown=""
-                        placement="right"
+                        class="dropdown-item"
                       >
-                        <span
-                          aria-expanded="false"
-                          class="dropdown-toggle float-end invisible"
-                          ngbdropdownanchor=""
-                        />
-                         Instructors in this course will give feedback on ... 
-                        <i
-                          class="fas fa-caret-right"
-                        />
-                        <ul
-                          class="dropdown-menu"
-                          ngbdropdownmenu=""
+                        <button
+                          class="dropdown-button"
                         >
-                          <li
-                            class="dropdown-item"
-                          >
-                            Nobody specific (For general class feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Giver (Self feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Instructors in the course
-                          </li>
-                        </ul>
+                           Instructors in this course will give feedback on ... 
+                          <i
+                            class="fa-caret-right fas"
+                          />
+                        </button>
                       </div>
                     </li>
                     <li
-                      class="dropdown-item"
+                      ngbdropdown=""
                       style=""
                     >
                       <div
-                        ngbdropdown=""
-                        placement="right"
+                        class="dropdown-item"
                       >
-                        <span
-                          aria-expanded="false"
-                          class="dropdown-toggle float-end invisible"
-                          ngbdropdownanchor=""
-                        />
-                         Feedback session creator (i.e., me) will give feedback on ... 
-                        <i
-                          class="fas fa-caret-right"
-                        />
-                        <ul
-                          class="dropdown-menu"
-                          ngbdropdownmenu=""
+                        <button
+                          class="dropdown-button"
                         >
-                          <li
-                            class="dropdown-item"
-                          >
-                            Nobody specific (For general class feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Giver (Self feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Instructors in the course
-                          </li>
-                        </ul>
+                           Feedback session creator (i.e., me) will give feedback on ... 
+                          <i
+                            class="fa-caret-right fas"
+                          />
+                        </button>
                       </div>
                     </li>
                     <li
-                      class="dropdown-item"
+                      ngbdropdown=""
                       style=""
                     >
                       <div
-                        ngbdropdown=""
-                        placement="right"
+                        class="dropdown-item"
                       >
-                        <span
-                          aria-expanded="false"
-                          class="dropdown-toggle float-end invisible"
-                          ngbdropdownanchor=""
-                        />
-                         Students in this course will give feedback on ... 
-                        <i
-                          class="fas fa-caret-right"
-                        />
-                        <ul
-                          class="dropdown-menu"
-                          ngbdropdownmenu=""
+                        <button
+                          class="dropdown-button"
                         >
-                          <li
-                            class="dropdown-item"
-                          >
-                            Nobody specific (For general class feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Giver (Self feedback)
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Instructors in the course
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Giver's team members
-                          </li>
-                          <li
-                            class="dropdown-item"
-                          >
-                            Giver's team members and Giver
-                          </li>
-                        </ul>
+                           Students in this course will give feedback on ... 
+                          <i
+                            class="fa-caret-right fas"
+                          />
+                        </button>
                       </div>
                     </li>
                     <li
                       class="dropdown-divider"
                     />
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                     >
-                      Custom feedback path...
+                      <button
+                        class="dropdown-button"
+                      >
+                         Custom feedback path... 
+                      </button>
                     </li>
                   </ul>
                 </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1532,7 +1532,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           <button
                             class="dropdown-button"
                           >
-                             Custom feedback path... 
+                            Custom feedback path...
                           </button>
                         </li>
                       </ul>
@@ -2200,7 +2200,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           <button
                             class="dropdown-button"
                           >
-                             Custom feedback path... 
+                            Custom feedback path...
                           </button>
                         </li>
                       </ul>
@@ -3947,7 +3947,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       <button
                         class="dropdown-button"
                       >
-                         Custom feedback path... 
+                        Custom feedback path...
                       </button>
                     </li>
                   </ul>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1478,7 +1478,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -1495,7 +1495,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -1512,7 +1512,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -2147,7 +2147,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -2164,7 +2164,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -2181,7 +2181,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         >
                           <div
-                            class="dropdown-item"
+                            class="text-wrap dropdown-item"
                           >
                             <button
                               class="dropdown-button"
@@ -3895,7 +3895,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       style=""
                     >
                       <div
-                        class="dropdown-item"
+                        class="text-wrap dropdown-item"
                       >
                         <button
                           class="dropdown-button"
@@ -3912,7 +3912,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       style=""
                     >
                       <div
-                        class="dropdown-item"
+                        class="text-wrap dropdown-item"
                       >
                         <button
                           class="dropdown-button"
@@ -3929,7 +3929,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       style=""
                     >
                       <div
-                        class="dropdown-item"
+                        class="text-wrap dropdown-item"
                       >
                         <button
                           class="dropdown-button"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1447,7 +1447,6 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
-                        aria-label="Feedback Path Dropdown"
                         class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
@@ -2116,7 +2115,6 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
-                        aria-label="Feedback Path Dropdown"
                         class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
@@ -3869,7 +3867,6 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                 >
                   <button
                     aria-expanded="false"
-                    aria-label="Feedback Path Dropdown"
                     class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
                     id="btn-feedback-path"
                     ngbdropdowntoggle=""


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Fix feedback path dropdown](https://github.com/TEAMMATES/teammates/projects/16#card-88348663)

**Outline of Solution**
Changed second dropdown to be below instead of to the side. Keeps track of which submenus are open via a map. Also added buttons for accessibility and added the `text-wrap` class to resolve overflow issues.

For E2E tests, changed the options to click on the button.
