### PR TITLE
Migrate FeedbackSession*RemindersAction classes

### DIFF
--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -452,6 +452,34 @@ public class Logic {
     }
 
     /**
+     * Returns returns a list of sessions that are going to close soon.
+     */
+    public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
+        return feedbackSessionsLogic.getFeedbackSessionsClosingWithinTimeLimit();
+    }
+
+    /**
+     * Returns returns a list of sessions that are going to open soon.
+     */
+    public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
+        return feedbackSessionsLogic.getFeedbackSessionsOpeningWithinTimeLimit();
+    }
+
+    /**
+     * Returns a list of sessions that require automated emails to be sent as they are published.
+     */
+    public List<FeedbackSession> getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent() {
+        return feedbackSessionsLogic.getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent();
+    }
+
+    /**
+     * Returns a list of feedback sessions that need an open email to be sent.
+     */
+    public List<FeedbackSession> getFeedbackSessionsWhichNeedOpenEmailsToBeSent() {
+        return feedbackSessionsLogic.getFeedbackSessionsWhichNeedOpenEmailsToBeSent();
+    }
+
+    /**
      * Get usage statistics within a time range.
      */
     public List<UsageStatistics> getUsageStatisticsForTimeRange(Instant startTime, Instant endTime) {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -445,6 +445,13 @@ public class Logic {
     }
 
     /**
+     * Returns returns a list of sessions that were closed within past hour.
+     */
+    public List<FeedbackSession> getFeedbackSessionsClosedWithinThePastHour() {
+        return feedbackSessionsLogic.getFeedbackSessionsClosedWithinThePastHour();
+    }
+
+    /**
      * Get usage statistics within a time range.
      */
     public List<UsageStatistics> getUsageStatisticsForTimeRange(Instant startTime, Instant endTime) {

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -14,6 +14,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
+import teammates.common.util.TimeHelper;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -34,6 +35,9 @@ public final class FeedbackSessionsLogic {
             + "Session has already been published.";
     private static final String ERROR_FS_ALREADY_UNPUBLISH = "Error unpublishing feedback session: "
             + "Session has already been unpublished.";
+
+    private static final int NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT = 24;
+    private static final int NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT = 24;
 
     private static final FeedbackSessionsLogic instance = new FeedbackSessionsLogic();
 
@@ -309,5 +313,92 @@ public final class FeedbackSessionsLogic {
         log.info(String.format("Number of sessions under consideration after filtering: %d",
                 requiredSessions.size()));
         return requiredSessions;
+    }
+
+    /**
+     * Gets a list of undeleted feedback sessions which start within the last 2 hours
+     * and need an open email to be sent.
+     */
+    public List<FeedbackSession> getFeedbackSessionsWhichNeedOpenEmailsToBeSent() {
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpenEmail();
+        List<FeedbackSession> sessionsToSendEmailsFor = new ArrayList<>();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        for (FeedbackSession session : sessions) {
+            if (session.isOpened() && session.getCourse().getDeletedAt() == null) {
+                sessionsToSendEmailsFor.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                sessionsToSendEmailsFor.size()));
+        return sessionsToSendEmailsFor;
+    }
+
+    /**
+     * Returns returns a list of sessions that are going to open in 24 hours.
+     */
+    public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
+        List<FeedbackSession> requiredSessions = new ArrayList<>();
+
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpeningSoonEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        for (FeedbackSession session : sessions) {
+            if (session.isOpeningWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT)
+                    && session.getCourse().getDeletedAt() == null) {
+                requiredSessions.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
+        return requiredSessions;
+    }
+
+    /**
+     * Returns returns a list of sessions that are going to close within the next 24 hours.
+     */
+    public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
+        List<FeedbackSession> requiredSessions = new ArrayList<>();
+
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingSoonEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        for (FeedbackSession session : sessions) {
+            if (session.isClosingWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
+                    && session.getCourse().getDeletedAt() == null) {
+                requiredSessions.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
+        return requiredSessions;
+    }
+
+    /**
+     * Criteria: must be published, publishEmail must be enabled and
+     * resultsVisibleTime must be custom.
+     *
+     * @return returns a list of sessions that require automated emails to be
+     *         sent as they are published
+     */
+    public List<FeedbackSession> getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent() {
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingPublishedEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+        List<FeedbackSession> sessionsToSendEmailsFor = new ArrayList<>();
+
+        for (FeedbackSession session : sessions) {
+            // automated emails are required only for custom publish times
+            if (session.isPublished()
+                    && !TimeHelper.isSpecialTime(session.getResultsVisibleFromTime())
+                    && session.getCourse().getDeletedAt() == null) {
+                sessionsToSendEmailsFor.add(session);
+            }
+        }
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                sessionsToSendEmailsFor.size()));
+        return sessionsToSendEmailsFor;
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -6,11 +6,13 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.common.util.TimeHelper;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 
@@ -202,6 +204,29 @@ public final class FeedbackSessionsDb extends EntitiesDb {
                 .where(cb.and(
                     cb.greaterThanOrEqualTo(root.get("startTime"), after),
                     cb.equal(root.get("courseId"), courseId)));
+
+        return HibernateUtil.createQuery(cr).getResultList();
+    }
+
+    /**
+     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
+     * and possibly need a closed email to be sent.
+     */
+    public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingClosedEmail() {
+        return getFeedbackSessionEntitiesPossiblyNeedingClosedEmail().stream()
+                .filter(session -> session.getDeletedAt() == null)
+                .collect(Collectors.toList());
+    }
+
+    private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosedEmail() {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
+        Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+
+        cr.select(root)
+                .where(cb.and(
+                    cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
+                    cb.equal(root.get("isClosingEmailEnabled"), true)));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -405,7 +405,7 @@ public class FeedbackSession extends BaseEntity {
      * This occurs only when the current time is after both the deadline and the grace period.
      */
     public boolean isClosed() {
-        return !isOpened() && Instant.now().isAfter(endTime);
+        return !isOpened() && Instant.now().isAfter(endTime.plus(gracePeriod));
     }
 
     /**
@@ -431,7 +431,7 @@ public class FeedbackSession extends BaseEntity {
     public boolean isOpenedGivenExtendedDeadline(Instant extendedDeadline) {
         Instant now = Instant.now();
         return (now.isAfter(startTime) || now.equals(startTime))
-                && now.isBefore(extendedDeadline.plus(gracePeriod)) || now.isBefore(endTime.plus(gracePeriod));
+                && (now.isBefore(extendedDeadline) || now.isBefore(endTime));
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -479,4 +479,15 @@ public class FeedbackSession extends BaseEntity {
     public boolean isCreator(String userEmail) {
         return creatorEmail.equals(userEmail);
     }
+
+    /**
+     * Checks if the session closed some time in the last one hour from calling this function.
+     *
+     * @return true if the session closed within the past hour; false otherwise.
+     */
+    public boolean isClosedWithinPastHour() {
+        Instant now = Instant.now();
+        Instant timeClosed = endTime.plus(gracePeriod);
+        return timeClosed.isBefore(now) && Duration.between(timeClosed, now).compareTo(Duration.ofHours(1)) < 0;
+    }
 }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -481,6 +481,32 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
+     * Returns true if the feedback session is closing (almost closed) after the number of specified hours.
+     */
+    public boolean isClosingWithinTimeLimit(long hours) {
+        Instant now = Instant.now();
+        Duration difference = Duration.between(now, endTime);
+        // If now and start are almost similar, it means the feedback session
+        // is open for only 24 hours.
+        // Hence we do not send a reminder e-mail for feedback session.
+        return now.isAfter(startTime)
+               && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
+               && difference.compareTo(Duration.ofHours(hours)) < 0;
+    }
+
+    /**
+     * Returns true if the feedback session opens after the number of specified hours.
+     */
+    public boolean isOpeningWithinTimeLimit(long hours) {
+        Instant now = Instant.now();
+        Duration difference = Duration.between(now, startTime);
+
+        return now.isBefore(startTime)
+                && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
+                && difference.compareTo(Duration.ofHours(hours)) < 0;
+    }
+
+    /**
      * Checks if the session closed some time in the last one hour from calling this function.
      *
      * @return true if the session closed within the past hour; false otherwise.

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
@@ -22,7 +22,7 @@ class FeedbackSessionClosedRemindersAction extends AdminOnlyAction {
         for (FeedbackSessionAttributes session : sessionAttributes) {
 
             // If course has been migrated, use sql email logic instead.
-            if (!isCourseMigrated(session.getCourseId())) {
+            if (isCourseMigrated(session.getCourseId())) {
                 continue;
             }
 

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
@@ -6,6 +6,7 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
 import teammates.common.util.RequestTracer;
+import teammates.storage.sqlentity.FeedbackSession;
 
 /**
  * Cron job: schedules feedback session opening soon emails to be sent.
@@ -15,8 +16,14 @@ class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute() {
-        List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsOpeningWithinTimeLimit();
-        for (FeedbackSessionAttributes session : sessions) {
+        List<FeedbackSessionAttributes> sessionAttributes = logic.getFeedbackSessionsOpeningWithinTimeLimit();
+        for (FeedbackSessionAttributes session : sessionAttributes) {
+
+            // If course has been migrated, use sql email logic instead.
+            if (isCourseMigrated(session.getCourseId())) {
+                continue;
+            }
+
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionOpeningSoonEmails(session);
             try {
@@ -31,6 +38,18 @@ class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
                 log.severe("Unexpected error", e);
             }
         }
+
+        List<FeedbackSession> sessions = sqlLogic.getFeedbackSessionsOpeningWithinTimeLimit();
+        for (FeedbackSession session : sessions) {
+            RequestTracer.checkRemainingTime();
+            List<EmailWrapper> emailsToBeSent = sqlEmailGenerator.generateFeedbackSessionOpeningSoonEmails(session);
+            try {
+                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+            } catch (Exception e) {
+                log.severe("Unexpected error", e);
+            }
+        }
+
         return new JsonResult("Successful");
     }
 }


### PR DESCRIPTION
Part of #12048.

This PR is currently on hold while waiting for expected changes to the `FeedbackSession` entity to be merged in in a separate PR.

---
**Outline of Solution**
* Migrated the following action classes:
    * `FeedbackSessionClosedRemindersAction.java`
    * `FeedbackSessionClosingRemindersAction.java`
    * `FeedbackSessionOpeningRemindersAction.java`
    * `FeedbackSessionOpeningSoonRemindersAction.java`
    * `FeedbackSessionPublishedRemindersAction.java`

* Minor changes to the FeedbackSession's open, in grace period and closed check logic.
    * Without `GivenExtendedDeadline`:
        * isOpen period (ie. evaluates to true): [startTime, endTime)
        * isInGracePeriod: (endTime, endTime + gracePeriod]
        * isClosed: [endTime + gracePeriod, infinity)
    * With `GivenExtendedDeadline`:
        * deadline = MAX(endTime, extendedDeadline)   → so that if extendedDeadline is before endTime, use endTime as the deadline.
       
        * isOpen period: [startTime, deadline)
        * isInGracePeriod: (deadline, deadline + gracePeriod]
        * isClosed: [deadline + gracePeriod, infinity)
