### PR TITLE
[#12048] Migrate Get Instructors Action

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
@@ -57,7 +57,6 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         InstructorsData output = (InstructorsData) jsonResult.getOutput();
         List<InstructorData> instructors = output.getInstructors();
 
-        // TODO: Integrate sqlLogic so we can getInstructorsForCourse.
         assertEquals(2, instructors.size());
 
         ______TS("Typical Success Case with no intent");

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
@@ -1,0 +1,123 @@
+package teammates.it.ui.webapi;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.request.Intent;
+import teammates.ui.webapi.GetInstructorsAction;
+
+/**
+ * SUT: {@link GetInstructorsAction}.
+ */
+public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.INSTRUCTORS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+        
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        Student student = typicalBundle.students.get("student1InCourse1");
+
+        ______TS("Course not found, logged in as instructor, intent FULL_DETAIL");
+        loginAsInstructor(instructor.getGoogleId());
+
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, "does-not-exist-id",
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+
+        verifyEntityNotFoundAcl(params);
+
+        ______TS("Course not found, logged in as student, intent undefined");
+        loginAsStudent(student.getGoogleId());
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, "does-not-exist-id",
+        };
+
+        verifyEntityNotFoundAcl(params);
+
+        ______TS("Unknown login entity, intent FULL_DETAIL");
+        loginAsUnregistered("unregistered");
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+
+        verifyCannotAccess(params);
+
+        ______TS("Unknown login entity, intent undefined");
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+        };
+
+        verifyCannotAccess(params);
+
+        ______TS("Unknown intent, logged in as instructor");
+        loginAsInstructor(instructor.getGoogleId());
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.INTENT, "Unknown",
+        };
+
+        verifyHttpParameterFailureAcl(params);
+
+        ______TS("Intent FULL_DETAIL, should authenticate as instructor");
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+
+        verifyOnlyInstructorsOfTheSameCourseCanAccess(instructor.getCourse(), params);
+
+        ______TS("Intent undefined, should authenticate as student, access own course");
+        loginAsStudent(student.getGoogleId());
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, student.getCourseId(),
+        };
+
+        verifyCanAccess(params);
+
+        ______TS("Intent undefined, should authenticate as student, access other course");
+        Student otherStudent = typicalBundle.students.get("student1InCourse2");
+
+        assertNotEquals(otherStudent.getCourse(), student.getCourse());
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, otherStudent.getCourseId(),
+        };
+
+        verifyCannotAccess(params);
+    }
+
+}

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -57,6 +57,13 @@
         "id": "course-1"
       },
       "name": "Section 1"
+    },
+    "section1InCourse2": {
+      "id": "00000000-0000-4000-8000-000000000202",
+      "course": {
+        "id": "idOfCourse2"
+      },
+      "name": "Section 2"
     }
   },
   "teams": {
@@ -64,6 +71,13 @@
       "id": "00000000-0000-4000-8000-000000000301",
       "section": {
         "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "name": "Team 1"
+    },
+    "team1InCourse2": {
+      "id": "00000000-0000-4000-8000-000000000302",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000202"
       },
       "name": "Team 1"
     }
@@ -173,6 +187,18 @@
       },
       "email": "student2@teammates.tmt",
       "name": "student2 In Course1",
+      "comments": ""
+    },
+    "student1InCourse2": {
+      "id": "00000000-0000-4000-8000-000000000603",
+      "course": {
+        "id": "idOfCourse2"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000302"
+      },
+      "email": "student1@teammates.tmt",
+      "name": "student1 In Course2",
       "comments": ""
     }
   },

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -390,6 +390,13 @@ public class Logic {
     }
 
     /**
+     * Gets instructors by associated {@code courseId}.
+     */
+    public List<Instructor> getInstructorsByCourse(String courseId) {
+        return usersLogic.getInstructorsForCourse(courseId);
+    }
+
+    /**
      * Creates an instructor.
      */
     public Instructor createInstructor(Instructor instructor)

--- a/src/main/java/teammates/ui/output/InstructorsData.java
+++ b/src/main/java/teammates/ui/output/InstructorsData.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.storage.sqlentity.Instructor;
 
 /**
  * The API output format of a list of instructors.
@@ -17,8 +17,8 @@ public class InstructorsData extends ApiOutput {
         this.instructors = new ArrayList<>();
     }
 
-    public InstructorsData(List<InstructorAttributes> instructorAttributesList) {
-        this.instructors = instructorAttributesList.stream().map(InstructorData::new).collect(Collectors.toList());
+    public InstructorsData(List<Instructor> instructorsList) {
+        this.instructors = instructorsList.stream().map(InstructorData::new).collect(Collectors.toList());
     }
 
     public List<InstructorData> getInstructors() {

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -17,7 +17,7 @@ import teammates.ui.request.Intent;
 /**
  * Get a list of instructors of a course.
  */
