### PR TITLE
[#11383] Fix PR checking workflow permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: Pull Request Checker
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -10,6 +10,8 @@ on:
 jobs:
   check-pr:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/github-script@v6
       with:


### PR DESCRIPTION
Part of #11383

The PR checking workflow is currently running into permissions issues. This is because Github provides read-only tokens to all forks for security reasons.

To fix this, the workflow trigger has been changed from `pull_request` to `pull_request_target`, so that the workflow is run on the target branch `master` where write permissions can be provided. Permissions have been limited to write permissions for PRs only for security reasons.

Note that this workflow will now only run after the changes are merged into `master`, hence testing of the workflow is not possible in this PR. I have opened a PR in my own fork to test this fix, at https://github.com/zhaojj2209/teammates/pull/39.

In the future, if I have the capacity, I may expand this workflow to include other actions such as labelling PRs.