### PR TITLE
[ #12277] - Deleting video link on Getting Started

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -4,7 +4,7 @@
     Welcome to TEAMMATES!
   </p>
   <p>
-    To get started using TEAMMATES, follow the following steps, or watch our <a href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1&rel=0" target="_blank"><i class="fas fa-film"></i> Video Tour</a>.<br>
+    To get started using TEAMMATES, follow the following steps.
     For more help, browse the answers to some <a [tmRouterLink]="instructorHelpPath">frequently asked questions</a>.
   </p>
   <ol>


### PR DESCRIPTION
Fixes Part of #12277

Deleted link to video tutorial on Getting Started page.