-class GetInstructorsAction extends Action {
+public class GetInstructorsAction extends Action {
 
     @Override
     AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -7,6 +7,9 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 import teammates.ui.output.InstructorData;
 import teammates.ui.output.InstructorsData;
 import teammates.ui.request.Intent;
@@ -28,69 +31,147 @@ class GetInstructorsAction extends Action {
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        CourseAttributes course = logic.getCourse(courseId);
-        if (course == null) {
-            throw new EntityNotFoundException("course not found");
-        }
 
-        String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
-        if (intentStr == null) {
-            // get partial details of instructors with information hiding
-            // student should belong to the course
-            StudentAttributes student = logic.getStudentForGoogleId(courseId, userInfo.getId());
-            gateKeeper.verifyAccessible(student, course);
-        } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
-            // get all instructors of a course without information hiding
-            // this need instructor privileges
-            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
-            gateKeeper.verifyAccessible(instructor, course);
+        if (isCourseMigrated(courseId)) {
+            Course course = sqlLogic.getCourse(courseId);
+
+            if (course == null) {
+                throw new EntityNotFoundException("course not found");
+            }
+
+            String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
+
+            if (intentStr == null) {
+                // get partial details of instructors with information hiding
+                // student should belong to the course
+                Student student = sqlLogic.getStudentByGoogleId(courseId, userInfo.getId());
+                gateKeeper.verifyAccessible(student, course);
+            } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+                // get all instructors of a course without information hiding
+                // this need instructor privileges
+                Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+                gateKeeper.verifyAccessible(instructor, course);
+            } else {
+                throw new InvalidHttpParameterException("unknown intent");
+            }
         } else {
-            throw new InvalidHttpParameterException("unknown intent");
-        }
+            CourseAttributes course = logic.getCourse(courseId);
+            if (course == null) {
+                throw new EntityNotFoundException("course not found");
+            }
 
+            String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
+            if (intentStr == null) {
+                // get partial details of instructors with information hiding
+                // student should belong to the course
+                StudentAttributes student = logic.getStudentForGoogleId(courseId, userInfo.getId());
+                gateKeeper.verifyAccessible(student, course);
+            } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+                // get all instructors of a course without information hiding
+                // this need instructor privileges
+                InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+                gateKeeper.verifyAccessible(instructor, course);
+            } else {
+                throw new InvalidHttpParameterException("unknown intent");
+            }
+        }
     }
 
     @Override
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        List<InstructorAttributes> instructorsOfCourse = logic.getInstructorsForCourse(courseId);
-
+        String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
         InstructorsData data;
 
