### PR TITLE
[#12081] User-friendliness: Fix all remaining sortable table headers

### DIFF
--- a/src/web/app/components/extension-confirm-modal/__snapshots__/extension-confirm-modal.component.spec.ts.snap
+++ b/src/web/app/components/extension-confirm-modal/__snapshots__/extension-confirm-modal.component.spec.ts.snap
@@ -59,75 +59,95 @@ exports[`ExtensionConfirmModalComponent should snap with the extended students a
           Students
         </h1>
         <table
-          class="table table-bordered"
+          class="table table-bordered mb-3"
           id="student-list-table"
         >
           <thead>
             <tr>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                <span>
-                  Original Deadline 
-                </span>
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                  <span>
+                    Original Deadline 
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>

--- a/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.html
+++ b/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.html
@@ -26,59 +26,69 @@
 
     <div class="table-responsive" *ngIf="selectedStudents.length !== 0">
       <h1>Students</h1>
-      <table id="student-list-table" class="table table-bordered">
+      <table id="student-list-table" class="table table-bordered mb-3">
         <thead>
           <tr>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SECTION_NAME)">
-              Section
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SECTION_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.SECTION_NAME)">
+              <button>
+                Section
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.TEAM_NAME)">
-              Team
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.TEAM_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.TEAM_NAME)">
+              <button>
+                Team
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_NAME)">
-              Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.RESPONDENT_NAME)">
+              <button>
+                Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_EMAIL)">
-              Email
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSortStudent(SortBy.RESPONDENT_EMAIL)">
+              <button>
+                Email
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SESSION_END_DATE)">
-              <span *ngIf="isExtendModal()">Original Deadline </span>
-              <span *ngIf="isDeleteModal() || isSessionDeleteModal()">Current Deadline </span>
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SESSION_END_DATE)" [attr.aria-sort]="getAriaSortStudent(SortBy.SESSION_END_DATE)">
+              <button>
+                <span *ngIf="isExtendModal()">Original Deadline </span>
+                <span *ngIf="isDeleteModal() || isSessionDeleteModal()">Current Deadline </span>
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
           </tr>
         </thead>
@@ -94,49 +104,57 @@
 
     <div class="table-responsive" *ngIf="selectedInstructors.length !== 0">
       <h1>Instructors</h1>
-      <table id="instructor-list-table" class="table table-bordered">
+      <table id="instructor-list-table" class="table table-bordered mb-3">
         <thead>
           <tr>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_NAME)">
-              Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSortInstructor(SortBy.RESPONDENT_NAME)">
+              <button>
+                Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_EMAIL)">
-              Email
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSortInstructor(SortBy.RESPONDENT_EMAIL)">
+              <button>
+                Email
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.INSTRUCTOR_PERMISSION_ROLE)">
-              Role
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.INSTRUCTOR_PERMISSION_ROLE)" [attr.aria-sort]="getAriaSortInstructor(SortBy.INSTRUCTOR_PERMISSION_ROLE)">
+              <button>
+                Role
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.SESSION_END_DATE)">
-              <span *ngIf="isExtendModal()">Original Deadline </span>
-              <span *ngIf="isDeleteModal() || isSessionDeleteModal()">Current Deadline </span>
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.SESSION_END_DATE)" [attr.aria-sort]="getAriaSortInstructor(SortBy.SESSION_END_DATE)">
+              <button>
+                <span *ngIf="isExtendModal()">Original Deadline </span>
+                <span *ngIf="isDeleteModal() || isSessionDeleteModal()">Current Deadline </span>
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
           </tr>
         </thead>

--- a/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.scss
+++ b/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.scss
@@ -1,3 +1,26 @@
 .form-check {
   float: right;
 }
+
+.sortable-header {
+  cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
+}

--- a/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
+++ b/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
@@ -72,6 +72,13 @@ export class ExtensionConfirmModalComponent {
     this.selectedStudents.sort(this.sortStudentPanelsBy(by));
   }
 
+  getAriaSortStudent(by: SortBy): String {
+    if (by !== this.sortStudentsBy) {
+      return 'none';
+    }
+    return this.sortStudentOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   sortStudentPanelsBy(
     by: SortBy,
   ): (a: StudentExtensionTableColumnModel, b: StudentExtensionTableColumnModel) => number {
@@ -111,6 +118,13 @@ export class ExtensionConfirmModalComponent {
     this.sortInstructorsBy = by;
     this.sortInstructorOrder = this.sortInstructorOrder === SortOrder.DESC ? SortOrder.ASC : SortOrder.DESC;
     this.selectedInstructors.sort(this.sortInstructorPanelsBy(by));
+  }
+
+  getAriaSortInstructor(by: SortBy): String {
+    if (by !== this.sortInstructorsBy) {
+      return 'none';
+    }
+    return this.sortInstructorOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
   sortInstructorPanelsBy(

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -2,37 +2,45 @@
   <table id="response-table" class="table table-bordered">
     <thead>
       <tr class="header">
-        <th class="sortable-header" (click)="sortResponses(SortBy.GIVER_TEAM)" *ngIf="showGiver">
-          Team
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i *ngIf="sortBy === SortBy.GIVER_TEAM && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-            <i *ngIf="sortBy === SortBy.GIVER_TEAM && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-          </span>
+        <th class="sortable-header" (click)="sortResponses(SortBy.GIVER_TEAM)" *ngIf="showGiver" [attr.aria-sort]="getAriaSort(SortBy.GIVER_TEAM)">
+          <button>
+            Team
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i *ngIf="sortBy === SortBy.GIVER_TEAM && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+              <i *ngIf="sortBy === SortBy.GIVER_TEAM && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortResponses(SortBy.GIVER_NAME)" *ngIf="showGiver">
-          Giver
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i *ngIf="sortBy === SortBy.GIVER_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-            <i *ngIf="sortBy === SortBy.GIVER_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-          </span>
+        <th class="sortable-header" (click)="sortResponses(SortBy.GIVER_NAME)" *ngIf="showGiver" [attr.aria-sort]="getAriaSort(SortBy.GIVER_NAME)">
+          <button>
+            Giver
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i *ngIf="sortBy === SortBy.GIVER_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+              <i *ngIf="sortBy === SortBy.GIVER_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortResponses(SortBy.RECIPIENT_TEAM)" *ngIf="showRecipient">
-          Team
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i *ngIf="sortBy === SortBy.RECIPIENT_TEAM && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-            <i *ngIf="sortBy === SortBy.RECIPIENT_TEAM && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-          </span>
+        <th class="sortable-header" (click)="sortResponses(SortBy.RECIPIENT_TEAM)" *ngIf="showRecipient" [attr.aria-sort]="getAriaSort(SortBy.RECIPIENT_TEAM)">
+          <button>
+            Team
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i *ngIf="sortBy === SortBy.RECIPIENT_TEAM && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+              <i *ngIf="sortBy === SortBy.RECIPIENT_TEAM && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortResponses(SortBy.RECIPIENT_NAME)" *ngIf="showRecipient">
-          Recipient
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i *ngIf="sortBy === SortBy.RECIPIENT_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-            <i *ngIf="sortBy === SortBy.RECIPIENT_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-          </span>
+        <th class="sortable-header" (click)="sortResponses(SortBy.RECIPIENT_NAME)" *ngIf="showRecipient" [attr.aria-sort]="getAriaSort(SortBy.RECIPIENT_NAME)">
+          <button>
+            Recipient
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i *ngIf="sortBy === SortBy.RECIPIENT_NAME && sortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+              <i *ngIf="sortBy === SortBy.RECIPIENT_NAME && sortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+            </span>
+          </button>
         </th>
         <th>Response</th>
         <th *ngIf="canResponseHasComment">Comment for Response</th>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.scss
@@ -1,6 +1,24 @@
 .sortable-header {
   cursor: pointer;
-  min-width: 120px;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 .color-neutral {

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -114,6 +114,13 @@ export class PerQuestionViewResponsesComponent extends InstructorResponsesViewBa
     this.responsesToShow.sort(this.sortResponsesBy(by, this.sortOrder));
   }
 
+  getAriaSort(by: SortBy): String {
+    if (by !== this.sortBy) {
+      return 'none';
+    }
+    return this.sortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   sortResponsesBy(by: SortBy, order: SortOrder):
     ((a: ResponseOutput, b: ResponseOutput) => number) {
     if (by === SortBy.NONE) {

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
@@ -14,41 +14,49 @@
             <tm-panel-chevron [isExpanded]="isRecycleBinExpanded"></tm-panel-chevron>
           </div>
         </div>
-      <div *ngIf="isRecycleBinExpanded" @collapseAnim>
-        <table id="deleted-sessions-table" class="table table-responsive-lg table-striped table-bordered recycle-bin-table">
+      <div *ngIf="isRecycleBinExpanded" class="table-responsive" @collapseAnim>
+        <table id="deleted-sessions-table" class="table table-striped table-bordered recycle-bin-table">
           <thead class="recycle-bin-table-header">
           <tr>
-            <th id="sort-deleted-course-id" (click)="sortRecycleBinFeedbackSessionRows(SortBy.COURSE_ID)" class="sortable-header">
-              Course ID
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-              </span>
+            <th id="sort-deleted-course-id" (click)="sortRecycleBinFeedbackSessionRows(SortBy.COURSE_ID)" class="sortable-header" [attr.aria-sort]="getAriaSort(SortBy.COURSE_ID)">
+              <button>
+                Course ID
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th id="sort-deleted-session-name" (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_NAME)" class="sortable-header">
-              Session Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-              </span>
+            <th id="sort-deleted-session-name" (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_NAME)" class="sortable-header" [attr.aria-sort]="getAriaSort(SortBy.SESSION_NAME)">
+              <button>
+                Session Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_CREATION_DATE)" class="sortable-header">
-              Creation Date
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-              </span>
+            <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_CREATION_DATE)" class="sortable-header" [attr.aria-sort]="getAriaSort(SortBy.SESSION_CREATION_DATE)">
+              <button>
+                Creation Date
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_DELETION_DATE)" class="sortable-header">
-              Deletion Date
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-                <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-              </span>
+            <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_DELETION_DATE)" class="sortable-header" [attr.aria-sort]="getAriaSort(SortBy.SESSION_DELETION_DATE)">
+              <button>
+                Deletion Date
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+                  <i *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
             <th class="text-center">Action(s)</th>
           </tr>

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.scss
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.scss
@@ -14,6 +14,25 @@
 
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 .actions-cell button {

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
@@ -68,6 +68,13 @@ export class SessionsRecycleBinTableComponent {
     this.sortRecycleBinFeedbackSessionRowsEvent.emit(by);
   }
 
+  getAriaSort(by: SortBy): String {
+    if (by !== this.recycleBinFeedbackSessionRowModelsSortBy) {
+      return 'none';
+    }
+    return this.recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Set row number of button clicked.
    */

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -40,43 +40,55 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
           class="bg-primary text-white"
         >
           <th
+            aria-sort="none"
             class="sort-session-name sortable-header"
           >
-             Session Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Session Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="ascending"
             class="sortable-header"
           >
-             Start Date 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-              <i
-                class="fas fa-sort-up"
-              />
-            </span>
+            <button>
+               Start Date 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+                <i
+                  class="fas fa-sort-up"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             End Date 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               End Date 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th>
             Submissions
@@ -491,31 +503,39 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
           class="bg-primary text-white"
         >
           <th
+            aria-sort="none"
             class="sort-course-id sortable-header"
           >
-             Course ID 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Course ID 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="ascending"
             class="sort-session-name sortable-header"
           >
-             Session Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-              <i
-                class="fas fa-sort-up"
-              />
-            </span>
+            <button>
+               Session Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+                <i
+                  class="fas fa-sort-up"
+                />
+              </span>
+            </button>
           </th>
           <th>
             Submissions

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -2,37 +2,45 @@
   <table class="sessions-table table table-responsive-lg table-striped table-bordered margin-bottom-0">
     <thead>
     <tr [ngClass]="{ 'bg-primary text-white': headerColorScheme === SessionsTableHeaderColorScheme.BLUE }">
-      <th class="sort-course-id sortable-header" (click)="sortSessionsTableRowModels(SortBy.COURSE_ID)" *ngIf="columnsToShow.includes(SessionsTableColumn.COURSE_ID)">
-        Course ID
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.COURSE_ID && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
-          <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.COURSE_ID && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
-        </span>
+      <th class="sort-course-id sortable-header" (click)="sortSessionsTableRowModels(SortBy.COURSE_ID)" *ngIf="columnsToShow.includes(SessionsTableColumn.COURSE_ID)" [attr.aria-sort]="getAriaSort(SortBy.COURSE_ID)">
+        <button>
+          Course ID
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.COURSE_ID && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
+            <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.COURSE_ID && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
+          </span>
+        </button>
       </th>
-      <th class="sort-session-name sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_NAME)">
-        Session Name
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_NAME && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
-          <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_NAME && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
-        </span>
+      <th class="sort-session-name sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_NAME)" [attr.aria-sort]="getAriaSort(SortBy.SESSION_NAME)">
+        <button>
+          Session Name
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_NAME && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
+            <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_NAME && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
+          </span>
+        </button>
       </th>
-      <th class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_START_DATE)" *ngIf="columnsToShow.includes(SessionsTableColumn.START_DATE)">
-        Start Date
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_START_DATE && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
-          <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_START_DATE && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
-        </span>
+      <th class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_START_DATE)" *ngIf="columnsToShow.includes(SessionsTableColumn.START_DATE)" [attr.aria-sort]="getAriaSort(SortBy.SESSION_START_DATE)">
+        <button>
+          Start Date
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_START_DATE && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
+            <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_START_DATE && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
+          </span>
+        </button>
       </th>
-      <th class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_END_DATE)" *ngIf="columnsToShow.includes(SessionsTableColumn.END_DATE)">
-        End Date
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_END_DATE && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
-          <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_END_DATE && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
-        </span>
+      <th class="sortable-header" (click)="sortSessionsTableRowModels(SortBy.SESSION_END_DATE)" *ngIf="columnsToShow.includes(SessionsTableColumn.END_DATE)" [attr.aria-sort]="getAriaSort(SortBy.SESSION_END_DATE)">
+        <button>
+          End Date
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort-down" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_END_DATE && sessionsTableRowModelsSortOrder === SortOrder.DESC"></i>
+            <i class="fas fa-sort-up" *ngIf="sessionsTableRowModelsSortBy === SortBy.SESSION_END_DATE && sessionsTableRowModelsSortOrder === SortOrder.ASC"></i>
+          </span>
+        </button>
       </th>
       <th>Submissions</th>
       <th>Responses</th>

--- a/src/web/app/components/sessions-table/sessions-table.component.scss
+++ b/src/web/app/components/sessions-table/sessions-table.component.scss
@@ -15,6 +15,25 @@
 
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 .clickable {

--- a/src/web/app/components/sessions-table/sessions-table.component.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.ts
@@ -97,6 +97,13 @@ export class SessionsTableComponent {
     this.sortSessionsTableRowModelsEvent.emit(by);
   }
 
+  getAriaSort(by: SortBy): String {
+    if (by !== this.sessionsTableRowModelsSortBy) {
+      return 'none';
+    }
+    return this.sessionsTableRowModelsSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Moves the feedback session to the recycle bin.
    */

--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -33,52 +33,68 @@ exports[`StudentListComponent should snap with default fields 1`] = `
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -127,64 +143,84 @@ exports[`StudentListComponent should snap with enable remind button set to true 
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Section 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Section 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -469,64 +505,84 @@ exports[`StudentListComponent should snap with enable remind button set to true,
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Section 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Section 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -805,64 +861,84 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Section 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Section 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -1135,64 +1211,84 @@ exports[`StudentListComponent should snap with some student list data and some s
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Section 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Section 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -1467,64 +1563,84 @@ exports[`StudentListComponent should snap with some student list data when not a
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Section 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Section 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -1797,52 +1913,68 @@ exports[`StudentListComponent should snap with some student list data with no se
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"
@@ -1945,52 +2077,68 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
       >
         <tr>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Team 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Team 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-name sortable-header"
           >
-             Student Name 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Student Name 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sort-by-status sortable-header"
           >
-             Status 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Status 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
+            aria-sort="none"
             class="sortable-header"
           >
-             Email 
-            <span
-              class="fa-stack"
-            >
-              <i
-                class="fas fa-sort"
-              />
-            </span>
+            <button>
+               Email 
+              <span
+                aria-hidden="true"
+                class="fa-stack"
+              >
+                <i
+                  class="fas fa-sort"
+                />
+              </span>
+            </button>
           </th>
           <th
             class="align-center"

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -5,45 +5,55 @@
         [hidden]="isHideTableHead"
     >
     <tr>
-      <th class="sortable-header" *ngIf="hasSection()" (click)="sortStudentList(SortBy.SECTION_NAME)">
-        Section
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+      <th class="sortable-header" *ngIf="hasSection()" (click)="sortStudentList(SortBy.SECTION_NAME)" [attr.aria-sort]="getAriaSort(SortBy.SECTION_NAME)">
+        <button>
+          Section
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
-      <th class="sortable-header" (click)="sortStudentList(SortBy.TEAM_NAME)">
-        Team
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+      <th class="sortable-header" (click)="sortStudentList(SortBy.TEAM_NAME)" [attr.aria-sort]="getAriaSort(SortBy.TEAM_NAME)">
+        <button>
+          Team
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
-      <th class="sort-by-name sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_NAME)">
-        Student Name
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+      <th class="sort-by-name sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSort(SortBy.RESPONDENT_NAME)">
+        <button>
+          Student Name
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
-      <th class="sort-by-status sortable-header" (click)="sortStudentList(SortBy.JOIN_STATUS)">
-        Status
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+      <th class="sort-by-status sortable-header" (click)="sortStudentList(SortBy.JOIN_STATUS)" [attr.aria-sort]="getAriaSort(SortBy.JOIN_STATUS)">
+        <button>
+          Status
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
-      <th class="sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_EMAIL)">
-        Email
-        <span class="fa-stack">
-          <i class="fas fa-sort"></i>
-          <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
-          <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
-        </span>
+      <th class="sortable-header" (click)="sortStudentList(SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSort(SortBy.RESPONDENT_EMAIL)">
+        <button>
+          Email
+          <span class="fa-stack" aria-hidden="true">
+            <i class="fas fa-sort"></i>
+            <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
+            <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
+          </span>
+        </button>
       </th>
       <th class="align-center">Action(s)</th>
     </tr>

--- a/src/web/app/components/student-list/student-list.component.scss
+++ b/src/web/app/components/student-list/student-list.component.scss
@@ -22,4 +22,23 @@ which usually match 2 classes (eg .btn.disabled)
 
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -127,4 +127,11 @@ export class StudentListComponent {
   sortStudentList(by: SortBy): void {
     this.sortStudentListEvent.emit(by);
   }
+
+  getAriaSort(by: SortBy): String {
+    if (by !== this.tableSortBy) {
+      return 'none';
+    }
+    return this.tableSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
 }

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/__snapshots__/notifications-table.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/__snapshots__/notifications-table.component.spec.ts.snap
@@ -31,79 +31,103 @@ exports[`NotificationsTableComponent should snap like in notification page with 
             class="bg-primary text-white"
           >
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Title 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Title 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Start Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Start Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               End Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 End Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Target User 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Target User 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Style 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Style 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="descending"
               class="sortable-header"
             >
-               Creation Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-                <i
-                  class="fas fa-sort-down"
-                />
-              </span>
+              <button>
+                 Creation Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                  <i
+                    class="fas fa-sort-down"
+                  />
+                </span>
+              </button>
             </th>
             <th>
               Actions
@@ -282,79 +306,103 @@ exports[`NotificationsTableComponent should snap like in notification page with 
             class="bg-primary text-white"
           >
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Title 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Title 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="descending"
               class="sortable-header"
             >
-               Start Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-                <i
-                  class="fas fa-sort-down"
-                />
-              </span>
+              <button>
+                 Start Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                  <i
+                    class="fas fa-sort-down"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               End Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 End Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Target User 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Target User 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Style 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Style 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Creation Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Creation Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th>
               Actions
@@ -533,79 +581,103 @@ exports[`NotificationsTableComponent should snap with default fields 1`] = `
             class="bg-primary text-white"
           >
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Title 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Title 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Start Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Start Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               End Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 End Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Target User 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Target User 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="none"
               class="sortable-header"
             >
-               Style 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-              </span>
+              <button>
+                 Style 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                </span>
+              </button>
             </th>
             <th
+              aria-sort="descending"
               class="sortable-header"
             >
-               Creation Time 
-              <span
-                class="fa-stack"
-              >
-                <i
-                  class="fas fa-sort"
-                />
-                <i
-                  class="fas fa-sort-down"
-                />
-              </span>
+              <button>
+                 Creation Time 
+                <span
+                  aria-hidden="true"
+                  class="fa-stack"
+                >
+                  <i
+                    class="fas fa-sort"
+                  />
+                  <i
+                    class="fas fa-sort-down"
+                  />
+                </span>
+              </button>
             </th>
             <th>
               Actions

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
@@ -3,53 +3,65 @@
     <table id="notifications-table" class="table table-responsive-lg table-striped table-bordered margin-bottom-0">
       <thead>
       <tr [ngClass]="{ 'bg-primary text-white': headerColorScheme === NotificationsTableHeaderColorScheme.BLUE }">
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_TITLE)">
-          Title
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TITLE && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TITLE && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_TITLE)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_TITLE)">
+          <button>
+            Title
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TITLE && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TITLE && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_START_TIME)">
-          Start Time
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_START_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_START_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_START_TIME)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_START_TIME)">
+          <button>
+            Start Time
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_START_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_START_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_END_TIME)">
-          End Time
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_END_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_END_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_END_TIME)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_END_TIME)">
+          <button>
+            End Time
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_END_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_END_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_TARGET_USER)">
-          Target User
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TARGET_USER && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TARGET_USER && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_TARGET_USER)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_TARGET_USER)">
+          <button>
+            Target User
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TARGET_USER && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_TARGET_USER && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_STYLE)">
-          Style
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_STYLE && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_STYLE && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_STYLE)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_STYLE)">
+          <button>
+            Style
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_STYLE && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_STYLE && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
-        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_CREATE_TIME)">
-          Creation Time
-          <span class="fa-stack">
-            <i class="fas fa-sort"></i>
-            <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_CREATE_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
-            <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_CREATE_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
-          </span>
+        <th class="sortable-header" (click)="sortNotificationsTableRowModels(SortBy.NOTIFICATION_CREATE_TIME)" [attr.aria-sort]="getAriaSort(SortBy.NOTIFICATION_CREATE_TIME)">
+          <button>
+            Creation Time
+            <span class="fa-stack" aria-hidden="true">
+              <i class="fas fa-sort"></i>
+              <i class="fas fa-sort-down" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_CREATE_TIME && notificationsTableRowModelsSortOrder === SortOrder.DESC"></i>
+              <i class="fas fa-sort-up" *ngIf="notificationsTableRowModelsSortBy === SortBy.NOTIFICATION_CREATE_TIME && notificationsTableRowModelsSortOrder === SortOrder.ASC"></i>
+            </span>
+          </button>
         </th>
         <th>Actions</th>
       </tr>

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.scss
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.scss
@@ -4,6 +4,25 @@
 
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 .clickable {

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.ts
@@ -48,6 +48,13 @@ export class NotificationsTableComponent {
     this.sortNotificationsTableRowModelsEvent.emit(by);
   }
 
+  getAriaSort(by: SortBy): String {
+    if (by !== this.notificationsTableRowModelsSortBy) {
+      return 'none';
+    }
+    return this.notificationsTableRowModelsSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Deletes a notification based on its ID.
    */

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -405,64 +405,84 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
               >
                 <tr>
                   <th
+                    aria-sort="none"
                     class="sortable-header"
                   >
-                     Section 
-                    <span
-                      class="fa-stack"
-                    >
-                      <i
-                        class="fas fa-sort"
-                      />
-                    </span>
+                    <button>
+                       Section 
+                      <span
+                        aria-hidden="true"
+                        class="fa-stack"
+                      >
+                        <i
+                          class="fas fa-sort"
+                        />
+                      </span>
+                    </button>
                   </th>
                   <th
+                    aria-sort="none"
                     class="sortable-header"
                   >
-                     Team 
-                    <span
-                      class="fa-stack"
-                    >
-                      <i
-                        class="fas fa-sort"
-                      />
-                    </span>
+                    <button>
+                       Team 
+                      <span
+                        aria-hidden="true"
+                        class="fa-stack"
+                      >
+                        <i
+                          class="fas fa-sort"
+                        />
+                      </span>
+                    </button>
                   </th>
                   <th
+                    aria-sort="none"
                     class="sort-by-name sortable-header"
                   >
-                     Student Name 
-                    <span
-                      class="fa-stack"
-                    >
-                      <i
-                        class="fas fa-sort"
-                      />
-                    </span>
+                    <button>
+                       Student Name 
+                      <span
+                        aria-hidden="true"
+                        class="fa-stack"
+                      >
+                        <i
+                          class="fas fa-sort"
+                        />
+                      </span>
+                    </button>
                   </th>
                   <th
+                    aria-sort="none"
                     class="sort-by-status sortable-header"
                   >
-                     Status 
-                    <span
-                      class="fa-stack"
-                    >
-                      <i
-                        class="fas fa-sort"
-                      />
-                    </span>
+                    <button>
+                       Status 
+                      <span
+                        aria-hidden="true"
+                        class="fa-stack"
+                      >
+                        <i
+                          class="fas fa-sort"
+                        />
+                      </span>
+                    </button>
                   </th>
                   <th
+                    aria-sort="none"
                     class="sortable-header"
                   >
-                     Email 
-                    <span
-                      class="fa-stack"
-                    >
-                      <i
-                        class="fas fa-sort"
-                      />
-                    </span>
+                    <button>
+                       Email 
+                      <span
+                        aria-hidden="true"
+                        class="fa-stack"
+                      >
+                        <i
+                          class="fas fa-sort"
+                        />
+                      </span>
+                    </button>
                   </th>
                   <th
                     class="align-center"

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
@@ -246,52 +246,68 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
                         #
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Instructor Name 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Instructor Name 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Instructor Email 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Instructor Email 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Displayed to Student As 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Displayed to Student As 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Access Level 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Access Level 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                     </tr>
                   </thead>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.html
@@ -30,37 +30,45 @@
                   <thead [ngClass]="{'bg-primary text-white': !course.isArchived, 'bg-info': course.isArchived}">
                     <tr>
                       <th>#</th>
-                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.RESPONDENT_NAME)">
-                        Instructor Name
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_NAME, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_NAME, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSort(course, SortBy.RESPONDENT_NAME)">
+                        <button>
+                          Instructor Name
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_NAME, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_NAME, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
-                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.RESPONDENT_EMAIL)">
-                        Instructor Email
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_EMAIL, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_EMAIL, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSort(course, SortBy.RESPONDENT_EMAIL)">
+                        <button>
+                          Instructor Email
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_EMAIL, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.RESPONDENT_EMAIL, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
-                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT)">
-                        Displayed to Student As
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT)" [attr.aria-sort]="getAriaSort(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT)">
+                        <button>
+                          Displayed to Student As
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_DISPLAYED_TEXT, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
-                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.INSTRUCTOR_PERMISSION_ROLE)">
-                        Access Level
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_PERMISSION_ROLE, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_PERMISSION_ROLE, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortInstructorsToCopyForCourse(course, SortBy.INSTRUCTOR_PERMISSION_ROLE)" [attr.aria-sort]="getAriaSort(course, SortBy.INSTRUCTOR_PERMISSION_ROLE)">
+                        <button>
+                          Access Level
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_PERMISSION_ROLE, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortInstructorsBy(course, SortBy.INSTRUCTOR_PERMISSION_ROLE, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
                     </tr>
                   </thead>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.scss
@@ -1,5 +1,24 @@
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 #copy-instructor-modal {

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
@@ -125,6 +125,13 @@ export class CopyInstructorsFromOtherCoursesModalComponent {
     this.courses.sort(this.sortCoursesBy(by));
   }
 
+  getAriaSort(course: CourseTabModel, by: SortBy): String {
+    if (course.instructorCandidatesSortBy !== by) {
+      return 'none';
+    }
+    return course.instructorCandidatesSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Sorts the list of instructors for a course.
    */

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -79,6 +79,7 @@ exports[`InstructorCoursesPageComponent should snap when archived courses are ex
       class="h3 text-muted"
     >
       <span
+        aria-hidden="true"
         class="fa fa-file-archive"
       />
        Archived courses 
@@ -120,44 +121,56 @@ exports[`InstructorCoursesPageComponent should snap when archived courses are ex
               class="background-color-medium-gray text-color-gray"
             >
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Course ID 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Course ID 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="ascending"
                 class="sortable-header"
               >
-                 Course Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-up"
-                    style=""
-                  />
-                </span>
+                <button>
+                   Course Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-up"
+                      style=""
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Creation Date 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Creation Date 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
                 class="text-center"
@@ -407,46 +420,58 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
                 class="bg-primary text-white"
               >
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-id"
                 >
-                   Course ID 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course ID 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-name"
                 >
-                   Course Name 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course Name 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="ascending"
                   class="sortable-header"
                   id="sort-creation-date"
                 >
-                   Creation Date 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                    <i
-                      class="fas fa-sort-up"
-                    />
-                  </span>
+                  <button>
+                     Creation Date 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                      <i
+                        class="fas fa-sort-up"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th>
                   Sections
@@ -691,6 +716,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
       class="h3 text-muted"
     >
       <span
+        aria-hidden="true"
         class="fa fa-file-archive"
       />
        Archived courses 
@@ -730,6 +756,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
         class="h3 text-muted"
       >
         <span
+          aria-hidden="true"
           class="fa fa-trash-alt"
         />
          Deleted courses 
@@ -751,6 +778,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
               class="btn btn-secondary btn-sm disabled"
             >
               <i
+                aria-hidden="true"
                 class="fas fa-check"
               />
                Restore All 
@@ -759,6 +787,7 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
               class="btn btn-secondary btn-sm disabled"
             >
               <i
+                aria-hidden="true"
                 class="fas fa-times"
               />
                Delete All 
@@ -1157,46 +1186,58 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
                 class="bg-primary text-white"
               >
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-id"
                 >
-                   Course ID 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course ID 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-name"
                 >
-                   Course Name 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course Name 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="ascending"
                   class="sortable-header"
                   id="sort-creation-date"
                 >
-                   Creation Date 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                    <i
-                      class="fas fa-sort-up"
-                    />
-                  </span>
+                  <button>
+                     Creation Date 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                      <i
+                        class="fas fa-sort-up"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th>
                   Sections
@@ -1441,6 +1482,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
       class="h3 text-muted"
     >
       <span
+        aria-hidden="true"
         class="fa fa-file-archive"
       />
        Archived courses 
@@ -1480,6 +1522,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
         class="h3 text-muted"
       >
         <span
+          aria-hidden="true"
           class="fa fa-trash-alt"
         />
          Deleted courses 
@@ -1503,6 +1546,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
               ngbtooltip="Restore all deleted courses and their corresponding students and sessions"
             >
               <i
+                aria-hidden="true"
                 class="fas fa-check"
               />
                Restore All 
@@ -1513,6 +1557,7 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
               ngbtooltip="Permanently delete all courses and their corresponding students and sessions"
             >
               <i
+                aria-hidden="true"
                 class="fas fa-times"
               />
                Delete All 
@@ -1687,46 +1732,58 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
                 class="bg-primary text-white"
               >
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-id"
                 >
-                   Course ID 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course ID 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="none"
                   class="sortable-header"
                   id="sort-course-name"
                 >
-                   Course Name 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                  </span>
+                  <button>
+                     Course Name 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th
+                  aria-sort="ascending"
                   class="sortable-header"
                   id="sort-creation-date"
                 >
-                   Creation Date 
-                  <span
-                    class="fa-stack"
-                  >
-                    <i
-                      class="fas fa-sort"
-                    />
-                    <i
-                      class="fas fa-sort-up"
-                    />
-                  </span>
+                  <button>
+                     Creation Date 
+                    <span
+                      aria-hidden="true"
+                      class="fa-stack"
+                    >
+                      <i
+                        class="fas fa-sort"
+                      />
+                      <i
+                        class="fas fa-sort-up"
+                      />
+                    </span>
+                  </button>
                 </th>
                 <th>
                   Sections

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -32,29 +32,35 @@
         <table id="active-courses-table" class="table table-striped table-bordered margin-0">
           <thead>
           <tr class="bg-primary text-white">
-            <th id="sort-course-id" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_ID)">
-              Course ID
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_ID && activeTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_ID && activeTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th id="sort-course-id" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_ID)" [attr.aria-sort]="getAriaSortActive(SortBy.COURSE_ID)">
+              <button>
+                Course ID
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_ID && activeTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_ID && activeTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
-            <th id="sort-course-name" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_NAME)">
-              Course Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_NAME && activeTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_NAME && activeTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th id="sort-course-name" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_NAME)" [attr.aria-sort]="getAriaSortActive(SortBy.COURSE_NAME)">
+              <button>
+                Course Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_NAME && activeTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_NAME && activeTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
-            <th id="sort-creation-date" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_CREATION_DATE)">
-              Creation Date
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_CREATION_DATE && activeTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_CREATION_DATE && activeTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th id="sort-creation-date" class="sortable-header" (click)="sortCoursesEvent(SortBy.COURSE_CREATION_DATE)" [attr.aria-sort]="getAriaSortActive(SortBy.COURSE_CREATION_DATE)">
+              <button>
+                Creation Date
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="activeTableSortBy === SortBy.COURSE_CREATION_DATE && activeTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="activeTableSortBy === SortBy.COURSE_CREATION_DATE && activeTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
             <th>Sections</th>
             <th>Teams</th>
