### PR TITLE
[#12081] Wrap buttons vertically in mobile for instructor edit sessions page

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -49,65 +49,69 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
         </tm-panel-chevron>
       </div>
       <div
-        class="d-flex flex-column text-start"
-        id="question-header"
+        class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start"
       >
         <div
-          class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
+          class="d-flex flex-column text-start"
+          id="question-header"
         >
-          <h2
-            class="question-number fw-bold me-1"
+          <div
+            class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
           >
-            Question 
-            <span
-              id="question-number"
+            <h2
+              class="question-number fw-bold me-1"
             >
-              0
+              Question 
+              <span
+                id="question-number"
+              >
+                0
+              </span>
+            </h2>
+            <span
+              id="question-type"
+            >
+              Essay question
             </span>
-          </h2>
-          <span
-            id="question-type"
-          >
-            Essay question
-          </span>
+          </div>
         </div>
-      </div>
-      <div
-        class="card-header-btn-toolbar"
-      >
-        <div>
-          <button
-            class="btn btn-primary btn-sm"
-            id="btn-edit-question"
-            type="button"
-          >
-            <i
-              class="fas fa-pencil-alt"
-            />
-             Edit 
-          </button>
-          <button
-            class="btn btn-primary btn-sm"
-            id="btn-delete-question"
-            type="button"
-          >
-            <i
-              class="fas fa-trash"
-            />
-             Delete 
-          </button>
-          <button
-            class="btn btn-primary btn-sm"
-            container="body"
-            id="btn-duplicate-question"
-            ngbtooltip="Make a copy of the existing question and add to the current feedback session."
-            type="button"
-          >
-            <i
-              class="far fa-copy"
-            />
-             Duplicate 
-          </button>
+        <div
+          class="card-header-btn-toolbar ms-0 ms-sm-auto text-start"
+        >
+          <div>
+            <button
+              class="btn btn-primary btn-sm"
+              id="btn-edit-question"
+              type="button"
+            >
+              <i
+                class="fas fa-pencil-alt"
+              />
+               Edit 
+            </button>
+            <button
+              class="btn btn-primary btn-sm"
+              id="btn-delete-question"
+              type="button"
+            >
+              <i
+                class="fas fa-trash"
+              />
+               Delete 
+            </button>
+            <button
+              class="btn btn-primary btn-sm"
+              container="body"
+              id="btn-duplicate-question"
+              ngbtooltip="Make a copy of the existing question and add to the current feedback session."
+              type="button"
+            >
+              <i
+                class="far fa-copy"
+              />
+               Duplicate 
+            </button>
+          </div>
         </div>
       </div>
     </button>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -3,56 +3,58 @@
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="!model.isCollapsed"></tm-panel-chevron>
     </div>
-    <div id="question-header" class="d-flex flex-column text-start">
-      <div class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start">
-        <h2 class="question-number fw-bold me-1">Question <span id="question-number" *ngIf="!model.isEditable">{{ model.questionNumber }}</span>
-          <select id="question-number-dropdown" class="form-control form-select question-number-select" [ngModel]="model.questionNumber" (ngModelChange)="triggerModelChange('questionNumber', $event)" *ngIf="model.isEditable" (click)="$event.stopPropagation()">
-            <option *ngFor="let i of range(numOfQuestions)" [ngValue]="i + 1">{{ i + 1 }}</option>
-          </select>
-        </h2>
-      <span id="question-type">{{ model.questionType | questionTypeName }}</span>
+    <div class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start">
+      <div id="question-header" class="d-flex flex-column text-start">
+        <div class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start">
+          <h2 class="question-number fw-bold me-1">Question <span id="question-number" *ngIf="!model.isEditable">{{ model.questionNumber }}</span>
+            <select id="question-number-dropdown" class="form-control form-select question-number-select" [ngModel]="model.questionNumber" (ngModelChange)="triggerModelChange('questionNumber', $event)" *ngIf="model.isEditable" (click)="$event.stopPropagation()">
+              <option *ngFor="let i of range(numOfQuestions)" [ngValue]="i + 1">{{ i + 1 }}</option>
+            </select>
+          </h2>
+        <span id="question-type">{{ model.questionType | questionTypeName }}</span>
+        </div>
+        <ng-container *ngIf="model.isCollapsed">
+          <div class="collapse-qn-description">{{ model.questionBrief }}</div>
+        </ng-container>
       </div>
-      <ng-container *ngIf="model.isCollapsed">
-        <div class="collapse-qn-description">{{ model.questionBrief }}</div>
-      </ng-container>
-    </div>
-    <div class="card-header-btn-toolbar">
-      <div *ngIf="formMode === QuestionEditFormMode.EDIT">
-        <button id="btn-edit-question" type="button" class="btn btn-primary btn-sm" *ngIf="!model.isEditable"
-                (click)="triggerModelChangeBatch({'isEditable': true, 'isCollapsed': false}); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-          <i class="fas fa-pencil-alt"></i> Edit
-        </button>
-        <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
-                (click)="saveQuestionHandler(); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-          <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
-        </button>
-        <button type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
-                (click)="discardChangesHandler(false); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-          <i class="fas fa-ban"></i> Cancel
-        </button>
-        <button id="btn-delete-question" type="button" class="btn btn-primary btn-sm"
-                (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-          <tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
-        </button>
-        <button id="btn-duplicate-question" type="button" class="btn btn-primary btn-sm" container="body"
-                (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
-                ngbTooltip="Make a copy of the existing question and add to the current feedback session."
-                container="body">
-          <tm-ajax-loading *ngIf="model.isDuplicating"></tm-ajax-loading><i class="far fa-copy"></i> Duplicate
-        </button>
-      </div>
-      <div *ngIf="formMode === QuestionEditFormMode.ADD">
-        <button type="button" class="btn btn-primary btn-sm"
-                (click)="discardChangesHandler(true); $event.stopPropagation();"
-                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-          <i class="fas fa-ban"></i>
-          Cancel
-        </button>
+      <div class="card-header-btn-toolbar ms-0 ms-sm-auto text-start">
+        <div *ngIf="formMode === QuestionEditFormMode.EDIT">
+          <button id="btn-edit-question" type="button" class="btn btn-primary btn-sm" *ngIf="!model.isEditable"
+                  (click)="triggerModelChangeBatch({'isEditable': true, 'isCollapsed': false}); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+            <i class="fas fa-pencil-alt"></i> Edit
+          </button>
+          <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
+                  (click)="saveQuestionHandler(); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+            <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
+          </button>
+          <button type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
+                  (click)="discardChangesHandler(false); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+            <i class="fas fa-ban"></i> Cancel
+          </button>
+          <button id="btn-delete-question" type="button" class="btn btn-primary btn-sm"
+                  (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+            <tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
+          </button>
+          <button id="btn-duplicate-question" type="button" class="btn btn-primary btn-sm" container="body"
+                  (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
+                  ngbTooltip="Make a copy of the existing question and add to the current feedback session."
+                  container="body">
+            <tm-ajax-loading *ngIf="model.isDuplicating"></tm-ajax-loading><i class="far fa-copy"></i> Duplicate
+          </button>
+        </div>
+        <div *ngIf="formMode === QuestionEditFormMode.ADD">
+          <button type="button" class="btn btn-primary btn-sm"
+                  (click)="discardChangesHandler(true); $event.stopPropagation();"
+                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+            <i class="fas fa-ban"></i>
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </button>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1299,84 +1299,88 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 </tm-panel-chevron>
               </div>
               <div
-                class="d-flex flex-column text-start"
-                id="question-header"
+                class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start"
               >
                 <div
-                  class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
+                  class="d-flex flex-column text-start"
+                  id="question-header"
                 >
-                  <h2
-                    class="question-number fw-bold me-1"
+                  <div
+                    class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
                   >
-                    Question 
-                    <select
-                      class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
-                      id="question-number-dropdown"
+                    <h2
+                      class="question-number fw-bold me-1"
                     >
-                      <option
-                        value="0: 1"
+                      Question 
+                      <select
+                        class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
+                        id="question-number-dropdown"
                       >
-                        1
-                      </option>
-                      <option
-                        value="1: 2"
-                      >
-                        2
-                      </option>
-                    </select>
-                  </h2>
-                  <span
-                    id="question-type"
-                  >
-                    Essay question
-                  </span>
+                        <option
+                          value="0: 1"
+                        >
+                          1
+                        </option>
+                        <option
+                          value="1: 2"
+                        >
+                          2
+                        </option>
+                      </select>
+                    </h2>
+                    <span
+                      id="question-type"
+                    >
+                      Essay question
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="card-header-btn-toolbar"
-              >
-                <div>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    id="btn-save-question"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-check"
-                    />
-                     Save 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-ban"
-                    />
-                     Cancel 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    id="btn-delete-question"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-trash"
-                    />
-                     Delete 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    container="body"
-                    id="btn-duplicate-question"
-                    ngbtooltip="Make a copy of the existing question and add to the current feedback session."
-                    type="button"
-                  >
-                    <i
-                      class="far fa-copy"
-                    />
-                     Duplicate 
-                  </button>
+                <div
+                  class="card-header-btn-toolbar ms-0 ms-sm-auto text-start"
+                >
+                  <div>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      id="btn-save-question"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-check"
+                      />
+                       Save 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-ban"
+                      />
+                       Cancel 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      id="btn-delete-question"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-trash"
+                      />
+                       Delete 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      container="body"
+                      id="btn-duplicate-question"
+                      ngbtooltip="Make a copy of the existing question and add to the current feedback session."
+                      type="button"
+                    >
+                      <i
+                        class="far fa-copy"
+                      />
+                       Duplicate 
+                    </button>
+                  </div>
                 </div>
               </div>
             </button>
@@ -2018,84 +2022,88 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 </tm-panel-chevron>
               </div>
               <div
-                class="d-flex flex-column text-start"
-                id="question-header"
+                class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start"
               >
                 <div
-                  class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
+                  class="d-flex flex-column text-start"
+                  id="question-header"
                 >
-                  <h2
-                    class="question-number fw-bold me-1"
+                  <div
+                    class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
                   >
-                    Question 
-                    <select
-                      class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
-                      id="question-number-dropdown"
+                    <h2
+                      class="question-number fw-bold me-1"
                     >
-                      <option
-                        value="0: 1"
+                      Question 
+                      <select
+                        class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
+                        id="question-number-dropdown"
                       >
-                        1
-                      </option>
-                      <option
-                        value="1: 2"
-                      >
-                        2
-                      </option>
-                    </select>
-                  </h2>
-                  <span
-                    id="question-type"
-                  >
-                    Essay question
-                  </span>
+                        <option
+                          value="0: 1"
+                        >
+                          1
+                        </option>
+                        <option
+                          value="1: 2"
+                        >
+                          2
+                        </option>
+                      </select>
+                    </h2>
+                    <span
+                      id="question-type"
+                    >
+                      Essay question
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="card-header-btn-toolbar"
-              >
-                <div>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    id="btn-save-question"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-check"
-                    />
-                     Save 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-ban"
-                    />
-                     Cancel 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    id="btn-delete-question"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-trash"
-                    />
-                     Delete 
-                  </button>
-                  <button
-                    class="btn btn-primary btn-sm"
-                    container="body"
-                    id="btn-duplicate-question"
-                    ngbtooltip="Make a copy of the existing question and add to the current feedback session."
-                    type="button"
-                  >
-                    <i
-                      class="far fa-copy"
-                    />
-                     Duplicate 
-                  </button>
+                <div
+                  class="card-header-btn-toolbar ms-0 ms-sm-auto text-start"
+                >
+                  <div>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      id="btn-save-question"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-check"
+                      />
+                       Save 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-ban"
+                      />
+                       Cancel 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      id="btn-delete-question"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-trash"
+                      />
+                       Delete 
+                    </button>
+                    <button
+                      class="btn btn-primary btn-sm"
+                      container="body"
+                      id="btn-duplicate-question"
+                      ngbtooltip="Make a copy of the existing question and add to the current feedback session."
+                      type="button"
+                    >
+                      <i
+                        class="far fa-copy"
+                      />
+                       Duplicate 
+                    </button>
+                  </div>
                 </div>
               </div>
             </button>
@@ -3929,47 +3937,51 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
             </tm-panel-chevron>
           </div>
           <div
-            class="d-flex flex-column text-start"
-            id="question-header"
+            class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start"
           >
             <div
-              class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
+              class="d-flex flex-column text-start"
+              id="question-header"
             >
-              <h2
-                class="question-number fw-bold me-1"
+              <div
+                class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start"
               >
-                Question 
-                <select
-                  class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
-                  id="question-number-dropdown"
+                <h2
+                  class="question-number fw-bold me-1"
                 >
-                  <option
-                    value="0: 1"
+                  Question 
+                  <select
+                    class="form-control form-select question-number-select ng-untouched ng-pristine ng-valid"
+                    id="question-number-dropdown"
                   >
-                    1
-                  </option>
-                </select>
-              </h2>
-              <span
-                id="question-type"
-              >
-                Essay question
-              </span>
+                    <option
+                      value="0: 1"
+                    >
+                      1
+                    </option>
+                  </select>
+                </h2>
+                <span
+                  id="question-type"
+                >
+                  Essay question
+                </span>
+              </div>
             </div>
-          </div>
-          <div
-            class="card-header-btn-toolbar"
-          >
-            <div>
-              <button
-                class="btn btn-primary btn-sm"
-                type="button"
-              >
-                <i
-                  class="fas fa-ban"
-                />
-                 Cancel 
-              </button>
+            <div
+              class="card-header-btn-toolbar ms-0 ms-sm-auto text-start"
+            >
+              <div>
+                <button
+                  class="btn btn-primary btn-sm"
+                  type="button"
+                >
+                  <i
+                    class="fas fa-ban"
+                  />
+                   Cancel 
+                </button>
+              </div>
             </div>
           </div>
         </button>


### PR DESCRIPTION
Part of #12081 
Sub-issue [Instructor edit sessions page: shift buttons from rightmost column to bottommost row on mobile](https://github.com/TEAMMATES/teammates/projects/16#card-88612309)

**Outline of Solution**

- Applied `flex-row` and `flex-col` to display in columns when in mobile and in rows when in desktop