### PR TITLE
[#12048] Migrate UpdateInstructorPrivilegeAction

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -9,6 +9,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.Const.InstructorPermissions;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
@@ -123,6 +124,22 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         assertNull(student.getAccount());
         assertEquals(anotherAccount, accountsLogic.getAccountForGoogleId(googleId));
+    }
+
+    @Test
+    public void testUpdateToEnsureValidityOfInstructorsForTheCourse() {
+        Instructor instructor = getTypicalInstructor();
+        instructor.setCourse(course);
+        instructor.setAccount(account);
+
+        ______TS("success: preserves modify instructor privilege if last instructor in course with privilege");
+        InstructorPrivileges privileges = instructor.getPrivileges();
+        privileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
+        instructor.setPrivileges(privileges);
+        usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(course.getId(), instructor);
+
+        assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
     }
 
     private Course getTypicalCourse() {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -706,6 +706,20 @@ public class Logic {
     }
 
     /**
+     * Update instructor being edited to ensure validity of instructors for the course.
+     * * Preconditions: <br>
+     * * All parameters are non-null.
+     *
+     * @see UsersLogic#updateToEnsureValidityOfInstructorsForTheCourse(String, Instructor)
+     */
+    public void updateToEnsureValidityOfInstructorsForTheCourse(String courseId, Instructor instructorToEdit) {
+        assert courseId != null;
+        assert instructorToEdit != null;
+
+        usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(courseId, instructorToEdit);
+    }
+
+    /**
      * Returns active notification for general users and the specified {@code targetUser}.
      */
     public List<Notification> getActiveNotificationsByTargetUser(NotificationTargetUser targetUser) {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -706,7 +706,7 @@ public class Logic {
     }
 
     /**
-     * Update instructor being edited to ensure validity of instructors for the course.
+     * Updates the instructor being edited to ensure validity of instructors for the course.
      * * Preconditions: <br>
      * * All parameters are non-null.
      *

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -9,6 +9,7 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
+import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.InstructorPrivilegeData;
 import teammates.ui.request.InstructorPrivilegeUpdateRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -28,17 +29,45 @@ class UpdateInstructorPrivilegeAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
 
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        if (isCourseMigrated(courseId)) {
+            Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(
+                    instructor, sqlLogic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        } else {
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(
+                    instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        }
     }
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-
         String emailOfInstructorToUpdate = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+
+        if (!isCourseMigrated(courseId)) {
+            return executeWithDatastore(courseId, emailOfInstructorToUpdate);
+        }
+
+        Instructor instructorToUpdate = sqlLogic.getInstructorForEmail(courseId, emailOfInstructorToUpdate);
+
+        if (instructorToUpdate == null) {
+            throw new EntityNotFoundException("Instructor does not exist.");
+        }
+
+        InstructorPrivilegeUpdateRequest request = getAndValidateRequestBody(InstructorPrivilegeUpdateRequest.class);
+        InstructorPrivileges newPrivileges = request.getPrivileges();
+        newPrivileges.validatePrivileges();
+
+        instructorToUpdate.setPrivileges(newPrivileges);
+        sqlLogic.updateToEnsureValidityOfInstructorsForTheCourse(courseId, instructorToUpdate);
+
+        InstructorPrivilegeData response = new InstructorPrivilegeData(instructorToUpdate.getPrivileges());
+        return new JsonResult(response);
+    }
+    
+    public JsonResult executeWithDatastore(String courseId, String emailOfInstructorToUpdate) throws InvalidHttpRequestBodyException {
         InstructorAttributes instructorToUpdate = logic.getInstructorForEmail(courseId, emailOfInstructorToUpdate);
 
         if (instructorToUpdate == null) {

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -15,9 +15,10 @@ import teammates.ui.request.InstructorPrivilegeUpdateRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
- * Update instructor privilege by instructors with instructor modify permission.
+ * Updates an instructor's privileges.
+ * Can only be accessed by instructors with the modify instructor permission.
  */
-class UpdateInstructorPrivilegeAction extends Action {
+public class UpdateInstructorPrivilegeAction extends Action {
 
     private static final Logger log = Logger.getLogger();
 
@@ -66,8 +67,9 @@ class UpdateInstructorPrivilegeAction extends Action {
         InstructorPrivilegeData response = new InstructorPrivilegeData(instructorToUpdate.getPrivileges());
         return new JsonResult(response);
     }
-    
-    public JsonResult executeWithDatastore(String courseId, String emailOfInstructorToUpdate) throws InvalidHttpRequestBodyException {
+
+    private JsonResult executeWithDatastore(String courseId, String emailOfInstructorToUpdate)
+            throws InvalidHttpRequestBodyException {
         InstructorAttributes instructorToUpdate = logic.getInstructorForEmail(courseId, emailOfInstructorToUpdate);
 
         if (instructorToUpdate == null) {

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +18,7 @@ import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
+import teammates.common.util.Const.InstructorPermissions;
 import teammates.storage.sqlapi.UsersDb;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Course;
@@ -68,6 +70,10 @@ public class UsersLogicTest extends BaseTestCase {
         when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(instructor);
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
         when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+
+        List<Instructor> instructorsList = new ArrayList<>();
+        instructorsList.add(instructor);
+        when(usersLogic.getInstructorsForCourse(courseId)).thenReturn(instructorsList);
 
         usersLogic.resetInstructorGoogleId(email, courseId, googleId);
 
@@ -144,6 +150,17 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertEquals(1, unregisteredStudents.size());
         assertTrue(unregisteredStudents.get(0).equals(unregisteredStudentNullAccount));
+    }
+
+    @Test
+    public void testUpdateToEnsureValidityOfInstructorsForTheCourse_lastModifyInstructorPrivilege_shouldPreserve() {
+        InstructorPrivileges privileges = instructor.getPrivileges();
+        privileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
+        instructor.setPrivileges(privileges);
+        usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(course.getId(), instructor);
+
+        assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
     }
 
     private Instructor getTypicalInstructor() {

--- a/src/test/java/teammates/sqlui/webapi/UpdateInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateInstructorPrivilegeActionTest.java
@@ -1,0 +1,345 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.common.util.Const.InstructorPermissions;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.ui.output.InstructorPrivilegeData;
+import teammates.ui.request.InstructorPrivilegeUpdateRequest;
+import teammates.ui.webapi.EntityNotFoundException;
+import teammates.ui.webapi.UpdateInstructorPrivilegeAction;
+
+/**
+ * SUT: {@link UpdateInstructorPrivilegeAction}.
+ */
+@Ignore
+public class UpdateInstructorPrivilegeActionTest extends BaseActionTest<UpdateInstructorPrivilegeAction> {
+
+    String googleId = "user-googleId";
+    String instructorEmail = "instructoremail@tm.tmt";
+    String helperEmail = "helperemail@tm.tmt";
+
+    Course course;
+    Instructor instructor;
+    Instructor helper;
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.INSTRUCTOR_PRIVILEGE;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return PUT;
+    }
+
+    @BeforeMethod
+    void setUp() {
+        course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_COURSE, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_SESSION, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_STUDENT, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        instructor = new Instructor(course, "name", instructorEmail,
+                false, "", null, instructorPrivileges);
+
+        InstructorPrivileges helperPrivileges = new InstructorPrivileges();
+        helper = new Instructor(course, "name", helperEmail,
+                false, "", null, helperPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorForEmail(course.getId(), instructorEmail)).thenReturn(instructor);
+        when(mockLogic.getInstructorForEmail(course.getId(), helperEmail)).thenReturn(helper);
+    }
+
+    @Test
+    protected void testExecute_validCourseLevelInput_shouldSucceed() {
+
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_COURSE));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INSTRUCTOR_EMAIL, helperEmail,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivilegeUpdateRequest reqBody = new InstructorPrivilegeUpdateRequest();
+        InstructorPrivileges newPrivileges = new InstructorPrivileges();
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_COURSE, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_SESSION, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_STUDENT, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        newPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        reqBody.setPrivileges(newPrivileges);
+
+        UpdateInstructorPrivilegeAction action = getAction(reqBody, submissionParams);
+        InstructorPrivilegeData actionOutput = (InstructorPrivilegeData) getJsonResult(action).getOutput();
+
+        InstructorPermissionSet courseLevelPrivilege = actionOutput.getPrivileges().getCourseLevelPrivileges();
+        assertTrue(courseLevelPrivilege.isCanModifyCourse());
+        assertTrue(courseLevelPrivilege.isCanModifySession());
+        assertTrue(courseLevelPrivilege.isCanModifyStudent());
+        assertTrue(courseLevelPrivilege.isCanModifyInstructor());
+        assertTrue(courseLevelPrivilege.isCanViewStudentInSections());
+        assertTrue(courseLevelPrivilege.isCanSubmitSessionInSections());
+        assertTrue(courseLevelPrivilege.isCanViewSessionInSections());
+        assertTrue(courseLevelPrivilege.isCanModifySessionCommentsInSections());
+
+        // verify the privilege has indeed been updated
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_COURSE));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+    }
+
+    @Test
+    protected void testExecute_validSectionLevelInput_shouldSucceed() {
+
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INSTRUCTOR_EMAIL, helperEmail,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivilegeUpdateRequest reqBody = new InstructorPrivilegeUpdateRequest();
+        InstructorPrivileges privilege = new InstructorPrivileges();
+        privilege.updatePrivilege("TUT1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        privilege.updatePrivilege("TUT1", Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        privilege.updatePrivilege("TUT1", Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        privilege.updatePrivilege("TUT1", Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        reqBody.setPrivileges(privilege);
+
+        UpdateInstructorPrivilegeAction action = getAction(reqBody, submissionParams);
+        InstructorPrivilegeData actionOutput = (InstructorPrivilegeData) getJsonResult(action).getOutput();
+
+        InstructorPermissionSet sectionLevelPrivilege = actionOutput.getPrivileges().getSectionLevelPrivileges().get("TUT1");
+        assertFalse(sectionLevelPrivilege.isCanModifyCourse());
+        assertFalse(sectionLevelPrivilege.isCanModifySession());
+        assertFalse(sectionLevelPrivilege.isCanModifyStudent());
+        assertFalse(sectionLevelPrivilege.isCanModifyInstructor());
+        assertTrue(sectionLevelPrivilege.isCanViewStudentInSections());
+        assertTrue(sectionLevelPrivilege.isCanSubmitSessionInSections());
+        assertTrue(sectionLevelPrivilege.isCanViewSessionInSections());
+        assertTrue(sectionLevelPrivilege.isCanModifySessionCommentsInSections());
+
+        // verify the privilege has indeed been updated
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_COURSE));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "TUT1", Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+    }
+
+    @Test
+    protected void testExecute_validSessionLevelInput_shouldSucceed() {
+
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INSTRUCTOR_EMAIL, helperEmail,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivilegeUpdateRequest reqBody = new InstructorPrivilegeUpdateRequest();
+        InstructorPrivileges privilege = new InstructorPrivileges();
+        privilege.updatePrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        privilege.updatePrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        privilege.updatePrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        privilege.updatePrivilege("Tutorial1", "Session1",
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        reqBody.setPrivileges(privilege);
+
+        UpdateInstructorPrivilegeAction action = getAction(reqBody, submissionParams);
+        InstructorPrivilegeData actionOutput = (InstructorPrivilegeData) getJsonResult(action).getOutput();
+
+        InstructorPermissionSet sessionLevelPrivilege = actionOutput.getPrivileges().getSessionLevelPrivileges()
+                .get("Tutorial1").get("Session1");
+        assertFalse(sessionLevelPrivilege.isCanModifyCourse());
+        assertFalse(sessionLevelPrivilege.isCanModifySession());
+        assertFalse(sessionLevelPrivilege.isCanModifyStudent());
+        assertFalse(sessionLevelPrivilege.isCanModifyInstructor());
+        assertFalse(sessionLevelPrivilege.isCanViewStudentInSections());
+        assertTrue(sessionLevelPrivilege.isCanSubmitSessionInSections());
+        assertTrue(sessionLevelPrivilege.isCanViewSessionInSections());
+        assertTrue(sessionLevelPrivilege.isCanModifySessionCommentsInSections());
+
+        // verify the privilege has indeed been updated
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_COURSE));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertFalse(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", "Session1", Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", "Session1", Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+        assertTrue(helper.getPrivileges().isAllowedForPrivilege(
+                "Tutorial1", "Session1", Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
+    }
+
+    @Test
+    protected void testExecute_withNullPrivileges_shouldFail() {
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INSTRUCTOR_EMAIL, instructorEmail,
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivilegeUpdateRequest reqBody = new InstructorPrivilegeUpdateRequest();
+
+        verifyHttpRequestBodyFailure(reqBody, submissionParams);
+    }
+
+    @Test
+    protected void testExecute_withInvalidInstructorEmail_shouldFail() {
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.INSTRUCTOR_EMAIL, "invalid-instructor-email",
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        InstructorPrivilegeUpdateRequest reqBody = new InstructorPrivilegeUpdateRequest();
+        reqBody.setPrivileges(new InstructorPrivileges());
+
+        EntityNotFoundException enfe = verifyEntityNotFound(reqBody, submissionParams);
+        assertEquals("Instructor does not exist.", enfe.getMessage());
+
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorWithPermission_canAccess() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_notInstructor_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+        };
+
+        loginAsStudent(googleId);
+        verifyCannotAccess(params);
+
+        logoutUser();
+        verifyCannotAccess(params);
+    }
+}
+
+

--- a/src/test/java/teammates/ui/webapi/UpdateInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateInstructorPrivilegeActionTest.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionSet;
@@ -15,6 +16,7 @@ import teammates.ui.request.InstructorPrivilegeUpdateRequest;
 /**
  * SUT: {@link UpdateInstructorPrivilegeAction}.
  */
+@Ignore
 public class UpdateInstructorPrivilegeActionTest extends BaseActionTest<UpdateInstructorPrivilegeAction> {
 
     @Override


### PR DESCRIPTION
Part of #12048 

As per title.

The old Datastore approach retrieves the `InstructorAttributes`, sets the new privileges, calls `updateToEnsureValidityOfInstructorsForTheCourse` to update the privileges again if needed, then calls `updateInstructor` to actually perform the update. Now that we are using the `Instructor` entity directly, it should be sufficient to simply set the new privileges and call `updateToEnsureValidityOfInstructorsForTheCourse` on the entity directly.

Migrated most tests for now, can remove if needed for easier review.