@@ -180,7 +186,7 @@
 
 <div class="course-section" *ngIf="archivedCourses.length">
   <h2 class="h3 text-muted">
-    <span class="fa fa-file-archive"></span> Archived courses
+    <span class="fa fa-file-archive" aria-hidden="true"></span> Archived courses
   </h2>
   <div class="card top-padded">
     <div id="archived-table-heading" class="card-header bg-info cursor-pointer" (click)="isArchivedCourseExpanded = !isArchivedCourseExpanded">
@@ -193,29 +199,35 @@
       <table id="archived-courses-table" class="table table-striped table-bordered archive-table">
         <thead>
           <tr class="background-color-medium-gray text-color-gray">
-            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_ID)">
-              Course ID
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_ID && archivedTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_ID && archivedTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_ID)" [attr.aria-sort]="getAriaSortArchived(SortBy.COURSE_ID)">
+              <button>
+                Course ID
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_ID && archivedTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_ID && archivedTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_NAME)">
-              Course Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_NAME && archivedTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_NAME && archivedTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_NAME)" [attr.aria-sort]="getAriaSortArchived(SortBy.COURSE_NAME)">
+              <button>
+                Course Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_NAME && archivedTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_NAME && archivedTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_CREATION_DATE)">
-              Creation Date
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_CREATION_DATE && archivedTableSortOrder === SortOrder.DESC"></i>
-                <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_CREATION_DATE && archivedTableSortOrder === SortOrder.ASC"></i>
-              </span>
+            <th class="sortable-header" (click)="sortArchivedCoursesEvent(SortBy.COURSE_CREATION_DATE)" [attr.aria-sort]="getAriaSortArchived(SortBy.COURSE_CREATION_DATE)">
+              <button>
+                Creation Date
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i class="fas fa-sort-down" *ngIf="archivedTableSortBy === SortBy.COURSE_CREATION_DATE && archivedTableSortOrder === SortOrder.DESC"></i>
+                  <i class="fas fa-sort-up" *ngIf="archivedTableSortBy === SortBy.COURSE_CREATION_DATE && archivedTableSortOrder === SortOrder.ASC"></i>
+                </span>
+              </button>
             </th>
             <th class="text-center">Action(s)</th>
           </tr>
