### PR TITLE
[#12081] User-friendliness: Add labels to input for essay question (instructor edit sessions page)

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -195,14 +195,18 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                     <div
                       class="col-12 question-recommended-length"
                     >
-                       [Optional] 
-                      <span
-                        class="ngb-tooltip-class"
-                        ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                      <label
+                        for="recommended-length"
                       >
-                         Recommended length 
-                      </span>
-                       for the response: 
+                         [Optional] 
+                        <span
+                          class="ngb-tooltip-class"
+                          ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                        >
+                           Recommended length 
+                        </span>
+                         (in words) for the response: 
+                      </label>
                       <input
                         aria-label="Recommended Length Input"
                         class="form-control ng-untouched ng-pristine ng-valid"
@@ -211,7 +215,6 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                         min="1"
                         type="number"
                       />
-                       words 
                     </div>
                   </div>
                 </tm-text-question-edit-details-form>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -189,9 +189,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                           disabled=""
                           type="checkbox"
                         />
-                        <a>
-                           Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers
-                        </a>
+                         Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers 
                       </label>
                     </div>
                     <div
@@ -206,6 +204,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                       </span>
                        for the response: 
                       <input
+                        aria-label="Recommended Length Input"
                         class="form-control ng-untouched ng-pristine ng-valid"
                         disabled=""
                         id="recommended-length"

--- a/src/web/app/components/question-types/question-edit-details-form/text-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/text-question-edit-details-form.component.html
@@ -9,12 +9,13 @@
     </label>
   </div>
   <div class="col-12 question-recommended-length">
-    [Optional]
-    <span class="ngb-tooltip-class" ngbTooltip="The recommended length is shown to the respondent but not enforced">
-      Recommended length
-    </span>
-    for the response:
+    <label for="recommended-length">
+      [Optional]
+      <span class="ngb-tooltip-class" ngbTooltip="The recommended length is shown to the respondent but not enforced">
+        Recommended length
+      </span>
+      (in words) for the response:
+    </label>
     <input id="recommended-length" type="number" class="form-control" [ngModel]="model.recommendedLength" (ngModelChange)="triggerModelChange('recommendedLength', $event)" [disabled]="!isEditable" min="1" aria-label="Recommended Length Input">
-    words
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-details-form/text-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/text-question-edit-details-form.component.html
@@ -5,7 +5,7 @@
              [checked]="model.shouldAllowRichText"
              (click)="triggerModelChange('shouldAllowRichText', $event.target.checked)"
              [disabled]="!isEditable">
-      <a> Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers</a>
+      Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers
     </label>
   </div>
   <div class="col-12 question-recommended-length">
@@ -14,7 +14,7 @@
       Recommended length
     </span>
     for the response:
-    <input id="recommended-length" type="number" class="form-control" [ngModel]="model.recommendedLength" (ngModelChange)="triggerModelChange('recommendedLength', $event)" [disabled]="!isEditable" min="1">
+    <input id="recommended-length" type="number" class="form-control" [ngModel]="model.recommendedLength" (ngModelChange)="triggerModelChange('recommendedLength', $event)" [disabled]="!isEditable" min="1" aria-label="Recommended Length Input">
     words
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1405,14 +1405,18 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             <div
                               class="col-12 question-recommended-length"
                             >
-                               [Optional] 
-                              <span
-                                class="ngb-tooltip-class"
-                                ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                              <label
+                                for="recommended-length"
                               >
-                                 Recommended length 
-                              </span>
-                               for the response: 
+                                 [Optional] 
+                                <span
+                                  class="ngb-tooltip-class"
+                                  ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                                >
+                                   Recommended length 
+                                </span>
+                                 (in words) for the response: 
+                              </label>
                               <input
                                 aria-label="Recommended Length Input"
                                 class="form-control ng-untouched ng-pristine ng-valid"
@@ -1420,7 +1424,6 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                                 min="1"
                                 type="number"
                               />
-                               words 
                             </div>
                           </div>
                         </tm-text-question-edit-details-form>
@@ -2110,14 +2113,18 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                             <div
                               class="col-12 question-recommended-length"
                             >
-                               [Optional] 
-                              <span
-                                class="ngb-tooltip-class"
-                                ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                              <label
+                                for="recommended-length"
                               >
-                                 Recommended length 
-                              </span>
-                               for the response: 
+                                 [Optional] 
+                                <span
+                                  class="ngb-tooltip-class"
+                                  ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                                >
+                                   Recommended length 
+                                </span>
+                                 (in words) for the response: 
+                              </label>
                               <input
                                 aria-label="Recommended Length Input"
                                 class="form-control ng-untouched ng-pristine ng-valid"
@@ -2125,7 +2132,6 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                                 min="1"
                                 type="number"
                               />
-                               words 
                             </div>
                           </div>
                         </tm-text-question-edit-details-form>
@@ -3900,14 +3906,18 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                         <div
                           class="col-12 question-recommended-length"
                         >
-                           [Optional] 
-                          <span
-                            class="ngb-tooltip-class"
-                            ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                          <label
+                            for="recommended-length"
                           >
-                             Recommended length 
-                          </span>
-                           for the response: 
+                             [Optional] 
+                            <span
+                              class="ngb-tooltip-class"
+                              ngbtooltip="The recommended length is shown to the respondent but not enforced"
+                            >
+                               Recommended length 
+                            </span>
+                             (in words) for the response: 
+                          </label>
                           <input
                             aria-label="Recommended Length Input"
                             class="form-control ng-untouched ng-pristine ng-valid"
@@ -3915,7 +3925,6 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                             min="1"
                             type="number"
                           />
-                           words 
                         </div>
                       </div>
                     </tm-text-question-edit-details-form>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1399,9 +1399,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                                 <input
                                   type="checkbox"
                                 />
-                                <a>
-                                   Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers
-                                </a>
+                                 Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers 
                               </label>
                             </div>
                             <div
@@ -1416,6 +1414,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                               </span>
                                for the response: 
                               <input
+                                aria-label="Recommended Length Input"
                                 class="form-control ng-untouched ng-pristine ng-valid"
                                 id="recommended-length"
                                 min="1"
@@ -2105,9 +2104,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                                 <input
                                   type="checkbox"
                                 />
-                                <a>
-                                   Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers
-                                </a>
+                                 Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers 
                               </label>
                             </div>
                             <div
@@ -2122,6 +2119,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                               </span>
                                for the response: 
                               <input
+                                aria-label="Recommended Length Input"
                                 class="form-control ng-untouched ng-pristine ng-valid"
                                 id="recommended-length"
                                 min="1"
@@ -3896,9 +3894,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                             <input
                               type="checkbox"
                             />
-                            <a>
-                               Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers
-                            </a>
+                             Allow rich-text formatting (e.g., bold text, links, bullet lists, colors, etc.) in the answers 
                           </label>
                         </div>
                         <div
@@ -3913,6 +3909,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                           </span>
                            for the response: 
                           <input
+                            aria-label="Recommended Length Input"
                             class="form-control ng-untouched ng-pristine ng-valid"
                             id="recommended-length"
                             min="1"


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Add label to recommended words input](https://github.com/TEAMMATES/teammates/projects/16#card-88348675)

**Outline of Solution**
Removed the `<a>` tag as it was causing the screen reader to read the text twice (and I don't think there's a use for it).

Wrapped the recommended length input text in a label and rephrased it slightly so that it flows better for the screen reader. Also added an `aria-label` to the input.
