### PR TITLE
[#12238] Instructors editing session dates: disable calendar popup if the form is not in edit mode

### DIFF
--- a/src/web/app/components/datepicker/datepicker.component.html
+++ b/src/web/app/components/datepicker/datepicker.component.html
@@ -8,7 +8,7 @@
   <input type="text" class="form-control" ngbDatepicker readonly
          [ngModel]="date" (ngModelChange)="changeDate($event)" aria-label="Date"
          [maxDate]="maxDate" [minDate]="minDate" #timeDp="ngbDatepicker" [disabled]="isDisabled" [footerTemplate]="footer"/>
-  <button class="btn btn-light input-group-text" aria-label="Change date" (click)="timeDp.toggle()" type="button">
+  <button class="btn btn-light input-group-text" aria-label="Change date" (click)="timeDp.toggle()" type="button" [disabled]="isDisabled">
     <i class="fas fa-calendar-alt"></i>
   </button>
 </div>

--- a/src/web/app/components/datepicker/datepicker.component.html
+++ b/src/web/app/components/datepicker/datepicker.component.html
@@ -7,7 +7,7 @@
   </ng-template>
   <input type="text" class="form-control" ngbDatepicker readonly
          [ngModel]="date" (ngModelChange)="changeDate($event)" aria-label="Date"
-         [maxDate]="maxDate" [minDate]="minDate" #timeDp="ngbDatepicker" [disabled]="disabled" [footerTemplate]="footer"/>
+         [maxDate]="maxDate" [minDate]="minDate" #timeDp="ngbDatepicker" [disabled]="isDisabled" [footerTemplate]="footer"/>
   <button class="btn btn-light input-group-text" aria-label="Change date" (click)="timeDp.toggle()" type="button">
     <i class="fas fa-calendar-alt"></i>
   </button>

--- a/src/web/app/components/datepicker/datepicker.component.ts
+++ b/src/web/app/components/datepicker/datepicker.component.ts
@@ -16,7 +16,7 @@ export class DatepickerComponent {
   date: DateFormat | undefined;
 
   @Input()
-  disabled: boolean = false;
+  isDisabled: boolean = false;
 
   @Input()
   maxDate: DateFormat | undefined;

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -137,7 +137,7 @@
             </div>
             <div class="row text-center align-items-center">
               <div id="submission-start-date" class="col-md-7 col-xs-center">
-                <tm-datepicker [disabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('submissionStartDate', $event)"
+                <tm-datepicker [isDisabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('submissionStartDate', $event)"
                                [minDate]="minDateForSubmissionStart" [maxDate]="maxDateForSubmissionStart"
                                [date]="model.submissionStartDate"></tm-datepicker>
               </div>
@@ -160,7 +160,7 @@
             </div>
             <div class="row align-items-center">
               <div id="submission-end-date" class="col-md-7 col-xs-center">
-                <tm-datepicker [disabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('submissionEndDate', $event)"
+                <tm-datepicker [isDisabled]="!model.isEditable" (dateChangeCallback)="triggerModelChange('submissionEndDate', $event)"
                                [minDate]="minDateForSubmissionEnd" [maxDate]="maxDateForSubmissionEnd"
                                [date]="model.submissionEndDate"></tm-datepicker>
               </div>
@@ -231,7 +231,7 @@
                 </div>
               </div>
               <div id="session-visibility-date" class="col-md-6">
-                <tm-datepicker [disabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
+                <tm-datepicker [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
                                (dateChangeCallback)="triggerModelChange('customSessionVisibleDate', $event)"
                                [minDate]="minDateForSessionVisible" [maxDate]="maxDateForSessionVisible"
                                [date]="model.customSessionVisibleDate"></tm-datepicker>
@@ -269,7 +269,7 @@
                   </div>
                 </div>
                 <div id="response-visibility-date" class="col-md-6">
-                  <tm-datepicker [disabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
+                  <tm-datepicker [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
                                  (dateChangeCallback)="triggerModelChange('customResponseVisibleDate', $event)"
                                  [minDate]="minDateForResponseVisible" [date]="model.customResponseVisibleDate"></tm-datepicker>
                 </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -748,6 +748,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           <button
                             aria-label="Change date"
                             class="btn btn-light input-group-text"
+                            disabled=""
                             type="button"
                           >
                             <i
@@ -955,6 +956,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                           <button
                             aria-label="Change date"
                             class="btn btn-light input-group-text"
+                            disabled=""
                             type="button"
                           >
                             <i
@@ -3376,6 +3378,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                           <button
                             aria-label="Change date"
                             class="btn btn-light input-group-text"
+                            disabled=""
                             type="button"
                           >
                             <i
@@ -3583,6 +3586,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                           <button
                             aria-label="Change date"
                             class="btn btn-light input-group-text"
+                            disabled=""
                             type="button"
                           >
                             <i


### PR DESCRIPTION
Calendar button is now disabled when the Instructor is out of the editing view for Sessions

Author: pgfrank1

Fixes #12238 

**Outline of Solution**
I updated the datepicker component to use isDisabled instead of disabled to keep consistency with other components. I then applied that change to the button component so the calendar cannot be opened.

<img width="657" alt="image" src="https://user-images.githubusercontent.com/44991712/227735144-964a82bb-cf55-4638-9f98-a9ff0ecbe3f8.png">