@@ -249,7 +261,7 @@
 <div class="row course-section margin-top-30px" *ngIf="softDeletedCourses.length">
   <div class="col-12">
     <h2 class="h3 text-muted">
-      <span class="fa fa-trash-alt"></span> Deleted courses
+      <span class="fa fa-trash-alt" aria-hidden="true"></span> Deleted courses
     </h2>
     <div class="card bg-light top-padded">
       <div id="deleted-table-heading" class="card-header bg-secondary text-white cursor-pointer" (click)="isRecycleBinExpanded = !isRecycleBinExpanded">
@@ -257,17 +269,17 @@
         <div class="card-header-btn-toolbar">
           <button id="btn-restore-all" class="btn btn-secondary btn-sm" *ngIf="canRestoreAll" (click)="$event.stopPropagation(); onRestoreAll()"
                   ngbTooltip="Restore all deleted courses and their corresponding students and sessions">
-            <i class="fas fa-check"></i> Restore All
+            <i class="fas fa-check" aria-hidden="true"></i> Restore All
           </button>
           <button class="btn btn-secondary btn-sm disabled" *ngIf="!canRestoreAll">
-            <i class="fas fa-check"></i> Restore All
+            <i class="fas fa-check" aria-hidden="true"></i> Restore All
           </button>
           <button id="btn-delete-all" class="btn btn-secondary btn-sm" *ngIf="canDeleteAll" (click)="$event.stopPropagation(); onDeleteAll()"
                   ngbTooltip="Permanently delete all courses and their corresponding students and sessions">
