### PR TITLE
[#12048] Restore sent*email fields

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -169,6 +169,8 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
                 Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"), Duration.ofMinutes(10),
                 true, true, true);
         expectedSession1.setId(actualSession1.getId());
+        expectedSession1.setOpenEmailSent(actualSession1.isOpenEmailSent());
+        expectedSession1.setOpeningSoonEmailSent(actualSession1.isOpeningSoonEmailSent());
         verifyEquals(expectedSession1, actualSession1);
 
         ______TS("verify feedback questions deserialized correctly");

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -173,6 +173,10 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
       "isPublishedEmailSent": false
     },
     "session2InTypicalCourse": {
@@ -191,6 +195,10 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
       "isPublishedEmailSent": false
     }
   },

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -58,7 +58,8 @@
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
-      "endTime": "2027-04-30T23:00:00Z"
+      "endTime": "2027-04-30T23:00:00Z",
+      "isClosingSoonEmailSent": false
     },
     "instructor1InTypicalCourseSession1": {
       "id": "00000000-0000-4000-8000-000000000402",
@@ -69,7 +70,8 @@
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
-      "endTime": "2027-04-30T23:00:00Z"
+      "endTime": "2027-04-30T23:00:00Z",
+      "isClosingSoonEmailSent": false
     }
   },
   "instructors": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -234,6 +234,10 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
       "isPublishedEmailSent": true
     },
     "session2InTypicalCourse": {
@@ -252,6 +256,10 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
       "isPublishedEmailSent": false
     },
     "unpublishedSession1InTypicalCourse": {
@@ -270,6 +278,10 @@
       "isOpeningEmailEnabled": true,
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
       "isPublishedEmailSent": false
     }
   },

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -92,7 +92,8 @@
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
-      "endTime": "2027-04-30T23:00:00Z"
+      "endTime": "2027-04-30T23:00:00Z",
+      "isClosingSoonEmailSent": false
     },
     "instructor1InCourse1Session1": {
       "id": "00000000-0000-4000-8000-000000000402",
@@ -103,7 +104,8 @@
       "feedbackSession": {
         "id": "00000000-0000-4000-8000-000000000701"
       },
-      "endTime": "2027-04-30T23:00:00Z"
+      "endTime": "2027-04-30T23:00:00Z",
+      "isClosingSoonEmailSent": false
     }
   },
   "instructors": {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -445,6 +445,15 @@ public class Logic {
     }
 
     /**
+     * After an update to feedback session's fields, may need to adjust the email status of the session.
+     * @param session recently updated session.
+     */
+    public void adjustFeedbackSessionEmailStatusAfterUpdate(FeedbackSession session) {
+        assert session != null;
+        feedbackSessionsLogic.adjustFeedbackSessionEmailStatusAfterUpdate(session);
+    }
+
+    /**
      * Get usage statistics within a time range.
      */
     public List<UsageStatistics> getUsageStatisticsForTimeRange(Instant startTime, Instant endTime) {

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -267,7 +267,7 @@ public final class SqlEmailGenerator {
         List<FeedbackSession> fsInCourse = fsLogic.getFeedbackSessionsForCourse(courseId);
 
         for (FeedbackSession fs : fsInCourse) {
-            if (fs.isOpened() || fs.isPublished()) {
+            if (fs.isOpenEmailSent() || fs.isPublishedEmailSent()) {
                 sessions.add(fs);
             }
         }

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -32,6 +32,9 @@ public final class FeedbackSessionsLogic {
     private static final String ERROR_FS_ALREADY_UNPUBLISH = "Error unpublishing feedback session: "
             + "Session has already been unpublished.";
 
+    private static final int NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT = 24;
+    private static final int NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT = 24;
+
     private static final FeedbackSessionsLogic instance = new FeedbackSessionsLogic();
 
     private FeedbackSessionsDb fsDb;
@@ -286,5 +289,39 @@ public final class FeedbackSessionsLogic {
 
         // if there is no question for instructor, session is attempted
         return !fqLogic.hasFeedbackQuestionsForInstructors(session.getFeedbackQuestions(), session.isCreator(userEmail));
+    }
+
+    /**
+     * After an update to feedback session's fields, may need to adjust the email status of the session.
+     * @param session recently updated session.
+     */
+    public void adjustFeedbackSessionEmailStatusAfterUpdate(FeedbackSession session) {
+        // reset isOpenEmailSent if the session has opened but is being un-opened
+        // now, or else leave it as sent if so.
+        if (session.isOpenEmailSent()) {
+            session.setOpenEmailSent(session.isOpened());
+
+            // also reset isOpeningSoonEmailSent
+            session.setOpeningSoonEmailSent(
+                    session.isOpened() || session.isOpeningInHours(NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT)
+            );
+        }
+
+        // reset isClosedEmailSent if the session has closed but is being un-closed
+        // now, or else leave it as sent if so.
+        if (session.isClosedEmailSent()) {
+            session.setClosedEmailSent(session.isClosed());
+
+            // also reset isClosingSoonEmailSent
+            session.setClosingSoonEmailSent(
+                    session.isClosed() || session.isClosedAfter(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
+            );
+        }
+
+        // reset isPublishedEmailSent if the session has been published but is
+        // going to be unpublished now, or else leave it as sent if so.
+        if (session.isPublishedEmailSent()) {
+            session.setPublishedEmailSent(session.isPublished());
+        }
     }
 }

--- a/src/main/java/teammates/storage/sqlentity/DeadlineExtension.java
+++ b/src/main/java/teammates/storage/sqlentity/DeadlineExtension.java
@@ -37,6 +37,9 @@ public class DeadlineExtension extends BaseEntity {
     @Column(nullable = false)
     private Instant endTime;
 
+    @Column(nullable = false)
+    private boolean isClosingSoonEmailSent;
+
     @UpdateTimestamp
     @Column(nullable = false)
     private Instant updatedAt;
@@ -84,6 +87,14 @@ public class DeadlineExtension extends BaseEntity {
         this.endTime = endTime;
     }
 
+    public boolean isClosingSoonEmailSent() {
+        return isClosingSoonEmailSent;
+    }
+
+    public void setClosingSoonEmailSent(boolean isClosingSoonEmailSent) {
+        this.isClosingSoonEmailSent = isClosingSoonEmailSent;
+    }
+
     public Instant getUpdatedAt() {
         return updatedAt;
     }
@@ -95,7 +106,8 @@ public class DeadlineExtension extends BaseEntity {
     @Override
     public String toString() {
         return "DeadlineExtension [id=" + id + ", user=" + user + ", feedbackSessionId=" + feedbackSession.getId()
-                + ", endTime=" + endTime + ", createdAt=" + getCreatedAt() + ", updatedAt=" + updatedAt + "]";
+                + ", endTime=" + endTime + ", isClosingSoonEmailSent=" + isClosingSoonEmailSent
+                + ", createdAt=" + getCreatedAt() + ", updatedAt=" + updatedAt + "]";
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -526,4 +526,20 @@ public class FeedbackSession extends BaseEntity {
     public boolean isCreator(String userEmail) {
         return creatorEmail.equals(userEmail);
     }
+
+    /**
+     * Returns true if session's start time is opening from now to anytime before
+     * now() + the specific number of {@param hours} supplied in the argument.
+     */
+    public boolean isOpeningInHours(long hours) {
+        return startTime.isAfter(Instant.now())
+                && Instant.now().plus(Duration.ofHours(hours)).isAfter(startTime);
+    }
+
+    /**
+     * Returns true if the feedback session is closed after the number of specified hours.
+     */
+    public boolean isClosedAfter(long hours) {
+        return Instant.now().plus(Duration.ofHours(hours)).isAfter(endTime);
+    }
 }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -338,7 +338,7 @@ public class FeedbackSession extends BaseEntity {
         return isOpeningSoonEmailSent;
     }
 
-    public void setOpeningEmailSent(boolean isOpeningSoonEmailSent) {
+    public void setOpeningSoonEmailSent(boolean isOpeningSoonEmailSent) {
         this.isOpeningSoonEmailSent = isOpeningSoonEmailSent;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -75,6 +75,18 @@ public class FeedbackSession extends BaseEntity {
     private boolean isPublishedEmailEnabled;
 
     @Column(nullable = false)
+    private boolean isOpeningSoonEmailSent;
+
+    @Column(nullable = false)
+    private boolean isOpenEmailSent;
+
+    @Column(nullable = false)
+    private boolean isClosingSoonEmailSent;
+
+    @Column(nullable = false)
+    private boolean isClosedEmailSent;
+
+    @Column(nullable = false)
     private boolean isPublishedEmailSent;
 
     @OneToMany(mappedBy = "feedbackSession", cascade = CascadeType.REMOVE)
@@ -322,6 +334,38 @@ public class FeedbackSession extends BaseEntity {
         this.feedbackQuestions = feedbackQuestions;
     }
 
+    public boolean isOpeningSoonEmailSent() {
+        return isOpeningSoonEmailSent;
+    }
+
+    public void setOpeningEmailSent(boolean isOpeningSoonEmailSent) {
+        this.isOpeningSoonEmailSent = isOpeningSoonEmailSent;
+    }
+
+    public boolean isOpenEmailSent() {
+        return isOpenEmailSent;
+    }
+
+    public void setOpenEmailSent(boolean isOpenEmailSent) {
+        this.isOpenEmailSent = isOpenEmailSent;
+    }
+
+    public boolean isClosingSoonEmailSent() {
+        return isClosingSoonEmailSent;
+    }
+
+    public void setClosingSoonEmailSent(boolean isClosingSoonEmailSent) {
+        this.isClosingSoonEmailSent = isClosingSoonEmailSent;
+    }
+
+    public boolean isClosedEmailSent() {
+        return isClosedEmailSent;
+    }
+
+    public void setClosedEmailSent(boolean isClosedEmailSent) {
+        this.isClosedEmailSent = isClosedEmailSent;
+    }
+
     public boolean isPublishedEmailSent() {
         return isPublishedEmailSent;
     }
@@ -354,7 +398,10 @@ public class FeedbackSession extends BaseEntity {
                 + ", sessionVisibleFromTime=" + sessionVisibleFromTime + ", resultsVisibleFromTime="
                 + resultsVisibleFromTime + ", gracePeriod=" + gracePeriod + ", isOpeningEmailEnabled="
                 + isOpeningEmailEnabled + ", isClosingEmailEnabled=" + isClosingEmailEnabled
-                + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled + ", deadlineExtensions=" + deadlineExtensions
+                + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled
+                + ", isOpeningSoonEmailSent=" + isOpeningSoonEmailSent + ", isOpenEmailSent=" + isOpenEmailSent
+                + ", isClosingSoonEmailSent=" + isClosingSoonEmailSent + ", isClosedEmailSent=" + isClosedEmailSent
+                + ", isPublishedEmailSent=" + isPublishedEmailSent + ", deadlineExtensions=" + deadlineExtensions
                 + ", feedbackQuestions=" + feedbackQuestions + ", createdAt=" + getCreatedAt()
                 + ", updatedAt=" + updatedAt + ", deletedAt=" + deletedAt + "]";
     }

--- a/src/main/java/teammates/ui/output/DeadlineExtensionData.java
+++ b/src/main/java/teammates/ui/output/DeadlineExtensionData.java
@@ -3,6 +3,8 @@ package teammates.ui.output;
 import java.time.Instant;
 
 import teammates.common.datatransfer.attributes.DeadlineExtensionAttributes;
+import teammates.storage.sqlentity.DeadlineExtension;
+import teammates.storage.sqlentity.Instructor;
 
 /**
  * Output format of deadline extension data.
@@ -32,6 +34,15 @@ public class DeadlineExtensionData extends ApiOutput {
         this.userEmail = deadlineExtension.getUserEmail();
         this.isInstructor = deadlineExtension.getIsInstructor();
         this.sentClosingEmail = deadlineExtension.getSentClosingEmail();
+        this.endTime = deadlineExtension.getEndTime().toEpochMilli();
+    }
+
+    public DeadlineExtensionData(DeadlineExtension deadlineExtension) {
+        this.courseId = deadlineExtension.getFeedbackSession().getCourse().getId();
+        this.feedbackSessionName = deadlineExtension.getFeedbackSession().getName();
+        this.userEmail = deadlineExtension.getUser().getEmail();
+        this.isInstructor = deadlineExtension.getUser() instanceof Instructor;
+        this.sentClosingEmail = deadlineExtension.isClosingSoonEmailSent();
         this.endTime = deadlineExtension.getEndTime().toEpochMilli();
     }
 

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedEmailWorkerAction.java
@@ -51,6 +51,7 @@ public class FeedbackSessionPublishedEmailWorkerAction extends AdminOnlyAction {
         try {
             taskQueuer.scheduleEmailsForSending(emailsToBeSent);
             session.setPublishedEmailSent(true);
+            sqlLogic.adjustFeedbackSessionEmailStatusAfterUpdate(session);
         } catch (Exception e) {
             log.severe("Unexpected error", e);
         }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionUnpublishedEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionUnpublishedEmailWorkerAction.java
@@ -53,6 +53,7 @@ public class FeedbackSessionUnpublishedEmailWorkerAction extends AdminOnlyAction
             taskQueuer.scheduleEmailsForSending(emailsToBeSent);
 
             session.setPublishedEmailSent(false);
+            sqlLogic.adjustFeedbackSessionEmailStatusAfterUpdate(session);
         } catch (Exception e) {
             log.severe("Unexpected error", e);
         }


### PR DESCRIPTION
Part of #12048.

* Restores `FeedbackSession` entities' fields: 
    * `isOpeningSoonEmailSent`
    * `isOpenEmailSent`
    * `isClosingSoonEmailSent`
    * `isClosingEmailSent`
* Restores `DeadlineExtension` entities' fields: 
    * `isClosingSoonEmailSent`

* These fields enable the conditional check if a particular email type has been sent for a particular feedbackSession.
* They are used in the Cron Jobs RemindersAction classes (see: `FeedbackSessionClosedRemindersAction`, `FeedbackSessionClosingRemindersAction`, `FeedbackSessionOpeningRemindersAction`, `FeedbackSessionOpeningSoonRemindersAction`, `FeedbackSessionPublishedRemindersAction`)
* Without these fields, no longer able to check if a cron job has been run to send an email.