### PR TITLE
[#12048] Migrate *EmailAction classes.

### DIFF
--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -580,6 +580,16 @@ public class Logic {
     }
 
     /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @return Empty list if none found.
+     */
+    public List<Student> getUnregisteredStudentsForCourse(String courseId) {
+        assert courseId != null;
+        return usersLogic.getUnregisteredStudentsForCourse(courseId);
+    }
+
+    /**
      * Gets a student by associated {@code regkey}.
      */
     public Student getStudentByRegistrationKey(String regKey) {

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -185,6 +185,22 @@ public final class UsersLogic {
     }
 
     /**
+     * Gets a list of students for the specified course.
+     */
+    public List<Student> getUnregisteredStudentsForCourse(String courseId) {
+        List<Student> students = getStudentsForCourse(courseId);
+        List<Student> unregisteredStudents = new ArrayList<>();
+
+        for (Student s : students) {
+            if (s.getGoogleId() == null || s.getGoogleId().trim().isEmpty()) {
+                unregisteredStudents.add(s);
+            }
+        }
+
+        return unregisteredStudents;
+    }
+
+    /**
      * Gets all students of a section.
      */
     public List<Student> getStudentsForSection(String sectionName, String courseId) {

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -185,14 +185,14 @@ public final class UsersLogic {
     }
 
     /**
-     * Gets a list of students for the specified course.
+     * Gets a list of unregistered students for the specified course.
      */
     public List<Student> getUnregisteredStudentsForCourse(String courseId) {
         List<Student> students = getStudentsForCourse(courseId);
         List<Student> unregisteredStudents = new ArrayList<>();
 
         for (Student s : students) {
-            if (s.getGoogleId() == null || s.getGoogleId().trim().isEmpty()) {
+            if (s.getAccount() == null) {
                 unregisteredStudents.add(s);
             }
         }

--- a/src/main/java/teammates/ui/webapi/GenerateEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/GenerateEmailAction.java
@@ -85,6 +85,6 @@ public class GenerateEmailAction extends AdminOnlyAction {
             throw new InvalidHttpParameterException("Email type " + emailType + " not accepted");
         }
 
-        return new JsonResult(new EmailData(email));        
+        return new JsonResult(new EmailData(email));
     }
 }

--- a/src/main/java/teammates/ui/webapi/GenerateEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/GenerateEmailAction.java
@@ -9,23 +9,60 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Student;
 import teammates.ui.output.EmailData;
 
 /**
  * Generate email content.
  */
-class GenerateEmailAction extends AdminOnlyAction {
+public class GenerateEmailAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        CourseAttributes course = logic.getCourse(courseId);
+
+        if (!isCourseMigrated(courseId)) {
+            CourseAttributes course = logic.getCourse(courseId);
+            if (course == null) {
+                throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
+            }
+
+            String studentEmail = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+            StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
+            if (student == null) {
+                throw new EntityNotFoundException("Student does not exist.");
+            }
+
+            String emailType = getNonNullRequestParamValue(Const.ParamsNames.EMAIL_TYPE);
+            String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+
+            EmailWrapper email;
+
+            if (emailType.equals(EmailType.STUDENT_COURSE_JOIN.name())) {
+                email = emailGenerator.generateStudentCourseJoinEmail(course, student);
+            } else if (emailType.equals(EmailType.FEEDBACK_SESSION_REMINDER.name())) {
+                if (feedbackSessionName == null) {
+                    throw new InvalidHttpParameterException("Feedback session name not specified");
+                }
+                FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+                email = emailGenerator.generateFeedbackSessionReminderEmails(
+                        feedbackSession, Collections.singletonList(student), new ArrayList<>(), null).get(0);
+            } else {
+                throw new InvalidHttpParameterException("Email type " + emailType + " not accepted");
+            }
+
+            return new JsonResult(new EmailData(email));
+        }
+
+        Course course = sqlLogic.getCourse(courseId);
         if (course == null) {
             throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
         }
 
         String studentEmail = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
+        Student student = sqlLogic.getStudentForEmail(courseId, studentEmail);
         if (student == null) {
             throw new EntityNotFoundException("Student does not exist.");
         }
@@ -36,18 +73,18 @@ class GenerateEmailAction extends AdminOnlyAction {
         EmailWrapper email;
 
         if (emailType.equals(EmailType.STUDENT_COURSE_JOIN.name())) {
-            email = emailGenerator.generateStudentCourseJoinEmail(course, student);
+            email = sqlEmailGenerator.generateStudentCourseJoinEmail(course, student);
         } else if (emailType.equals(EmailType.FEEDBACK_SESSION_REMINDER.name())) {
             if (feedbackSessionName == null) {
                 throw new InvalidHttpParameterException("Feedback session name not specified");
             }
-            FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-            email = emailGenerator.generateFeedbackSessionReminderEmails(
+            FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
+            email = sqlEmailGenerator.generateFeedbackSessionReminderEmails(
                     feedbackSession, Collections.singletonList(student), new ArrayList<>(), null).get(0);
         } else {
             throw new InvalidHttpParameterException("Email type " + emailType + " not accepted");
         }
 
-        return new JsonResult(new EmailData(email));
+        return new JsonResult(new EmailData(email));        
     }
 }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -42,7 +42,8 @@ public class SendJoinReminderEmailAction extends Action {
                 gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
             } else {
                 // this is sending registration emails to all students in the course and we will check if the instructor
-                // canmodifystudent for course level since for modifystudent privilege there is only course level setting for now
+                // canmodifystudent for course level since for modifystudent privilege there is only course level setting
+                // for now
                 gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
             }
 
@@ -80,14 +81,14 @@ public class SendJoinReminderEmailAction extends Action {
             if (course == null) {
                 throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
             }
-    
+
             String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
             String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
             boolean isSendingToStudent = studentEmail != null;
             boolean isSendingToInstructor = instructorEmail != null;
-    
+
             JsonResult statusMsg;
-    
+
             if (isSendingToStudent) {
                 taskQueuer.scheduleCourseRegistrationInviteToStudent(courseId, studentEmail, false);
                 StudentAttributes studentData = logic.getStudentForEmail(courseId, studentEmail);
@@ -96,18 +97,18 @@ public class SendJoinReminderEmailAction extends Action {
                             "Student with email " + studentEmail + " does not exist in course " + courseId + "!");
                 }
                 statusMsg = new JsonResult("An email has been sent to " + studentEmail);
-    
+
             } else if (isSendingToInstructor) {
                 taskQueuer.scheduleCourseRegistrationInviteToInstructor(userInfo.id,
                         instructorEmail, courseId, false);
-    
+
                 InstructorAttributes instructorData = logic.getInstructorForEmail(courseId, instructorEmail);
                 if (instructorData == null) {
                     throw new EntityNotFoundException(
                             "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
                 }
                 statusMsg = new JsonResult("An email has been sent to " + instructorEmail);
-    
+
             } else {
                 List<StudentAttributes> studentDataList = logic.getUnregisteredStudentsForCourse(courseId);
                 for (StudentAttributes student : studentDataList) {
@@ -115,7 +116,7 @@ public class SendJoinReminderEmailAction extends Action {
                 }
                 statusMsg = new JsonResult("Emails have been sent to unregistered students.");
             }
-    
+
             return statusMsg;
         }
 

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -6,11 +6,14 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 
 /**
  * Send join reminder emails to register for a course.
  */
-class SendJoinReminderEmailAction extends Action {
+public class SendJoinReminderEmailAction extends Action {
 
     @Override
     AuthType getMinAuthLevel() {
@@ -21,14 +24,39 @@ class SendJoinReminderEmailAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        CourseAttributes course = logic.getCourse(courseId);
+        if (!isCourseMigrated(courseId)) {
+            CourseAttributes course = logic.getCourse(courseId);
+            if (course == null) {
+                throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
+            }
+
+            String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+            String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+
+            boolean isSendingToStudent = studentEmail != null;
+            boolean isSendingToInstructor = instructorEmail != null;
+            if (isSendingToStudent) {
+                gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            } else if (isSendingToInstructor) {
+                gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+            } else {
+                // this is sending registration emails to all students in the course and we will check if the instructor
+                // canmodifystudent for course level since for modifystudent privilege there is only course level setting for now
+                gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            }
+
+            return;
+        }
+
+        Course course = sqlLogic.getCourse(courseId);
         if (course == null) {
             throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
         }
 
         String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
         String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+        Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.id);
 
         boolean isSendingToStudent = studentEmail != null;
         boolean isSendingToInstructor = instructorEmail != null;
@@ -47,7 +75,51 @@ class SendJoinReminderEmailAction extends Action {
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        CourseAttributes course = logic.getCourse(courseId);
+        if (!isCourseMigrated(courseId)) {
+            CourseAttributes course = logic.getCourse(courseId);
+            if (course == null) {
+                throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
+            }
+    
+            String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+            String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+            boolean isSendingToStudent = studentEmail != null;
+            boolean isSendingToInstructor = instructorEmail != null;
+    
+            JsonResult statusMsg;
+    
+            if (isSendingToStudent) {
+                taskQueuer.scheduleCourseRegistrationInviteToStudent(courseId, studentEmail, false);
+                StudentAttributes studentData = logic.getStudentForEmail(courseId, studentEmail);
+                if (studentData == null) {
+                    throw new EntityNotFoundException(
+                            "Student with email " + studentEmail + " does not exist in course " + courseId + "!");
+                }
+                statusMsg = new JsonResult("An email has been sent to " + studentEmail);
+    
+            } else if (isSendingToInstructor) {
+                taskQueuer.scheduleCourseRegistrationInviteToInstructor(userInfo.id,
+                        instructorEmail, courseId, false);
+    
+                InstructorAttributes instructorData = logic.getInstructorForEmail(courseId, instructorEmail);
+                if (instructorData == null) {
+                    throw new EntityNotFoundException(
+                            "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
+                }
+                statusMsg = new JsonResult("An email has been sent to " + instructorEmail);
+    
+            } else {
+                List<StudentAttributes> studentDataList = logic.getUnregisteredStudentsForCourse(courseId);
+                for (StudentAttributes student : studentDataList) {
+                    taskQueuer.scheduleCourseRegistrationInviteToStudent(course.getId(), student.getEmail(), false);
+                }
+                statusMsg = new JsonResult("Emails have been sent to unregistered students.");
+            }
+    
+            return statusMsg;
+        }
+
+        Course course = sqlLogic.getCourse(courseId);
         if (course == null) {
             throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
         }
@@ -61,7 +133,7 @@ class SendJoinReminderEmailAction extends Action {
 
         if (isSendingToStudent) {
             taskQueuer.scheduleCourseRegistrationInviteToStudent(courseId, studentEmail, false);
-            StudentAttributes studentData = logic.getStudentForEmail(courseId, studentEmail);
+            Student studentData = sqlLogic.getStudentForEmail(courseId, studentEmail);
             if (studentData == null) {
                 throw new EntityNotFoundException(
                         "Student with email " + studentEmail + " does not exist in course " + courseId + "!");
@@ -72,7 +144,7 @@ class SendJoinReminderEmailAction extends Action {
             taskQueuer.scheduleCourseRegistrationInviteToInstructor(userInfo.id,
                     instructorEmail, courseId, false);
 
-            InstructorAttributes instructorData = logic.getInstructorForEmail(courseId, instructorEmail);
+            Instructor instructorData = sqlLogic.getInstructorForEmail(courseId, instructorEmail);
             if (instructorData == null) {
                 throw new EntityNotFoundException(
                         "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
@@ -80,8 +152,8 @@ class SendJoinReminderEmailAction extends Action {
             statusMsg = new JsonResult("An email has been sent to " + instructorEmail);
 
         } else {
-            List<StudentAttributes> studentDataList = logic.getUnregisteredStudentsForCourse(courseId);
-            for (StudentAttributes student : studentDataList) {
+            List<Student> studentDataList = sqlLogic.getUnregisteredStudentsForCourse(courseId);
+            for (Student student : studentDataList) {
                 taskQueuer.scheduleCourseRegistrationInviteToStudent(course.getId(), student.getEmail(), false);
             }
             statusMsg = new JsonResult("Emails have been sent to unregistered students.");
@@ -89,5 +161,4 @@ class SendJoinReminderEmailAction extends Action {
 
         return statusMsg;
     }
-
 }

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -120,6 +122,36 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertEquals(ERROR_UPDATE_NON_EXISTENT
                 + "Student [courseId=" + courseId + ", email=" + email + "]", exception.getMessage());
+    }
+
+    @Test
+    public void testGetUnregisteredStudentsForCourse_success() {
+        Account registeredAccount = new Account("valid-google-id", "student-name", "valid1-student@email.tmt");
+        Student registeredStudent = new Student(course, "reg-student-name", "valid1-student@email.tmt", "comments");
+        registeredStudent.setAccount(registeredAccount);
+
+        Student unregisteredStudent_nullGoogleId = new Student(course, "unreg1-student-name", "valid2-student@email.tmt", "comments");;
+        unregisteredStudent_nullGoogleId.setAccount(null);
+
+        Account unregisteredAccount_emptyStringGoogleId = new Account("", "unreg2-student-name", "valid3-student@email.tmt");
+        Student unregisteredStudent_emptyStringGoogleId = new Student(course, "unreg2-student-name", "vali3-student@email.tmt", "comments");;
+        unregisteredStudent_emptyStringGoogleId.setAccount(unregisteredAccount_emptyStringGoogleId);
+
+        List<Student> students = Arrays.asList(
+                registeredStudent,
+                unregisteredStudent_nullGoogleId,
+                unregisteredStudent_emptyStringGoogleId);
+
+        when(usersDb.getStudentsForCourse(course.getId())).thenReturn(students);
+
+        List<Student> unregisteredStudents = usersLogic.getUnregisteredStudentsForCourse(course.getId());
+
+        assertEquals(2, unregisteredStudents.size());
+        for (Student unregisteredStudent : unregisteredStudents) {
+            assertTrue(
+                    unregisteredStudent.equals(unregisteredStudent_nullGoogleId) ||
+                    unregisteredStudent.equals(unregisteredStudent_emptyStringGoogleId));
+        }
     }
 
     private Instructor getTypicalInstructor() {

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -130,17 +130,20 @@ public class UsersLogicTest extends BaseTestCase {
         Student registeredStudent = new Student(course, "reg-student-name", "valid1-student@email.tmt", "comments");
         registeredStudent.setAccount(registeredAccount);
 
-        Student unregisteredStudent_nullGoogleId = new Student(course, "unreg1-student-name", "valid2-student@email.tmt", "comments");;
-        unregisteredStudent_nullGoogleId.setAccount(null);
+        Student unregisteredStudentNullGoogleId =
+                new Student(course, "unreg1-student-name", "valid2-student@email.tmt", "comments");
+        unregisteredStudentNullGoogleId.setAccount(null);
 
-        Account unregisteredAccount_emptyStringGoogleId = new Account("", "unreg2-student-name", "valid3-student@email.tmt");
-        Student unregisteredStudent_emptyStringGoogleId = new Student(course, "unreg2-student-name", "vali3-student@email.tmt", "comments");;
-        unregisteredStudent_emptyStringGoogleId.setAccount(unregisteredAccount_emptyStringGoogleId);
+        Account unregisteredAccountEmptyStringGoogleId =
+                new Account("", "unreg2-student-name", "valid3-student@email.tmt");
+        Student unregisteredStudentEmptyStringGoogleId =
+                new Student(course, "unreg2-student-name", "vali3-student@email.tmt", "comments");
+        unregisteredStudentEmptyStringGoogleId.setAccount(unregisteredAccountEmptyStringGoogleId);
 
         List<Student> students = Arrays.asList(
                 registeredStudent,
-                unregisteredStudent_nullGoogleId,
-                unregisteredStudent_emptyStringGoogleId);
+                unregisteredStudentNullGoogleId,
+                unregisteredStudentEmptyStringGoogleId);
 
         when(usersDb.getStudentsForCourse(course.getId())).thenReturn(students);
 
@@ -149,8 +152,8 @@ public class UsersLogicTest extends BaseTestCase {
         assertEquals(2, unregisteredStudents.size());
         for (Student unregisteredStudent : unregisteredStudents) {
             assertTrue(
-                    unregisteredStudent.equals(unregisteredStudent_nullGoogleId) ||
-                    unregisteredStudent.equals(unregisteredStudent_emptyStringGoogleId));
+                    unregisteredStudent.equals(unregisteredStudentNullGoogleId)
+                    || unregisteredStudent.equals(unregisteredStudentEmptyStringGoogleId));
         }
     }
 

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -130,31 +130,20 @@ public class UsersLogicTest extends BaseTestCase {
         Student registeredStudent = new Student(course, "reg-student-name", "valid1-student@email.tmt", "comments");
         registeredStudent.setAccount(registeredAccount);
 
-        Student unregisteredStudentNullGoogleId =
+        Student unregisteredStudentNullAccount =
                 new Student(course, "unreg1-student-name", "valid2-student@email.tmt", "comments");
-        unregisteredStudentNullGoogleId.setAccount(null);
-
-        Account unregisteredAccountEmptyStringGoogleId =
-                new Account("", "unreg2-student-name", "valid3-student@email.tmt");
-        Student unregisteredStudentEmptyStringGoogleId =
-                new Student(course, "unreg2-student-name", "vali3-student@email.tmt", "comments");
-        unregisteredStudentEmptyStringGoogleId.setAccount(unregisteredAccountEmptyStringGoogleId);
+        unregisteredStudentNullAccount.setAccount(null);
 
         List<Student> students = Arrays.asList(
                 registeredStudent,
-                unregisteredStudentNullGoogleId,
-                unregisteredStudentEmptyStringGoogleId);
+                unregisteredStudentNullAccount);
 
         when(usersDb.getStudentsForCourse(course.getId())).thenReturn(students);
 
         List<Student> unregisteredStudents = usersLogic.getUnregisteredStudentsForCourse(course.getId());
 
-        assertEquals(2, unregisteredStudents.size());
-        for (Student unregisteredStudent : unregisteredStudents) {
-            assertTrue(
-                    unregisteredStudent.equals(unregisteredStudentNullGoogleId)
-                    || unregisteredStudent.equals(unregisteredStudentEmptyStringGoogleId));
-        }
+        assertEquals(1, unregisteredStudents.size());
+        assertTrue(unregisteredStudents.get(0).equals(unregisteredStudentNullAccount));
     }
 
     private Instructor getTypicalInstructor() {

--- a/src/test/java/teammates/sqlui/webapi/GenerateEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GenerateEmailActionTest.java
@@ -1,0 +1,164 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.EmailData;
+import teammates.ui.webapi.GenerateEmailAction;
+
+/**
+ * SUT: {@link GenerateEmailAction}.
+ */
+public class GenerateEmailActionTest
+        extends BaseActionTest<GenerateEmailAction> {
+
+    private Course course;
+    private FeedbackSession session;
+    private Student student;
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.EMAIL;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @BeforeMethod
+    void setUp() {
+        course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        session = new FeedbackSession(
+                "session-name", course, "creater_email@tm.tmt", null,
+                Instant.parse("2020-01-01T00:00:00.000Z"), Instant.parse("2020-10-01T00:00:00.000Z"),
+                Instant.parse("2020-01-01T00:00:00.000Z"), Instant.parse("2020-11-01T00:00:00.000Z"),
+                null, false, false, false);
+        student = new Student(course, "student name", "student_email@tm.tmt", null);
+
+        loginAsAdmin();
+    }
+
+    @Test
+    public void testExecute_studentCourseJoinEmailType_success() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+        };
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+
+        EmailWrapper email = new EmailWrapper();
+        email.setRecipient(student.getEmail());
+        email.setType(EmailType.STUDENT_COURSE_JOIN);
+        email.setSubjectFromType(course.getName(), course.getId());
+
+        when(mockSqlEmailGenerator.generateStudentCourseJoinEmail(course, student)).thenReturn(email);
+
+        GenerateEmailAction action = getAction(params);
+        EmailData actionOutput = (EmailData) getJsonResult(action).getOutput();
+
+        assertEquals(String.format(
+            EmailType.STUDENT_COURSE_JOIN.getSubject(), 
+            course.getName(),
+            course.getId()),
+            actionOutput.getSubject());
+        assertEquals(student.getEmail(), actionOutput.getRecipient());
+    }
+
+    @Test
+    public void testExecute_feedbackSessionReminderEmailType_success() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+            Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
+            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+        };
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+        when(mockLogic.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
+        
+        EmailWrapper email = new EmailWrapper();
+        email.setRecipient(student.getEmail());
+        email.setType(EmailType.FEEDBACK_SESSION_REMINDER);
+        email.setSubjectFromType(course.getName(), session.getName());
+
+        List<EmailWrapper> emails = List.of(email);
+
+        when(mockSqlEmailGenerator.generateFeedbackSessionReminderEmails(session, Collections.singletonList(student), new ArrayList<>(), null)).thenReturn(emails);
+
+        GenerateEmailAction action = getAction(params);
+        EmailData actionOutput = (EmailData) getJsonResult(action).getOutput();
+
+        assertEquals(String.format(
+            EmailType.FEEDBACK_SESSION_REMINDER.getSubject(), 
+            course.getName(),
+            session.getName()),
+            actionOutput.getSubject());
+        assertEquals(student.getEmail(), actionOutput.getRecipient());
+    }
+
+    @Test
+    public void testExecute_courseDoesNotExist_throwsEntityNotFoundException() {
+        String nonExistCourseId = "non-exist-course-id";
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, nonExistCourseId,
+            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+        };
+
+        when(mockLogic.getCourse(nonExistCourseId)).thenReturn(null);
+
+        verifyEntityNotFound(params);
+    }
+
+    @Test
+    public void testExecute_studentDoesNotExist_throwsEntityNotFoundException() {
+        String nonExistStudentEmail = "nonExistStudent@tm.tmt";
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, nonExistStudentEmail,
+            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+        };
+
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentForEmail(course.getId(), nonExistStudentEmail)).thenReturn(null);
+
+        verifyEntityNotFound(params);
+    }
+
+    @Test
+    public void testExecute_invalidFeedbackSessionname_throwsInvalidHttpParameterException() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+            Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
+        };
+
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+
+        verifyHttpParameterFailure(params);
+    }
+}

--- a/src/test/java/teammates/sqlui/webapi/GenerateEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GenerateEmailActionTest.java
@@ -55,10 +55,10 @@ public class GenerateEmailActionTest
     @Test
     public void testExecute_studentCourseJoinEmailType_success() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
-            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
         };
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -75,26 +75,26 @@ public class GenerateEmailActionTest
         EmailData actionOutput = (EmailData) getJsonResult(action).getOutput();
 
         assertEquals(String.format(
-            EmailType.STUDENT_COURSE_JOIN.getSubject(), 
-            course.getName(),
-            course.getId()),
-            actionOutput.getSubject());
+                EmailType.STUDENT_COURSE_JOIN.getSubject(),
+                course.getName(),
+                course.getId()),
+                actionOutput.getSubject());
         assertEquals(student.getEmail(), actionOutput.getRecipient());
     }
 
     @Test
     public void testExecute_feedbackSessionReminderEmailType_success() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-            Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
-            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
         };
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
         when(mockLogic.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
-        
+
         EmailWrapper email = new EmailWrapper();
         email.setRecipient(student.getEmail());
         email.setType(EmailType.FEEDBACK_SESSION_REMINDER);
@@ -102,16 +102,19 @@ public class GenerateEmailActionTest
 
         List<EmailWrapper> emails = List.of(email);
 
-        when(mockSqlEmailGenerator.generateFeedbackSessionReminderEmails(session, Collections.singletonList(student), new ArrayList<>(), null)).thenReturn(emails);
+        when(mockSqlEmailGenerator.generateFeedbackSessionReminderEmails(
+                session,
+                Collections.singletonList(student),
+                new ArrayList<>(), null)).thenReturn(emails);
 
         GenerateEmailAction action = getAction(params);
         EmailData actionOutput = (EmailData) getJsonResult(action).getOutput();
 
         assertEquals(String.format(
-            EmailType.FEEDBACK_SESSION_REMINDER.getSubject(), 
-            course.getName(),
-            session.getName()),
-            actionOutput.getSubject());
+                EmailType.FEEDBACK_SESSION_REMINDER.getSubject(),
+                course.getName(),
+                session.getName()),
+                actionOutput.getSubject());
         assertEquals(student.getEmail(), actionOutput.getRecipient());
     }
 