-        String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
-        if (intentStr == null) {
-            instructorsOfCourse =
-                    instructorsOfCourse.stream()
-                            .filter(InstructorAttributes::isDisplayedToStudents)
-                            .collect(Collectors.toList());
-            data = new InstructorsData(instructorsOfCourse);
+        if (isCourseMigrated(courseId)) {
+            List<Instructor> instructorsOfCourse = sqlLogic.getInstructorsByCourse(courseId);
 
-            // hide information
-            data.getInstructors().forEach(i -> {
-                i.setGoogleId(null);
-                i.setJoinState(null);
-                i.setIsDisplayedToStudents(null);
-                i.setRole(null);
-            });
-        } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
-            // get all instructors of a course without information hiding
-            // adds googleId if caller is admin or has the appropriate privilege to modify instructor
-            if (userInfo.isAdmin || logic.getInstructorForGoogleId(courseId, userInfo.getId()).getPrivileges()
-                    .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
+            if (intentStr == null) {
+                instructorsOfCourse = instructorsOfCourse
+                        .stream()
+                        .filter(Instructor::isDisplayedToStudents)
+                        .collect(Collectors.toList());
                 data = new InstructorsData();
-                for (InstructorAttributes instructor : instructorsOfCourse) {
-                    InstructorData instructorData = new InstructorData(instructor);
-                    instructorData.setGoogleId(instructor.getGoogleId());
-                    if (userInfo.isAdmin) {
-                        instructorData.setKey(instructor.getKey());
+
+                List<InstructorData> instructorDataList = instructorsOfCourse
+                        .stream()
+                        .map(InstructorData::new)
+                        .collect(Collectors.toList());
+
+                data.setInstructors(instructorDataList);
+
+                // hide information
+                data.getInstructors().forEach(i -> {
+                    i.setGoogleId(null);
+                    i.setJoinState(null);
+                    i.setIsDisplayedToStudents(null);
+                    i.setRole(null);
+                });
+            } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+                // get all instructors of a course without information hiding
+                // adds googleId if caller is admin or has the appropriate privilege to modify instructor
+                if (userInfo.isAdmin || sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()).getPrivileges()
+                        .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
+                    data = new InstructorsData();
+
+                    for (Instructor instructor : instructorsOfCourse) {
+                        InstructorData instructorData = new InstructorData(instructor);
+                        instructorData.setGoogleId(instructor.getAccount().getGoogleId());
+                        if (userInfo.isAdmin) {
+                            instructorData.setKey(instructor.getRegKey());
+                        }
+                        data.getInstructors().add(instructorData);
                     }
-                    data.getInstructors().add(instructorData);
+                } else {
+                    data = new InstructorsData();
+
+                    List<InstructorData> instructorDataList = instructorsOfCourse
+                            .stream()
+                            .map(InstructorData::new)
+                            .collect(Collectors.toList());
+
+                    data.setInstructors(instructorDataList);
                 }
             } else {
-                data = new InstructorsData(instructorsOfCourse);
+                throw new InvalidHttpParameterException("unknown intent");
             }
         } else {
-            throw new InvalidHttpParameterException("unknown intent");
+            List<InstructorAttributes> instructorsOfCourse = logic.getInstructorsForCourse(courseId);
+
+            if (intentStr == null) {
+                instructorsOfCourse =
+                        instructorsOfCourse.stream()
+                                .filter(InstructorAttributes::isDisplayedToStudents)
+                                .collect(Collectors.toList());
+                data = new InstructorsData(instructorsOfCourse);
+
+                // hide information
+                data.getInstructors().forEach(i -> {
+                    i.setGoogleId(null);
+                    i.setJoinState(null);
+                    i.setIsDisplayedToStudents(null);
+                    i.setRole(null);
+                });
+            } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+                // get all instructors of a course without information hiding
+                // adds googleId if caller is admin or has the appropriate privilege to modify instructor
+                if (userInfo.isAdmin || logic.getInstructorForGoogleId(courseId, userInfo.getId()).getPrivileges()
+                        .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
+                    data = new InstructorsData();
+                    for (InstructorAttributes instructor : instructorsOfCourse) {
+                        InstructorData instructorData = new InstructorData(instructor);
+                        instructorData.setGoogleId(instructor.getGoogleId());
+                        if (userInfo.isAdmin) {
+                            instructorData.setKey(instructor.getKey());
+                        }
+                        data.getInstructors().add(instructorData);
+                    }
+                } else {
+                    data = new InstructorsData(instructorsOfCourse);
+                }
+            } else {
+                throw new InvalidHttpParameterException("unknown intent");
+            }
         }
 
         return new JsonResult(data);

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -93,8 +93,6 @@ public class GetInstructorsAction extends Action {
                                 .filter(InstructorAttributes::isDisplayedToStudents)
                                 .collect(Collectors.toList());
 
-                // To map each InstructorAttributes object to InstructorData format
-                // in order to fill the list in InstructorsData via the setter method.
                 List<InstructorData> instructorDataList = instructorsOfCourse
                         .stream()
                         .map(InstructorData::new)
@@ -126,8 +124,6 @@ public class GetInstructorsAction extends Action {
                 } else {
                     data = new InstructorsData();
 
-                    // To map each InstructorAttributes object to InstructorData format
-                    // in order to fill the list in InstructorsData via the setter method.
                     List<InstructorData> instructorDataList = instructorsOfCourse
                             .stream()
                             .map(InstructorData::new)

--- a/src/test/java/teammates/ui/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorsActionTest.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import java.util.List;
 
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
@@ -16,6 +17,7 @@ import teammates.ui.request.Intent;
 /**
  * SUT: {@link GetInstructorsAction}.
  */
+@Ignore
 public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsAction> {
 
     @Override


### PR DESCRIPTION
Part of #12048.

**Things to highlight**

Not sure if it is the best way to do this (similar to PR #12211):

```java
EntitysData data = new EntitysData();
List<EntityData> entityDataList = entitysForCourse
        .stream()
        .map(EntityData::new)
        .collect(Collectors.toList());

data.setEntitys(entityDataList);
```

As EntitysData class current constructor with EntityAttribute will cause a type erasure problem when adding another constructor taking in a List of different data type.