### PR TITLE
[#12081] User-friendliness: Fix screen reader issue for question description

### DIFF
--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
@@ -9,7 +9,10 @@
   </div>
   <div class="row padding-15px text-start">
     <div class="col-md-2">
-      <div class="question-basic-info">[Optional]<br/>Description</div>
+      <pre role="text" class="question-basic-info">
+        [Optional]
+        Description
+      </pre>
     </div>
     <div class="col-md-10">
       <tm-rich-text-editor [richText]="description" (richTextChange)="triggerDescriptionChange($event)" [isDisabled]="isDescriptionDisabled" minHeightInPx="100" [placeholderText]="'More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;'"></tm-rich-text-editor>

--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.scss
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.scss
@@ -10,3 +10,10 @@
   padding-left: 15px;
   font-weight: bold;
 }
+
+pre {
+  white-space:pre-line;
+  font-size:inherit;
+  font-family: inherit;
+  margin-bottom: 0;
+}

--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.scss
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.scss
@@ -12,8 +12,8 @@
 }
 
 pre {
-  white-space:pre-line;
-  font-size:inherit;
+  white-space: pre-line;
+  font-size: inherit;
   font-family: inherit;
   margin-bottom: 0;
 }

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -149,13 +149,13 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                     <div
                       class="col-md-2"
                     >
-                      <div
+                      <pre
                         class="question-basic-info"
+                        role="text"
                       >
-                        [Optional]
-                        <br />
-                        Description
-                      </div>
+                                [Optional]
+          Description
+                      </pre>
                     </div>
                     <div
                       class="col-md-10"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1360,13 +1360,13 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             <div
                               class="col-md-2"
                             >
-                              <div
+                              <pre
                                 class="question-basic-info"
+                                role="text"
                               >
-                                [Optional]
-                                <br />
-                                Description
-                              </div>
+                                        [Optional]
+          Description
+                              </pre>
                             </div>
                             <div
                               class="col-md-10"
@@ -2066,13 +2066,13 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             <div
                               class="col-md-2"
                             >
-                              <div
+                              <pre
                                 class="question-basic-info"
+                                role="text"
                               >
-                                [Optional]
-                                <br />
-                                Description
-                              </div>
+                                        [Optional]
+          Description
+                              </pre>
                             </div>
                             <div
                               class="col-md-10"
@@ -3857,13 +3857,13 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         <div
                           class="col-md-2"
                         >
-                          <div
+                          <pre
                             class="question-basic-info"
+                            role="text"
                           >
-                            [Optional]
-                            <br />
-                            Description
-                          </div>
+                                    [Optional]
+          Description
+                          </pre>
                         </div>
                         <div
                           class="col-md-10"


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Remove empty group between "[Optional]" and "Description" for question description](https://github.com/TEAMMATES/teammates/projects/16#card-88348922)

**Outline of Solution**
The `<br/>` was causing the screen reader to treat the "[Optional] Description" text as 2 separate elements. Tried several solutions found online, but none seemed to work.

Hence, I just removed the `<br>` in favour of `<pre>` and added some styles to make it look the same as before.