@@ -119,10 +122,10 @@ public class GenerateEmailActionTest
     public void testExecute_courseDoesNotExist_throwsEntityNotFoundException() {
         String nonExistCourseId = "non-exist-course-id";
         String[] params = {
-            Const.ParamsNames.COURSE_ID, nonExistCourseId,
-            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
-            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+                Const.ParamsNames.COURSE_ID, nonExistCourseId,
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
         };
 
         when(mockLogic.getCourse(nonExistCourseId)).thenReturn(null);
@@ -134,12 +137,11 @@ public class GenerateEmailActionTest
     public void testExecute_studentDoesNotExist_throwsEntityNotFoundException() {
         String nonExistStudentEmail = "nonExistStudent@tm.tmt";
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, nonExistStudentEmail,
-            Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
-            Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, nonExistStudentEmail,
+                Const.ParamsNames.EMAIL_TYPE, EmailType.STUDENT_COURSE_JOIN.name(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getName(),
         };
-
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), nonExistStudentEmail)).thenReturn(null);
@@ -150,11 +152,10 @@ public class GenerateEmailActionTest
     @Test
     public void testExecute_invalidFeedbackSessionname_throwsInvalidHttpParameterException() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-            Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.EMAIL_TYPE, EmailType.FEEDBACK_SESSION_REMINDER.name(),
         };