-            <i class="fas fa-times"></i> Delete All
+            <i class="fas fa-times" aria-hidden="true"></i> Delete All
           </button>
           <button class="btn btn-secondary btn-sm disabled" *ngIf="!canDeleteAll">
-            <i class="fas fa-times"></i> Delete All
+            <i class="fas fa-times" aria-hidden="true"></i> Delete All
           </button>
           <tm-panel-chevron [isExpanded]="isRecycleBinExpanded"></tm-panel-chevron>
         </div>
@@ -276,37 +288,45 @@
         <table id="deleted-courses-table" class="table table-responsive-lg table-striped table-bordered recycle-bin-table">
           <thead>
             <tr class="background-color-medium-gray text-color-gray">
-              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_ID)">
-                Course ID
-                <span class="fa-stack">
-                  <i class="fas fa-sort"></i>
-                  <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_ID && deletedTableSortOrder === SortOrder.DESC"></i>
-                  <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_ID && deletedTableSortOrder === SortOrder.ASC"></i>
-                </span>
+              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_ID)" [attr.aria-sort]="getAriaSortDeleted(SortBy.COURSE_ID)">
+                <button>
+                  Course ID
+                  <span class="fa-stack" aria-hidden="true">
+                    <i class="fas fa-sort"></i>
+                    <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_ID && deletedTableSortOrder === SortOrder.DESC"></i>
+                    <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_ID && deletedTableSortOrder === SortOrder.ASC"></i>
+                  </span>
+                </button>
               </th>
