### PR TITLE
[#12081] User-friendliness: Add labels to instructor edit sessions page questions

### DIFF
--- a/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
@@ -4,13 +4,13 @@
     <b>Total Points to distribute:</b>
   </div>
   <div class="col-11 offset-half margin-top-10px">
-    <div class="form-check">
+    <div class="row form-check">
       <label class="row form-check-label">
         <div class="col-sm-3">
           <input id="total-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="false"
-                 (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable">
+                 (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Checkbox">
           <input id="total-points" type="number" class="form-control" min="1" step="1"
-                 [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption">
+                 [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption" aria-label="Total Points Input">
         </div>
         <div class="col-sm-9 text-start">
           <b class="ngb-tooltip-class" ngbTooltip="Respondents will have to distribute the total points specified here among the recipients, e.g. if you specify 100 points here and there are 3 recipients, respondents will have to distribute 100 points among 3 recipients.">in total</b>
@@ -21,12 +21,12 @@
       <label class="form-check-label row">
         <div class="col-sm-3">
           <input id="per-option-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="true"
-                 (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable">
+                 (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Times Number of Recipients Checkbox">
           <input id="per-option-points" type="number" class="form-control" min="1" step="1"
-                 [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption">
+                 [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption" aria-label="Points Input">
         </div>
-        <div class="col-sm-9">
-          <b class="ngb-tooltip-class" ngbTooltip="The number of points to distribute will vary based on the number of recipients, e.g. if you specify 100 points here and there are 3 recipients, the total number of points to distribute among 3 recipients will be 300 (i.e. 100 x 3).">X (number of recipients)</b>
+        <div class="col-sm-9 text-start">
+          <b class="ngb-tooltip-class" ngbTooltip="The number of points to distribute will vary based on the number of recipients, e.g. if you specify 100 points here and there are 3 recipients, the total number of points to distribute among 3 recipients will be 300 (i.e. 100 x 3)."> times (number of recipients)</b>
         </div>
       </label>
     </div>
@@ -35,14 +35,14 @@
     <div class="col-sm-3">
       <input id="uneven-distribution-checkbox" class="form-check-input" type="checkbox"
              [ngModel]="model.forceUnevenDistribution"
-             (ngModelChange)="onForceUnevenDistribution($event)" [disabled]="!isEditable">
+             (ngModelChange)="onForceUnevenDistribution($event)" [disabled]="!isEditable" aria-label="Uneven Distribution Checkbox">
       <select id="uneven-distribution-dropdown" class="form-control form-select" [ngModel]="model.distributePointsFor"
               [disabled]="!isEditable || model.distributePointsFor === FeedbackConstantSumDistributePointsType.NONE"
-              (ngModelChange)="triggerModelChange('distributePointsFor', $event)">
-        <option [value]="FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY">
+              (ngModelChange)="triggerModelChange('distributePointsFor', $event)" aria-label="Uneven Distribution Options">
+        <option [value]="FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY" aria-label="Every Option to Receive a Different Number of Points">
           Every option
         </option>
-        <option [value]="FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY">
+        <option [value]="FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY" aria-label="At Least Some Options to Receive a Different Number of Points">
           At least some options
         </option>
       </select>

--- a/src/web/app/components/question-types/question-edit-details-form/contribution-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/contribution-question-edit-details-form.component.html
@@ -2,23 +2,23 @@
   <br>
   <div class="col-12">
     <div class="form-check form-check-inline">
-      <label class="form-check-label">
+      <div class="form-check-label">
         <input id="zero-sum-checkbox" class="form-check-input" type="checkbox" [ngModel]="model.isZeroSum" (ngModelChange)="triggerModelChangeForIsZeroSum($event)" [disabled]="!isEditable">
-        <b>Zero-sum i.e., ratings must add up to <code>(Team Size) x (Equal Share)</code></b>&nbsp;
+        <label for="zero-sum-checkbox" class="fw-bold">Zero-sum i.e., ratings must add up to (Team Size) times (Equal Share)</label>&nbsp;
         <a class="small" tmRouterLink="/web/instructor/help" [queryParams]="{questionId: QuestionsSectionQuestions.CONTRIBUTION, section: Sections.questions}" rel="noopener noreferrer" target="_blank">
           <i class="fa fa-info-circle" aria-hidden="true"></i>
           more info
         </a>
-      </label>
+      </div>
     </div>
   </div>
   <div class="col-12">
     <div class="form-check form-check-inline">
-      <label class="form-check-label">
+      <div class="form-check-label">
         <input id="not-sure-checkbox" class="form-check-input" type="checkbox" [ngModel]="model.isNotSureAllowed" (ngModelChange)="triggerModelChange('isNotSureAllowed', $event)" [disabled]="model.isZeroSum || !isEditable">
-        <b class="ngb-tooltip-class" ngbTooltip="Not applicable if the zero-sum option is enabled"
-           [ngClass]="{'text-muted': model.isZeroSum || !isEditable}">Allow response giver to select 'Not Sure' as the answer</b>
-      </label>
+        <label for="not-sure-checkbox" class="ngb-tooltip-class fw-bold" ngbTooltip="Not applicable if the zero-sum option is enabled"
+           [ngClass]="{'text-muted': model.isZeroSum || !isEditable}">Allow response giver to select 'Not Sure' as the answer</label>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
@@ -1,16 +1,16 @@
 <div class="row">
   <div class="col-sm-4">
     <span class="ngb-tooltip-class" ngbTooltip="Minimum acceptable response value">Minimum value:</span>
-    <input id="min-value" type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1">
+    <input id="min-value" type="number" class="form-control" [ngModel]="model.minScale" (ngModelChange)="triggerModelChange('minScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1" aria-label="Minimum Value Input">
   </div>
   <div class="col-sm-4">
     <span class="ngb-tooltip-class" ngbTooltip="Value to be increased/decreased each step">Increment:</span>
     <input id="increment-value" type="number" class="form-control" [ngModel]="model.step" (ngModelChange)="triggerModelChange('step', $event)" [disabled]="!isEditable"
-           step="any" min="0">
+           step="any" min="0" aria-label="Increment Value Input">
   </div>
   <div class="col-sm-4">
     <span class="ngb-tooltip-class" ngbTooltip="Maximum acceptable response value">Maximum value:</span>
-    <input id="max-value" type="number" class="form-control" [ngModel]="model.maxScale" (ngModelChange)="triggerModelChange('maxScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1" min="{{ Math.ceil(model.minScale + model.step) }}">
+    <input id="max-value" type="number" class="form-control" [ngModel]="model.maxScale" (ngModelChange)="triggerModelChange('maxScale', $event === null ? $event : Math.ceil($event))" [disabled]="!isEditable" [step]="1" min="{{ Math.ceil(model.minScale + model.step) }}" aria-label="Maximum Value Input">
   </div>
 </div>
 <br>


### PR DESCRIPTION
Part of #12081 
Sub-issues: [Add labels for team contribution question](https://github.com/TEAMMATES/teammates/projects/16#card-88348684)
[Add labels for distribute points (recipients) question](https://github.com/TEAMMATES/teammates/projects/16#card-88348683)
[Add labels for numerical scale question](https://github.com/TEAMMATES/teammates/projects/16#card-88348680)

**Outline of Solution**
Usual `aria-label` changes for distribute points (recipients) question and numerical scale question. Also changed "X" to "times" for screen reader clarity. Shifted the `<label>` tag down for team contribution question to avoid screen reader reading the label twice. Unfortunately, this shift also means that the `<code>` tag has to be removed (extra tag in label = screen reader reads twice).
