### PR TITLE
[#12264] fix/removed extra space form links

### DIFF
--- a/src/web/app/pages-static/about-page/about-page.component.html
+++ b/src/web/app/pages-static/about-page/about-page.component.html
@@ -33,7 +33,6 @@
       <span>&nbsp;&nbsp;</span>
       <b><a href="https://saucelabs.com" target="_blank" rel="noopener noreferrer">SauceLabs</a></b>, for providing us with a free <a href="https://saucelabs.com/open-source" target="_blank" rel="noopener noreferrer">Open Sauce account</a> for cross-browser testing.
     </li>
-
   </ul>
   <p>
     TEAMMATES has benefitted from the work of {{ nDevelopers }} developers.

--- a/src/web/app/pages-static/about-page/about-page.component.html
+++ b/src/web/app/pages-static/about-page/about-page.component.html
@@ -25,12 +25,15 @@
     </li>
     <li>
       <img src="assets/images/yklogo.png" width="100">
-      <b><a href="https://www.yourkit.com" target="_blank" rel="noopener noreferrer">&nbsp;YourKit LLC</a></b>, for providing us with free licenses for the <a href="https://www.yourkit.com/java/profiler" target="_blank" rel="noopener noreferrer">YourKit Java Profiler</a>.
+      <span>&nbsp;&nbsp;</span>
+      <b><a href="https://www.yourkit.com" target="_blank" rel="noopener noreferrer">YourKit LLC</a></b>, for providing us with free licenses for the <a href="https://www.yourkit.com/java/profiler" target="_blank" rel="noopener noreferrer">YourKit Java Profiler</a>.
     </li>
     <li>
       <img src="assets/images/saucelabs.png" width="100">
-      <b><a href="https://saucelabs.com" target="_blank" rel="noopener noreferrer">&nbsp;SauceLabs</a></b>, for providing us with a free <a href="https://saucelabs.com/open-source" target="_blank" rel="noopener noreferrer">Open Sauce account</a> for cross-browser testing.
+      <span>&nbsp;&nbsp;</span>
+      <b><a href="https://saucelabs.com" target="_blank" rel="noopener noreferrer">SauceLabs</a></b>, for providing us with a free <a href="https://saucelabs.com/open-source" target="_blank" rel="noopener noreferrer">Open Sauce account</a> for cross-browser testing.
     </li>
+
   </ul>
   <p>
     TEAMMATES has benefitted from the work of {{ nDevelopers }} developers.


### PR DESCRIPTION
Fixes  #12264  

Outline of Solution :
removed the space from the link and added it to the span tag.
