### PR TITLE
[#12048] Migrate GetFeedbackSessionAction

### DIFF
--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -206,6 +206,16 @@ public class Logic {
     }
 
     /**
+     * Fetch the deadline extension for a given user and session feedback.
+     *
+     * @return deadline extension instant if exists, else the default end time instant
+     *         for the session feedback.
+     */
+    public Instant getDeadlineForUser(FeedbackSession session, User user) {
+        return deadlineExtensionsLogic.getDeadlineForUser(session, user);
+    }
+
+    /**
      * Gets a feedback session.
      *
      * @return null if not found.

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -299,8 +299,6 @@ public class FeedbackSession extends BaseEntity {
         this.deletedAt = deletedAt;
     }
 
-
-
     @Override
     public String toString() {
         return "FeedbackSession [id=" + id + ", course=" + course + ", name=" + name + ", creatorEmail=" + creatorEmail
@@ -390,8 +388,8 @@ public class FeedbackSession extends BaseEntity {
         }
 
         DeadlineExtension dExtension = deadlineExtensions.stream()
-            .filter(de -> de.getUser().equals(user) && de.getFeedbackSession().equals(this))
-            .findFirst().orElse(null);
+                .filter(de -> de.getUser().equals(user) && de.getFeedbackSession().equals(this))
+                .findFirst().orElse(null);
 
         if (dExtension != null) {
             return dExtension.getEndTime();

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -98,7 +98,7 @@ public class FeedbackSession extends BaseEntity {
         this.setEndTime(endTime);
         this.setSessionVisibleFromTime(sessionVisibleFromTime);
         this.setResultsVisibleFromTime(resultsVisibleFromTime);
-        this.setGracePeriod(Objects.requireNonNullElse(gracePeriod, Duration.ZERO));
+        this.setGracePeriod(gracePeriod);
         this.setOpeningEmailEnabled(isOpeningEmailEnabled);
         this.setClosingEmailEnabled(isClosingEmailEnabled);
         this.setPublishedEmailEnabled(isPublishedEmailEnabled);
@@ -240,7 +240,7 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public void setGracePeriod(Duration gracePeriod) {
-        this.gracePeriod = gracePeriod;
+        this.gracePeriod = Objects.requireNonNullElse(gracePeriod, Duration.ZERO);
     }
 
     public boolean isOpeningEmailEnabled() {
@@ -354,10 +354,10 @@ public class FeedbackSession extends BaseEntity {
 
     /**
      * Checks if the feedback session is closed.
-     * This occurs when the current time is after both the deadline and the grace period.
+     * This occurs only when the current time is after both the deadline and the grace period.
      */
     public boolean isClosed() {
-        return Instant.now().isAfter(endTime.plus(gracePeriod));
+        return !isOpened() && Instant.now().isAfter(endTime);
     }
 
     /**
@@ -375,6 +375,33 @@ public class FeedbackSession extends BaseEntity {
      */
     public boolean isInGracePeriod() {
         return Instant.now().isAfter(endTime) && !isClosed();
+    }
+
+    /**
+     * Checks if the feedback session is opened given the extendedDeadline and grace period.
+     */
+    public boolean isOpenedGivenExtendedDeadline(Instant extendedDeadline) {
+        Instant now = Instant.now();
+        return (now.isAfter(startTime) || now.equals(startTime))
+                && now.isBefore(extendedDeadline.plus(gracePeriod)) || now.isBefore(endTime.plus(gracePeriod));
+    }
+
+    /**
+     * Checks if the feedback session is closed given the extendedDeadline and grace period.
+     * This occurs only when it is after the extended deadline or end time plus grace period.
+     */
+    public boolean isClosedGivenExtendedDeadline(Instant extendedDeadline) {
+        Instant now = Instant.now();
+        return !isOpenedGivenExtendedDeadline(extendedDeadline)
+                && now.isAfter(endTime.plus(gracePeriod)) && now.isAfter(extendedDeadline.plus(gracePeriod));
+    }
+
+    /**
+     * Checks if the feedback session is during the grace period given the extendedDeadline.
+     */
+    public boolean isInGracePeriodGivenExtendedDeadline(Instant extendedDeadline) {
+        Instant now = Instant.now();
+        return now.isAfter(endTime) && now.isAfter(extendedDeadline) && !isClosedGivenExtendedDeadline(extendedDeadline);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -378,27 +378,6 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
-     * Returns the deadline for the given user based on the stored deadline extensions.
-     * If there is a deadline extension for the user, return the extended deadline.
-     * Else, return the default endtime for this feedback session.
-     */
-    public Instant getUserDeadline(User user) {
-        if (user == null) {
-            return endTime;
-        }
-
-        DeadlineExtension dExtension = deadlineExtensions.stream()
-                .filter(de -> de.getUser().equals(user) && de.getFeedbackSession().equals(this))
-                .findFirst().orElse(null);
-
-        if (dExtension != null) {
-            return dExtension.getEndTime();
-        } else {
-            return endTime;
-        }
-    }
-
-    /**
      * Returns {@code true} if the results of the feedback session is visible; {@code false} if not.
      *         Does not care if the session has ended or not.
      */

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -299,6 +299,8 @@ public class FeedbackSession extends BaseEntity {
         this.deletedAt = deletedAt;
     }
 
+
+
     @Override
     public String toString() {
         return "FeedbackSession [id=" + id + ", course=" + course + ", name=" + name + ", creatorEmail=" + creatorEmail
@@ -370,6 +372,35 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
+     * Checks if the feedback session is during the grace period.
+     * This occurs when the current time is after end time, but before the end of the grace period.
+     */
+    public boolean isInGracePeriod() {
+        return Instant.now().isAfter(endTime) && !isClosed();
+    }
+
+    /**
+     * Returns the deadline for the given user based on the stored deadline extensions.
+     * If there is a deadline extension for the user, return the extended deadline.
+     * Else, return the default endtime for this feedback session.
+     */
+    public Instant getUserDeadline(User user) {
+        if (user == null) {
+            return endTime;
+        }
+
+        DeadlineExtension dExtension = deadlineExtensions.stream()
+            .filter(de -> de.getUser().equals(user) && de.getFeedbackSession().equals(this))
+            .findFirst().orElse(null);
+
+        if (dExtension != null) {
+            return dExtension.getEndTime();
+        } else {
+            return endTime;
+        }
+    }
+
+    /**
      * Returns {@code true} if the results of the feedback session is visible; {@code false} if not.
      *         Does not care if the session has ended or not.
      */
@@ -389,4 +420,5 @@ public class FeedbackSession extends BaseEntity {
         Instant now = Instant.now();
         return now.isAfter(publishTime) || now.equals(publishTime);
     }
+
 }

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -445,20 +445,22 @@ public class FeedbackSessionData extends ApiOutput {
         setCreatedAtTimestamp(0);
 
         // filter deadline extensions for a specific user's email
-        this.studentDeadlines = new HashMap<>();
-        this.instructorDeadlines = new HashMap<>();
+        if (this.feedbackSession != null) {
+            this.studentDeadlines = new HashMap<>();
+            this.instructorDeadlines = new HashMap<>();
 
-        for (DeadlineExtension de : this.feedbackSession.getDeadlineExtensions()) {
-            if (de.getUser().getEmail().equals(this.feedbackSessionUserEmail)) {
-                if (de.getUser() instanceof Student) {
-                    this.studentDeadlines.put(de.getUser().getEmail(),
-                            TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-                                    de.getEndTime(), timeZone, true).toEpochMilli());
-                }
-                if (de.getUser() instanceof Instructor) {
-                    this.instructorDeadlines.put(de.getUser().getEmail(),
-                            TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-                                    de.getEndTime(), timeZone, true).toEpochMilli());
+            for (DeadlineExtension de : this.feedbackSession.getDeadlineExtensions()) {
+                if (de.getUser().getEmail().equals(this.feedbackSessionUserEmail)) {
+                    if (de.getUser() instanceof Student) {
+                        this.studentDeadlines.put(de.getUser().getEmail(),
+                                TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                                        de.getEndTime(), timeZone, true).toEpochMilli());
+                    }
+                    if (de.getUser() instanceof Instructor) {
+                        this.instructorDeadlines.put(de.getUser().getEmail(),
+                                TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                                        de.getEndTime(), timeZone, true).toEpochMilli());
+                    }
                 }
             }
         }

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -22,11 +22,12 @@ import teammates.storage.sqlentity.Student;
 public class FeedbackSessionData extends ApiOutput {
     private final String courseId;
     private final String timeZone;
-    // TODO: set as final after migration
-    private FeedbackSession feedbackSession;
     private final String feedbackSessionName;
     private String feedbackSessionUserEmail;
     private final String instructions;
+
+    // TODO: set as final after migration, cant do so now since the attributes constructor does not have this.
+    private FeedbackSession feedbackSession;
 
     private final Long submissionStartTimestamp;
     private final Long submissionEndTimestamp;
@@ -62,6 +63,7 @@ public class FeedbackSessionData extends ApiOutput {
     private Map<String, Long> instructorDeadlines;
 
     public FeedbackSessionData(FeedbackSessionAttributes feedbackSessionAttributes) {
+        this.feedbackSessionUserEmail = feedbackSessionAttributes.getUserEmail();
         String timeZone = feedbackSessionAttributes.getTimeZone();
         this.courseId = feedbackSessionAttributes.getCourseId();
         this.timeZone = timeZone;

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -230,10 +230,8 @@ public class FeedbackSessionData extends ApiOutput {
      * Constructs FeedbackSessionData for a given user deadline.
      */
     public FeedbackSessionData(FeedbackSession feedbackSession, String userEmail, Instant extendedDeadline) {
-        String timeZone = feedbackSession.getCourse().getTimeZone();
-        this.courseId = feedbackSession.getCourse().getId();
-        this.timeZone = timeZone;
-        this.feedbackSessionName = feedbackSession.getName();
+        FeedbackSessionData(feedbackSession);
+        // Changed fields
         this.instructions = feedbackSession.getInstructions();
         this.submissionStartTimestamp = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
                 feedbackSession.getStartTime(), timeZone, true).toEpochMilli();

--- a/src/main/java/teammates/ui/output/FeedbackSessionData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionData.java
@@ -11,7 +11,6 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.storage.sqlentity.FeedbackSession;
-import teammates.storage.sqlentity.User;
 
 /**
  * The API output format of {@link FeedbackSessionAttributes}.
@@ -151,8 +150,10 @@ public class FeedbackSessionData extends ApiOutput {
                 feedbackSession.getStartTime(), timeZone, true).toEpochMilli();
         this.submissionEndTimestamp = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
                 feedbackSession.getEndTime(), timeZone, true).toEpochMilli();
+        // If no deadline extension time is provided, then the end time with extension is assumed to be
+        // just the end time.
         this.submissionEndWithExtensionTimestamp = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-            feedbackSession.getUserDeadline(null), timeZone, true).toEpochMilli();
+            feedbackSession.getEndTime(), timeZone, true).toEpochMilli();
         this.gracePeriod = feedbackSession.getGracePeriod().toMinutes();
 
         Instant sessionVisibleTime = feedbackSession.getSessionVisibleFromTime();
@@ -211,12 +212,12 @@ public class FeedbackSessionData extends ApiOutput {
     }
 
     /**
-     * Constructs FeedbackSessionData for a specific user.
+     * Constructs FeedbackSessionData for a given user deadline.
      */
-    public FeedbackSessionData(FeedbackSession feedbackSession, User user) {
+    public FeedbackSessionData(FeedbackSession feedbackSession, Instant userDeadline) {
         this(feedbackSession);
         this.submissionEndWithExtensionTimestamp = TimeHelper.getMidnightAdjustedInstantBasedOnZone(
-            feedbackSession.getUserDeadline(user), timeZone, true).toEpochMilli();
+            userDeadline, timeZone, true).toEpochMilli();
     }
 
     public String getCourseId() {

--- a/src/main/java/teammates/ui/output/FeedbackSessionSubmissionStatus.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionSubmissionStatus.java
@@ -13,7 +13,7 @@ public enum FeedbackSessionSubmissionStatus {
     /**
      * Feedback session is visible to view but not yet open for submission.
      */
-    VISIBLE_NOT_YET_OPEN,
+    VISIBLE_NOT_OPEN,
 
     /**
      * Feedback session is open for submission.

--- a/src/main/java/teammates/ui/output/FeedbackSessionSubmissionStatus.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionSubmissionStatus.java
@@ -11,9 +11,9 @@ public enum FeedbackSessionSubmissionStatus {
     NOT_VISIBLE,
 
     /**
-     * Feedback session is visible to view but not open for submission.
+     * Feedback session is visible to view but not yet open for submission.
      */
-    VISIBLE_NOT_OPEN,
+    VISIBLE_NOT_YET_OPEN,
 
     /**
      * Feedback session is open for submission.

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -90,24 +90,23 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             case STUDENT_RESULT:
                 Student student = getSqlStudentOfCourseFromRequest(courseId);
                 Instant studentDeadline = sqlLogic.getDeadlineForUser(feedbackSession, student);
-                response = new FeedbackSessionData(feedbackSession, student.getEmail(), studentDeadline);
-                response.hideInformationForStudent();
+                response = new FeedbackSessionData(feedbackSession, studentDeadline);
+                response.hideInformationForStudent(feedbackSession.getDeadlineExtensions(), student.getEmail());
                 break;
             case INSTRUCTOR_SUBMISSION:
                 Instructor instructorSubmission = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
-                        instructorSubmission.getEmail(),
                         sqlLogic.getDeadlineForUser(feedbackSession,
                         instructorSubmission));
-                response.hideInformationForInstructorSubmission();
+                response.hideInformationForInstructorSubmission(feedbackSession.getDeadlineExtensions(),
+                        instructorSubmission.getEmail());
                 break;
             case INSTRUCTOR_RESULT:
                 Instructor instructorResult = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
-                        instructorResult.getEmail(),
                         sqlLogic.getDeadlineForUser(feedbackSession,
                         instructorResult));
-                response.hideInformationForInstructor();
+                response.hideInformationForInstructor(feedbackSession.getDeadlineExtensions(), instructorResult.getEmail());
                 break;
             case FULL_DETAIL:
                 response = new FeedbackSessionData(feedbackSession);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -4,6 +4,8 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.Intent;
 
@@ -21,24 +23,30 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSessionAttributes feedbackSessionAttributes = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
 
         switch (intent) {
         case STUDENT_SUBMISSION:
         case STUDENT_RESULT:
             StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
-            checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSession);
+            checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSessionAttributes);
             break;
         case INSTRUCTOR_SUBMISSION:
         case INSTRUCTOR_RESULT:
             InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
-            checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSession);
+            checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSessionAttributes);
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(courseId, userInfo.getId()),
+            if (!isCourseMigrated(courseId)) {
+                gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(courseId, userInfo.getId()),
+                    feedbackSessionAttributes, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            } else {
+                gateKeeper.verifyAccessible(sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()),
                     feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            }
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -6,6 +6,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.Intent;
 
@@ -23,33 +24,52 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        FeedbackSessionAttributes feedbackSessionAttributes = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
 
-        switch (intent) {
-        case STUDENT_SUBMISSION:
-        case STUDENT_RESULT:
-            StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
-            checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSessionAttributes);
-            break;
-        case INSTRUCTOR_SUBMISSION:
-        case INSTRUCTOR_RESULT:
-            InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
-            checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSessionAttributes);
-            break;
-        case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            if (!isCourseMigrated(courseId)) {
+        if (!isCourseMigrated(courseId)) {
+            FeedbackSessionAttributes feedbackSessionAttributes = getNonNullFeedbackSession(feedbackSessionName, courseId);
+
+            switch (intent) {
+            case STUDENT_SUBMISSION:
+            case STUDENT_RESULT:
+                StudentAttributes studentAttributes = getStudentOfCourseFromRequest(courseId);
+                checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSessionAttributes);
+                break;
+            case INSTRUCTOR_SUBMISSION:
+            case INSTRUCTOR_RESULT:
+                InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(courseId);
+                checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSessionAttributes);
+                break;
+            case FULL_DETAIL:
+                gateKeeper.verifyLoggedInUserPrivileges(userInfo);
                 gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(courseId, userInfo.getId()),
                     feedbackSessionAttributes, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
-            } else {
-                gateKeeper.verifyAccessible(sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()),
-                    feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+                break;
+            default:
+                throw new InvalidHttpParameterException("Unknown intent " + intent);
             }
-            break;
-        default:
-            throw new InvalidHttpParameterException("Unknown intent " + intent);
+        } else {
+            FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
+
+            switch (intent) {
+                case STUDENT_SUBMISSION:
+                case STUDENT_RESULT:
+                    Student student = getSqlStudentOfCourseFromRequest(courseId);
+                    checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
+                    break;
+                case INSTRUCTOR_SUBMISSION:
+                case INSTRUCTOR_RESULT:
+                    Instructor instructor = getSqlInstructorOfCourseFromRequest(courseId);
+                    checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
+                    break;
+                case FULL_DETAIL:
+                    gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+                    gateKeeper.verifyAccessible(sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()),
+                        feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+                    break;
+                default:
+                    throw new InvalidHttpParameterException("Unknown intent " + intent);
+                }
         }
     }
 
@@ -57,30 +77,61 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         FeedbackSessionData response;
-        switch (intent) {
-        case STUDENT_SUBMISSION:
-        case STUDENT_RESULT:
-            response = getStudentFeedbackSessionData(feedbackSession);
-            response.hideInformationForStudent();
-            break;
-        case INSTRUCTOR_SUBMISSION:
-            response = getInstructorFeedbackSessionData(feedbackSession);
-            response.hideInformationForInstructorSubmission();
-            break;
-        case INSTRUCTOR_RESULT:
-            response = getInstructorFeedbackSessionData(feedbackSession);
-            response.hideInformationForInstructor();
-            break;
-        case FULL_DETAIL:
-            response = new FeedbackSessionData(feedbackSession);
-            break;
-        default:
-            throw new InvalidHttpParameterException("Unknown intent " + intent);
+
+        if (!isCourseMigrated(courseId)) {
+            FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+
+            switch (intent) {
+                case STUDENT_SUBMISSION:
+                case STUDENT_RESULT:
+                    response = getStudentFeedbackSessionData(feedbackSession);
+                    response.hideInformationForStudent();
+                    break;
+                case INSTRUCTOR_SUBMISSION:
+                    response = getInstructorFeedbackSessionData(feedbackSession);
+                    response.hideInformationForInstructorSubmission();
+                    break;
+                case INSTRUCTOR_RESULT:
+                    response = getInstructorFeedbackSessionData(feedbackSession);
+                    response.hideInformationForInstructor();
+                    break;
+                case FULL_DETAIL:
+                    response = new FeedbackSessionData(feedbackSession);
+                    break;
+                default:
+                    throw new InvalidHttpParameterException("Unknown intent " + intent);
+                }
+                return new JsonResult(response);
+        } else {
+            FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
+
+            switch (intent) {
+                case STUDENT_SUBMISSION:
+                case STUDENT_RESULT:
+                    Student student = getSqlStudentOfCourseFromRequest(courseId);
+                    response = new FeedbackSessionData(feedbackSession, student);
+                    response.hideInformationForStudent();
+                    break;
+                case INSTRUCTOR_SUBMISSION:
+                    response = new FeedbackSessionData(feedbackSession,
+                        getSqlInstructorOfCourseFromRequest(courseId));
+                    response.hideInformationForInstructorSubmission();
+                    break;
+                case INSTRUCTOR_RESULT:
+                    response = new FeedbackSessionData(feedbackSession,
+                        getSqlInstructorOfCourseFromRequest(courseId));
+                    response.hideInformationForInstructor();
+                    break;
+                case FULL_DETAIL:
+                    response = new FeedbackSessionData(feedbackSession);
+                    break;
+                default:
+                    throw new InvalidHttpParameterException("Unknown intent " + intent);
+                }
+                return new JsonResult(response);
         }
-        return new JsonResult(response);
     }
 
     private FeedbackSessionData getStudentFeedbackSessionData(FeedbackSessionAttributes session) {

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import java.time.Instant;
+
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -87,17 +89,20 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             case STUDENT_SUBMISSION:
             case STUDENT_RESULT:
                 Student student = getSqlStudentOfCourseFromRequest(courseId);
-                response = new FeedbackSessionData(feedbackSession, student);
+                Instant studentDeadline = sqlLogic.getDeadlineForUser(feedbackSession, student);
+                response = new FeedbackSessionData(feedbackSession, studentDeadline);
                 response.hideInformationForStudent();
                 break;
             case INSTRUCTOR_SUBMISSION:
                 response = new FeedbackSessionData(feedbackSession,
-                    getSqlInstructorOfCourseFromRequest(courseId));
+                        sqlLogic.getDeadlineForUser(feedbackSession,
+                                getSqlInstructorOfCourseFromRequest(courseId)));
                 response.hideInformationForInstructorSubmission();
                 break;
             case INSTRUCTOR_RESULT:
                 response = new FeedbackSessionData(feedbackSession,
-                    getSqlInstructorOfCourseFromRequest(courseId));
+                        sqlLogic.getDeadlineForUser(feedbackSession,
+                                getSqlInstructorOfCourseFromRequest(courseId)));
                 response.hideInformationForInstructor();
                 break;
             case FULL_DETAIL:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -91,22 +91,21 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
                 Student student = getSqlStudentOfCourseFromRequest(courseId);
                 Instant studentDeadline = sqlLogic.getDeadlineForUser(feedbackSession, student);
                 response = new FeedbackSessionData(feedbackSession, studentDeadline);
-                response.hideInformationForStudent(feedbackSession.getDeadlineExtensions(), student.getEmail());
+                response.hideInformationForStudent(student.getEmail());
                 break;
             case INSTRUCTOR_SUBMISSION:
                 Instructor instructorSubmission = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
                         sqlLogic.getDeadlineForUser(feedbackSession,
                         instructorSubmission));
-                response.hideInformationForInstructorSubmission(feedbackSession.getDeadlineExtensions(),
-                        instructorSubmission.getEmail());
+                response.hideInformationForInstructorSubmission(instructorSubmission.getEmail());
                 break;
             case INSTRUCTOR_RESULT:
                 Instructor instructorResult = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
                         sqlLogic.getDeadlineForUser(feedbackSession,
                         instructorResult));
-                response.hideInformationForInstructor(feedbackSession.getDeadlineExtensions(), instructorResult.getEmail());
+                response.hideInformationForInstructor(instructorResult.getEmail());
                 break;
             case FULL_DETAIL:
                 response = new FeedbackSessionData(feedbackSession);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -15,7 +15,7 @@ import teammates.ui.request.Intent;
 /**
  * Get a feedback session.
  */
-class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
+public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
 
     @Override
     AuthType getMinAuthLevel() {
@@ -90,19 +90,23 @@ class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             case STUDENT_RESULT:
                 Student student = getSqlStudentOfCourseFromRequest(courseId);
                 Instant studentDeadline = sqlLogic.getDeadlineForUser(feedbackSession, student);
-                response = new FeedbackSessionData(feedbackSession, studentDeadline);
+                response = new FeedbackSessionData(feedbackSession, student.getEmail(), studentDeadline);
                 response.hideInformationForStudent();
                 break;
             case INSTRUCTOR_SUBMISSION:
+                Instructor instructorSubmission = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
+                        instructorSubmission.getEmail(),
                         sqlLogic.getDeadlineForUser(feedbackSession,
-                                getSqlInstructorOfCourseFromRequest(courseId)));
+                        instructorSubmission));
                 response.hideInformationForInstructorSubmission();
                 break;
             case INSTRUCTOR_RESULT:
+                Instructor instructorResult = getSqlInstructorOfCourseFromRequest(courseId);
                 response = new FeedbackSessionData(feedbackSession,
+                        instructorResult.getEmail(),
                         sqlLogic.getDeadlineForUser(feedbackSession,
-                                getSqlInstructorOfCourseFromRequest(courseId)));
+                        instructorResult));
                 response.hideInformationForInstructor();
                 break;
             case FULL_DETAIL:

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
@@ -1,0 +1,314 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.DeadlineExtension;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.FeedbackSessionData;
+import teammates.ui.output.FeedbackSessionPublishStatus;
+import teammates.ui.output.FeedbackSessionSubmissionStatus;
+import teammates.ui.request.Intent;
+import teammates.ui.webapi.GetFeedbackSessionAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link GetFeedbackSessionAction}.
+ */
+public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSessionAction> {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SESSION;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    protected void textExecute_studentSubmission() {
+
+        // init instances for test
+        Course course1 = generateCourse1();
+        Student student1 = generateStudent1InCourse(course1);
+
+        loginAsStudent(student1.getAccount().getGoogleId());
+
+        FeedbackSession feedbackSession1 = generateSession1InCourse(course1);
+
+        when(mockLogic.getFeedbackSession(feedbackSession1.getName(), course1.getId())).thenReturn(feedbackSession1);
+        when(mockLogic.getStudentByGoogleId(course1.getId(), student1.getAccount().getGoogleId())).thenReturn(student1);
+
+        String courseId = feedbackSession1.getCourse().getId();
+        String feedbackSessionName = feedbackSession1.getName();
+        String timeZone = feedbackSession1.getCourse().getTimeZone();
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+        };
+
+        ______TS("get submission by student with no extension; before end time");
+
+        Instant newStartTime = Instant.now();
+        Instant newEndTime = newStartTime.plusSeconds(60 * 60);
+        Duration newGracePeriod = Duration.ZERO;
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+
+        // mock no deadline extension
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(feedbackSession1.getEndTime());
+
+        GetFeedbackSessionAction a = getAction(params);
+
+        JsonResult r = getJsonResult(a);
+        FeedbackSessionData response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(courseId, response.getCourseId());
+        assertEquals(feedbackSessionName, response.getFeedbackSessionName());
+        assertEquals(timeZone, response.getTimeZone());
+        assertEquals(feedbackSession1.getInstructions(), response.getInstructions());
+
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(feedbackSession1.getStartTime(),
+                        timeZone, true).toEpochMilli(),
+                response.getSubmissionStartTimestamp());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(newEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndTimestamp());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(newEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+        assertNull(response.getGracePeriod());
+
+        assertNull(response.getSessionVisibleSetting());
+        assertNull(response.getSessionVisibleFromTimestamp());
+        assertNull(response.getCustomSessionVisibleTimestamp());
+
+        assertNull(response.getResponseVisibleSetting());
+        assertNull(response.getResultVisibleFromTimestamp());
+        assertNull(response.getCustomResponseVisibleTimestamp());
+
+        assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
+        assertEquals(FeedbackSessionPublishStatus.NOT_PUBLISHED, response.getPublishStatus());
+
+        assertNull(response.getIsClosingEmailEnabled());
+        assertNull(response.getIsPublishedEmailEnabled());
+
+        assertEquals(0, response.getCreatedAtTimestamp());
+        assertNull(response.getDeletedAtTimestamp());
+
+        assertTrue(response.getStudentDeadlines().isEmpty());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+
+        ______TS("get submission by student with no extension; after end time but within grace period");
+
+        newStartTime = Instant.now().plusSeconds(-120);
+        newEndTime = newStartTime.plusSeconds(60);
+        newGracePeriod = Duration.ofDays(2);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+
+        // mock no deadline extension
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(feedbackSession1.getEndTime());
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().isEmpty());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(newEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        ______TS("get submission by student with no extension; after end time and beyond grace period");
+
+        newStartTime = Instant.now().plusSeconds(-60);
+        newEndTime = newStartTime.plusSeconds(20);
+        newGracePeriod = Duration.ofSeconds(10);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+
+        // mock no deadline extension
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(feedbackSession1.getEndTime());
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().isEmpty());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(newEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        ______TS("get submission by student with extension; before end time");
+
+        newStartTime = Instant.now();
+        newEndTime = newStartTime.plusSeconds(60 * 60);
+        newGracePeriod = Duration.ZERO;
+        Instant extendedEndTime = newStartTime.plusSeconds(60 * 60 * 21);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+        feedbackSession1.setDeadlineExtensions(new ArrayList<>());
+        feedbackSession1.getDeadlineExtensions().add(new DeadlineExtension(student1, feedbackSession1, extendedEndTime));
+
+        // mock deadline extension exists for student1
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(extendedEndTime);
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().containsKey(student1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(extendedEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        ______TS("get submission by student with extension; after end time but before extended deadline");
+
+        newStartTime = Instant.now().plusSeconds(-60);
+        newEndTime = newStartTime.plusSeconds(20);
+        newGracePeriod = Duration.ZERO;
+        extendedEndTime = Instant.now().plusSeconds(60 * 60);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+        feedbackSession1.setDeadlineExtensions(new ArrayList<>());
+        feedbackSession1.getDeadlineExtensions().add(new DeadlineExtension(student1, feedbackSession1, extendedEndTime));
+
+        // mock deadline extension exists for student1
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(extendedEndTime);
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.OPEN, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().containsKey(student1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(extendedEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        ______TS("get submission by student with extension; after extended deadline but within grace period");
+
+        newStartTime = Instant.now().plusSeconds(-120);
+        newEndTime = newStartTime.plusSeconds(20);
+        extendedEndTime = newEndTime.plusSeconds(20);
+        newGracePeriod = Duration.ofDays(1);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+        feedbackSession1.setDeadlineExtensions(new ArrayList<>());
+        feedbackSession1.getDeadlineExtensions().add(new DeadlineExtension(student1, feedbackSession1, extendedEndTime));
+
+        // mock deadline extension exists for student1
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(extendedEndTime);
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().containsKey(student1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(extendedEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        ______TS("get submission by student with extension; after extended deadline and beyond grace period");
+
+        newStartTime = Instant.now().plusSeconds(-60 * 60 * 24);
+        newEndTime = newStartTime.plusSeconds(10);
+        extendedEndTime = newEndTime.plusSeconds(10);
+        newGracePeriod = Duration.ofSeconds(10);
+
+        feedbackSession1.setStartTime(newStartTime);
+        feedbackSession1.setEndTime(newEndTime);
+        feedbackSession1.setGracePeriod(newGracePeriod);
+        feedbackSession1.setDeadlineExtensions(new ArrayList<>());
+        feedbackSession1.getDeadlineExtensions().add(new DeadlineExtension(student1, feedbackSession1, extendedEndTime));
+
+        // mock deadline extension exists for student1
+        when(mockLogic.getDeadlineForUser(feedbackSession1, student1)).thenReturn(extendedEndTime);
+
+        a = getAction(params);
+        r = getJsonResult(a);
+        response = (FeedbackSessionData) r.getOutput();
+
+        assertEquals(FeedbackSessionSubmissionStatus.CLOSED, response.getSubmissionStatus());
+
+        assertTrue(response.getStudentDeadlines().containsKey(student1.getEmail()));
+        assertEquals(1, response.getStudentDeadlines().size());
+        assertTrue(response.getInstructorDeadlines().isEmpty());
+        assertEquals(TimeHelper.getMidnightAdjustedInstantBasedOnZone(extendedEndTime, timeZone, true)
+                        .toEpochMilli(),
+                response.getSubmissionEndWithExtensionTimestamp());
+
+        logoutUser();
+    }
+
+    private Course generateCourse1() {
+        Course c = new Course("course-1", "Typical Course 1",
+                "Africa/Johannesburg", "TEAMMATES Test Institute 0");
+        c.setCreatedAt(Instant.parse("2023-01-01T00:00:00Z"));
+        c.setUpdatedAt(Instant.parse("2023-01-01T00:00:00Z"));
+        return c;
+    }
+
+    private Student generateStudent1InCourse(Course courseStudentIsIn) {
+        String email = "student1@gmail.com";
+        String name = "student-1";
+        String googleId = "student-1";
+        Student s = new Student(courseStudentIsIn, name, email, "comment for student-1");
+        s.setAccount(new Account(googleId, name, email));
+        return s;
+    }
+
+    private FeedbackSession generateSession1InCourse(Course course) {
+        FeedbackSession fs = new FeedbackSession("feedbacksession-1", course,
+                "instructor1@gmail.com", "generic instructions",
+                Instant.parse("2012-04-01T22:00:00Z"), Instant.parse("2027-04-30T22:00:00Z"),
+                Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"),
+                Duration.ofHours(10), true, true, true);
+        fs.setCreatedAt(Instant.parse("2023-01-01T00:00:00Z"));
+        fs.setUpdatedAt(Instant.parse("2023-01-01T00:00:00Z"));
+
+        return fs;
+    }
+}

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
@@ -432,7 +432,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         } else if (expectedSession.isInGracePeriod()) {
             assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, data.getSubmissionStatus());
         } else if (expectedSession.isVisible() && !expectedSession.isOpened()) {
-            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN, data.getSubmissionStatus());
+            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_YET_OPEN, data.getSubmissionStatus());
         }
 
         if (expectedSession.getDeletedTime() == null) {
@@ -489,7 +489,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         } else if (expectedSession.isInGracePeriod()) {
             assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, data.getSubmissionStatus());
         } else if (expectedSession.isVisible() && !expectedSession.isOpened()) {
-            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN, data.getSubmissionStatus());
+            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_YET_OPEN, data.getSubmissionStatus());
         }
 
         if (expectedSession.isPublished()) {

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
@@ -432,7 +432,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         } else if (expectedSession.isInGracePeriod()) {
             assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, data.getSubmissionStatus());
         } else if (expectedSession.isVisible() && !expectedSession.isOpened()) {
-            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_YET_OPEN, data.getSubmissionStatus());
+            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN, data.getSubmissionStatus());
         }
 
         if (expectedSession.getDeletedTime() == null) {
@@ -489,7 +489,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         } else if (expectedSession.isInGracePeriod()) {
             assertEquals(FeedbackSessionSubmissionStatus.GRACE_PERIOD, data.getSubmissionStatus());
         } else if (expectedSession.isVisible() && !expectedSession.isOpened()) {
-            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_YET_OPEN, data.getSubmissionStatus());
+            assertEquals(FeedbackSessionSubmissionStatus.VISIBLE_NOT_OPEN, data.getSubmissionStatus());
         }
 
         if (expectedSession.isPublished()) {


### PR DESCRIPTION
Since the new FeedbackSession no longer stores all student deadlines but rather Deadline Extensions, to deal with a specific user's feedback session deadline: 

* i perform a search to find if the user has a deadline extension. 
* if there is, then return the extended deadline. Else return the default endtime for the feedback session. 

Currently using the getDeadlineForUser method for DeadlineExtensions to get the specific FeedbackSessionData for a user. 