### PR TITLE
[#12048] Migrate get feedback responses action

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -14,13 +14,16 @@ import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.DataBundleLogic;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -177,6 +180,14 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
                 List.of(FeedbackParticipantType.INSTRUCTORS), questionDetails1);
         expectedQuestion1.setId(actualQuestion1.getId());
         verifyEquals(expectedQuestion1, actualQuestion1);
+
+        ______TS("verify feedback responses deserialized correctly");
+        FeedbackResponse actualResponse1 = dataBundle.feedbackResponses.get("response1ForQ1S1C1");
+        FeedbackResponseDetails responseDetails1 = new FeedbackTextResponseDetails("Student 1 self feedback.");
+        FeedbackResponse expectedResponse1 = FeedbackResponse.makeResponse(actualQuestion1, "student1@teammates.tmt",
+                expectedSection, "student1@teammates.tmt", expectedSection, responseDetails1);
+        expectedResponse1.setId(actualResponse1.getId());
+        verifyEquals(expectedResponse1, actualResponse1);
     }
 
     @Test

--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -193,8 +193,9 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("verify feedback response comments deserialized correctly");
         FeedbackResponseComment actualComment1 = dataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
-        FeedbackResponseComment expectedComment1 = new FeedbackResponseComment(expectedResponse1, "instr1@teammates.tmt", FeedbackParticipantType.INSTRUCTORS,
-                expectedSection, expectedSection, "Instructor 1 comment to student 1 self feedback", false, false,
+        FeedbackResponseComment expectedComment1 = new FeedbackResponseComment(expectedResponse1, "instr1@teammates.tmt",
+                FeedbackParticipantType.INSTRUCTORS, expectedSection, expectedSection,
+                "Instructor 1 comment to student 1 self feedback", false, false,
                 new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(), "instr1@teammates.tmt");
         expectedComment1.setId(actualComment1.getId());
         verifyEquals(expectedComment1, actualComment1);

--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -2,6 +2,7 @@ package teammates.it.sqllogic.core;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
@@ -24,6 +25,7 @@ import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -188,6 +190,14 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
                 expectedSection, "student1@teammates.tmt", expectedSection, responseDetails1);
         expectedResponse1.setId(actualResponse1.getId());
         verifyEquals(expectedResponse1, actualResponse1);
+
+        ______TS("verify feedback response comments deserialized correctly");
+        FeedbackResponseComment actualComment1 = dataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
+        FeedbackResponseComment expectedComment1 = new FeedbackResponseComment(expectedResponse1, "instr1@teammates.tmt", FeedbackParticipantType.INSTRUCTORS,
+                expectedSection, expectedSection, "Instructor 1 comment to student 1 self feedback", false, false,
+                new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(), "instr1@teammates.tmt");
+        expectedComment1.setId(actualComment1.getId());
+        verifyEquals(expectedComment1, actualComment1);
     }
 
     @Test

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponseCommentsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponseCommentsDbIT.java
@@ -1,0 +1,48 @@
+package teammates.it.storage.sqlapi;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.util.HibernateUtil;
+import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
+import teammates.storage.sqlapi.FeedbackResponseCommentsDb;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
+
+/**
+ * SUT: {@link FeedbackResponseCommentsDb}.
+ */
+public class FeedbackResponseCommentsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
+
+    private final FeedbackResponseCommentsDb frcDb = FeedbackResponseCommentsDb.inst();
+
+    private SqlDataBundle typicalDataBundle;
+
+    @Override
+    @BeforeClass
+    public void setupClass() {
+        super.setupClass();
+        typicalDataBundle = getTypicalSqlDataBundle();
+    }
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalDataBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Test
+    public void testGetFeedbackResponseCommentForResponseFromParticipant() {
+        ______TS("success: typical case");
+        FeedbackResponse fr = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+
+        FeedbackResponseComment expectedComment = typicalDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
+        FeedbackResponseComment actualComment = frcDb.getFeedbackResponseCommentForResponseFromParticipant(fr.getId());
+
+        assertEquals(expectedComment, actualComment);
+    }
+}

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
@@ -1,0 +1,53 @@
+package teammates.it.storage.sqlapi;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.util.HibernateUtil;
+import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
+import teammates.storage.sqlapi.FeedbackResponsesDb;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+
+/**
+ * SUT: {@link FeedbackResponsesDb}.
+ */
+public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
+
+    private final FeedbackResponsesDb frDb = FeedbackResponsesDb.inst();
+
+    private SqlDataBundle typicalDataBundle;
+
+    @Override
+    @BeforeClass
+    public void setupClass() {
+        super.setupClass();
+        typicalDataBundle = getTypicalSqlDataBundle();
+    }
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalDataBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Test
+    public void testGetFeedbackResponsesFromGiverForQuestion() {
+        ______TS("success: typical case");
+        FeedbackQuestion fq = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        FeedbackResponse fr = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+
+        List<FeedbackResponse> expectedQuestions = List.of(fr);
+
+        List<FeedbackResponse> actualQuestions = frDb.getFeedbackResponsesFromGiverForQuestion(fq.getId(), "student1@teammates.tmt");
+
+        assertEquals(expectedQuestions.size(), actualQuestions.size());
+        assertTrue(expectedQuestions.containsAll(actualQuestions));
+    }
+}

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
@@ -45,7 +45,8 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         List<FeedbackResponse> expectedQuestions = List.of(fr);
 
-        List<FeedbackResponse> actualQuestions = frDb.getFeedbackResponsesFromGiverForQuestion(fq.getId(), "student1@teammates.tmt");
+        List<FeedbackResponse> actualQuestions =
+                frDb.getFeedbackResponsesFromGiverForQuestion(fq.getId(), "student1@teammates.tmt");
 
         assertEquals(expectedQuestions.size(), actualQuestions.size());
         assertTrue(expectedQuestions.containsAll(actualQuestions));

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -32,6 +32,7 @@ import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -148,7 +149,12 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
             FeedbackResponse actualResponse = (FeedbackResponse) actual;
             equalizeIrrelevantData(expectedResponse, actualResponse);
             assertEquals(JsonUtils.toJson(expectedResponse), JsonUtils.toJson(actualResponse));
-        } else if (expected instanceof Notification) {
+        } else if (expected instanceof FeedbackResponseComment) {
+            FeedbackResponseComment expectedComment = (FeedbackResponseComment) expected;
+            FeedbackResponseComment actualComment = (FeedbackResponseComment) actual;
+            equalizeIrrelevantData(expectedComment, actualComment);
+            assertEquals(JsonUtils.toJson(expectedComment), JsonUtils.toJson(actualComment));
+        }  else if (expected instanceof Notification) {
             Notification expectedNotification = (Notification) expected;
             Notification actualNotification = (Notification) actual;
             equalizeIrrelevantData(expectedNotification, actualNotification);
@@ -249,6 +255,13 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
         expected.setCreatedAt(actual.getCreatedAt());
         expected.setUpdatedAt(actual.getUpdatedAt());
     }
+
+    private void equalizeIrrelevantData(FeedbackResponseComment expected, FeedbackResponseComment actual) {
+        // Ignore time field as it is stamped at the time of creation in testing
+        expected.setCreatedAt(actual.getCreatedAt());
+        expected.setUpdatedAt(actual.getUpdatedAt());
+    }
+
 
     private void equalizeIrrelevantData(Notification expected, Notification actual) {
         // Ignore time field as it is stamped at the time of creation in testing

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -154,7 +154,7 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
             FeedbackResponseComment actualComment = (FeedbackResponseComment) actual;
             equalizeIrrelevantData(expectedComment, actualComment);
             assertEquals(JsonUtils.toJson(expectedComment), JsonUtils.toJson(actualComment));
-        }  else if (expected instanceof Notification) {
+        } else if (expected instanceof Notification) {
             Notification expectedNotification = (Notification) expected;
             Notification actualNotification = (Notification) actual;
             equalizeIrrelevantData(expectedNotification, actualNotification);
@@ -261,7 +261,6 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
         expected.setCreatedAt(actual.getCreatedAt());
         expected.setUpdatedAt(actual.getUpdatedAt());
     }
-
 
     private void equalizeIrrelevantData(Notification expected, Notification actual) {
         // Ignore time field as it is stamped at the time of creation in testing

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -31,6 +31,7 @@ import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -142,6 +143,11 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
             FeedbackQuestion actualQuestion = (FeedbackQuestion) actual;
             equalizeIrrelevantData(expectedQuestion, actualQuestion);
             assertEquals(JsonUtils.toJson(expectedQuestion), JsonUtils.toJson(actualQuestion));
+        } else if (expected instanceof FeedbackResponse) {
+            FeedbackResponse expectedResponse = (FeedbackResponse) expected;
+            FeedbackResponse actualResponse = (FeedbackResponse) actual;
+            equalizeIrrelevantData(expectedResponse, actualResponse);
+            assertEquals(JsonUtils.toJson(expectedResponse), JsonUtils.toJson(actualResponse));
         } else if (expected instanceof Notification) {
             Notification expectedNotification = (Notification) expected;
             Notification actualNotification = (Notification) actual;
@@ -233,6 +239,12 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
     }
 
     private void equalizeIrrelevantData(FeedbackQuestion expected, FeedbackQuestion actual) {
+        // Ignore time field as it is stamped at the time of creation in testing
+        expected.setCreatedAt(actual.getCreatedAt());
+        expected.setUpdatedAt(actual.getUpdatedAt());
+    }
+
+    private void equalizeIrrelevantData(FeedbackResponse expected, FeedbackResponse actual) {
         // Ignore time field as it is stamped at the time of creation in testing
         expected.setCreatedAt(actual.getCreatedAt());
         expected.setUpdatedAt(actual.getUpdatedAt());

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -248,11 +248,11 @@
         ]
       },
       "giver": "student1@teammates.tmt",
-      "receiver": "student1@teammates.tmt",
+      "recipient": "student1@teammates.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
-      "receiverSection": {
+      "recipientSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
       "answer": {

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -220,7 +220,47 @@
       ]
     }
   },
