### PR TITLE
[#12222] Instructor help page: Page not scrolling to the right section

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -1,5 +1,5 @@
 <div class="flex-container">
-  <div class="main-body col-lg-10" #helpPage>
+  <div class="main-body col-lg-10">
     <div id={{Sections.body}}>
       <h1 class="color-orange"> Help for Instructors</h1>
       <div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -107,7 +107,7 @@ export class InstructorHelpPageComponent implements AfterViewInit {
       document: this.document,
       duration: 500,
       scrollTarget: `#${section}`,
-      scrollOffset: 70
+      scrollOffset: 70,
     });
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Inject, ViewChild } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { PageScrollService } from 'ngx-page-scroll-core';
 import { environment } from '../../../environments/environment';
@@ -42,7 +42,6 @@ export class InstructorHelpPageComponent implements AfterViewInit {
   questionIdToExpand: string = '';
   section: string = '';
 
-  @ViewChild('helpPage') bodyRef ?: ElementRef;
   @ViewChild('studentsHelpSection') studentsHelpSection?: InstructorHelpStudentsSectionComponent;
   @ViewChild('coursesHelpSection') coursesHelpSection?: InstructorHelpCoursesSectionComponent;
   @ViewChild('sessionsHelpSection') sessionsHelpSection?: InstructorHelpSessionsSectionComponent;
@@ -104,13 +103,10 @@ export class InstructorHelpPageComponent implements AfterViewInit {
    * Scrolls to the section passed in
    */
   scroll(section: string): void {
-    if (this.bodyRef) {
-      const el: any = Array.prototype.slice
-          .call(this.bodyRef.nativeElement.childNodes).find((x: any) => x.id === section);
-      if (el) {
-        el.scrollIntoView();
-        window.scrollBy(0, -50);
-      }
+    const el: HTMLElement | null = this.document.getElementById(section);
+    if (el) {
+      const y: number = el.getBoundingClientRect().top + window.scrollY - 70;
+      window.scrollTo({ top: y, behavior: 'auto' });
     }
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -103,11 +103,12 @@ export class InstructorHelpPageComponent implements AfterViewInit {
    * Scrolls to the section passed in
    */
   scroll(section: string): void {
-    const el: HTMLElement | null = this.document.getElementById(section);
-    if (el) {
-      const y: number = el.getBoundingClientRect().top + window.scrollY - 70;
-      window.scrollTo({ top: y, behavior: 'auto' });
-    }
+    this.pageScrollService.scroll({
+      document: this.document,
+      duration: 500,
+      scrollTarget: `#${section}`,
+      scrollOffset: 70
+    });
   }
 
   scrollTo(target: string, timeout?: number): void {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -1,5 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
 
+html {
+  scroll-behavior: auto !important;
+}
+
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: .875rem;

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 
 html {
-  scroll-behavior: auto !important;
+  scroll-behavior: auto !important; // Bootstrap is setting scroll behavior to smooth and that is not working with ngx-page-scroll service (for more details: https://github.com/TEAMMATES/teammates/pull/12224#issuecomment-1480350769).
 }
 
 body {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -1,7 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 
+// Required to use ngx-page-scroll service https://github.com/TEAMMATES/teammates/pull/12224#issuecomment-1480350769.
 html {
-  scroll-behavior: auto !important; // Bootstrap is setting scroll behavior to smooth and that is not working with ngx-page-scroll service (for more details: https://github.com/TEAMMATES/teammates/pull/12224#issuecomment-1480350769).
+  scroll-behavior: auto !important;
 }
 
 body {


### PR DESCRIPTION
Fixes #12222

**Outline of Solution**
<!-- Tell us how you solved the issue. -->
To resolve this issue, I use to calculate the y coordinate of the section and I used the scrollTo function directly to do it.
The problem was in these two lines :
`el.scrollIntoView();
 window.scrollBy(0, -50);`
 
 The second instruction is not waiting for the first one to finish and do the scroll by -50px.
 
 I removed the '#helpPage' because it is not necessary to get all the children and then search for the section using the id.
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
