### PR TITLE
[#12081] Minimise modal margin for mobile

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
@@ -5,7 +5,7 @@
 #copy-question-modal {
   table-layout: auto;
   margin-bottom: 10px;
-  width: 70vw;
+  min-width: 70vw;
 }
 
 .modal-footer {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -100,15 +100,21 @@ h6,
   }
 }
 
-@media (max-width: 768px) {
-  .modal-dialog {
-    max-width: 80vw;
-    min-width: 65vw;
-  }
-}
-
 .modal-large .modal-dialog {
   width: 1000px;
+}
+
+@media (max-width: 768px) {
+  .modal-dialog {
+    max-width: none;
+    min-width: 65vw;
+    max-height: none;
+    width: 95vw;
+  }
+
+  .modal-large .modal-dialog {
+    width: 95vw;
+  }
 }
 
 .close:focus {


### PR DESCRIPTION
Part of #12081 
Sub-issue [Minimise margins for modals on mobile (e.g. copy questions modal](https://github.com/TEAMMATES/teammates/projects/16#card-88348641)

**Outline of Solution**

<img width="341" alt="Screen Shot 2023-03-20 at 1 36 07 AM" src="https://user-images.githubusercontent.com/25262042/226199580-07d9cf0b-ec09-4d13-9cbe-9b676034db68.png">

- Set width for modal to `95vw` for mobile
- Tested for following modals:
    - `comment-table-modal`
    - `copy-course-modal`
    - `copy-session-modal`
    - `extension-confirm-modal`
    - `resend-results-link-to-respondants-modal`
    - `send-reminders-to-respondants-modal`
    - `copy-instructors-from-other-courses-modal`
    - `view-role-privileges-modal`
    - `copy-questions-from-other-sessions-modal`
    - `template-question-modal`
    - `individual-extension-date-modal`
    - `copy-from-other-sessions-modal`
    - `session-permanent-deletion-confirm-modal`
    - `sessions-permanent-deletion-confirm-modal`
    - `saving-complete-modal-component`