-  "feedbackResponses": {},
+  "feedbackResponses": {
+    "response1ForQ1S1C1": {
+      "feedbackQuestion":
+      {
+        "id": "00000000-0000-4000-8000-000000000801",
+        "feedbackSession": {
+          "id": "00000000-0000-4000-8000-000000000701"
+        },
+        "questionDetails": {
+          "questionType": "TEXT",
+          "questionText": "What is the best selling point of your product?"
+        },
+        "description": "This is a text question.",
+        "questionNumber": 1,
+        "giverType": "STUDENTS",
+        "recipientType": "SELF",
+        "numOfEntitiesToGiveFeedbackTo": 1,
+        "showResponsesTo": [
+          "INSTRUCTORS"
+        ],
+        "showGiverNameTo": [
+          "INSTRUCTORS"
+        ],
+        "showRecipientNameTo": [
+          "INSTRUCTORS"
+        ]
+      },
+      "giver": "student1@teammates.tmt",
+      "receiver": "student1@teammates.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "receiverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "answer": {
+        "questionType": "TEXT",
+        "answer": "Student 1 self feedback."
+      }
+    }
+  },
   "feedbackResponseComments": {},
   "notifications": {
     "notification1": {

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -222,6 +222,7 @@
   },
   "feedbackResponses": {
     "response1ForQ1S1C1": {
+      "id": "00000000-0000-4000-8000-000000000901",
       "feedbackQuestion":
       {
         "id": "00000000-0000-4000-8000-000000000801",
@@ -261,7 +262,64 @@
       }
     }
   },
-  "feedbackResponseComments": {},
+  "feedbackResponseComments": {
+    "comment1ToResponse1ForQ1": {
+      "feedbackResponse":  {
+        "id": "00000000-0000-4000-8000-000000000901",
+        "feedbackQuestion":
+        {
+          "id": "00000000-0000-4000-8000-000000000801",
+          "feedbackSession": {
+            "id": "00000000-0000-4000-8000-000000000701"
+          },
+          "questionDetails": {
+            "questionType": "TEXT",
+            "questionText": "What is the best selling point of your product?"
+          },
+          "description": "This is a text question.",
+          "questionNumber": 1,
+          "giverType": "STUDENTS",
+          "recipientType": "SELF",
+          "numOfEntitiesToGiveFeedbackTo": 1,
+          "showResponsesTo": [
+            "INSTRUCTORS"
+          ],
+          "showGiverNameTo": [
+            "INSTRUCTORS"
+          ],
+          "showRecipientNameTo": [
+            "INSTRUCTORS"
+          ]
+        },
+        "giver": "student1@teammates.tmt",
+        "recipient": "student1@teammates.tmt",
+        "giverSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "recipientSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "answer": {
+          "questionType": "TEXT",
+          "answer": "Student 1 self feedback."
+        }
+      },
+      "giver": "instr1@teammates.tmt",
+      "giverType": "INSTRUCTORS",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "commentText": "Instructor 1 comment to student 1 self feedback",
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "lastEditorEmail": "instr1@teammates.tmt"
+    }
+  },
   "notifications": {
     "notification1": {
       "id": "00000000-0000-4000-8000-000000001101",

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -287,6 +287,7 @@
       ]
     },
     "qn2InSession1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000802",
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
@@ -313,6 +314,7 @@
       ]
     },
     "qn3InSession1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000803",
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
@@ -345,6 +347,7 @@
       ]
     },
     "qn4InSession1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000804",
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
@@ -377,6 +380,7 @@
       ]
     },
     "qn5InSession1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000805",
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
@@ -401,7 +405,84 @@
       ]
     }
   },
-  "feedbackResponses": {},
+  "feedbackResponses": {
+    "response1ForQ1": {
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801",
+        "feedbackSession": {
+          "id": "00000000-0000-4000-8000-000000000701"
+        },
+        "questionDetails": {
+          "questionType": "TEXT",
+          "questionText": "What is the best selling point of your product?"
+        },
+        "description": "This is a text question.",
+        "questionNumber": 1,
+        "giverType": "STUDENTS",
+        "recipientType": "SELF",
+        "numOfEntitiesToGiveFeedbackTo": 1,
+        "showResponsesTo": [
+          "INSTRUCTORS"
+        ],
+        "showGiverNameTo": [
+          "INSTRUCTORS"
+        ],
+        "showRecipientNameTo": [
+          "INSTRUCTORS"
+        ]
+      },
+      "giver": "student1@teammates.tmt",
+      "receiver": "student1@teammates.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "receiverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "answer": {
+        "questionType": "TEXT",
+        "answer": "Student 1 self feedback."
+      }
+    },
+    "response2ForQ1": {
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801",
+        "feedbackSession": {
+          "id": "00000000-0000-4000-8000-000000000701"
+        },
+        "questionDetails": {
+          "questionType": "TEXT",
+          "questionText": "What is the best selling point of your product?"
+        },
+        "description": "This is a text question.",
+        "questionNumber": 1,
+        "giverType": "STUDENTS",
+        "recipientType": "SELF",
+        "numOfEntitiesToGiveFeedbackTo": 1,
+        "showResponsesTo": [
+          "INSTRUCTORS"
+        ],
+        "showGiverNameTo": [
+          "INSTRUCTORS"
+        ],
+        "showRecipientNameTo": [
+          "INSTRUCTORS"
+        ]
+      },
+      "giver": "student2@teammates.tmt",
+      "receiver": "student2@teammates.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "receiverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "answer": {
+        "questionType": "TEXT",
+        "answer": "Student 2 self feedback."
+      }
+    }
+  },
   "feedbackResponseComments": {},
   "notifications": {
     "notification1": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -432,11 +432,11 @@
         ]
       },
       "giver": "student1@teammates.tmt",
-      "receiver": "student1@teammates.tmt",
+      "recipient": "student1@teammates.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
-      "receiverSection": {
+      "recipientSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
       "answer": {
@@ -470,11 +470,11 @@
         ]
       },
       "giver": "student2@teammates.tmt",
-      "receiver": "student2@teammates.tmt",
+      "recipient": "student2@teammates.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
-      "receiverSection": {
+      "recipientSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
       "answer": {
@@ -483,7 +483,24 @@
       }
     }
   },
