### PR TITLE
[#12120] Instructor help page: page not scrolling to content when anchor links used

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -62,13 +62,19 @@ export class InstructorHelpPageComponent implements AfterViewInit {
   }
 
   ngAfterViewInit(): void {
+    let target: string = '';
     this.route.queryParams.subscribe((queryParam: Params) => {
-      if (queryParam['questionId'] && queryParam['section']) {
-        this.questionIdToExpand = queryParam['questionId'];
+      if (queryParam['section']) {
         this.section = queryParam['section'];
-        this.scrollTo(queryParam['questionId']);
+        target = this.section;
+        if (queryParam['questionId']) {
+          this.questionIdToExpand = queryParam['questionId'];
+          target = this.questionIdToExpand;
+          this.expandQuestionTab();
+        }
       }
     });
+    this.scrollTo(target);
   }
 
   expandQuestionTab(): void {
@@ -115,12 +121,11 @@ export class InstructorHelpPageComponent implements AfterViewInit {
   }
 
   scrollTo(target: string, timeout?: number): void {
-    this.expandQuestionTab();
     setTimeout(() => this.pageScrollService.scroll({
       document: this.document,
       duration: 500,
       scrollTarget: `#${target}`,
-      scrollOffset: 70,
+      scrollOffset: 60,
     }), timeout || 500);
   }
 

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -1,5 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
 
+html {
+  scroll-behavior: auto !important;
+}
+
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: .875rem;


### PR DESCRIPTION
Fixes #12120

**Outline of Solution**
First of all, I made changes to the `ngAfterViewInit()` function to accommodate the `section` and `questionId` anchors:
- I introduced a `target` variable, which identifies the more precise anchor between `section` and `questionId`
- if the anchor has a `questionId`, the corresponding question tab is expanded directly, and not in `scrollTo()`, because we don't need to do this if we only have `section` in the URL parameters
- the call to `scrollTo()` is also modified to handle the case where we only have `section` in the URL parameters, without a `questionId`

I also changed the `scrollOffset` in `scrollTo()` to 60, because I think it feels better. However, feel free to undo this change if you prefer the previous value.

Finally, I added the changes related to bug #12222 to ensure that we scroll correctly to the appropriate anchor.