### PR TITLE
[#12081] User-friendliness: Fix custom visibility options

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1173,9 +1173,7 @@ public class InstructorFeedbackEditPage extends AppPage {
 
     private void clickSaveNewQuestionButton() {
         WebElement saveButton = browser.driver.findElement(By.id("btn-save-new"));
-        WebElement actualButton = saveButton.findElement(By.xpath("./.."));
-        click(actualButton);
-        // click(saveButton);
+        click(saveButton);
         waitForElementStaleness(saveButton);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1145,7 +1145,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
         click(visibilityPanel.findElement(By.id("btn-question-visibility")));
         WebElement dropdown = visibilityPanel.findElement(By.id("question-visibility-dropdown"));
-        List<WebElement> options = dropdown.findElements(By.className("dropdown-item"));
+        List<WebElement> options = dropdown.findElements(By.className("dropdown-button"));
         for (WebElement option : options) {
             if (option.getText().equals(text)) {
                 click(option);

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -1173,7 +1173,9 @@ public class InstructorFeedbackEditPage extends AppPage {
 
     private void clickSaveNewQuestionButton() {
         WebElement saveButton = browser.driver.findElement(By.id("btn-save-new"));
-        click(saveButton);
+        WebElement actualButton = saveButton.findElement(By.xpath("./.."));
+        click(actualButton);
+        // click(saveButton);
         waitForElementStaleness(saveButton);
     }
 

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -376,7 +376,11 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                   class="dropdown-item"
                   style=""
                 >
-                  Custom visibility options...
+                  <button
+                    class="dropdown-button"
+                  >
+                    Custom visibility options...
+                  </button>
                 </li>
               </ul>
             </div>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -369,6 +369,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                   Common visibility options
                 </li>
                 <li
+                  aria-hidden="true"
                   class="dropdown-divider"
                   style=""
                 />

--- a/src/web/app/components/visibility-panel/visibility-panel.component.html
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.html
@@ -6,7 +6,7 @@
     </div>
     <b [ngClass]="{ 'visibility-title': !model.isQuestionHasResponses }">Visibility</b> (Who can see the responses?)
   </div>
-  <div ngbDropdown class="margin-top-15px">
+  <div #mainMenu="ngbDropdown" ngbDropdown class="margin-top-15px">
     <button id="btn-question-visibility" class="btn btn-light white-space-normal" ngbDropdownToggle [disabled]="!model.isEditable">
       <span *ngIf="!model.isUsingOtherVisibilitySetting">
         {{ model.commonVisibilitySettingName }}
@@ -15,10 +15,13 @@
     </button>
     <ul id="question-visibility-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common visibility options</li>
-      <li class="dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings"
-          (click)="applyCommonVisibilitySettings(visibilityOption)">{{ visibilityOption.name }}</li>
+      <li class="dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings">
+        <button class="dropdown-button" (click)="applyCommonVisibilitySettings(visibilityOption); mainMenu.close()">{{ visibilityOption.name }}</button>
+      </li>
       <li class="dropdown-divider" *ngIf="isCustomFeedbackVisibilitySettingAllowed"></li>
-      <li class="dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed" (click)="triggerCustomVisibilitySetting()">Custom visibility options...</li>
+      <li class="dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed">
+        <button class="dropdown-button" (click)="triggerCustomVisibilitySetting(); mainMenu.close()">Custom visibility options...</button>
+      </li>
     </ul>
   </div>
   <table class="table margin-top-15px background-color-white table-striped" *ngIf="model.isUsingOtherVisibilitySetting">
@@ -36,7 +39,8 @@
           <input type="checkbox"
                  (click)="modifyVisibilityControl($event.target.checked, visibilityType, visibilityControl)"
                  [checked]="visibilityStateMachine.isVisible(visibilityType, visibilityControl)"
-                 [disabled]="!visibilityStateMachine.isCellEditable(visibilityType, visibilityControl) || !model.isEditable">
+                 [disabled]="!visibilityStateMachine.isCellEditable(visibilityType, visibilityControl) || !model.isEditable"
+                 [attr.aria-label]="getCheckboxAriaLabel(visibilityType, visibilityControl)">
         </td>
       </tr>
     </ng-container>

--- a/src/web/app/components/visibility-panel/visibility-panel.component.html
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.html
@@ -6,7 +6,7 @@
     </div>
     <b [ngClass]="{ 'visibility-title': !model.isQuestionHasResponses }">Visibility</b> (Who can see the responses?)
   </div>
-  <div #mainMenu="ngbDropdown" ngbDropdown class="margin-top-15px">
+  <div ngbDropdown class="margin-top-15px">
     <button id="btn-question-visibility" class="btn btn-light white-space-normal" ngbDropdownToggle [disabled]="!model.isEditable">
       <span *ngIf="!model.isUsingOtherVisibilitySetting">
         {{ model.commonVisibilitySettingName }}
@@ -16,11 +16,11 @@
     <ul id="question-visibility-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common visibility options</li>
       <li class="dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings">
-        <button class="dropdown-button" (click)="applyCommonVisibilitySettings(visibilityOption); mainMenu.close()">{{ visibilityOption.name }}</button>
+        <button class="dropdown-button" (click)="applyCommonVisibilitySettings(visibilityOption)">{{ visibilityOption.name }}</button>
       </li>
       <li class="dropdown-divider" *ngIf="isCustomFeedbackVisibilitySettingAllowed" aria-hidden="true"></li>
       <li class="dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed">
-        <button class="dropdown-button" (click)="triggerCustomVisibilitySetting(); mainMenu.close()">Custom visibility options...</button>
+        <button class="dropdown-button" (click)="triggerCustomVisibilitySetting()">Custom visibility options...</button>
       </li>
     </ul>
   </div>

--- a/src/web/app/components/visibility-panel/visibility-panel.component.html
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.html
@@ -18,13 +18,13 @@
       <li class="dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings">
         <button class="dropdown-button" (click)="applyCommonVisibilitySettings(visibilityOption); mainMenu.close()">{{ visibilityOption.name }}</button>
       </li>
-      <li class="dropdown-divider" *ngIf="isCustomFeedbackVisibilitySettingAllowed"></li>
+      <li class="dropdown-divider" *ngIf="isCustomFeedbackVisibilitySettingAllowed" aria-hidden="true"></li>
       <li class="dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed">
         <button class="dropdown-button" (click)="triggerCustomVisibilitySetting(); mainMenu.close()">Custom visibility options...</button>
       </li>
     </ul>
   </div>
-  <table class="table margin-top-15px background-color-white table-striped" *ngIf="model.isUsingOtherVisibilitySetting">
+  <table class="table margin-top-15px background-color-white table-striped" *ngIf="model.isUsingOtherVisibilitySetting" aria-label="Custom Visibility Options Table">
     <thead>
     <tr>
       <th scope="col" class="text-start">User/Group</th>

--- a/src/web/app/components/visibility-panel/visibility-panel.component.scss
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.scss
@@ -39,3 +39,10 @@
 .dropdown-item {
   cursor: pointer;
 }
+
+.dropdown-button {
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -90,33 +90,27 @@ export class VisibilityPanelComponent {
   @Output()
   visibilityStateMachineChange: EventEmitter<VisibilityStateMachine> = new EventEmitter<VisibilityStateMachine>();
 
+  visibilityTypeAriaLabels: Map<FeedbackVisibilityType, string> = new Map([
+    [FeedbackVisibilityType.RECIPIENT, 'Recipient(s)'],
+    [FeedbackVisibilityType.GIVER_TEAM_MEMBERS, 'Giver\'s Team Members'],
+    [FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS, 'Recipient\'s Team Members'],
+    [FeedbackVisibilityType.STUDENTS, 'Other Students'],
+    [FeedbackVisibilityType.INSTRUCTORS, 'Instructors'],
+  ]);
+
+  visibilityControlAriaLabels: Map<VisibilityControl, string> = new Map([
+    [VisibilityControl.SHOW_RESPONSE, 'Answer'],
+    [VisibilityControl.SHOW_GIVER_NAME, 'Giver\'s Name'],
+    [VisibilityControl.SHOW_RECIPIENT_NAME, 'Recipient\'s Name'],
+  ])
+
   triggerCustomVisibilitySetting(): void {
     this.customVisibilitySetting.emit(true);
   }
 
   getCheckboxAriaLabel(visibilityType: FeedbackVisibilityType, visibilityControl: VisibilityControl): string {
-    let group: string = '';
-    if (visibilityType === FeedbackVisibilityType.RECIPIENT) {
-      group = 'Recipient(s)';
-    } else if (visibilityType === FeedbackVisibilityType.GIVER_TEAM_MEMBERS) {
-      group = 'Giver\'s Team Members';
-    } else if (visibilityType === FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS) {
-      group = 'Recipient\'s Team Members';
-    } else if (visibilityType === FeedbackVisibilityType.STUDENTS) {
-      group = 'Other Students';
-    } else if (visibilityType === FeedbackVisibilityType.INSTRUCTORS) {
-      group = 'Instructors';
-    }
-
-    let groupVisibility: string = '';
-    if (visibilityControl === VisibilityControl.SHOW_RESPONSE) {
-      groupVisibility = 'Answer';
-    } else if (visibilityControl === VisibilityControl.SHOW_GIVER_NAME) {
-      groupVisibility = 'Giver\'s Name';
-    } else if (visibilityControl === VisibilityControl.SHOW_RECIPIENT_NAME) {
-      groupVisibility = 'Recipient\'s Name';
-    }
-
+    let group: string = this.visibilityTypeAriaLabels.get(visibilityType) || '';
+    let groupVisibility: string = this.visibilityControlAriaLabels.get(visibilityControl) || '';
     return `${group} can see ${groupVisibility}`;
   }
 

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -101,9 +101,9 @@ export class VisibilityPanelComponent {
     } else if (visibilityType === FeedbackVisibilityType.GIVER_TEAM_MEMBERS) {
       group = 'Giver\'s Team Members';
     } else if (visibilityType === FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS) {
-      group = 'Recipient\'s Team Members'
+      group = 'Recipient\'s Team Members';
     } else if (visibilityType === FeedbackVisibilityType.STUDENTS) {
-      group = 'Other Students'
+      group = 'Other Students';
     } else if (visibilityType === FeedbackVisibilityType.INSTRUCTORS) {
       group = 'Instructors';
     }

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -94,6 +94,32 @@ export class VisibilityPanelComponent {
     this.customVisibilitySetting.emit(true);
   }
 
+  getCheckboxAriaLabel(visibilityType: FeedbackVisibilityType, visibilityControl: VisibilityControl): string {
+    let group: string = '';
+    if (visibilityType === FeedbackVisibilityType.RECIPIENT) {
+      group = 'Recipient(s)';
+    } else if (visibilityType === FeedbackVisibilityType.GIVER_TEAM_MEMBERS) {
+      group = 'Giver\'s Team Members';
+    } else if (visibilityType === FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS) {
+      group = 'Recipient\'s Team Members'
+    } else if (visibilityType === FeedbackVisibilityType.STUDENTS) {
+      group = 'Other Students'
+    } else if (visibilityType === FeedbackVisibilityType.INSTRUCTORS) {
+      group = 'Instructors';
+    }
+
+    let groupVisibility: string = '';
+    if (visibilityControl === VisibilityControl.SHOW_RESPONSE) {
+      groupVisibility = 'Answer';
+    } else if (visibilityControl === VisibilityControl.SHOW_GIVER_NAME) {
+      groupVisibility = 'Giver\'s Name';
+    } else if (visibilityControl === VisibilityControl.SHOW_RECIPIENT_NAME) {
+      groupVisibility = 'Recipient\'s Name';
+    }
+
+    return `${group} can see ${groupVisibility}`;
+  }
+
   /**
    * Applies the common visibility setting.
    */

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -102,15 +102,15 @@ export class VisibilityPanelComponent {
     [VisibilityControl.SHOW_RESPONSE, 'Answer'],
     [VisibilityControl.SHOW_GIVER_NAME, 'Giver\'s Name'],
     [VisibilityControl.SHOW_RECIPIENT_NAME, 'Recipient\'s Name'],
-  ])
+  ]);
 
   triggerCustomVisibilitySetting(): void {
     this.customVisibilitySetting.emit(true);
   }
 
   getCheckboxAriaLabel(visibilityType: FeedbackVisibilityType, visibilityControl: VisibilityControl): string {
-    let group: string = this.visibilityTypeAriaLabels.get(visibilityType) || '';
-    let groupVisibility: string = this.visibilityControlAriaLabels.get(visibilityControl) || '';
+    const group: string = this.visibilityTypeAriaLabels.get(visibilityType) || '';
+    const groupVisibility: string = this.visibilityControlAriaLabels.get(visibilityControl) || '';
     return `${group} can see ${groupVisibility}`;
   }
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1750,6 +1750,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
+                          aria-hidden="true"
                           class="dropdown-divider"
                           style=""
                         />
@@ -1766,6 +1767,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                       </ul>
                     </div>
                     <table
+                      aria-label="Custom Visibility Options Table"
                       class="table margin-top-15px background-color-white table-striped"
                       style=""
                     >
@@ -2525,6 +2527,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
+                          aria-hidden="true"
                           class="dropdown-divider"
                           style=""
                         />
@@ -2541,6 +2544,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                       </ul>
                     </div>
                     <table
+                      aria-label="Custom Visibility Options Table"
                       class="table margin-top-15px background-color-white table-striped"
                       style=""
                     >
@@ -4531,6 +4535,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
+                      aria-hidden="true"
                       class="dropdown-divider"
                       style=""
                     />
@@ -4547,6 +4552,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                   </ul>
                 </div>
                 <table
+                  aria-label="Custom Visibility Options Table"
                   class="table margin-top-15px background-color-white table-striped"
                   style=""
                 >

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1703,31 +1703,51 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient and instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient and instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient, visible to instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient, visible to instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient and giver's team members, visible to instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient and giver's team members, visible to instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Visible to instructors only
+                          <button
+                            class="dropdown-button"
+                          >
+                            Visible to instructors only
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Visible to recipient and instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Visible to recipient and instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-divider"
@@ -1737,7 +1757,11 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="dropdown-item"
                           style=""
                         >
-                          Custom visibility options...
+                          <button
+                            class="dropdown-button"
+                          >
+                            Custom visibility options...
+                          </button>
                         </li>
                       </ul>
                     </div>
@@ -1789,6 +1813,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -1796,6 +1821,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1803,6 +1829,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Recipient's Name"
                               disabled=""
                               type="checkbox"
                             />
@@ -1821,6 +1848,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -1828,6 +1856,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1835,6 +1864,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1852,6 +1882,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -1859,6 +1890,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1866,6 +1898,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1883,6 +1916,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -1890,6 +1924,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -1897,6 +1932,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2442,31 +2478,51 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient and instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient and instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient, visible to instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient, visible to instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Shown anonymously to recipient and giver's team members, visible to instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Shown anonymously to recipient and giver's team members, visible to instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Visible to instructors only
+                          <button
+                            class="dropdown-button"
+                          >
+                            Visible to instructors only
+                          </button>
                         </li>
                         <li
                           class="dropdown-item"
                           style=""
                         >
-                          Visible to recipient and instructors
+                          <button
+                            class="dropdown-button"
+                          >
+                            Visible to recipient and instructors
+                          </button>
                         </li>
                         <li
                           class="dropdown-divider"
@@ -2476,7 +2532,11 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           class="dropdown-item"
                           style=""
                         >
-                          Custom visibility options...
+                          <button
+                            class="dropdown-button"
+                          >
+                            Custom visibility options...
+                          </button>
                         </li>
                       </ul>
                     </div>
@@ -2528,6 +2588,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -2535,6 +2596,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2542,6 +2604,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Recipient(s) can see Recipient's Name"
                               disabled=""
                               type="checkbox"
                             />
@@ -2560,6 +2623,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -2567,6 +2631,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2574,6 +2639,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Giver's Team Members can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2591,6 +2657,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -2598,6 +2665,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2605,6 +2673,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Other Students can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2622,6 +2691,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Answer"
                               type="checkbox"
                             />
                           </td>
@@ -2629,6 +2699,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Giver's Name"
                               type="checkbox"
                             />
                           </td>
@@ -2636,6 +2707,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             class="text-center"
                           >
                             <input
+                              aria-label="Instructors can see Recipient's Name"
                               type="checkbox"
                             />
                           </td>
@@ -4402,37 +4474,61 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       class="dropdown-item"
                       style=""
                     >
-                      Shown anonymously to recipient and instructors
+                      <button
+                        class="dropdown-button"
+                      >
+                        Shown anonymously to recipient and instructors
+                      </button>
                     </li>
                     <li
                       class="dropdown-item"
                       style=""
                     >
-                      Shown anonymously to recipient, visible to instructors
+                      <button
+                        class="dropdown-button"
+                      >
+                        Shown anonymously to recipient, visible to instructors
+                      </button>
                     </li>
                     <li
                       class="dropdown-item"
                       style=""
                     >
-                      Shown anonymously to recipient and giver/recipient's team members, visible to instructors
+                      <button
+                        class="dropdown-button"
+                      >
+                        Shown anonymously to recipient and giver/recipient's team members, visible to instructors
+                      </button>
                     </li>
                     <li
                       class="dropdown-item"
                       style=""
                     >
-                      Shown anonymously to recipient and giver's team members, visible to instructors
+                      <button
+                        class="dropdown-button"
+                      >
+                        Shown anonymously to recipient and giver's team members, visible to instructors
+                      </button>
                     </li>
                     <li
                       class="dropdown-item"
                       style=""
                     >
-                      Visible to instructors only
+                      <button
+                        class="dropdown-button"
+                      >
+                        Visible to instructors only
+                      </button>
                     </li>
                     <li
                       class="dropdown-item"
                       style=""
                     >
-                      Visible to recipient and instructors
+                      <button
+                        class="dropdown-button"
+                      >
+                        Visible to recipient and instructors
+                      </button>
                     </li>
                     <li
                       class="dropdown-divider"
@@ -4442,7 +4538,11 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       class="dropdown-item"
                       style=""
                     >
-                      Custom visibility options...
+                      <button
+                        class="dropdown-button"
+                      >
+                        Custom visibility options...
+                      </button>
                     </li>
                   </ul>
                 </div>
@@ -4494,6 +4594,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient(s) can see Answer"
                           type="checkbox"
                         />
                       </td>
@@ -4501,6 +4602,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient(s) can see Giver's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4508,6 +4610,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient(s) can see Recipient's Name"
                           disabled=""
                           type="checkbox"
                         />
@@ -4526,6 +4629,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Giver's Team Members can see Answer"
                           type="checkbox"
                         />
                       </td>
@@ -4533,6 +4637,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Giver's Team Members can see Giver's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4540,6 +4645,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Giver's Team Members can see Recipient's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4557,6 +4663,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient's Team Members can see Answer"
                           type="checkbox"
                         />
                       </td>
@@ -4564,6 +4671,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient's Team Members can see Giver's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4571,6 +4679,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Recipient's Team Members can see Recipient's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4588,6 +4697,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Other Students can see Answer"
                           type="checkbox"
                         />
                       </td>
@@ -4595,6 +4705,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Other Students can see Giver's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4602,6 +4713,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Other Students can see Recipient's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4619,6 +4731,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Instructors can see Answer"
                           type="checkbox"
                         />
                       </td>
@@ -4626,6 +4739,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Instructors can see Giver's Name"
                           type="checkbox"
                         />
                       </td>
@@ -4633,6 +4747,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         class="text-center"
                       >
                         <input
+                          aria-label="Instructors can see Recipient's Name"
                           type="checkbox"
                         />
                       </td>


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Fix custom visibility options](https://github.com/TEAMMATES/teammates/projects/16#card-88348707)

**Outline of Solution**
Added `aria-label`s to the table and checkboxes, and changed the dropdown divider to `aria-hidden`. Also changed the dropdown items to be buttons, which fixed the screen reader issue.

The `getCheckboxAriaLabel` function looks rather inelegant to me. I'm considering moving most of the logic to 2 `Map` variables outside of the function... would that be better?
Edit: Thought about it and I think this improves understanding of the code, so I've made the change