-  "feedbackResponseComments": {},
+  "feedbackResponseComments": {
+    "comment1FromResponse1ForQ1": {
+      "commentGiver": "instr1@teammates.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "receiverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "commentText": "Instructor 1 comment to student 1 self feedback",
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "commentGiverType": "INSTRUCTORS",
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "lastEditorEmail": "instructor1@course1.tmt"
+    }
+  },
   "notifications": {
     "notification1": {
       "id": "00000000-0000-4000-8000-000000001101",

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -407,6 +407,7 @@
   },
   "feedbackResponses": {
     "response1ForQ1": {
+      "id": "00000000-0000-4000-8000-000000000901",
       "feedbackQuestion": {
         "id": "00000000-0000-4000-8000-000000000801",
         "feedbackSession": {
@@ -445,6 +446,7 @@
       }
     },
     "response2ForQ1": {
+      "id": "00000000-0000-4000-8000-000000000902",
       "feedbackQuestion": {
         "id": "00000000-0000-4000-8000-000000000801",
         "feedbackSession": {
@@ -484,22 +486,118 @@
     }
   },
   "feedbackResponseComments": {
-    "comment1FromResponse1ForQ1": {
-      "commentGiver": "instr1@teammates.tmt",
+    "comment1ToResponse1ForQ1": {
+      "feedbackResponse":  {
+        "id": "00000000-0000-4000-8000-000000000901",
+        "feedbackQuestion":
+        {
+          "id": "00000000-0000-4000-8000-000000000801",
+          "feedbackSession": {
+            "id": "00000000-0000-4000-8000-000000000701"
+          },
+          "questionDetails": {
+            "questionType": "TEXT",
+            "questionText": "What is the best selling point of your product?"
+          },
+          "description": "This is a text question.",
+          "questionNumber": 1,
+          "giverType": "STUDENTS",
+          "recipientType": "SELF",
+          "numOfEntitiesToGiveFeedbackTo": 1,
+          "showResponsesTo": [
+            "INSTRUCTORS"
+          ],
+          "showGiverNameTo": [
+            "INSTRUCTORS"
+          ],
+          "showRecipientNameTo": [
+            "INSTRUCTORS"
+          ]
+        },
+        "giver": "student1@teammates.tmt",
+        "recipient": "student1@teammates.tmt",
+        "giverSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "recipientSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "answer": {
+          "questionType": "TEXT",
+          "answer": "Student 1 self feedback."
+        }
+      },
+      "giver": "instr1@teammates.tmt",
+      "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
-      "receiverSection": {
+      "recipientSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
       "commentText": "Instructor 1 comment to student 1 self feedback",
-      "showCommentTo": [],
-      "showGiverNameTo": [],
-      "commentGiverType": "INSTRUCTORS",
       "isVisibilityFollowingFeedbackQuestion": false,
       "isCommentFromFeedbackParticipant": false,
-      "lastEditorEmail": "instructor1@course1.tmt"
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "lastEditorEmail": "instr1@teammates.tmt"
     }
+  },
+    "comment2ToResponse2ForQ1": {
+      "id": 2,
+      "feedbackResponse":  {
+        "id": "00000000-0000-4000-8000-000000000902",
+        "feedbackQuestion": {
+          "id": "00000000-0000-4000-8000-000000000801",
+          "feedbackSession": {
+            "id": "00000000-0000-4000-8000-000000000701"
+          },
+          "questionDetails": {
+            "questionType": "TEXT",
+            "questionText": "What is the best selling point of your product?"
+          },
+          "description": "This is a text question.",
+          "questionNumber": 1,
+          "giverType": "STUDENTS",
+          "recipientType": "SELF",
+          "numOfEntitiesToGiveFeedbackTo": 1,
+          "showResponsesTo": [
+            "INSTRUCTORS"
+          ],
+          "showGiverNameTo": [
+            "INSTRUCTORS"
+          ],
+          "showRecipientNameTo": [
+            "INSTRUCTORS"
+          ]
+        },
+        "giver": "student2@teammates.tmt",
+        "recipient": "student2@teammates.tmt",
+        "giverSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "recipientSection": {
+          "id": "00000000-0000-4000-8000-000000000201"
+        },
+        "answer": {
+          "questionType": "TEXT",
+          "answer": "Student 2 self feedback."
+        }
+      },
+      "giver": "instr2@teammates.tmt",
+      "giverType": "INSTRUCTORS",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "commentText": "Instructor 2 comment to student 2 self feedback",
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "lastEditorEmail": "instr2@teammates.tmt"
   },
   "notifications": {
     "notification1": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -487,7 +487,7 @@
   },
   "feedbackResponseComments": {
     "comment1ToResponse1ForQ1": {
-      "feedbackResponse":  {
+      "feedbackResponse": {
         "id": "00000000-0000-4000-8000-000000000901",
         "feedbackQuestion":
         {
@@ -541,10 +541,9 @@
       "showCommentTo": [],
       "showGiverNameTo": [],
       "lastEditorEmail": "instr1@teammates.tmt"
-    }
-  },
+    },
     "comment2ToResponse2ForQ1": {
-      "feedbackResponse":  {
+      "feedbackResponse": {
         "id": "00000000-0000-4000-8000-000000000902",
         "feedbackQuestion": {
           "id": "00000000-0000-4000-8000-000000000801",
@@ -597,6 +596,7 @@
       "showCommentTo": [],
       "showGiverNameTo": [],
       "lastEditorEmail": "instr2@teammates.tmt"
+    }
   },
   "notifications": {
     "notification1": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -544,7 +544,6 @@
     }
   },
     "comment2ToResponse2ForQ1": {
-      "id": 2,
       "feedbackResponse":  {
         "id": "00000000-0000-4000-8000-000000000902",
         "feedbackQuestion": {

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -25,6 +25,7 @@ import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.User;
@@ -37,6 +38,15 @@ import teammates.storage.sqlentity.questions.FeedbackRankOptionsQuestion;
 import teammates.storage.sqlentity.questions.FeedbackRankRecipientsQuestion;
 import teammates.storage.sqlentity.questions.FeedbackRubricQuestion;
 import teammates.storage.sqlentity.questions.FeedbackTextQuestion;
+import teammates.storage.sqlentity.responses.FeedbackConstantSumResponse;
+import teammates.storage.sqlentity.responses.FeedbackContributionResponse;
+import teammates.storage.sqlentity.responses.FeedbackMcqResponse;
+import teammates.storage.sqlentity.responses.FeedbackMsqResponse;
+import teammates.storage.sqlentity.responses.FeedbackNumericalScaleResponse;
+import teammates.storage.sqlentity.responses.FeedbackRankOptionsResponse;
+import teammates.storage.sqlentity.responses.FeedbackRankRecipientsResponse;
+import teammates.storage.sqlentity.responses.FeedbackRubricResponse;
+import teammates.storage.sqlentity.responses.FeedbackTextResponse;
 
 import jakarta.persistence.OneToMany;
 
@@ -61,6 +71,7 @@ public final class JsonUtils {
                 .registerTypeAdapter(ZoneId.class, new ZoneIdAdapter())
                 .registerTypeAdapter(Duration.class, new DurationMinutesAdapter())
                 .registerTypeAdapter(FeedbackQuestion.class, new FeedbackQuestionAdapter())
+                .registerTypeAdapter(FeedbackResponse.class, new FeedbackResponseAdapter())
                 .registerTypeAdapter(FeedbackQuestionDetails.class, new FeedbackQuestionDetailsAdapter())
                 .registerTypeAdapter(FeedbackResponseDetails.class, new FeedbackResponseDetailsAdapter())
                 .registerTypeAdapter(LogDetails.class, new LogDetailsAdapter())
@@ -225,6 +236,65 @@ public final class JsonUtils {
         public Duration deserialize(JsonElement element, Type type, JsonDeserializationContext context) {
             synchronized (this) {
                 return Duration.ofMinutes(element.getAsLong());
+            }
+        }
+    }
+
+    private static class FeedbackResponseAdapter implements JsonSerializer<FeedbackResponse>,
+    JsonDeserializer<FeedbackResponse> {
+
+        @Override
+        public JsonElement serialize(FeedbackResponse src, Type typeOfSrc, JsonSerializationContext context) {
+            if (src instanceof FeedbackConstantSumResponse) {
+                return context.serialize(src, FeedbackConstantSumResponse.class);
+            } else if (src instanceof FeedbackContributionResponse) {
+                return context.serialize(src, FeedbackContributionResponse.class);
+            } else if (src instanceof FeedbackMcqResponse) {
+                return context.serialize(src, FeedbackMcqResponse.class);
+            } else if (src instanceof FeedbackMsqResponse) {
+                return context.serialize(src, FeedbackMsqResponse.class);
+            } else if (src instanceof FeedbackNumericalScaleResponse) {
+                return context.serialize(src, FeedbackNumericalScaleResponse.class);
+            } else if (src instanceof FeedbackRankOptionsResponse) {
+                return context.serialize(src, FeedbackRankOptionsResponse.class);
+            } else if (src instanceof FeedbackRankRecipientsResponse) {
+                return context.serialize(src,FeedbackRankRecipientsResponse.class);
+            } else if (src instanceof FeedbackRubricResponse) {
+                return context.serialize(src, FeedbackRubricResponse.class);
+            } else if (src instanceof FeedbackTextResponse) {
+                return context.serialize(src, FeedbackTextResponse.class);
+            }
+            return null;
+        }
+
+        @Override
+        public FeedbackResponse deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        FeedbackQuestionType questionType =
+                FeedbackQuestionType.valueOf(json.getAsJsonObject().get("answer")
+                        .getAsJsonObject().get("questionType").getAsString());
+            switch (questionType) {
+            case MCQ:
+                return context.deserialize(json, FeedbackMcqResponse.class);
+            case MSQ:
+                return context.deserialize(json, FeedbackMsqResponse.class);
+            case TEXT:
+                return context.deserialize(json, FeedbackTextResponse.class);
+            case RUBRIC:
+                return context.deserialize(json, FeedbackRubricResponse.class);
+            case CONTRIB:
+                return context.deserialize(json, FeedbackContributionResponse.class);
+            case CONSTSUM:
+            case CONSTSUM_RECIPIENTS:
+            case CONSTSUM_OPTIONS:
+                return context.deserialize(json, FeedbackConstantSumResponse.class);
+            case NUMSCALE:
+                return context.deserialize(json, FeedbackNumericalScaleResponse.class);
+            case RANK_OPTIONS:
+                return context.deserialize(json, FeedbackRankOptionsResponse.class);
+            case RANK_RECIPIENTS:
+                return context.deserialize(json, FeedbackRankRecipientsResponse.class);
+            default:
+                return null;
             }
         }
     }

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -241,7 +241,7 @@ public final class JsonUtils {
     }
 
     private static class FeedbackResponseAdapter implements JsonSerializer<FeedbackResponse>,
-    JsonDeserializer<FeedbackResponse> {
+            JsonDeserializer<FeedbackResponse> {
 
         @Override
         public JsonElement serialize(FeedbackResponse src, Type typeOfSrc, JsonSerializationContext context) {
@@ -258,7 +258,7 @@ public final class JsonUtils {
             } else if (src instanceof FeedbackRankOptionsResponse) {
                 return context.serialize(src, FeedbackRankOptionsResponse.class);
             } else if (src instanceof FeedbackRankRecipientsResponse) {
-                return context.serialize(src,FeedbackRankRecipientsResponse.class);
+                return context.serialize(src, FeedbackRankRecipientsResponse.class);
             } else if (src instanceof FeedbackRubricResponse) {
                 return context.serialize(src, FeedbackRubricResponse.class);
             } else if (src instanceof FeedbackTextResponse) {
@@ -269,8 +269,8 @@ public final class JsonUtils {
 
         @Override
         public FeedbackResponse deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-        FeedbackQuestionType questionType =
-                FeedbackQuestionType.valueOf(json.getAsJsonObject().get("answer")
+            FeedbackQuestionType questionType =
+                    FeedbackQuestionType.valueOf(json.getAsJsonObject().get("answer")
                         .getAsJsonObject().get("questionType").getAsString());
             switch (questionType) {
             case MCQ:

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -20,6 +20,8 @@ import teammates.sqllogic.core.CoursesLogic;
 import teammates.sqllogic.core.DataBundleLogic;
 import teammates.sqllogic.core.DeadlineExtensionsLogic;
 import teammates.sqllogic.core.FeedbackQuestionsLogic;
+import teammates.sqllogic.core.FeedbackResponseCommentsLogic;
+import teammates.sqllogic.core.FeedbackResponsesLogic;
 import teammates.sqllogic.core.FeedbackSessionsLogic;
 import teammates.sqllogic.core.NotificationsLogic;
 import teammates.sqllogic.core.UsageStatisticsLogic;
@@ -29,6 +31,8 @@ import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -50,6 +54,8 @@ public class Logic {
     final CoursesLogic coursesLogic = CoursesLogic.inst();
     final DeadlineExtensionsLogic deadlineExtensionsLogic = DeadlineExtensionsLogic.inst();
     final FeedbackQuestionsLogic feedbackQuestionsLogic = FeedbackQuestionsLogic.inst();
+    final FeedbackResponsesLogic feedbackResponsesLogic = FeedbackResponsesLogic.inst();
+    final FeedbackResponseCommentsLogic feedbackResponseCommentsLogic = FeedbackResponseCommentsLogic.inst();
     final FeedbackSessionsLogic feedbackSessionsLogic = FeedbackSessionsLogic.inst();
     final UsageStatisticsLogic usageStatisticsLogic = UsageStatisticsLogic.inst();
     final UsersLogic usersLogic = UsersLogic.inst();
@@ -719,4 +725,30 @@ public class Logic {
         return feedbackQuestionsLogic.getRecipientsOfQuestion(question, instructorGiver, studentGiver, null);
     }
 
+    /**
+     * Get existing feedback responses from instructor for the given question.
+     */
+    public List<FeedbackResponse> getFeedbackResponsesFromInstructorForQuestion(
+            FeedbackQuestion question, Instructor instructor) {
+        return feedbackResponsesLogic.getFeedbackResponsesFromInstructorForQuestion(
+                question, instructor);
+    }
+
+    /**
+     * Get existing feedback responses from student or his team for the given
+     * question.
+     */
+    public List<FeedbackResponse> getFeedbackResponsesFromStudentOrTeamForQuestion(
+            FeedbackQuestion question, Student student) {
+        return feedbackResponsesLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(
+                question, student);
+    }
+
+    /**
+     * Gets the comment associated with the response.
+     */
+    public FeedbackResponseComment getFeedbackResponseCommentForResponseFromParticipant(
+            UUID feedbackResponseId) {
+        return feedbackResponseCommentsLogic.getFeedbackResponseCommentForResponseFromParticipant(feedbackResponseId);
+    }
 }

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -14,7 +14,6 @@ import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.sqllogic.core.FeedbackQuestionsLogic;
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -14,6 +14,7 @@ import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.sqllogic.core.FeedbackQuestionsLogic;
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -290,6 +290,7 @@ public final class DataBundleLogic {
         }
 
         for (FeedbackResponseComment responseComment : responseComments) {
+            responseComment.setId(null);
             frcLogic.createFeedbackResponseComment(responseComment);
         }
 

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -15,6 +15,7 @@ import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -40,6 +41,7 @@ public final class DataBundleLogic {
     private FeedbackSessionsLogic fsLogic;
     private FeedbackQuestionsLogic fqLogic;
     private FeedbackResponsesLogic frLogic;
+    private FeedbackResponseCommentsLogic frcLogic;
     private NotificationsLogic notificationsLogic;
     private UsersLogic usersLogic;
 
@@ -55,6 +57,7 @@ public final class DataBundleLogic {
             CoursesLogic coursesLogic,
             DeadlineExtensionsLogic deadlineExtensionsLogic, FeedbackSessionsLogic fsLogic,
             FeedbackQuestionsLogic fqLogic, FeedbackResponsesLogic frLogic,
+            FeedbackResponseCommentsLogic frcLogic,
             NotificationsLogic notificationsLogic, UsersLogic usersLogic) {
         this.accountsLogic = accountsLogic;
         this.accountRequestsLogic = accountRequestsLogic;
@@ -63,6 +66,7 @@ public final class DataBundleLogic {
         this.fsLogic = fsLogic;
         this.fqLogic = fqLogic;
         this.frLogic = frLogic;
+        this.frcLogic = frcLogic;
         this.notificationsLogic = notificationsLogic;
         this.usersLogic = usersLogic;
     }
@@ -87,8 +91,7 @@ public final class DataBundleLogic {
         Collection<FeedbackSession> sessions = dataBundle.feedbackSessions.values();
         Collection<FeedbackQuestion> questions = dataBundle.feedbackQuestions.values();
         Collection<FeedbackResponse> responses = dataBundle.feedbackResponses.values();
-        // Collection<FeedbackResponseComment> responseComments =
-        // dataBundle.feedbackResponseComments.values();
+        Collection<FeedbackResponseComment> responseComments = dataBundle.feedbackResponseComments.values();
         Collection<DeadlineExtension> deadlineExtensions = dataBundle.deadlineExtensions.values();
         Collection<Notification> notifications = dataBundle.notifications.values();
         Collection<ReadNotification> readNotifications = dataBundle.readNotifications.values();
@@ -99,6 +102,7 @@ public final class DataBundleLogic {
         Map<UUID, Team> teamsMap = new HashMap<>();
         Map<UUID, FeedbackSession> sessionsMap = new HashMap<>();
         Map<UUID, FeedbackQuestion> questionMap = new HashMap<>();
+        Map<UUID, FeedbackResponse> responseMap = new HashMap<>();
         Map<UUID, Account> accountsMap = new HashMap<>();
         Map<UUID, User> usersMap = new HashMap<>();
         Map<UUID, Notification> notificationsMap = new HashMap<>();
@@ -148,13 +152,24 @@ public final class DataBundleLogic {
         }
 
         for (FeedbackResponse response : responses) {
+            UUID placeholderId = response.getId();
             response.setId(UUID.randomUUID());
+            responseMap.put(placeholderId, response);
             FeedbackQuestion fq = questionMap.get(response.getFeedbackQuestion().getId());
             Section giverSection = sectionsMap.get(response.getGiverSection().getId());
             Section recipientSection = sectionsMap.get(response.getRecipientSection().getId());
             response.setFeedbackQuestion(fq);
             response.setGiverSection(giverSection);
             response.setRecipientSection(recipientSection);
+        }
+
+        for (FeedbackResponseComment responseComment : responseComments) {
+            FeedbackResponse fr = responseMap.get(responseComment.getFeedbackResponse().getId());
+            Section giverSection = sectionsMap.get(responseComment.getGiverSection().getId());
+            Section recipientSection = sectionsMap.get(responseComment.getRecipientSection().getId());
+            responseComment.setFeedbackResponse(fr);
+            responseComment.setGiverSection(giverSection);
+            responseComment.setRecipientSection(recipientSection);
         }
 
         for (Account account : accounts) {
@@ -238,8 +253,7 @@ public final class DataBundleLogic {
         Collection<FeedbackSession> sessions = dataBundle.feedbackSessions.values();
         Collection<FeedbackQuestion> questions = dataBundle.feedbackQuestions.values();
         Collection<FeedbackResponse> responses = dataBundle.feedbackResponses.values();
-        // Collection<FeedbackResponseComment> responseComments =
-        // dataBundle.feedbackResponseComments.values();
+        Collection<FeedbackResponseComment> responseComments = dataBundle.feedbackResponseComments.values();
         Collection<DeadlineExtension> deadlineExtensions = dataBundle.deadlineExtensions.values();
         Collection<Notification> notifications = dataBundle.notifications.values();
 
@@ -273,6 +287,10 @@ public final class DataBundleLogic {
 
         for (FeedbackResponse response : responses) {
             frLogic.createFeedbackResponse(response);
+        }
+
+        for (FeedbackResponseComment responseComment : responseComments) {
+            frcLogic.createFeedbackResponseComment(responseComment);
         }
 
         for (Account account : accounts) {

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -151,10 +151,10 @@ public final class DataBundleLogic {
             response.setId(UUID.randomUUID());
             FeedbackQuestion fq = questionMap.get(response.getFeedbackQuestion().getId());
             Section giverSection = sectionsMap.get(response.getGiverSection().getId());
-            Section receiverSection = sectionsMap.get(response.getReceiverSection().getId());
+            Section recipientSection = sectionsMap.get(response.getRecipientSection().getId());
             response.setFeedbackQuestion(fq);
             response.setGiverSection(giverSection);
-            response.setReceiverSection(receiverSection);
+            response.setRecipientSection(recipientSection);
         }
 
         for (Account account : accounts) {

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -14,6 +14,7 @@ import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
@@ -38,6 +39,7 @@ public final class DataBundleLogic {
     private DeadlineExtensionsLogic deadlineExtensionsLogic;
     private FeedbackSessionsLogic fsLogic;
     private FeedbackQuestionsLogic fqLogic;
+    private FeedbackResponsesLogic frLogic;
     private NotificationsLogic notificationsLogic;
     private UsersLogic usersLogic;
 
@@ -52,7 +54,7 @@ public final class DataBundleLogic {
     void initLogicDependencies(AccountsLogic accountsLogic, AccountRequestsLogic accountRequestsLogic,
             CoursesLogic coursesLogic,
             DeadlineExtensionsLogic deadlineExtensionsLogic, FeedbackSessionsLogic fsLogic,
-            FeedbackQuestionsLogic fqLogic,
+            FeedbackQuestionsLogic fqLogic, FeedbackResponsesLogic frLogic,
             NotificationsLogic notificationsLogic, UsersLogic usersLogic) {
         this.accountsLogic = accountsLogic;
         this.accountRequestsLogic = accountRequestsLogic;
@@ -60,6 +62,7 @@ public final class DataBundleLogic {
         this.deadlineExtensionsLogic = deadlineExtensionsLogic;
         this.fsLogic = fsLogic;
         this.fqLogic = fqLogic;
+        this.frLogic = frLogic;
         this.notificationsLogic = notificationsLogic;
         this.usersLogic = usersLogic;
     }
@@ -83,8 +86,7 @@ public final class DataBundleLogic {
         Collection<Student> students = dataBundle.students.values();
         Collection<FeedbackSession> sessions = dataBundle.feedbackSessions.values();
         Collection<FeedbackQuestion> questions = dataBundle.feedbackQuestions.values();
-        // Collection<FeedbackResponse> responses =
-        // dataBundle.feedbackResponses.values();
+        Collection<FeedbackResponse> responses = dataBundle.feedbackResponses.values();
         // Collection<FeedbackResponseComment> responseComments =
         // dataBundle.feedbackResponseComments.values();
         Collection<DeadlineExtension> deadlineExtensions = dataBundle.deadlineExtensions.values();
@@ -96,7 +98,7 @@ public final class DataBundleLogic {
         Map<UUID, Section> sectionsMap = new HashMap<>();
         Map<UUID, Team> teamsMap = new HashMap<>();
         Map<UUID, FeedbackSession> sessionsMap = new HashMap<>();
-        // Map<UUID, FeedbackQuestion> questionMap = new HashMap<>();
+        Map<UUID, FeedbackQuestion> questionMap = new HashMap<>();
         Map<UUID, Account> accountsMap = new HashMap<>();
         Map<UUID, User> usersMap = new HashMap<>();
         Map<UUID, Notification> notificationsMap = new HashMap<>();
@@ -138,11 +140,21 @@ public final class DataBundleLogic {
         }
 
         for (FeedbackQuestion question : questions) {
-            // UUID placeholderId = question.getId();
+            UUID placeholderId = question.getId();
             question.setId(UUID.randomUUID());
-            // questionMap.put(placeholderId, question);
+            questionMap.put(placeholderId, question);
             FeedbackSession fs = sessionsMap.get(question.getFeedbackSession().getId());
             question.setFeedbackSession(fs);
+        }
+
+        for (FeedbackResponse response : responses) {
+            response.setId(UUID.randomUUID());
+            FeedbackQuestion fq = questionMap.get(response.getFeedbackQuestion().getId());
+            Section giverSection = sectionsMap.get(response.getGiverSection().getId());
+            Section receiverSection = sectionsMap.get(response.getReceiverSection().getId());
+            response.setFeedbackQuestion(fq);
+            response.setGiverSection(giverSection);
+            response.setReceiverSection(receiverSection);
         }
 
         for (Account account : accounts) {
@@ -225,8 +237,7 @@ public final class DataBundleLogic {
         Collection<Student> students = dataBundle.students.values();
         Collection<FeedbackSession> sessions = dataBundle.feedbackSessions.values();
         Collection<FeedbackQuestion> questions = dataBundle.feedbackQuestions.values();
-        // Collection<FeedbackResponse> responses =
-        // dataBundle.feedbackResponses.values();
+        Collection<FeedbackResponse> responses = dataBundle.feedbackResponses.values();
         // Collection<FeedbackResponseComment> responseComments =
         // dataBundle.feedbackResponseComments.values();
         Collection<DeadlineExtension> deadlineExtensions = dataBundle.deadlineExtensions.values();
@@ -258,6 +269,10 @@ public final class DataBundleLogic {
 
         for (FeedbackQuestion question : questions) {
             fqLogic.createFeedbackQuestion(question);
+        }
+
+        for (FeedbackResponse response : responses) {
+            frLogic.createFeedbackResponse(response);
         }
 
         for (Account account : accounts) {

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -36,7 +36,7 @@ public final class FeedbackResponseCommentsLogic {
      * @param id of feedback response comment.
      * @return the specified feedback response comment.
      */
-    public FeedbackResponseComment getFeedbackQuestion(UUID id) {
+    public FeedbackResponseComment getFeedbackResponseComment(Long id) {
         return frcDb.getFeedbackResponseComment(id);
     }
 

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -39,4 +39,12 @@ public final class FeedbackResponseCommentsLogic {
     public FeedbackResponseComment getFeedbackQuestion(UUID id) {
         return frcDb.getFeedbackResponseComment(id);
     }
+
+    /**
+     * Gets the comment associated with the response.
+     */
+    public FeedbackResponseComment getFeedbackResponseCommentForResponseFromParticipant(
+            UUID feedbackResponseId) {
+        return frcDb.getFeedbackResponseCommentForResponseFromParticipant(feedbackResponseId);
+    }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -2,6 +2,8 @@ package teammates.sqllogic.core;
 
 import java.util.UUID;
 
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackResponseCommentsDb;
 import teammates.storage.sqlentity.FeedbackResponseComment;
 
@@ -46,5 +48,15 @@ public final class FeedbackResponseCommentsLogic {
     public FeedbackResponseComment getFeedbackResponseCommentForResponseFromParticipant(
             UUID feedbackResponseId) {
         return frcDb.getFeedbackResponseCommentForResponseFromParticipant(feedbackResponseId);
+    }
+
+    /**
+     * Creates a feedback response comment.
+     * @throws EntityAlreadyExistsException if the comment alreadty exists
+     * @throws InvalidParametersException if the comment is invalid
+     */
+    public FeedbackResponseComment createFeedbackResponseComment(FeedbackResponseComment frc)
+        throws InvalidParametersException, EntityAlreadyExistsException {
+        return frcDb.createFeedbackResponseComment(frc);
     }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -56,7 +56,7 @@ public final class FeedbackResponseCommentsLogic {
      * @throws InvalidParametersException if the comment is invalid
      */
     public FeedbackResponseComment createFeedbackResponseComment(FeedbackResponseComment frc)
-        throws InvalidParametersException, EntityAlreadyExistsException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         return frcDb.createFeedbackResponseComment(frc);
     }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -1,8 +1,18 @@
 package teammates.sqllogic.core;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.SqlCourseRoster;
 import teammates.storage.sqlapi.FeedbackResponsesDb;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 
 /**
  * Handles operations related to feedback sessions.
@@ -14,7 +24,8 @@ public final class FeedbackResponsesLogic {
 
     private static final FeedbackResponsesLogic instance = new FeedbackResponsesLogic();
 
-    // private FeedbackResponsesDb frDb;
+    private FeedbackResponsesDb frDb;
+    private UsersLogic usersLogic;
 
     private FeedbackResponsesLogic() {
         // prevent initialization
@@ -27,8 +38,9 @@ public final class FeedbackResponsesLogic {
     /**
      * Initialize dependencies for {@code FeedbackResponsesLogic}.
      */
-    void initLogicDependencies(FeedbackResponsesDb frDb) {
-        // this.frDb = frDb;
+    void initLogicDependencies(FeedbackResponsesDb frDb, UsersLogic usersLogic) {
+        this.frDb = frDb;
+        this.usersLogic = usersLogic;
     }
 
     /**
@@ -63,5 +75,45 @@ public final class FeedbackResponsesLogic {
      */
     public boolean isResponseOfFeedbackQuestionVisibleToInstructor(FeedbackQuestion question) {
         return question.isResponseVisibleTo(FeedbackParticipantType.INSTRUCTORS);
+    }
+
+    /**
+     * Get existing feedback responses from instructor for the given question.
+     */
+    public List<FeedbackResponse> getFeedbackResponsesFromInstructorForQuestion(
+            FeedbackQuestion question, Instructor instructor) {
+        return frDb.getFeedbackResponsesFromGiverForQuestion(
+                question.getId(), instructor.getEmail());
+    }
+
+    /**
+     * Get existing feedback responses from student or his team for the given
+     * question.
+     */
+    public List<FeedbackResponse> getFeedbackResponsesFromStudentOrTeamForQuestion(
+            FeedbackQuestion question, Student student) {
+        if (question.getGiverType() == FeedbackParticipantType.TEAMS) {
+            return getFeedbackResponsesFromTeamForQuestion(
+                    question.getId(), question.getCourseId(), student.getTeam().getName(), null);
+        }
+        return frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), student.getEmail());
+    }
+
+    private List<FeedbackResponse> getFeedbackResponsesFromTeamForQuestion(
+        UUID feedbackQuestionId, String courseId, String teamName, @Nullable SqlCourseRoster courseRoster) {
+
+        List<FeedbackResponse> responses = new ArrayList<>();
+        List<Student> studentsInTeam = courseRoster == null
+                ? usersLogic.getStudentsForTeam(teamName, courseId) : courseRoster.getTeamToMembersTable().get(teamName);
+
+        for (Student student : studentsInTeam) {
+            responses.addAll(frDb.getFeedbackResponsesFromGiverForQuestion(
+                    feedbackQuestionId, student.getEmail()));
+        }
+
+        responses.addAll(frDb.getFeedbackResponsesFromGiverForQuestion(
+                                        feedbackQuestionId, teamName));
+
+        return responses;
     }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -81,13 +81,12 @@ public final class FeedbackResponsesLogic {
 
     /**
      * Creates a feedback response.
-     * 
      * @return the created response
      * @throws InvalidParametersException if the response is not valid
      * @throws EntityAlreadyExistsException if the response already exist
      */
     public FeedbackResponse createFeedbackResponse(FeedbackResponse feedbackResponse)
-        throws InvalidParametersException, EntityAlreadyExistsException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         return frDb.createFeedbackResponse(feedbackResponse);
     }
 
@@ -114,7 +113,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private List<FeedbackResponse> getFeedbackResponsesFromTeamForQuestion(
-        UUID feedbackQuestionId, String courseId, String teamName, @Nullable SqlCourseRoster courseRoster) {
+            UUID feedbackQuestionId, String courseId, String teamName, @Nullable SqlCourseRoster courseRoster) {
 
         List<FeedbackResponse> responses = new ArrayList<>();
         List<Student> studentsInTeam = courseRoster == null

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -8,6 +8,8 @@ import javax.annotation.Nullable;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.SqlCourseRoster;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackResponsesDb;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
@@ -75,6 +77,18 @@ public final class FeedbackResponsesLogic {
      */
     public boolean isResponseOfFeedbackQuestionVisibleToInstructor(FeedbackQuestion question) {
         return question.isResponseVisibleTo(FeedbackParticipantType.INSTRUCTORS);
+    }
+
+    /**
+     * Creates a feedback response.
+     * 
+     * @return the created response
+     * @throws InvalidParametersException if the response is not valid
+     * @throws EntityAlreadyExistsException if the response already exist
+     */
+    public FeedbackResponse createFeedbackResponse(FeedbackResponse feedbackResponse)
+        throws InvalidParametersException, EntityAlreadyExistsException {
+        return frDb.createFeedbackResponse(feedbackResponse);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -48,7 +48,7 @@ public class LogicStarter implements ServletContextListener {
                 notificationsLogic, usersLogic);
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst());
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), coursesLogic, frLogic, fqLogic);
-        frLogic.initLogicDependencies(FeedbackResponsesDb.inst());
+        frLogic.initLogicDependencies(FeedbackResponsesDb.inst(), usersLogic);
         frcLogic.initLogicDependencies(FeedbackResponseCommentsDb.inst());
         fqLogic.initLogicDependencies(FeedbackQuestionsDb.inst(), coursesLogic, usersLogic);
         notificationsLogic.initLogicDependencies(NotificationsDb.inst());

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -44,7 +44,7 @@ public class LogicStarter implements ServletContextListener {
         accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,
-                deadlineExtensionsLogic, fsLogic, fqLogic, frLogic,
+                deadlineExtensionsLogic, fsLogic, fqLogic, frLogic, frcLogic,
                 notificationsLogic, usersLogic);
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst());
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), coursesLogic, frLogic, fqLogic);

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -44,7 +44,7 @@ public class LogicStarter implements ServletContextListener {
         accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,
-                deadlineExtensionsLogic, fsLogic, fqLogic,
+                deadlineExtensionsLogic, fsLogic, fqLogic, frLogic,
                 notificationsLogic, usersLogic);
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst());
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), coursesLogic, frLogic, fqLogic);

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -51,7 +51,8 @@ public final class FeedbackResponseCommentsDb extends EntitiesDb {
             throw new InvalidParametersException(feedbackResponseComment.getInvalidityInfo());
         }
 
-        if (getFeedbackResponseComment(feedbackResponseComment.getId()) != null) {
+        if (feedbackResponseComment.getId() != null
+            && getFeedbackResponseComment(feedbackResponseComment.getId()) != null) {
             throw new EntityAlreadyExistsException(
                     String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, feedbackResponseComment.toString()));
         }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -4,15 +4,16 @@ import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 
 import java.util.UUID;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.Root;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
 
 /**
  * Handles CRUD operations for feedbackResponseComments.
@@ -52,7 +53,7 @@ public final class FeedbackResponseCommentsDb extends EntitiesDb {
         }
 
         if (feedbackResponseComment.getId() != null
-            && getFeedbackResponseComment(feedbackResponseComment.getId()) != null) {
+                && getFeedbackResponseComment(feedbackResponseComment.getId()) != null) {
             throw new EntityAlreadyExistsException(
                     String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, feedbackResponseComment.toString()));
         }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -34,7 +34,7 @@ public final class FeedbackResponseCommentsDb extends EntitiesDb {
     /**
      * Gets a feedbackResponseComment or null if it does not exist.
      */
-    public FeedbackResponseComment getFeedbackResponseComment(UUID frId) {
+    public FeedbackResponseComment getFeedbackResponseComment(Long frId) {
         assert frId != null;
 
         return HibernateUtil.get(FeedbackResponseComment.class, frId);

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -4,9 +4,14 @@ import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 
 import java.util.UUID;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
 
 /**
@@ -62,6 +67,21 @@ public final class FeedbackResponseCommentsDb extends EntitiesDb {
         if (feedbackResponseComment != null) {
             delete(feedbackResponseComment);
         }
+    }
+
+    /**
+     * Gets the comment associated with the feedback response.
+     */
+    public FeedbackResponseComment getFeedbackResponseCommentForResponseFromParticipant(
+            UUID feedbackResponseId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
+        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
+        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
+        cq.select(root)
+                .where(cb.and(
+                        cb.equal(frJoin.get("id"), feedbackResponseId)));
+        return HibernateUtil.createQuery(cq).getResultStream().findFirst().orElse(null);
     }
 
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -2,11 +2,17 @@ package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 
+import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 /**
@@ -62,6 +68,19 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         if (feedbackResponse != null) {
             delete(feedbackResponse);
         }
+    }
+
+    public List<FeedbackResponse> getFeedbackResponsesFromGiverForQuestion(
+        UUID feedbackQuestionId, String giverEmail) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackResponse> cq = cb.createQuery(FeedbackResponse.class);
+        Root<FeedbackResponse> root = cq.from(FeedbackResponse.class);
+        Join<FeedbackResponse, FeedbackQuestion> frJoin = root.join("feedbackQuestion");
+        cq.select(root)
+                .where(cb.and(
+                        cb.equal(frJoin.get("id"), feedbackQuestionId),
+                        cb.equal(root.get("giver"), giverEmail)));
+        return HibernateUtil.createQuery(cq).getResultList();
     }
 
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -5,15 +5,16 @@ import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.Root;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
 
 /**
  * Handles CRUD operations for feedbackResponses.
@@ -70,8 +71,13 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         }
     }
 
+    /**
+     * Gets the feedback responses for a feedback question.
+     * @param feedbackQuestionId the Id of the feedback question.
+     * @param giverEmail the email of the response giver.
+     */
     public List<FeedbackResponse> getFeedbackResponsesFromGiverForQuestion(
-        UUID feedbackQuestionId, String giverEmail) {
+            UUID feedbackQuestionId, String giverEmail) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackResponse> cq = cb.createQuery(FeedbackResponse.class);
         Root<FeedbackResponse> root = cq.from(FeedbackResponse.class);

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -10,6 +10,15 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 
+import teammates.storage.sqlentity.responses.FeedbackConstantSumResponse;
+import teammates.storage.sqlentity.responses.FeedbackContributionResponse;
+import teammates.storage.sqlentity.responses.FeedbackMcqResponse;
+import teammates.storage.sqlentity.responses.FeedbackMsqResponse;
+import teammates.storage.sqlentity.responses.FeedbackNumericalScaleResponse;
+import teammates.storage.sqlentity.responses.FeedbackRankOptionsResponse;
+import teammates.storage.sqlentity.responses.FeedbackRubricResponse;
+import teammates.storage.sqlentity.responses.FeedbackTextResponse;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -69,6 +78,67 @@ public abstract class FeedbackResponse extends BaseEntity {
         this.setGiverSection(giverSection);
         this.setReceiver(receiver);
         this.setReceiverSection(receiverSection);
+    }
+
+    /**
+     * Creates a feedback response according to its {@code FeedbackQuestionType}.
+     */
+    public static FeedbackResponse makeResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        FeedbackResponse feedbackResponse = null;
+        switch (responseDetails.getQuestionType()) {
+        case TEXT:
+            feedbackResponse = new FeedbackTextResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case MCQ:
+            feedbackResponse = new FeedbackMcqResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case MSQ:
+            feedbackResponse = new FeedbackMsqResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case NUMSCALE:
+            feedbackResponse = new FeedbackNumericalScaleResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case CONSTSUM:
+        case CONSTSUM_OPTIONS:
+        case CONSTSUM_RECIPIENTS:
+            feedbackResponse = new FeedbackConstantSumResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case CONTRIB:
+            feedbackResponse = new FeedbackContributionResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case RUBRIC:
+            feedbackResponse = new FeedbackRubricResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case RANK_OPTIONS:
+            feedbackResponse = new FeedbackRankOptionsResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        case RANK_RECIPIENTS:
+            feedbackResponse = new FeedbackContributionResponse(
+                feedbackQuestion, giver, giverSection, receiver, receiverSection, responseDetails
+            );
+            break;
+        }
+        return feedbackResponse;
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -8,12 +8,10 @@ import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
-import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
@@ -36,10 +34,6 @@ public abstract class FeedbackResponse extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "questionId")
     private FeedbackQuestion feedbackQuestion;
-
-    @Column(nullable = false)
-    @Convert(converter = FeedbackQuestionTypeConverter.class)
-    private FeedbackQuestionType type;
 
     @OneToMany(mappedBy = "feedbackResponse", cascade = CascadeType.REMOVE)
     private List<FeedbackResponseComment> feedbackResponseComments = new ArrayList<>();
@@ -66,12 +60,11 @@ public abstract class FeedbackResponse extends BaseEntity {
     }
 
     public FeedbackResponse(
-            FeedbackQuestion feedbackQuestion, FeedbackQuestionType type, String giver,
+            FeedbackQuestion feedbackQuestion, String giver,
             Section giverSection, String receiver, Section receiverSection
     ) {
         this.setId(UUID.randomUUID());
         this.setFeedbackQuestion(feedbackQuestion);
-        this.setFeedbackQuestionType(type);
         this.setGiver(giver);
         this.setGiverSection(giverSection);
         this.setReceiver(receiver);
@@ -97,14 +90,6 @@ public abstract class FeedbackResponse extends BaseEntity {
 
     public void setFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
         this.feedbackQuestion = feedbackQuestion;
-    }
-
-    public FeedbackQuestionType getFeedbackQuestionType() {
-        return type;
-    }
-
-    public void setFeedbackQuestionType(FeedbackQuestionType type) {
-        this.type = type;
     }
 
     public List<FeedbackResponseComment> getFeedbackResponseComments() {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -84,9 +84,9 @@ public abstract class FeedbackResponse extends BaseEntity {
      * Creates a feedback response according to its {@code FeedbackQuestionType}.
      */
     public static FeedbackResponse makeResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         FeedbackResponse feedbackResponse = null;
         switch (responseDetails.getQuestionType()) {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -76,6 +77,11 @@ public abstract class FeedbackResponse extends BaseEntity {
         this.setReceiver(receiver);
         this.setReceiverSection(receiverSection);
     }
+
+    /**
+     * Gets a copy of the question details of the feedback question.
+     */
+    public abstract FeedbackResponseDetails getFeedbackResponseDetailsCopy();
 
     public UUID getId() {
         return id;

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
-
 import teammates.storage.sqlentity.responses.FeedbackConstantSumResponse;
 import teammates.storage.sqlentity.responses.FeedbackContributionResponse;
 import teammates.storage.sqlentity.responses.FeedbackMcqResponse;

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -55,11 +55,11 @@ public abstract class FeedbackResponse extends BaseEntity {
     private Section giverSection;
 
     @Column(nullable = false)
-    private String receiver;
+    private String recipient;
 
     @ManyToOne
-    @JoinColumn(name = "receiverSectionId")
-    private Section receiverSection;
+    @JoinColumn(name = "recipientSectionId")
+    private Section recipientSection;
 
     @UpdateTimestamp
     private Instant updatedAt;
@@ -70,14 +70,14 @@ public abstract class FeedbackResponse extends BaseEntity {
 
     public FeedbackResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection
+            Section giverSection, String recipient, Section recipientSection
     ) {
         this.setId(UUID.randomUUID());
         this.setFeedbackQuestion(feedbackQuestion);
         this.setGiver(giver);
         this.setGiverSection(giverSection);
-        this.setReceiver(receiver);
-        this.setReceiverSection(receiverSection);
+        this.setRecipient(recipient);
+        this.setRecipientSection(recipientSection);
     }
 
     /**
@@ -186,20 +186,20 @@ public abstract class FeedbackResponse extends BaseEntity {
         this.giverSection = giverSection;
     }
 
-    public String getReceiver() {
-        return receiver;
+    public String getRecipient() {
+        return recipient;
     }
 
-    public void setReceiver(String receiver) {
-        this.receiver = receiver;
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
     }
 
-    public Section getReceiverSection() {
-        return receiverSection;
+    public Section getRecipientSection() {
+        return recipientSection;
     }
 
-    public void setReceiverSection(Section receiverSection) {
-        this.receiverSection = receiverSection;
+    public void setRecipientSection(Section recipientSection) {
+        this.recipientSection = recipientSection;
     }
 
     public Instant getUpdatedAt() {
@@ -217,7 +217,7 @@ public abstract class FeedbackResponse extends BaseEntity {
 
     @Override
     public String toString() {
-        return "FeedbackResponse [id=" + id + ", giver=" + giver + ", receiver=" + receiver
+        return "FeedbackResponse [id=" + id + ", giver=" + giver + ", recipient=" + recipient
                 + ", createdAt=" + getCreatedAt() + ", updatedAt=" + updatedAt + "]";
     }
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,6 +13,7 @@ import teammates.common.util.FieldValidator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,7 +26,8 @@ import jakarta.persistence.Table;
 @Table(name = "FeedbackResponseComments")
 public class FeedbackResponseComment extends BaseEntity {
     @Id
-    private UUID id;
+    @GeneratedValue
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "responseId")
@@ -44,8 +45,8 @@ public class FeedbackResponseComment extends BaseEntity {
     private Section giverSection;
 
     @ManyToOne
-    @JoinColumn(name = "receiverSectionId")
-    private Section receiverSection;
+    @JoinColumn(name = "recipientSectionId")
+    private Section recipientSection;
 
     @Column(nullable = false)
     private String commentText;
@@ -76,17 +77,16 @@ public class FeedbackResponseComment extends BaseEntity {
 
     public FeedbackResponseComment(
             FeedbackResponse feedbackResponse, String giver, FeedbackParticipantType giverType,
-            Section giverSection, Section receiverSection, String commentText,
+            Section giverSection, Section recipientSection, String commentText,
             boolean isVisibilityFollowingFeedbackQuestion, boolean isCommentFromFeedbackParticipant,
             List<FeedbackParticipantType> showCommentTo, List<FeedbackParticipantType> showGiverNameTo,
             String lastEditorEmail
     ) {
-        this.setId(UUID.randomUUID());
         this.setFeedbackResponse(feedbackResponse);
         this.setGiver(giver);
         this.setGiverType(giverType);
         this.setGiverSection(giverSection);
-        this.setReceiverSection(receiverSection);
+        this.setRecipientSection(recipientSection);
         this.setCommentText(commentText);
         this.setIsVisibilityFollowingFeedbackQuestion(isVisibilityFollowingFeedbackQuestion);
         this.setIsCommentFromFeedbackParticipant(isCommentFromFeedbackParticipant);
@@ -95,11 +95,11 @@ public class FeedbackResponseComment extends BaseEntity {
         this.setLastEditorEmail(lastEditorEmail);
     }
 
-    public UUID getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(UUID id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
@@ -135,12 +135,12 @@ public class FeedbackResponseComment extends BaseEntity {
         this.giverSection = giverSection;
     }
 
-    public Section getReceiverSection() {
-        return receiverSection;
+    public Section getRecipientSection() {
+        return recipientSection;
     }
 
-    public void setReceiverSection(Section receiverSection) {
-        this.receiverSection = receiverSection;
+    public void setRecipientSection(Section recipientSection) {
+        this.recipientSection = recipientSection;
     }
 
     public String getCommentText() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -26,9 +26,9 @@ public class FeedbackConstantSumResponse extends FeedbackResponse {
     }
 
     public FeedbackConstantSumResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackConstantSumResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -2,7 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackConstantSumResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,6 +23,15 @@ public class FeedbackConstantSumResponse extends FeedbackResponse {
 
     protected FeedbackConstantSumResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackConstantSumResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackConstantSumResponseDetails) responseDetails);
     }
 
     public FeedbackConstantSumResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackConstantSumResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -28,6 +29,11 @@ public class FeedbackConstantSumResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackConstantSumResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -27,10 +27,10 @@ public class FeedbackConstantSumResponse extends FeedbackResponse {
 
     public FeedbackConstantSumResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackConstantSumResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -1,7 +1,10 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackContributionResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -20,6 +23,15 @@ public class FeedbackContributionResponse extends FeedbackResponse {
 
     protected FeedbackContributionResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackContributionResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackContributionResponseDetails) responseDetails);
     }
 
     public FeedbackContributionResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -31,6 +31,11 @@ public class FeedbackContributionResponse extends FeedbackResponse {
     }
 
     @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
+    }
+
+    @Override
     public String toString() {
         return "FeedbackContributionResponse [id=" + super.getId()
             + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -26,9 +26,9 @@ public class FeedbackContributionResponse extends FeedbackResponse {
     }
 
     public FeedbackContributionResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackContributionResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -27,10 +27,10 @@ public class FeedbackContributionResponse extends FeedbackResponse {
 
     public FeedbackContributionResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackContributionResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -31,6 +31,11 @@ public class FeedbackMcqResponse extends FeedbackResponse {
     }
 
     @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
+    }
+
+    @Override
     public String toString() {
         return "FeedbackMcqResponse [id=" + super.getId()
             + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -26,9 +26,9 @@ public class FeedbackMcqResponse extends FeedbackResponse {
     }
 
     public FeedbackMcqResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackMcqResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -27,10 +27,10 @@ public class FeedbackMcqResponse extends FeedbackResponse {
 
     public FeedbackMcqResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackMcqResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -1,7 +1,10 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackMcqResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -20,6 +23,15 @@ public class FeedbackMcqResponse extends FeedbackResponse {
 
     protected FeedbackMcqResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackMcqResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackMcqResponseDetails) responseDetails);
     }
 
     public FeedbackMcqResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackMsqResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -28,6 +29,11 @@ public class FeedbackMsqResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackMsqResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -26,9 +26,9 @@ public class FeedbackMsqResponse extends FeedbackResponse {
     }
 
     public FeedbackMsqResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackMsqResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -2,7 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackMsqResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,6 +23,15 @@ public class FeedbackMsqResponse extends FeedbackResponse {
 
     protected FeedbackMsqResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackMsqResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackMsqResponseDetails) responseDetails);
     }
 
     public FeedbackMsqResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -27,10 +27,10 @@ public class FeedbackMsqResponse extends FeedbackResponse {
 
     public FeedbackMsqResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackMsqResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -2,7 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,6 +23,15 @@ public class FeedbackNumericalScaleResponse extends FeedbackResponse {
 
     protected FeedbackNumericalScaleResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackNumericalScaleResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackNumericalScaleResponseDetails) responseDetails);
     }
 
     public FeedbackNumericalScaleResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -26,9 +26,9 @@ public class FeedbackNumericalScaleResponse extends FeedbackResponse {
     }
 
     public FeedbackNumericalScaleResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackNumericalScaleResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -28,6 +29,11 @@ public class FeedbackNumericalScaleResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackNumericalScaleResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -27,10 +27,10 @@ public class FeedbackNumericalScaleResponse extends FeedbackResponse {
 
     public FeedbackNumericalScaleResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackNumericalScaleResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -2,7 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackRankOptionsResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,6 +23,15 @@ public class FeedbackRankOptionsResponse extends FeedbackResponse {
 
     protected FeedbackRankOptionsResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackRankOptionsResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackRankOptionsResponseDetails) responseDetails);
     }
 
     public FeedbackRankOptionsResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -26,9 +26,9 @@ public class FeedbackRankOptionsResponse extends FeedbackResponse {
     }
 
     public FeedbackRankOptionsResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackRankOptionsResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackRankOptionsResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -28,6 +29,11 @@ public class FeedbackRankOptionsResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackRankOptionsResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -27,10 +27,10 @@ public class FeedbackRankOptionsResponse extends FeedbackResponse {
 
     public FeedbackRankOptionsResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackRankOptionsResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -26,9 +26,9 @@ public class FeedbackRankRecipientsResponse extends FeedbackResponse {
     }
 
     public FeedbackRankRecipientsResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackRankRecipientsResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -2,7 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackRankRecipientsResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Section;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,6 +23,15 @@ public class FeedbackRankRecipientsResponse extends FeedbackResponse {
 
     protected FeedbackRankRecipientsResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackRankRecipientsResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackRankRecipientsResponseDetails) responseDetails);
     }
 
     public FeedbackRankRecipientsResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -1,6 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackRankRecipientsResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -28,6 +29,11 @@ public class FeedbackRankRecipientsResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackRankRecipientsResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -27,10 +27,10 @@ public class FeedbackRankRecipientsResponse extends FeedbackResponse {
 
     public FeedbackRankRecipientsResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackRankRecipientsResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -2,8 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackRubricResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
-
+import teammates.storage.sqlentity.Section;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -21,6 +22,15 @@ public class FeedbackRubricResponse extends FeedbackResponse {
 
     protected FeedbackRubricResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackRubricResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer((FeedbackRubricResponseDetails) responseDetails);
     }
 
     public FeedbackRubricResponseDetails getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -5,6 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackRubricResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -25,9 +26,9 @@ public class FeedbackRubricResponse extends FeedbackResponse {
     }
 
     public FeedbackRubricResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackRubricResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -27,10 +27,10 @@ public class FeedbackRubricResponse extends FeedbackResponse {
 
     public FeedbackRubricResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackRubricResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -1,5 +1,6 @@
 package teammates.storage.sqlentity.responses;
 
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackRubricResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
@@ -28,6 +29,11 @@ public class FeedbackRubricResponse extends FeedbackResponse {
 
     public void setAnswer(FeedbackRubricResponseDetails answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return answer.getDeepCopy();
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -26,9 +26,9 @@ public class FeedbackTextResponse extends FeedbackResponse {
     }
 
     public FeedbackTextResponse(
-        FeedbackQuestion feedbackQuestion, String giver,
-        Section giverSection, String receiver, Section receiverSection,
-        FeedbackResponseDetails responseDetails
+            FeedbackQuestion feedbackQuestion, String giver,
+            Section giverSection, String receiver, Section receiverSection,
+            FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
         this.setAnswer((FeedbackTextResponseDetails) responseDetails);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -1,5 +1,7 @@
 package teammates.storage.sqlentity.responses;
 
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.storage.sqlentity.FeedbackResponse;
 
 import jakarta.persistence.Column;
@@ -24,6 +26,11 @@ public class FeedbackTextResponse extends FeedbackResponse {
 
     public void setAnswer(String answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
+        return new FeedbackTextResponseDetails(answer);
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -2,8 +2,9 @@ package teammates.storage.sqlentity.responses;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
-
+import teammates.storage.sqlentity.Section;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 
@@ -18,6 +19,15 @@ public class FeedbackTextResponse extends FeedbackResponse {
 
     protected FeedbackTextResponse() {
         // required by Hibernate
+    }
+
+    public FeedbackTextResponse(
+        FeedbackQuestion feedbackQuestion, String giver,
+        Section giverSection, String receiver, Section receiverSection,
+        FeedbackResponseDetails responseDetails
+    ) {
+        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        this.setAnswer(((FeedbackTextResponseDetails) responseDetails).getAnswer());
     }
 
     public String getAnswer() {

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -27,10 +27,10 @@ public class FeedbackTextResponse extends FeedbackResponse {
 
     public FeedbackTextResponse(
             FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            Section giverSection, String recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
-        super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
+        super(feedbackQuestion, giver, giverSection, recipient, recipientSection);
         this.setAnswer((FeedbackTextResponseDetails) responseDetails);
     }
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -5,7 +5,10 @@ import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Converter;
 import jakarta.persistence.Entity;
 
 /**
@@ -15,7 +18,8 @@ import jakarta.persistence.Entity;
 public class FeedbackTextResponse extends FeedbackResponse {
 
     @Column(nullable = false)
-    private String answer;
+    @Convert(converter = FeedbackTextResponseDetailsConverter.class)
+    private FeedbackTextResponseDetails answer;
 
     protected FeedbackTextResponse() {
         // required by Hibernate
@@ -27,25 +31,33 @@ public class FeedbackTextResponse extends FeedbackResponse {
         FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, receiver, receiverSection);
-        this.setAnswer(((FeedbackTextResponseDetails) responseDetails).getAnswer());
+        this.setAnswer((FeedbackTextResponseDetails) responseDetails);
     }
 
-    public String getAnswer() {
+    public FeedbackTextResponseDetails getAnswer() {
         return answer;
     }
 
-    public void setAnswer(String answer) {
+    public void setAnswer(FeedbackTextResponseDetails answer) {
         this.answer = answer;
     }
 
     @Override
     public FeedbackResponseDetails getFeedbackResponseDetailsCopy() {
-        return new FeedbackTextResponseDetails(answer);
+        return answer;
     }
 
     @Override
     public String toString() {
         return "FeedbackTextResponse [id=" + super.getId()
             + ", createdAt=" + super.getCreatedAt() + ", updatedAt=" + super.getUpdatedAt() + "]";
+    }
+
+    /**
+     * Converter for FeedbackMcqResponse specific attributes.
+     */
+    @Converter
+    public static class FeedbackTextResponseDetailsConverter
+            extends FeedbackResponseDetailsConverter {
     }
 }

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.storage.sqlentity.FeedbackResponseComment;
 
 /**
  * The API output format of {@link teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes}.
@@ -33,6 +34,18 @@ public class FeedbackResponseCommentData extends ApiOutput {
         this.lastEditedAt = frc.getLastEditedAt().toEpochMilli();
         this.lastEditorEmail = frc.getLastEditorEmail();
         this.isVisibilityFollowingFeedbackQuestion = frc.isVisibilityFollowingFeedbackQuestion();
+    }
+
+    public FeedbackResponseCommentData(FeedbackResponseComment frc) {
+        this.feedbackResponseCommentId = frc.getId();
+        this.commentText = frc.getCommentText();
+        this.commentGiver = frc.getGiver();
+        this.showGiverNameTo = convertToFeedbackVisibilityType(frc.getShowGiverNameTo());
+        this.showCommentTo = convertToFeedbackVisibilityType(frc.getShowCommentTo());
+        this.createdAt = frc.getCreatedAt().toEpochMilli();
+        this.lastEditedAt = frc.getUpdatedAt().toEpochMilli();
+        this.lastEditorEmail = frc.getLastEditorEmail();
+        this.isVisibilityFollowingFeedbackQuestion = frc.getIsVisibilityFollowingFeedbackQuestion();
     }
 
     /**

--- a/src/main/java/teammates/ui/output/FeedbackResponseData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseData.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.util.StringHelper;
+import teammates.storage.sqlentity.FeedbackResponse;
 
 /**
  * The API output format of {@link FeedbackResponseAttributes}.
@@ -27,6 +28,13 @@ public class FeedbackResponseData extends ApiOutput {
         this.giverIdentifier = feedbackResponseAttributes.getGiver();
         this.recipientIdentifier = feedbackResponseAttributes.getRecipient();
         this.responseDetails = feedbackResponseAttributes.getResponseDetailsCopy();
+    }
+
+    public FeedbackResponseData(FeedbackResponse feedbackResponse) {
+        this.feedbackResponseId = feedbackResponse.getId().toString();
+        this.giverIdentifier = feedbackResponse.getGiver();
+        this.recipientIdentifier = feedbackResponse.getReceiver();
+        this.responseDetails = feedbackResponse.getFeedbackResponseDetailsCopy();
     }
 
     public String getFeedbackResponseId() {

--- a/src/main/java/teammates/ui/output/FeedbackResponseData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseData.java
@@ -33,7 +33,7 @@ public class FeedbackResponseData extends ApiOutput {
     public FeedbackResponseData(FeedbackResponse feedbackResponse) {
         this.feedbackResponseId = feedbackResponse.getId().toString();
         this.giverIdentifier = feedbackResponse.getGiver();
-        this.recipientIdentifier = feedbackResponse.getReceiver();
+        this.recipientIdentifier = feedbackResponse.getRecipient();
         this.responseDetails = feedbackResponse.getFeedbackResponseDetailsCopy();
     }
 

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
@@ -94,12 +94,10 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
             switch (intent) {
             case STUDENT_SUBMISSION:
                 StudentAttributes studentAttributes = getStudentOfCourseFromRequest(question.getCourseId());
-
                 recipient = logic.getRecipientsOfQuestion(question, null, studentAttributes);
                 break;
             case INSTRUCTOR_SUBMISSION:
                 InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(question.getCourseId());
-
                 recipient = logic.getRecipientsOfQuestion(question, instructorAttributes, null);
                 break;
             default:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
@@ -31,8 +31,30 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        FeedbackQuestionAttributes feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+
+        FeedbackQuestionAttributes feedbackQuestion = null;
+        FeedbackQuestion sqlFeedbackQuestion = null;
+        String courseId;
+
+        UUID feedbackQuestionSqlId;
+
+        try {
+            feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+            sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
+        } catch (InvalidHttpParameterException verifyHttpParameterFailure) {
+            // if the question id cannot be converted to UUID, we check the datastore for the question
+            feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        }
+
         if (feedbackQuestion != null) {
+            courseId = feedbackQuestion.getCourseId();
+        } else if (sqlFeedbackQuestion != null) {
+            courseId = sqlFeedbackQuestion.getCourseId();
+        } else {
+            throw new EntityNotFoundException("Feedback Question not found");
+        }
+
+        if (!isCourseMigrated(courseId)) {
             verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
 
             Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
@@ -53,12 +75,6 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
                 throw new InvalidHttpParameterException("Unknown intent " + intent);
             }
             return;
-        }
-
-        UUID feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        FeedbackQuestion sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
-        if (sqlFeedbackQuestion == null) {
-            throw new EntityNotFoundException("The feedback question does not exist.");
         }
 
         verifyInstructorCanSeeQuestionIfInModeration(sqlFeedbackQuestion);
@@ -86,10 +102,31 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
     @Override
     public JsonResult execute() {
         String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
-        FeedbackQuestionAttributes question = logic.getFeedbackQuestion(feedbackQuestionId);
+        FeedbackQuestionAttributes question = null;
+        FeedbackQuestion sqlFeedbackQuestion = null;
+        String courseId;
+
+        UUID feedbackQuestionSqlId;
+
+        try {
+            feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+            sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
+        } catch (InvalidHttpParameterException verifyHttpParameterFailure) {
+            // if the question id cannot be converted to UUID, we check the datastore for the question
+            question = logic.getFeedbackQuestion(feedbackQuestionId);
+        }
 
         if (question != null) {
+            courseId = question.getCourseId();
+        } else if (sqlFeedbackQuestion != null) {
+            courseId = sqlFeedbackQuestion.getCourseId();
+        } else {
+            throw new EntityNotFoundException("Feedback Question not found");
+        }
+
+        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
+
+        if (!isCourseMigrated(courseId)) {
             Map<String, FeedbackQuestionRecipient> recipient;
             switch (intent) {
             case STUDENT_SUBMISSION:
@@ -106,10 +143,7 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
             return new JsonResult(new FeedbackQuestionRecipientsData(recipient));
         }
 
-        UUID feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        FeedbackQuestion sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
         Map<String, FeedbackQuestionRecipient> recipient;
-        String courseId = sqlFeedbackQuestion.getCourseId();
         switch (intent) {
         case STUDENT_SUBMISSION:
             Student student = getSqlStudentOfCourseFromRequest(courseId);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -11,6 +12,12 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 import teammates.ui.output.FeedbackResponseCommentData;
 import teammates.ui.output.FeedbackResponseData;
 import teammates.ui.output.FeedbackResponsesData;
@@ -30,11 +37,41 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
         FeedbackQuestionAttributes feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-        if (feedbackQuestion == null) {
+
+        if (feedbackQuestion != null) {
+            FeedbackSessionAttributes feedbackSession =
+                    getNonNullFeedbackSession(feedbackQuestion.getFeedbackSessionName(), feedbackQuestion.getCourseId());
+
+            verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
+            verifyNotPreview();
+
+            Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
+            switch (intent) {
+            case STUDENT_SUBMISSION:
+                gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
+                StudentAttributes studentAttributes = getStudentOfCourseFromRequest(feedbackSession.getCourseId());
+                checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSession);
+                break;
+            case INSTRUCTOR_SUBMISSION:
+                gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
+                InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(feedbackSession.getCourseId());
+                checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSession);
+                break;
+            default:
+                throw new InvalidHttpParameterException("Unknown intent " + intent);
+            }
+            return;
+        }
+
+        UUID feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        FeedbackQuestion sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
+        if (sqlFeedbackQuestion == null) {
             throw new EntityNotFoundException("The feedback question does not exist.");
         }
-        FeedbackSessionAttributes feedbackSession =
-                getNonNullFeedbackSession(feedbackQuestion.getFeedbackSessionName(), feedbackQuestion.getCourseId());
+
+        FeedbackSession feedbackSession =
+                getNonNullSqlFeedbackSession(sqlFeedbackQuestion.getFeedbackSession().getName(),
+                                                sqlFeedbackQuestion.getCourseId());
 
         verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
         verifyNotPreview();
@@ -43,13 +80,13 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         switch (intent) {
         case STUDENT_SUBMISSION:
             gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
-            StudentAttributes studentAttributes = getStudentOfCourseFromRequest(feedbackSession.getCourseId());
-            checkAccessControlForStudentFeedbackSubmission(studentAttributes, feedbackSession);
+            Student student = getSqlStudentOfCourseFromRequest(feedbackSession.getCourse().getId());
+            checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
             gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
-            InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(feedbackSession.getCourseId());
-            checkAccessControlForInstructorFeedbackSubmission(instructorAttributes, feedbackSession);
+            Instructor instructor = getSqlInstructorOfCourseFromRequest(feedbackSession.getCourse().getId());
+            checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
@@ -62,16 +99,59 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         FeedbackQuestionAttributes questionAttributes = logic.getFeedbackQuestion(feedbackQuestionId);
 
-        List<FeedbackResponseAttributes> responses;
+        if (questionAttributes != null) {
+            List<FeedbackResponseAttributes> responses;
+            switch (intent) {
+            case STUDENT_SUBMISSION:
+                StudentAttributes studentAttributes = getStudentOfCourseFromRequest(questionAttributes.getCourseId());
+                responses = logic.getFeedbackResponsesFromStudentOrTeamForQuestion(questionAttributes, studentAttributes);
+                break;
+            case INSTRUCTOR_SUBMISSION:
+                InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(questionAttributes.getCourseId());
+                responses = logic.getFeedbackResponsesFromInstructorForQuestion(questionAttributes, instructorAttributes);
+                break;
+            default:
+                throw new InvalidHttpParameterException("Unknown intent " + intent);
+            }
+    
+            List<FeedbackResponseData> responsesData = new LinkedList<>();
+            responses.forEach(response -> {
+                FeedbackResponseData data = new FeedbackResponseData(response);
+                if (questionAttributes.getQuestionType() == FeedbackQuestionType.MCQ
+                        || questionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
+                    // Only MCQ and MSQ questions can have participant comment
+                    FeedbackResponseCommentAttributes comment =
+                            logic.getFeedbackResponseCommentForResponseFromParticipant(response.getId());
+                    if (comment != null) {
+                        data.setGiverComment(new FeedbackResponseCommentData(comment));
+                    }
+                }
+                responsesData.add(data);
+            });
+            FeedbackResponsesData result = new FeedbackResponsesData();
+            if (!responsesData.isEmpty()) {
+                result.setResponses(responsesData);
+            }
+    
+            return new JsonResult(result);
+        }
+
+        UUID feedbackQuestionSqlId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        FeedbackQuestion sqlFeedbackQuestion = sqlLogic.getFeedbackQuestion(feedbackQuestionSqlId);
+
+        if (sqlFeedbackQuestion == null) {
+            throw new EntityNotFoundException("The feedback question does not exist.");
+        }
+
+        List<FeedbackResponse> responses;
         switch (intent) {
         case STUDENT_SUBMISSION:
-            StudentAttributes studentAttributes = getStudentOfCourseFromRequest(questionAttributes.getCourseId());
-            responses = logic.getFeedbackResponsesFromStudentOrTeamForQuestion(questionAttributes, studentAttributes);
+            Student student = getSqlStudentOfCourseFromRequest(sqlFeedbackQuestion.getCourseId());
+            responses = sqlLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(sqlFeedbackQuestion, student);
             break;
         case INSTRUCTOR_SUBMISSION:
-            InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(questionAttributes.getCourseId());
-            responses = logic.getFeedbackResponsesFromInstructorForQuestion(questionAttributes, instructorAttributes);
-            break;
+            Instructor instructor = getSqlInstructorOfCourseFromRequest(sqlFeedbackQuestion.getCourseId());
+            responses = sqlLogic.getFeedbackResponsesFromInstructorForQuestion(sqlFeedbackQuestion, instructor);
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
@@ -79,11 +159,11 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         List<FeedbackResponseData> responsesData = new LinkedList<>();
         responses.forEach(response -> {
             FeedbackResponseData data = new FeedbackResponseData(response);
-            if (questionAttributes.getQuestionType() == FeedbackQuestionType.MCQ
-                    || questionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
+            if (sqlFeedbackQuestion.getQuestionDetailsCopy().getQuestionType() == FeedbackQuestionType.MCQ
+                    || sqlFeedbackQuestion.getQuestionDetailsCopy().getQuestionType() == FeedbackQuestionType.MSQ) {
                 // Only MCQ and MSQ questions can have participant comment
-                FeedbackResponseCommentAttributes comment =
-                        logic.getFeedbackResponseCommentForResponseFromParticipant(response.getId());
+                FeedbackResponseComment comment =
+                        sqlLogic.getFeedbackResponseCommentForResponseFromParticipant(response.getId());
                 if (comment != null) {
                     data.setGiverComment(new FeedbackResponseCommentData(comment));
                 }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -118,14 +118,16 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
             List<FeedbackResponseData> responsesData = new LinkedList<>();
             responses.forEach(response -> {
                 FeedbackResponseData data = new FeedbackResponseData(response);
-                if (questionAttributes.getQuestionType() == FeedbackQuestionType.MCQ
-                        || questionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
-                    // Only MCQ and MSQ questions can have participant comment
-                    FeedbackResponseCommentAttributes comment =
-                            logic.getFeedbackResponseCommentForResponseFromParticipant(response.getId());
-                    if (comment != null) {
-                        data.setGiverComment(new FeedbackResponseCommentData(comment));
-                    }
+                if (questionAttributes.getQuestionType() != FeedbackQuestionType.MCQ
+                        || questionAttributes.getQuestionType() != FeedbackQuestionType.MSQ) {
+                    responsesData.add(data);
+                    return;
+                }
+                // Only MCQ and MSQ questions can have participant comment
+                FeedbackResponseCommentAttributes comment =
+                        logic.getFeedbackResponseCommentForResponseFromParticipant(response.getId());
+                if (comment != null) {
+                    data.setGiverComment(new FeedbackResponseCommentData(comment));
                 }
                 responsesData.add(data);
             });

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -107,13 +107,14 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
                 responses = logic.getFeedbackResponsesFromStudentOrTeamForQuestion(questionAttributes, studentAttributes);
                 break;
             case INSTRUCTOR_SUBMISSION:
-                InstructorAttributes instructorAttributes = getInstructorOfCourseFromRequest(questionAttributes.getCourseId());
+                InstructorAttributes instructorAttributes =
+                        getInstructorOfCourseFromRequest(questionAttributes.getCourseId());
                 responses = logic.getFeedbackResponsesFromInstructorForQuestion(questionAttributes, instructorAttributes);
                 break;
             default:
                 throw new InvalidHttpParameterException("Unknown intent " + intent);
             }
-    
+
             List<FeedbackResponseData> responsesData = new LinkedList<>();
             responses.forEach(response -> {
                 FeedbackResponseData data = new FeedbackResponseData(response);
@@ -132,7 +133,7 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
             if (!responsesData.isEmpty()) {
                 result.setResponses(responsesData);
             }
-    
+
             return new JsonResult(result);
         }
 
@@ -152,6 +153,7 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         case INSTRUCTOR_SUBMISSION:
             Instructor instructor = getSqlInstructorOfCourseFromRequest(sqlFeedbackQuestion.getCourseId());
             responses = sqlLogic.getFeedbackResponsesFromInstructorForQuestion(sqlFeedbackQuestion, instructor);
+            break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -119,7 +119,7 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
             responses.forEach(response -> {
                 FeedbackResponseData data = new FeedbackResponseData(response);
                 if (questionAttributes.getQuestionType() != FeedbackQuestionType.MCQ
-                        || questionAttributes.getQuestionType() != FeedbackQuestionType.MSQ) {
+                        && questionAttributes.getQuestionType() != FeedbackQuestionType.MSQ) {
                     responsesData.add(data);
                     return;
                 }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -73,18 +73,18 @@ class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
                 getNonNullSqlFeedbackSession(sqlFeedbackQuestion.getFeedbackSession().getName(),
                                                 sqlFeedbackQuestion.getCourseId());
 
-        verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
+        verifyInstructorCanSeeQuestionIfInModeration(sqlFeedbackQuestion);
         verifyNotPreview();
 
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         switch (intent) {
         case STUDENT_SUBMISSION:
-            gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
+            gateKeeper.verifyAnswerableForStudent(sqlFeedbackQuestion);
             Student student = getSqlStudentOfCourseFromRequest(feedbackSession.getCourse().getId());
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-            gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
+            gateKeeper.verifyAnswerableForInstructor(sqlFeedbackQuestion);
             Instructor instructor = getSqlInstructorOfCourseFromRequest(feedbackSession.getCourse().getId());
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -229,7 +229,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "randomNonExistId",
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
-        verifyHttpParameterFailureAcl(nonExistParams);
+        verifyEntityNotFoundAcl(nonExistParams);
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -229,7 +229,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "randomNonExistId",
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
-        verifyEntityNotFoundAcl(nonExistParams);
+        verifyHttpParameterFailureAcl(nonExistParams);
     }
 
     @Test


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
- Created factory method for `FeedbackResponse`, similar to `FeedbackQuestion`
- Changed `receiver` to `recipient` and `receiverSection` to `recipientSection` in `FeedbackResponse` and `FeedbackResponseComment`
- Added `FeedbackResponse` and `FeedbackResponseComments` to data bundle
- Added `getFeedbackResponsesFromGiverForQuestion` in `FeedbackResponsesDb`
- Added  `getFeedbackResponseCommentForResponseFromParticipant` in `FeedbackresponseCommentsDb`