-              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_NAME)">
-                Course Name
-                <span class="fa-stack">
-                  <i class="fas fa-sort"></i>
-                  <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_NAME && deletedTableSortOrder === SortOrder.DESC"></i>
-                  <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_NAME && deletedTableSortOrder === SortOrder.ASC"></i>
-                </span>
+              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_NAME)" [attr.aria-sort]="getAriaSortDeleted(SortBy.COURSE_NAME)">
+                <button>
+                  Course Name
+                  <span class="fa-stack" aria-hidden="true">
+                    <i class="fas fa-sort"></i>
+                    <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_NAME && deletedTableSortOrder === SortOrder.DESC"></i>
+                    <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_NAME && deletedTableSortOrder === SortOrder.ASC"></i>
+                  </span>
+                </button>
               </th>
-              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_CREATION_DATE)">
-                Creation Date
-                <span class="fa-stack">
-                  <i class="fas fa-sort"></i>
-                  <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_CREATION_DATE && deletedTableSortOrder === SortOrder.DESC"></i>
-                  <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_CREATION_DATE && deletedTableSortOrder === SortOrder.ASC"></i>
-                </span>
+              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_CREATION_DATE)" [attr.aria-sort]="getAriaSortDeleted(SortBy.COURSE_CREATION_DATE)">
+                <button>
+                  Creation Date
+                  <span class="fa-stack" aria-hidden="true">
+                    <i class="fas fa-sort"></i>
+                    <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_CREATION_DATE && deletedTableSortOrder === SortOrder.DESC"></i>
+                    <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_CREATION_DATE && deletedTableSortOrder === SortOrder.ASC"></i>
+                  </span>
+                </button>
               </th>