-
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);

--- a/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
@@ -1,0 +1,219 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.webapi.SendJoinReminderEmailAction;
+
+/**
+ * SUT: {@link SendJoinReminderEmailAction}.
+ */
+public class SendJoinReminderEmailActionTest
+        extends BaseActionTest<SendJoinReminderEmailAction> {
+    
+    private Course course;
+    private Student student;
+    private Instructor instructor;
+    private String instructorGoogleId;
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.JOIN_REMIND;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return POST;
+    }
+
+    @BeforeMethod
+    void setUp() {
+        course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        student = new Student(course, "student name", "student_email@tm.tmt", null);
+        instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
+
+        instructorGoogleId = "user-id";
+        loginAsInstructor(instructorGoogleId);
+    }
+
+    @Test
+    public void testExecute_sendToStudent_success() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+            Const.ParamsNames.INSTRUCTOR_EMAIL, null,
+        };
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+
+        SendJoinReminderEmailAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals(
+                "An email has been sent to " + student.getEmail(),
+                actionOutput.getMessage());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.STUDENT_COURSE_JOIN_EMAIL_QUEUE_NAME, 1);
+    }
+
+    @Test
+    public void testExecute_sendToInstructor_success() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, null,
+            Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+        };
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
+
+        SendJoinReminderEmailAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals(
+                "An email has been sent to " + instructor.getEmail(),
+                actionOutput.getMessage());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.INSTRUCTOR_COURSE_JOIN_EMAIL_QUEUE_NAME, 1);
+    }
+
+    @Test
+    public void testExecute_sendToAllUnregisteredStudents_success() {
+        String[] params = {
+            Const.ParamsNames.COURSE_ID, course.getId(),
+            Const.ParamsNames.STUDENT_EMAIL, null,
+            Const.ParamsNames.INSTRUCTOR_EMAIL, null,
+        };
+
+        List<Student> unregisteredStudents = List.of(student);
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getUnregisteredStudentsForCourse(course.getId())).thenReturn(unregisteredStudents);
+
+        SendJoinReminderEmailAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals(
+                "Emails have been sent to unregistered students.",
+                actionOutput.getMessage());
+
+        verifySpecifiedTasksAdded(Const.TaskQueue.STUDENT_COURSE_JOIN_EMAIL_QUEUE_NAME, unregisteredStudents.size());
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToStudent_instructorCanModifyStudent_canAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+        };
+
+        InstructorPrivileges canModifyStudentPrivileges = new InstructorPrivileges();
+        canModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
+
+        instructor.setPrivileges(canModifyStudentPrivileges);
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToStudent_instructorCannotModifyStudent_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+        };
+
+        InstructorPrivileges cannotModifyStudentPrivileges = new InstructorPrivileges();
+        cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
+    
+        instructor.setPrivileges(cannotModifyStudentPrivileges);
+    
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCannotAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToAllUnregisteredStudents_instructorCanModifyStudent_canAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivileges canModifyStudentPrivileges = new InstructorPrivileges();
+        canModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
+
+        instructor.setPrivileges(canModifyStudentPrivileges);
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToAllUnregisteredStudents_instructorCannotModifyStudent_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivileges cannotModifyStudentPrivileges = new InstructorPrivileges();
+        cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
+    
+        instructor.setPrivileges(cannotModifyStudentPrivileges);
+    
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCannotAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToInstructor_instructorCanModifyInstructor_canAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+        };
+
+        InstructorPrivileges canModifyInstructorPrivileges = new InstructorPrivileges();
+        canModifyInstructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+
+        instructor.setPrivileges(canModifyInstructorPrivileges);
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_sendToInstructor_instructorCannotModifyInstructor_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+        };
+
+        InstructorPrivileges cannotModifyInstructorPrivileges = new InstructorPrivileges();
+        cannotModifyInstructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
+    
+        instructor.setPrivileges(cannotModifyInstructorPrivileges);
+    
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+
+        verifyCannotAccess(params);
+    }
+}

