### PR TITLE
[#12048] Add published email sent field to feedback sessions

### DIFF
--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -172,7 +172,8 @@
       "gracePeriod": 10,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "isPublishedEmailSent": false
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
@@ -189,7 +190,8 @@
       "gracePeriod": 5,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "isPublishedEmailSent": false
     }
   },
   "feedbackQuestions": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -221,7 +221,8 @@
       "gracePeriod": 10,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "isPublishedEmailSent": true
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
@@ -238,7 +239,8 @@
       "gracePeriod": 5,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "isPublishedEmailSent": false
     },
     "unpublishedSession1InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000703",
@@ -255,7 +257,8 @@
       "gracePeriod": 5,
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "isPublishedEmailSent": false
     }
   },
   "feedbackQuestions": {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -71,6 +71,9 @@ public class FeedbackSession extends BaseEntity {
     @Column(nullable = false)
     private boolean isPublishedEmailEnabled;
 
+    @Column(nullable = false)
+    private boolean isPublishedEmailSent;
+
     @OneToMany(mappedBy = "feedbackSession")
     private List<DeadlineExtension> deadlineExtensions = new ArrayList<>();
 
@@ -281,6 +284,14 @@ public class FeedbackSession extends BaseEntity {
 
     public void setFeedbackQuestions(List<FeedbackQuestion> feedbackQuestions) {
         this.feedbackQuestions = feedbackQuestions;
+    }
+
+    public boolean isPublishedEmailSent() {
+        return isPublishedEmailSent;
+    }
+
+    public void setPublishedEmailSent(boolean isPublishedEmailSent) {
+        this.isPublishedEmailSent = isPublishedEmailSent;
     }
 
     public Instant getUpdatedAt() {


### PR DESCRIPTION
Part of #12048

Required because emails are sent when sessions are published manually.
Without the flag, it will be sent again when cron job is run.