-              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_DELETION_DATE)">
-                Deletion Date
-                <span class="fa-stack">
-                  <i class="fas fa-sort"></i>
-                  <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_DELETION_DATE && deletedTableSortOrder === SortOrder.DESC"></i>
-                  <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_DELETION_DATE && deletedTableSortOrder === SortOrder.ASC"></i>
-                </span>
+              <th class="sortable-header" (click)="sortDeletedCoursesEvent(SortBy.COURSE_DELETION_DATE)" [attr.aria-sort]="getAriaSortDeleted(SortBy.COURSE_DELETION_DATE)">
+                <button>
+                  Deletion Date
+                  <span class="fa-stack" aria-hidden="true">
+                    <i class="fas fa-sort"></i>
+                    <i class="fas fa-sort-down" *ngIf="deletedTableSortBy === SortBy.COURSE_DELETION_DATE && deletedTableSortOrder === SortOrder.DESC"></i>
+                    <i class="fas fa-sort-up" *ngIf="deletedTableSortBy === SortBy.COURSE_DELETION_DATE && deletedTableSortOrder === SortOrder.ASC"></i>
+                  </span>
+                </button>
               </th>
               <th class="text-center">Action(s)</th>
             </tr>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.scss
@@ -1,5 +1,24 @@
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 .course-section {

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -802,6 +802,13 @@ export class InstructorCoursesPageComponent implements OnInit {
     this.activeCourses.sort(this.sortBy(by, this.activeTableSortOrder));
   }
 
+  getAriaSortActive(by: SortBy): String {
+    if (by !== this.activeTableSortBy) {
+      return 'none';
+    }
+    return this.activeTableSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Active courses default sort on page load
    */
@@ -821,6 +828,13 @@ export class InstructorCoursesPageComponent implements OnInit {
     this.archivedCourses.sort(this.sortBy(by, this.archivedTableSortOrder));
   }
 
+  getAriaSortArchived(by: SortBy): String {
+    if (by !== this.archivedTableSortBy) {
+      return 'none';
+    }
+    return this.archivedTableSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Archived courses default sort on page load
    */
@@ -838,6 +852,13 @@ export class InstructorCoursesPageComponent implements OnInit {
         ? SortOrder.DESC : SortOrder.ASC;
     this.deletedTableSortBy = by;
     this.softDeletedCourses.sort(this.sortBy(by, this.deletedTableSortOrder));
+  }
+
+  getAriaSortDeleted(by: SortBy): String {
+    if (by !== this.deletedTableSortBy) {
+      return 'none';
+    }
+    return this.deletedTableSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -531,40 +531,52 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                     <thead>
                       <tr>
                         <th
+                          aria-sort="none"
                           class="sort-session-name sortable-header"
                         >
-                           Session Name 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             Session Name 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th
+                          aria-sort="none"
                           class="sortable-header"
                         >
-                           Start Date 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             Start Date 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th
+                          aria-sort="none"
                           class="sortable-header"
                         >
-                           End Date 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             End Date 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th>
                           Submissions
@@ -1012,40 +1024,52 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                     <thead>
                       <tr>
                         <th
+                          aria-sort="none"
                           class="sort-session-name sortable-header"
                         >
-                           Session Name 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             Session Name 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th
+                          aria-sort="none"
                           class="sortable-header"
                         >
-                           Start Date 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             Start Date 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th
+                          aria-sort="none"
                           class="sortable-header"
                         >
-                           End Date 
-                          <span
-                            class="fa-stack"
-                          >
-                            <i
-                              class="fas fa-sort"
-                            />
-                          </span>
+                          <button>
+                             End Date 
+                            <span
+                              aria-hidden="true"
+                              class="fa-stack"
+                            >
+                              <i
+                                class="fas fa-sort"
+                              />
+                            </span>
+                          </button>
                         </th>
                         <th>
                           Submissions

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -159,64 +159,84 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                 >
                   <tr>
                     <th
+                      aria-sort="none"
                       class="sortable-header"
                     >
-                       Section 
-                      <span
-                        class="fa-stack"
-                      >
-                        <i
-                          class="fas fa-sort"
-                        />
-                      </span>
+                      <button>
+                         Section 
+                        <span
+                          aria-hidden="true"
+                          class="fa-stack"
+                        >
+                          <i
+                            class="fas fa-sort"
+                          />
+                        </span>
+                      </button>
                     </th>
                     <th
+                      aria-sort="none"
                       class="sortable-header"
                     >
-                       Team 
-                      <span
-                        class="fa-stack"
-                      >
-                        <i
-                          class="fas fa-sort"
-                        />
-                      </span>
+                      <button>
+                         Team 
+                        <span
+                          aria-hidden="true"
+                          class="fa-stack"
+                        >
+                          <i
+                            class="fas fa-sort"
+                          />
+                        </span>
+                      </button>
                     </th>
                     <th
+                      aria-sort="none"
                       class="sort-by-name sortable-header"
                     >
-                       Student Name 
-                      <span
-                        class="fa-stack"
-                      >
-                        <i
-                          class="fas fa-sort"
-                        />
-                      </span>
+                      <button>
+                         Student Name 
+                        <span
+                          aria-hidden="true"
+                          class="fa-stack"
+                        >
+                          <i
+                            class="fas fa-sort"
+                          />
+                        </span>
+                      </button>
                     </th>
                     <th
+                      aria-sort="none"
                       class="sort-by-status sortable-header"
                     >
-                       Status 
-                      <span
-                        class="fa-stack"
-                      >
-                        <i
-                          class="fas fa-sort"
-                        />
-                      </span>
+                      <button>
+                         Status 
+                        <span
+                          aria-hidden="true"
+                          class="fa-stack"
+                        >
+                          <i
+                            class="fas fa-sort"
+                          />
+                        </span>
+                      </button>
                     </th>
                     <th
+                      aria-sort="none"
                       class="sortable-header"
                     >
-                       Email 
-                      <span
-                        class="fa-stack"
-                      >
-                        <i
-                          class="fas fa-sort"
-                        />
-                      </span>
+                      <button>
+                         Email 
+                        <span
+                          aria-hidden="true"
+                          class="fa-stack"
+                        >
+                          <i
+                            class="fas fa-sort"
+                          />
+                        </span>
+                      </button>
                     </th>
                     <th
                       class="align-center"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
@@ -108,28 +108,36 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
                         #
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Question Type 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Question Type 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                       <th
+                        aria-sort="none"
                         class="sortable-header"
                       >
-                         Question Text 
-                        <span
-                          class="fa-stack"
-                        >
-                          <i
-                            class="fas fa-sort"
-                          />
-                        </span>
+                        <button>
+                           Question Text 
+                          <span
+                            aria-hidden="true"
+                            class="fa-stack"
+                          >
+                            <i
+                              class="fas fa-sort"
+                            />
+                          </span>
+                        </button>
                       </th>
                     </tr>
                   </thead>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.html
@@ -29,21 +29,25 @@
                   <thead class="bg-primary text-white">
                     <tr>
                       <th>#</th>
-                      <th class="sortable-header" (click)="sortQuestionsToCopyForFeedbackSession(feedbackSessionTabModel, SortBy.QUESTION_TYPE)">
-                        Question Type
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TYPE, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TYPE, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortQuestionsToCopyForFeedbackSession(feedbackSessionTabModel, SortBy.QUESTION_TYPE)" [attr.aria-sort]="getAriaSort(feedbackSessionTabModel, SortBy.QUESTION_TYPE)">
+                        <button>
+                          Question Type
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TYPE, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TYPE, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
-                      <th class="sortable-header" (click)="sortQuestionsToCopyForFeedbackSession(feedbackSessionTabModel, SortBy.QUESTION_TEXT)">
-                        Question Text
-                        <span class="fa-stack">
-                          <i class="fas fa-sort"></i>
-                          <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TEXT, SortOrder.DESC)" class="fas fa-sort-down"></i>
-                          <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TEXT, SortOrder.ASC)" class="fas fa-sort-up"></i>
-                        </span>
+                      <th class="sortable-header" (click)="sortQuestionsToCopyForFeedbackSession(feedbackSessionTabModel, SortBy.QUESTION_TEXT)" [attr.aria-sort]="getAriaSort(feedbackSessionTabModel, SortBy.QUESTION_TEXT)">
+                        <button>
+                          Question Text
+                          <span class="fa-stack" aria-hidden="true">
+                            <i class="fas fa-sort"></i>
+                            <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TEXT, SortOrder.DESC)" class="fas fa-sort-down"></i>
+                            <i *ngIf="isSortQuestionsBy(feedbackSessionTabModel, SortBy.QUESTION_TEXT, SortOrder.ASC)" class="fas fa-sort-up"></i>
+                          </span>
+                        </button>
                       </th>
                     </tr>
                   </thead>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.scss
@@ -1,5 +1,24 @@
 .sortable-header {
   cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
 }
 
 #copy-question-modal {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component.ts
@@ -103,6 +103,13 @@ export class CopyQuestionsFromOtherSessionsModalComponent {
     return model.questionsTableRowModelsSortBy === by && model.questionsTableRowModelsSortOrder === order;
   }
 
+  getAriaSort(model: FeedbackSessionTabModel, by: SortBy): String {
+    if (model.questionsTableRowModelsSortBy !== by) {
+      return 'none';
+    }
+    return model.questionsTableRowModelsSortOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   /**
    * Sorts the list of feedback sessions.
    */

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
@@ -150,74 +150,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -327,62 +349,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -617,74 +658,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -794,62 +857,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1004,74 +1086,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1096,62 +1200,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1337,74 +1460,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1514,62 +1659,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1755,74 +1919,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -1847,62 +2033,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -2139,74 +2344,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -2316,62 +2543,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -2607,74 +2853,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -2891,62 +3159,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -3055,74 +3342,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -3147,62 +3456,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -3311,74 +3639,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -3403,62 +3753,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -3644,74 +4013,96 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all students"
                   id="select-all-student-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-student-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Section 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Section 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Team 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Team 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -4020,62 +4411,81 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
             <tr>
               <th>
                 <input
-                  aria-label="Select all instructors"
                   id="select-all-instructor-btn"
                   type="checkbox"
                 />
-                 Select all 
+                <label
+                  for="select-all-instructor-btn"
+                >
+                   Select all
+                </label>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Name 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Name 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Email 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Email 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="none"
                 class="sortable-header"
               >
-                 Role 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                </span>
+                <button>
+                   Role 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                  </span>
+                </button>
               </th>
               <th
+                aria-sort="descending"
                 class="sortable-header"
               >
-                 Current Deadline 
-                <span
-                  class="fa-stack"
-                >
-                  <i
-                    class="fas fa-sort"
-                  />
-                  <i
-                    class="fas fa-sort-down"
-                  />
-                </span>
+                <button>
+                   Current Deadline 
+                  <span
+                    aria-hidden="true"
+                    class="fa-stack"
+                  >
+                    <i
+                      class="fas fa-sort"
+                    />
+                    <i
+                      class="fas fa-sort-down"
+                    />
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.html
@@ -49,58 +49,68 @@
         <thead>
           <tr>
             <th (click)="selectAllStudents()">
-              <input type="checkbox" id="select-all-student-btn" [checked]="isAllStudentsSelected" aria-label="Select all students" />
-              Select all
+              <input type="checkbox" id="select-all-student-btn" [checked]="isAllStudentsSelected"/>
+              <label for="select-all-student-btn">&nbsp;Select all</label>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SECTION_NAME)">
-              Section
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SECTION_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.SECTION_NAME)">
+              <button>
+                Section
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SECTION_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.TEAM_NAME)">
-              Team
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.TEAM_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.TEAM_NAME)">
+              <button>
+                Team
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.TEAM_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_NAME)">
-              Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSortStudent(SortBy.RESPONDENT_NAME)">
+              <button>
+                Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_NAME && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_EMAIL)">
-              Email
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSortStudent(SortBy.RESPONDENT_EMAIL)">
+              <button>
+                Email
+                <span class="fa-stack">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.RESPONDENT_EMAIL && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SESSION_END_DATE)">
-              Current Deadline
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortStudentColumnsBy(SortBy.SESSION_END_DATE)" [attr.aria-sort]="getAriaSortStudent(SortBy.SESSION_END_DATE)">
+              <button>
+                Current Deadline
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortStudentsBy === SortBy.SESSION_END_DATE && sortStudentOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
           </tr>
         </thead>
