### PR TITLE
[#12262] fix/resized the images in features page for mobile screens

### DIFF
--- a/src/web/app/pages-static/features-page/features-page.component.scss
+++ b/src/web/app/pages-static/features-page/features-page.component.scss
@@ -6,3 +6,13 @@ img {
 .inner-content {
   margin: 0 20px;
 }
+
+@media (pointer: coarse)  {
+  img {
+    margin: 0;
+    max-width: 100%;
+  }
+  .inner-content {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Fixes #12262 

Outline of Solution :
detected the type of the screen by using pointer interaction type and removed the margins both inner and outer for images on the mobile screen 
