### PR TITLE
[#12035] Fix ChromeDriver setup for E2E tests

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/Browser.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/Browser.java
@@ -188,6 +188,7 @@ public class Browser {
             ChromeOptions options = new ChromeOptions();
             options.setExperimentalOption("prefs", chromePrefs);
             options.addArguments("--allow-file-access-from-files");
+            options.addArguments("--remote-allow-origins=*");
             if (TestProperties.isDevServer()) {
                 options.addArguments("incognito");
             }


### PR DESCRIPTION
Part of #12035

Currently, all E2E tests fail when using ChromeDriver due to an `Unable to establish websocket connection` error. This PR fixes this error using a [fix found on StackOverflow](https://stackoverflow.com/questions/75680149/unable-to-establish-websocket-connection).

Since the cross-browser workflow is only run on push to the master/release branches, I've tested the workflow on my own fork instead. [Link to workflow](https://github.com/zhaojj2209/teammates/actions/runs/4436835989/jobs/7785762463)

Note that this PR only fixes ChromeDriver setup so that E2E tests can be run using ChromeDriver. A portion of tests are still failing due to timeouts or otherwise (even though they pass on Firefox).