@@ -133,48 +143,56 @@
         <thead>
           <tr>
             <th (click)="selectAllInstructors()">
-              <input type="checkbox" id="select-all-instructor-btn" [checked]="isAllInstructorsSelected" aria-label="Select all instructors" />
-              Select all
+              <input type="checkbox" id="select-all-instructor-btn" [checked]="isAllInstructorsSelected"/>
+              <label for="select-all-instructor-btn">&nbsp;Select all</label>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_NAME)">
-              Name
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_NAME)" [attr.aria-sort]="getAriaSortInstructor(SortBy.RESPONDENT_NAME)">
+              <button>
+                Name
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_NAME && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_EMAIL)">
-              Email
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.RESPONDENT_EMAIL)" [attr.aria-sort]="getAriaSortInstructor(SortBy.RESPONDENT_EMAIL)">
+              <button>
+                Email
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.RESPONDENT_EMAIL && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.INSTRUCTOR_PERMISSION_ROLE)">
-              Role
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.INSTRUCTOR_PERMISSION_ROLE)" [attr.aria-sort]="getAriaSortInstructor(SortBy.INSTRUCTOR_PERMISSION_ROLE)">
+              <button>
+                Role
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.INSTRUCTOR_PERMISSION_ROLE && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
-            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.SESSION_END_DATE)">
-              Current Deadline
-              <span class="fa-stack">
-                <i class="fas fa-sort"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.DESC"
-                  class="fas fa-sort-down"></i>
-                <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.ASC"
-                  class="fas fa-sort-up"></i>
-              </span>
+            <th class="sortable-header" (click)="sortInstructorsColumnsBy(SortBy.SESSION_END_DATE)" [attr.aria-sort]="getAriaSortInstructor(SortBy.SESSION_END_DATE)">
+              <button>
+                Current Deadline
+                <span class="fa-stack" aria-hidden="true">
+                  <i class="fas fa-sort"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.DESC"
+                    class="fas fa-sort-down"></i>
+                  <i *ngIf="sortInstructorsBy === SortBy.SESSION_END_DATE && sortInstructorOrder === SortOrder.ASC"
+                    class="fas fa-sort-up"></i>
+                </span>
+              </button>
             </th>
           </tr>
         </thead>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.scss