--- a/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
@@ -20,7 +20,7 @@ import teammates.ui.webapi.SendJoinReminderEmailAction;
  */
 public class SendJoinReminderEmailActionTest
         extends BaseActionTest<SendJoinReminderEmailAction> {
-    
+
     private Course course;
     private Student student;
     private Instructor instructor;
@@ -49,9 +49,9 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testExecute_sendToStudent_success() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-            Const.ParamsNames.INSTRUCTOR_EMAIL, null,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.INSTRUCTOR_EMAIL, null,
         };
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -70,9 +70,9 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testExecute_sendToInstructor_success() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, null,
-            Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, null,
+                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
         };
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -91,9 +91,9 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testExecute_sendToAllUnregisteredStudents_success() {
         String[] params = {
-            Const.ParamsNames.COURSE_ID, course.getId(),
-            Const.ParamsNames.STUDENT_EMAIL, null,
-            Const.ParamsNames.INSTRUCTOR_EMAIL, null,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, null,
+                Const.ParamsNames.INSTRUCTOR_EMAIL, null,
         };
 
         List<Student> unregisteredStudents = List.of(student);
@@ -112,7 +112,7 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToStudent_instructorCanModifyStudent_canAccess() {
+    public void testSpecificAccessControl_sendToStudentInstructorCanModifyStudent_canAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
@@ -130,7 +130,7 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToStudent_instructorCannotModifyStudent_cannotAccess() {
+    public void testSpecificAccessControl_sendToStudentInstructorCannotModifyStudent_cannotAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
@@ -138,9 +138,9 @@ public class SendJoinReminderEmailActionTest
 
         InstructorPrivileges cannotModifyStudentPrivileges = new InstructorPrivileges();
         cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
-    
+
         instructor.setPrivileges(cannotModifyStudentPrivileges);
-    
+
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
@@ -148,7 +148,7 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToAllUnregisteredStudents_instructorCanModifyStudent_canAccess() {
+    public void testSpecificAccessControl_sendToAllUnregisteredStudentsInstructorCanModifyStudent_canAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
         };
@@ -165,16 +165,16 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToAllUnregisteredStudents_instructorCannotModifyStudent_cannotAccess() {
+    public void testSpecificAccessControl_sendToAllUnregisteredStudentsInstructorCannotModifyStudent_cannotAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
         };
 
         InstructorPrivileges cannotModifyStudentPrivileges = new InstructorPrivileges();
         cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
-    
+
         instructor.setPrivileges(cannotModifyStudentPrivileges);
-    
+
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
@@ -182,7 +182,7 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToInstructor_instructorCanModifyInstructor_canAccess() {
+    public void testSpecificAccessControl_sendToInstructorInstructorCanModifyInstructor_canAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
@@ -200,7 +200,7 @@ public class SendJoinReminderEmailActionTest
     }
 
     @Test
-    public void testSpecificAccessControl_sendToInstructor_instructorCannotModifyInstructor_cannotAccess() {
+    public void testSpecificAccessControl_sendToInstructorInstructorCannotModifyInstructor_cannotAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
@@ -208,9 +208,9 @@ public class SendJoinReminderEmailActionTest
 
         InstructorPrivileges cannotModifyInstructorPrivileges = new InstructorPrivileges();
         cannotModifyInstructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
-    
+
         instructor.setPrivileges(cannotModifyInstructorPrivileges);
-    
+
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 


### PR DESCRIPTION
Part of #12048.

**Outline of Solution**

* Migrate `GenerateEmailAction` and `SendJoinReminderEmailAction` with minimal unit tests.
* Migrated `getUnregisteredStudentsForCourse` method (in logic layer).
