### PR TITLE
[#12081] User-friendliness: Change feedback path dropdowns to column format on mobile

### DIFF
--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -33,7 +33,7 @@
     </ul>
   </div>
   <div class="row margin-top-15px" *ngIf="model.isUsingOtherFeedbackPath">
-    <div class="col-6">
+    <div class="col-sm-6 mb-2 mb-sm-0">
       <div class="row">
         <div class="col-12">
           <strong>Who will give the feedback:</strong>
@@ -47,7 +47,7 @@
         </div>
       </div>
     </div>
-    <div class="col-6">
+    <div class="col-sm-6">
       <div class="row">
         <div class="col-12">
           <strong>Who the feedback is about:</strong>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -4197,7 +4197,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                   style=""
                 >
                   <div
-                    class="col-6"
+                    class="col-sm-6 mb-2 mb-sm-0"
                   >
                     <div
                       class="row"
@@ -4245,7 +4245,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                     </div>
                   </div>
                   <div
-                    class="col-6"
+                    class="col-sm-6"
                   >
                     <div
                       class="row"


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Change feedback path dropdowns to column format on mobile](https://github.com/TEAMMATES/teammates/projects/16#card-88540819)

**Outline of Solution**
Added breakpoints to `.col-6` classes. Also added a bottom margin for mobile.