@@ -4,3 +4,26 @@
   flex-direction: row;
   gap: 20px;
 }
+
+.sortable-header {
+  cursor: pointer;
+
+  i {
+    margin-left: .3em;
+  }
+
+  .fa-stack {
+    width: 20%;
+  }
+
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+    font: inherit;
+    cursor: inherit;
+  }
+}

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -450,6 +450,13 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
     this.studentsOfCourse.sort(this.sortStudentPanelsBy(by));
   }
 
+  getAriaSortStudent(by: SortBy): String {
+    if (by !== this.sortStudentsBy) {
+      return 'none';
+    }
+    return this.sortStudentOrder === SortOrder.ASC ? 'ascending' : 'descending';
+  }
+
   private resetTables(): void {
     this.isAllInstructorsSelected = false;
     this.isAllStudentsSelected = false;
@@ -494,6 +501,13 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
     this.sortInstructorsBy = by;
     this.sortInstructorOrder = this.sortInstructorOrder === SortOrder.DESC ? SortOrder.ASC : SortOrder.DESC;
     this.instructorsOfCourse.sort(this.sortInstructorPanelsBy(by));
+  }
+
+  getAriaSortInstructor(by: SortBy): String {
+    if (by !== this.sortInstructorsBy) {
+      return 'none';
+    }
+    return this.sortInstructorOrder === SortOrder.ASC ? 'ascending' : 'descending';
   }
 
   private sortInstructorPanelsBy(


### PR DESCRIPTION
Part of #12081 
Sub-issue: [Fix all remaining sortable table headers](https://github.com/TEAMMATES/teammates/projects/16#card-88660895)

**Outline of Solution**
10 affected components (1 commit per component), each with generally the same solution:
- Add some form of `getAriaSort` function to get the sort status of the table header
- Call the function for each sortable table header
- Make the sortable table headers buttons so the screen reader shows that they are clickable
- Set `aria-hidden` attribute on the sort icons
- Update style for sortable table so that the default button style doesn't show up and the sort icons don't overflow into the next cell

Possible next actions: refactor the components to use the `sortable-table` component. Leaving this for another time as it likely takes quite a bit of refactoring, and might also require the change of the `sortable-table` component to be more general.