### PR TITLE
[#12383] Instructor edit feedback session page: missing indication for tooltip 

### DIFF
--- a/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
@@ -15,7 +15,8 @@
                container="body">
           <input id="weights-checkbox" class="form-check-input" type="checkbox" [ngModel]="model.hasAssignedWeights"
                  [disabled]="!isEditable"
-                 (ngModelChange)="triggerWeightsColumn($event)">
+                 (ngModelChange)="triggerWeightsColumn($event)"
+                 ngbTooltip="Assign weights to the choices for calculating statistics">
           Options are weighted
         </label>
       </div>


### PR DESCRIPTION
Fixes #12383

Added ngbTooltip to add the tooptip in "Options are weighted" option in checkbox.