### PR TITLE
[#12081] User-friendliness: Fix visibility dropdown overflow

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -392,7 +392,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                   style=""
                 />
                 <li
-                  class="dropdown-item"
+                  class="text-wrap dropdown-item"
                   style=""
                 >
                   <button

--- a/src/web/app/components/visibility-panel/visibility-panel.component.html
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.html
@@ -15,11 +15,11 @@
     </button>
     <ul id="question-visibility-dropdown" ngbDropdownMenu>
       <li class="dropdown-header">Common visibility options</li>
-      <li class="dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings">
+      <li class="text-wrap dropdown-item" *ngFor="let visibilityOption of commonFeedbackVisibilitySettings">
         <button class="dropdown-button" (click)="applyCommonVisibilitySettings(visibilityOption)">{{ visibilityOption.name }}</button>
       </li>
       <li class="dropdown-divider" *ngIf="isCustomFeedbackVisibilitySettingAllowed" aria-hidden="true"></li>
-      <li class="dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed">
+      <li class="text-wrap dropdown-item" *ngIf="isCustomFeedbackVisibilitySettingAllowed">
         <button class="dropdown-button" (click)="triggerCustomVisibilitySetting()">Custom visibility options...</button>
       </li>
     </ul>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1698,7 +1698,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           Common visibility options
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -1708,7 +1708,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -1718,7 +1718,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -1728,7 +1728,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -1738,7 +1738,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -1753,7 +1753,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         />
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2417,7 +2417,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           Common visibility options
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2427,7 +2427,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2437,7 +2437,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2447,7 +2447,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2457,7 +2457,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           </button>
                         </li>
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -2472,7 +2472,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           style=""
                         />
                         <li
-                          class="dropdown-item"
+                          class="text-wrap dropdown-item"
                           style=""
                         >
                           <button
@@ -4425,7 +4425,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       Common visibility options
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4435,7 +4435,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4445,7 +4445,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4455,7 +4455,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4465,7 +4465,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4475,7 +4475,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       </button>
                     </li>
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button
@@ -4490,7 +4490,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                       style=""
                     />
                     <li
-                      class="dropdown-item"
+                      class="text-wrap dropdown-item"
                       style=""
                     >
                       <button


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Fix overflow on mobile for visibility dropdown](https://github.com/TEAMMATES/teammates/projects/16#card-88540814)

**Outline of Solution**
Add `.text-wrap` classes to the relevant dropdown items
