### PR TITLE
[#7678] Instructor: edit question: do not warn about deleting responses if destructive changes are cancelled

### DIFF
--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.ts
@@ -80,7 +80,7 @@ export class FeedbackPathPanelComponent {
     new EventEmitter<NumberOfEntitiesToGiveFeedbackToSetting>();
 
   @Output()
-  triggerModelChangeBatch: EventEmitter<Partial<QuestionEditFormModel>> =
+  triggerUnsavedModelChangeBatch: EventEmitter<Partial<QuestionEditFormModel>> =
     new EventEmitter<Partial<QuestionEditFormModel>>();
 
   subMenuStatuses: Map<FeedbackParticipantType, boolean> = new Map();
@@ -129,12 +129,12 @@ export class FeedbackPathPanelComponent {
       // do not reset the visibility settings if reverting feedback path to preset template provided
       if (this.model.isUsingOtherFeedbackPath) {
         // remove the custom feedback if selecting a common feedback path
-        this.triggerModelChangeBatch.emit({
+        this.triggerUnsavedModelChangeBatch.emit({
           isUsingOtherFeedbackPath: false,
         });
       }
     } else {
-      this.triggerModelChangeBatch.emit({
+      this.triggerUnsavedModelChangeBatch.emit({
         giverType,
         recipientType: newRecipientType,
         commonVisibilitySettingName: 'Please select a visibility option',

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -26,6 +26,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
   numOfQuestions="0"
   saveExistingQuestionEvent={[Function EventEmitter_]}
   simpleModalService={[Function SimpleModalService]}
+  unsavedModel={[Function Object]}
   visibilityStateMachine={[Function VisibilityStateMachine]}
 >
   <div

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -1,56 +1,56 @@
-<div id="question-form-{{ model.questionNumber }}" class="card">
-  <button class="card-header bg-primary text-white cursor-pointer border-0" (click)="triggerModelChange('isCollapsed', !model.isCollapsed)">
+<div id="question-form-{{ unsavedModel.questionNumber }}" class="card">
+  <button class="card-header bg-primary text-white cursor-pointer border-0" (click)="triggerUnsavedModelChange('isCollapsed', !unsavedModel.isCollapsed)">
     <div class="collapse-caret">
-      <tm-panel-chevron [isExpanded]="!model.isCollapsed"></tm-panel-chevron>
+      <tm-panel-chevron [isExpanded]="!unsavedModel.isCollapsed"></tm-panel-chevron>
     </div>
     <div class="d-flex flex-fill flex-sm-row flex-column align-items-sm-center align-items-start">
       <div id="question-header" class="d-flex flex-column text-start">
         <div class="d-flex flex-sm-row flex-column align-items-sm-center align-items-start">
-          <h2 class="question-number fw-bold me-1">Question <span id="question-number" *ngIf="!model.isEditable">{{ model.questionNumber }}</span>
-            <select id="question-number-dropdown" class="form-control form-select question-number-select" [ngModel]="model.questionNumber" (ngModelChange)="triggerModelChange('questionNumber', $event)" *ngIf="model.isEditable" (click)="$event.stopPropagation()">
+          <h2 class="question-number fw-bold me-1">Question <span id="question-number" *ngIf="!unsavedModel.isEditable">{{ unsavedModel.questionNumber }}</span>
+            <select id="question-number-dropdown" class="form-control form-select question-number-select" [ngModel]="unsavedModel.questionNumber" (ngModelChange)="triggerUnsavedModelChange('questionNumber', $event)" *ngIf="unsavedModel.isEditable" (click)="$event.stopPropagation()">
               <option *ngFor="let i of range(numOfQuestions)" [ngValue]="i + 1">{{ i + 1 }}</option>
             </select>
           </h2>
-        <span id="question-type">{{ model.questionType | questionTypeName }}</span>
+        <span id="question-type">{{ unsavedModel.questionType | questionTypeName }}</span>
         </div>
-        <ng-container *ngIf="model.isCollapsed">
-          <div class="collapse-qn-description">{{ model.questionBrief }}</div>
+        <ng-container *ngIf="unsavedModel.isCollapsed">
+          <div class="collapse-qn-description">{{ unsavedModel.questionBrief }}</div>
         </ng-container>
       </div>
       <div class="card-header-btn-toolbar ms-0 ms-sm-auto text-start">
         <div *ngIf="formMode === QuestionEditFormMode.EDIT">
-          <button id="btn-edit-question" type="button" class="btn btn-primary btn-sm" *ngIf="!model.isEditable"
-                  (click)="triggerModelChangeBatch({'isEditable': true, 'isCollapsed': false}); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+          <button id="btn-edit-question" type="button" class="btn btn-primary btn-sm" *ngIf="!unsavedModel.isEditable"
+                  (click)="triggerUnsavedModelChangeBatch({'isEditable': true, 'isCollapsed': false}); $event.stopPropagation();"
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
             <i class="fas fa-pencil-alt"></i> Edit
           </button>
-          <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
+          <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="unsavedModel.isEditable"
                   (click)="saveQuestionHandler(); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-            <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
+            <tm-ajax-loading *ngIf="unsavedModel.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
           </button>
-          <button type="button" class="btn btn-primary btn-sm" *ngIf="model.isEditable"
+          <button type="button" class="btn btn-primary btn-sm" *ngIf="unsavedModel.isEditable"
                   (click)="discardChangesHandler(false); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
             <i class="fas fa-ban"></i> Cancel
           </button>
           <button id="btn-delete-question" type="button" class="btn btn-primary btn-sm"
                   (click)="deleteCurrentQuestionHandler(); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
-            <tm-ajax-loading *ngIf="model.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
+            <tm-ajax-loading *ngIf="unsavedModel.isDeleting"></tm-ajax-loading><i class="fas fa-trash"></i> Delete
           </button>
           <button id="btn-duplicate-question" type="button" class="btn btn-primary btn-sm" container="body"
                   (click)="duplicateCurrentQuestionHandler(); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating"
                   ngbTooltip="Make a copy of the existing question and add to the current feedback session."
                   container="body">
-            <tm-ajax-loading *ngIf="model.isDuplicating"></tm-ajax-loading><i class="far fa-copy"></i> Duplicate
+            <tm-ajax-loading *ngIf="unsavedModel.isDuplicating"></tm-ajax-loading><i class="far fa-copy"></i> Duplicate
           </button>
         </div>
         <div *ngIf="formMode === QuestionEditFormMode.ADD">
           <button type="button" class="btn btn-primary btn-sm"
                   (click)="discardChangesHandler(true); $event.stopPropagation();"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
             <i class="fas fa-ban"></i>
             Cancel
           </button>
@@ -58,51 +58,51 @@
       </div>
     </div>
   </button>
-  <div *ngIf="!model.isCollapsed" @collapseAnim>
+  <div *ngIf="!unsavedModel.isCollapsed" @collapseAnim>
     <div class="card-body">
       <div class="background-color-light-blue">
         <div class="row">
           <div class="col-12">
-            <tm-question-edit-brief-description-form [brief]="model.questionBrief" (briefChange)="triggerModelChange('questionBrief', $event)" [isBriefDisabled]="!model.isEditable"
-                                                     [description]="model.questionDescription" (descriptionChange)="triggerModelChange('questionDescription', $event)" [isDescriptionDisabled]="!model.isEditable"
+            <tm-question-edit-brief-description-form [brief]="unsavedModel.questionBrief" (briefChange)="triggerUnsavedModelChange('questionBrief', $event)" [isBriefDisabled]="!unsavedModel.isEditable"
+                                                     [description]="unsavedModel.questionDescription" (descriptionChange)="triggerUnsavedModelChange('questionDescription', $event)" [isDescriptionDisabled]="!unsavedModel.isEditable"
             ></tm-question-edit-brief-description-form>
             <div class="padding-15px">
-              <tm-text-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.TEXT" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-text-question-edit-details-form>
-              <tm-contribution-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.CONTRIB" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-contribution-question-edit-details-form>
-              <tm-mcq-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.MCQ" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-mcq-question-edit-details-form>
-              <tm-msq-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.MSQ" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-msq-question-edit-details-form>
-              <tm-num-scale-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.NUMSCALE" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-num-scale-question-edit-details-form>
-              <tm-rank-options-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.RANK_OPTIONS" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-rank-options-question-edit-details-form>
-              <tm-rank-recipients-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-rank-recipients-question-edit-details-form>
-              <tm-rubric-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.RUBRIC" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-rubric-question-edit-details-form>
-              <tm-constsum-options-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-constsum-options-question-edit-details-form>
-              <tm-constsum-recipients-question-edit-details-form *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [details]="model.questionDetails" (detailsChange)="triggerModelChange('questionDetails', $event)" [isEditable]="model.isEditable"></tm-constsum-recipients-question-edit-details-form>
+              <tm-text-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.TEXT" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-text-question-edit-details-form>
+              <tm-contribution-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.CONTRIB" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-contribution-question-edit-details-form>
+              <tm-mcq-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.MCQ" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-mcq-question-edit-details-form>
+              <tm-msq-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.MSQ" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-msq-question-edit-details-form>
+              <tm-num-scale-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.NUMSCALE" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-num-scale-question-edit-details-form>
+              <tm-rank-options-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.RANK_OPTIONS" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-rank-options-question-edit-details-form>
+              <tm-rank-recipients-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.RANK_RECIPIENTS" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-rank-recipients-question-edit-details-form>
+              <tm-rubric-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.RUBRIC" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-rubric-question-edit-details-form>
+              <tm-constsum-options-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-constsum-options-question-edit-details-form>
+              <tm-constsum-recipients-question-edit-details-form *ngIf="unsavedModel.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS" [details]="unsavedModel.questionDetails" (detailsChange)="triggerUnsavedModelChange('questionDetails', $event)" [isEditable]="unsavedModel.isEditable"></tm-constsum-recipients-question-edit-details-form>
             </div>
           </div>
         </div>
       </div>
-      <tm-feedback-path-panel [model]="model" [commonFeedbackPaths]="commonFeedbackPaths"
+      <tm-feedback-path-panel [model]="unsavedModel" [commonFeedbackPaths]="commonFeedbackPaths"
                               [allowedFeedbackPaths]="allowedFeedbackPaths"
-                              (customFeedbackPath)="triggerModelChange('isUsingOtherFeedbackPath', $event)"
-                              (customNumberOfEntitiesToGiveFeedbackTo)="triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)"
-                              (numberOfEntitiesToGiveFeedbackToSetting)="triggerModelChange('numberOfEntitiesToGiveFeedbackToSetting', $event)"
-                              (triggerModelChangeBatch)="triggerModelChangeBatch($event)"></tm-feedback-path-panel>
-      <tm-visibility-panel [model]="model" [isCustomFeedbackVisibilitySettingAllowed]="isCustomFeedbackVisibilitySettingAllowed"
+                              (customFeedbackPath)="triggerUnsavedModelChange('isUsingOtherFeedbackPath', $event)"
+                              (customNumberOfEntitiesToGiveFeedbackTo)="triggerUnsavedModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)"
+                              (numberOfEntitiesToGiveFeedbackToSetting)="triggerUnsavedModelChange('numberOfEntitiesToGiveFeedbackToSetting', $event)"
+                              (triggerUnsavedModelChangeBatch)="triggerUnsavedModelChangeBatch($event)"></tm-feedback-path-panel>
+      <tm-visibility-panel [model]="unsavedModel" [isCustomFeedbackVisibilitySettingAllowed]="isCustomFeedbackVisibilitySettingAllowed"
                            [commonFeedbackVisibilitySettings]="commonFeedbackVisibilitySettings"
-                           (customVisibilitySetting)="triggerModelChange('isUsingOtherVisibilitySetting', $event)"
-                           (triggerModelChangeBatch)="triggerModelChangeBatch($event)"
+                           (customVisibilitySetting)="triggerUnsavedModelChange('isUsingOtherVisibilitySetting', $event)"
+                           (triggerUnsavedModelChangeBatch)="triggerUnsavedModelChangeBatch($event)"
                            [visibilityStateMachine]="visibilityStateMachine"></tm-visibility-panel>
       <div class="row margin-top-15px" *ngIf="!isDisplayOnly">
         <div class="col-12 text-end">
-          <button type="button" class="btn btn-light btn-margin-right" *ngIf="model.isEditable"
+          <button type="button" class="btn btn-light btn-margin-right" *ngIf="unsavedModel.isEditable"
                   (click)="discardChangesHandler(false)"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating">
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
             <i class="fas fa-ban"></i> Cancel
           </button>
           <button class="btn btn-success"
-              [disabled]="!model.isEditable || model.isSaving || model.isDeleting || model.isDuplicating"
+              [disabled]="!unsavedModel.isEditable || unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating"
               (click)="saveQuestionHandler()">
-            <tm-ajax-loading *ngIf="model.isSaving"></tm-ajax-loading>
+            <tm-ajax-loading *ngIf="unsavedModel.isSaving"></tm-ajax-loading>
             <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>
             <span id="btn-save-new" *ngIf="formMode === QuestionEditFormMode.ADD"><i class="fas fa-check"></i> Save Question</span>
           </button>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -26,7 +26,8 @@
           </button>
           <button id="btn-save-question" type="button" class="btn btn-primary btn-sm" *ngIf="unsavedModel.isEditable"
                   (click)="saveQuestionHandler(); $event.stopPropagation();"
-                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating">
+                  [disabled]="unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating
+                  || isVisibilityEmpty()">
             <tm-ajax-loading *ngIf="unsavedModel.isSaving"></tm-ajax-loading><i class="fas fa-check"></i> Save
           </button>
           <button type="button" class="btn btn-primary btn-sm" *ngIf="unsavedModel.isEditable"
@@ -100,7 +101,8 @@
             <i class="fas fa-ban"></i> Cancel
           </button>
           <button class="btn btn-success"
-              [disabled]="!unsavedModel.isEditable || unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating"
+              [disabled]="!unsavedModel.isEditable || unsavedModel.isSaving || unsavedModel.isDeleting || unsavedModel.isDuplicating
+              || isVisibilityEmpty()"
               (click)="saveQuestionHandler()">
             <tm-ajax-loading *ngIf="unsavedModel.isSaving"></tm-ajax-loading>
             <span *ngIf="formMode === QuestionEditFormMode.EDIT" ><i class="fas fa-check"></i> Save Changes</span>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.spec.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.spec.ts
@@ -3,9 +3,15 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import SpyInstance = jest.SpyInstance;
+
+import { SimpleModalService } from '../../../services/simple-modal.service';
+import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
 import { mockTinyMceUuid } from '../../../test-helpers/mock-tinymce-uuid';
+import { FeedbackParticipantType, NumberOfEntitiesToGiveFeedbackToSetting } from '../../../types/api-output';
+import { FeedbackVisibilityType } from '../../../types/api-request';
 import {
-  EXAMPLE_ESSAY_QUESTION_MODEL,
+  EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES,
 } from '../../pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data';
 import { AjaxLoadingModule } from '../ajax-loading/ajax-loading.module';
 import { FeedbackPathPanelModule } from '../feedback-path-panel/feedback-path-panel.module';
@@ -16,6 +22,7 @@ import {
 import {
   QuestionEditDetailsFormModule,
 } from '../question-types/question-edit-details-form/question-edit-details-form.module';
+import { SimpleModalType } from '../simple-modal/simple-modal-type';
 import { TeammatesCommonModule } from '../teammates-common/teammates-common.module';
 import { VisibilityMessagesModule } from '../visibility-messages/visibility-messages.module';
 import { VisibilityPanelModule } from '../visibility-panel/visibility-panel.module';
@@ -25,6 +32,20 @@ import { QuestionEditFormComponent } from './question-edit-form.component';
 describe('QuestionEditFormComponent', () => {
   let component: QuestionEditFormComponent;
   let fixture: ComponentFixture<QuestionEditFormComponent>;
+  let simpleModalService: SimpleModalService;
+
+  /**
+   * Helper function to check if a model is equal to
+   * EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES.
+   */
+  const verifyEqualsToExampleQuestionModel: (model: QuestionEditFormModel) => void =
+  (model: QuestionEditFormModel): void => {
+    expect(model).toStrictEqual(EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES);
+    expect(model.isUsingOtherFeedbackPath).toBeFalsy();
+    expect(model.commonVisibilitySettingName).toBeTruthy();
+    expect(model.isUsingOtherVisibilitySetting).toBeFalsy();
+    expect(component.isCustomFeedbackVisibilitySettingAllowed).toBeTruthy();
+  };
 
   mockTinyMceUuid();
 
@@ -47,12 +68,16 @@ describe('QuestionEditFormComponent', () => {
         BrowserAnimationsModule,
         PanelChevronModule,
       ],
+      providers: [
+        SimpleModalService,
+      ],
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QuestionEditFormComponent);
+    simpleModalService = TestBed.inject(SimpleModalService);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -61,35 +86,201 @@ describe('QuestionEditFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('set up with EXAMPLE_ESSAY_QUESTION_MODEL', () => {
-    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL;
+  it('set up with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
     const model: QuestionEditFormModel = component.model;
-    expect(model).toBe(EXAMPLE_ESSAY_QUESTION_MODEL);
-    expect(model.isUsingOtherFeedbackPath).toBeFalsy();
-    expect(model.commonVisibilitySettingName).toBeTruthy();
-    expect(model.isUsingOtherVisibilitySetting).toBeFalsy();
-    expect(component.isCustomFeedbackVisibilitySettingAllowed).toBeTruthy();
+    verifyEqualsToExampleQuestionModel(model);
+
+    const unsavedModel: QuestionEditFormModel = component.model;
+    verifyEqualsToExampleQuestionModel(unsavedModel);
+    expect(unsavedModel).toStrictEqual(model);
   });
 
-  it('triggerModelChange with EXAMPLE_ESSAY_QUESTION_MODEL', () => {
-    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL;
-    component.formModelChange.subscribe((data: QuestionEditFormModel) => {
-      component.formModel = data;
-    });
+  it('triggerUnsavedModelChange with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
     const testStr: string = 'Hello World';
-    component.triggerModelChange('questionNumber', 2);
-    component.triggerModelChange('questionBrief', testStr);
-    component.triggerModelChange('questionDescription', testStr);
-    component.triggerModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('questionNumber', 2);
+    component.triggerUnsavedModelChange('questionBrief', testStr);
+    component.triggerUnsavedModelChange('questionDescription', testStr);
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
 
     const model: QuestionEditFormModel = component.model;
-    expect(model.questionNumber).toBe(2);
-    expect(model.questionBrief).toBe(testStr);
-    expect(model.questionDescription).toBe(testStr);
-    expect(model.isQuestionHasResponses).toBeTruthy();
+    verifyEqualsToExampleQuestionModel(model);
+
+    const unsavedModel: QuestionEditFormModel = component.unsavedModel;
+    expect(unsavedModel.questionNumber).toBe(2);
+    expect(unsavedModel.questionBrief).toBe(testStr);
+    expect(unsavedModel.questionDescription).toBe(testStr);
+    expect(unsavedModel.isQuestionHasResponses).toBeTruthy();
   });
 
   it('should snap with default view', () => {
     expect(fixture).toMatchSnapshot();
+  });
+
+  it('triggerUnsavedModelChangeBatch with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    const testObj: Partial<QuestionEditFormModel> = {
+      giverType: FeedbackParticipantType.STUDENTS,
+      recipientType: FeedbackParticipantType.INSTRUCTORS,
+      isUsingOtherFeedbackPath: false,
+      numberOfEntitiesToGiveFeedbackToSetting:
+      NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+      customNumberOfEntitiesToGiveFeedbackTo: undefined,
+
+    };
+    component.triggerUnsavedModelChangeBatch(testObj);
+
+    const model: QuestionEditFormModel = component.model;
+    verifyEqualsToExampleQuestionModel(model);
+
+    const unsavedModel: QuestionEditFormModel = component.unsavedModel;
+    expect(unsavedModel.giverType).toBe(testObj.giverType);
+    expect(unsavedModel.recipientType).toBe(testObj.recipientType);
+    expect(unsavedModel.isUsingOtherFeedbackPath).toBeFalsy();
+    expect(unsavedModel.numberOfEntitiesToGiveFeedbackToSetting)
+    .toBe(testObj.numberOfEntitiesToGiveFeedbackToSetting);
+    expect(unsavedModel.customNumberOfEntitiesToGiveFeedbackTo)
+    .toBe(testObj.customNumberOfEntitiesToGiveFeedbackTo);
+  });
+
+  it('discardChangesHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES', async () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isUsingOtherFeedbackPath', true);
+    component.triggerUnsavedModelChange('showResponsesTo', [FeedbackVisibilityType.RECIPIENT]);
+    component.triggerUnsavedModelChange('showGiverNameTo', [FeedbackVisibilityType.RECIPIENT]);
+    component.triggerUnsavedModelChange('showRecipientNameTo', [FeedbackVisibilityType.RECIPIENT]);
+    component.triggerUnsavedModelChange('giverType', FeedbackParticipantType.STUDENTS_EXCLUDING_SELF);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.discardChangesHandler(false);
+    await promise;
+    expect(modalSpy).toHaveBeenCalledTimes(1);
+    expect(modalSpy).toHaveBeenLastCalledWith('Discard unsaved edits?', SimpleModalType.WARNING,
+    'Warning: Any unsaved changes will be lost',
+    { cancelMessage: 'No, go back to editing' });
+  });
+
+  it('discardChangesHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where changes reverted', async () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('giverType', FeedbackParticipantType.STUDENTS_EXCLUDING_SELF);
+    component.triggerUnsavedModelChange('giverType', FeedbackParticipantType.STUDENTS);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.discardChangesHandler(false);
+    await promise;
+    expect(modalSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where feedback path changed', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('recipientType', FeedbackParticipantType.STUDENTS_EXCLUDING_SELF);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+    expect(modalSpy).toHaveBeenCalledTimes(1);
+
+    const modalContent: string = `
+            <p>You seem to have changed the feedback path settings of this question. Please note that changing the
+            feedback path will cause <b>all existing responses to be deleted.</b> Proceed?</p>
+        `;
+    expect(modalSpy).toHaveBeenCalledWith('Save the question?', SimpleModalType.DANGER, modalContent);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where feedback path reverted', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('recipientType', FeedbackParticipantType.STUDENTS_EXCLUDING_SELF);
+    component.triggerUnsavedModelChange('recipientType', FeedbackParticipantType.OWN_TEAM_MEMBERS);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+    expect(modalSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where question details changed', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('questionDescription', 'A new description for this question');
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+
+    expect(modalSpy).toHaveBeenCalledTimes(1);
+
+    const modalContent: string = `
+            <p>Editing question settings in a way that potentially affects the validity of existing responses <b> may
+            cause all the existing responses for this question to be deleted.</b> Proceed?</p>
+        `;
+    expect(modalSpy).toHaveBeenCalledWith('Save the question?', SimpleModalType.DANGER, modalContent);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where question details reverted', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('questionDescription', 'A new description for this question');
+    component.triggerUnsavedModelChange('questionDescription', '');
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+    expect(modalSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where visibility changed', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('showRecipientNameTo',
+    [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.STUDENTS]);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+    expect(modalSpy).toHaveBeenCalledTimes(1);
+
+    const modalContent: string = `
+            <p>You seem to have changed the visibility settings of this question. Please note that <b>the existing
+            responses will remain but their visibility will be changed as per the new visibility settings.</b>
+            Proceed?</p>
+        `;
+    expect(modalSpy).toHaveBeenCalledWith('Save the question?', SimpleModalType.WARNING, modalContent);
+  });
+
+  it('saveQuestionHandler with EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES where visibility reverted', () => {
+    component.formModel = EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES;
+
+    component.triggerUnsavedModelChange('isQuestionHasResponses', true);
+    component.triggerUnsavedModelChange('showRecipientNameTo',
+    [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT, FeedbackVisibilityType.STUDENTS]);
+    component.triggerUnsavedModelChange('showRecipientNameTo',
+    [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT]);
+
+    const promise: Promise<void> = Promise.resolve();
+    const modalSpy: SpyInstance = jest.spyOn(simpleModalService, 'openConfirmationModal')
+        .mockReturnValue(createMockNgbModalRef({}, promise));
+    component.saveQuestionHandler();
+    expect(modalSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -223,7 +223,6 @@ export class QuestionEditFormComponent {
   @Output()
   discardNewQuestionEvent: EventEmitter<void> = new EventEmitter();
 
-
   commonFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
 
   allowedFeedbackPaths: Map<FeedbackParticipantType, FeedbackParticipantType[]> = new Map();
@@ -243,7 +242,6 @@ export class QuestionEditFormComponent {
     return setA.length === setB.length && setA.every((ele: FeedbackVisibilityType) => setB.includes(ele));
   }
 
-
   /**
    * Triggers the change of the unsaved model for the form.
    */
@@ -261,7 +259,7 @@ export class QuestionEditFormComponent {
     };
   }
 
-    /**
+  /**
    * Triggers the change of the unsaved model for the form.
    */
     triggerUnsavedModelChangeBatch(obj: Partial<QuestionEditFormModel>): void {
@@ -294,7 +292,7 @@ export class QuestionEditFormComponent {
   /**
    * Handle event to discard changes users made.
    */
-  discardChangesHandler(isNewQuestion: boolean): void {;
+  discardChangesHandler(isNewQuestion: boolean): void {
     if (!this.checkChangesNeedWarning()) {
       this.discardChanges();
       return;
@@ -304,7 +302,7 @@ export class QuestionEditFormComponent {
       `Discard unsaved ${isNewQuestion ? 'question' : 'edits'}?`, SimpleModalType.WARNING,
       'Warning: Any unsaved changes will be lost',
       { cancelMessage: 'No, go back to editing' });
-      
+
       modalRef.result.then(() => {
         this.discardChanges();
       }, () => {});
@@ -320,13 +318,12 @@ export class QuestionEditFormComponent {
     }
   }
 
-
   /**
    * Saves the question.
    */
   saveQuestionHandler(): void {
     const doChangesNeedWarning: boolean = this.checkChangesNeedWarning();
-    this.model = {...this.unsavedModel};
+    this.model = { ...this.unsavedModel };
     this.formModelChange.emit(this.model);
 
     if (this.formMode === QuestionEditFormMode.EDIT) {
@@ -376,10 +373,10 @@ export class QuestionEditFormComponent {
   }
 
   private checkChangesNeedWarning(): boolean {
-    this.unsavedModel.isVisibilityChanged &&=  this.checkVisibilityValuesDifferent(); 
+    this.unsavedModel.isVisibilityChanged &&= this.checkVisibilityValuesDifferent();
     this.unsavedModel.isQuestionDetailsChanged &&= this.checkQuestionDetailValuesDifferent();
     this.unsavedModel.isFeedbackPathChanged &&= this.checkPropertyValuesDifferent(FEEDBACK_PATH_PROPERTIES);
-   
+
     return this.unsavedModel.isVisibilityChanged
     || this.unsavedModel.isQuestionDetailsChanged
     || this.unsavedModel.isFeedbackPathChanged;
@@ -393,8 +390,8 @@ export class QuestionEditFormComponent {
   }
 
   private checkFeedbackQuestionDetailsDifferent(): boolean {
-    const modelQuestionDetails = this.model['questionDetails'];
-    const unsavedModelQuestionDetails = this.unsavedModel['questionDetails'];
+    const modelQuestionDetails = this.model.questionDetails;
+    const unsavedModelQuestionDetails = this.unsavedModel.questionDetails;
 
     const modelQuestionText = modelQuestionDetails.questionText;
     const unsavedModelQuestionText = unsavedModelQuestionDetails.questionText;
@@ -407,8 +404,8 @@ export class QuestionEditFormComponent {
   }
 
   private checkPropertyValuesDifferent(properties: Set<string>): boolean {
-    for(var property of properties) {
-      if(this.checkPropertyValueDifferent(property)){
+    for (const property of properties) {
+      if (this.checkPropertyValueDifferent(property)) {
         return true;
       }
     }
@@ -417,8 +414,8 @@ export class QuestionEditFormComponent {
   }
 
   private checkPropertyValueDifferent(property: string): boolean {
-    const field: keyof QuestionEditFormModel 
-    = property as keyof QuestionEditFormModel;
+    const field: keyof QuestionEditFormModel =
+    property as keyof QuestionEditFormModel;
 
     const modelField = this.model[field];
     const unsavedModelField = this.unsavedModel[field];
@@ -428,32 +425,32 @@ export class QuestionEditFormComponent {
   }
 
   private checkVisibilityValuesDifferent(): boolean {
-    if (this.unsavedModel['isUsingOtherVisibilitySetting']) {
-      this.unsavedModel['commonVisibilitySettingName'] = undefined;
+    if (this.unsavedModel.isUsingOtherVisibilitySetting) {
+      this.unsavedModel.commonVisibilitySettingName = undefined;
     }
 
     return this.checkPropertyValueDifferent('isUsingOtherVisibilitySetting')
     || this.checkPropertyValueDifferent('commonVisibilitySettingName')
-  
+
     || this.checkValueArrayDifferent('showResponsesTo')
     || this.checkValueArrayDifferent('showGiverNameTo')
     || this.checkValueArrayDifferent('showRecipientNameTo');
   }
 
   private checkValueArrayDifferent(property: string) : boolean {
-    const field: keyof QuestionEditFormModel
-    = property as keyof QuestionEditFormModel;
-    
-    const modelValueArray: any[]= this.model[field] as any[];
+    const field: keyof QuestionEditFormModel =
+    property as keyof QuestionEditFormModel;
+
+    const modelValueArray: any[] = this.model[field] as any[];
     const unsavedModelValueArray: any[] = this.unsavedModel[field] as any[];
 
-    if(!modelValueArray || !unsavedModelValueArray
+    if (!modelValueArray || !unsavedModelValueArray
       || modelValueArray.length !== unsavedModelValueArray.length) {
         return true;
       }
 
-    return modelValueArray.some((value, index) => 
-    value !== unsavedModelValueArray[index])
+    return modelValueArray.some((value, index) =>
+    value !== unsavedModelValueArray[index]);
   }
 
   /**

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -323,14 +323,14 @@ export class QuestionEditFormComponent {
    */
   saveQuestionHandler(): void {
     const doChangesNeedWarning: boolean = this.checkChangesNeedWarning();
-    this.model = { ...this.unsavedModel };
-    this.formModelChange.emit(this.model);
 
     if (this.formMode === QuestionEditFormMode.EDIT) {
 
       if (!this.isQuestionPublished && (!this.model.isQuestionHasResponses || !doChangesNeedWarning)) {
+        this.formModelChange.emit(this.unsavedModel);
         this.saveExistingQuestionEvent.emit();
-      } else if (this.model.isFeedbackPathChanged) {
+
+      } else if (this.unsavedModel.isFeedbackPathChanged) {
         // warn user that editing feedback path will delete all messages
         const modalContent: string = `
             <p>You seem to have changed the feedback path settings of this question. Please note that changing the
@@ -339,9 +339,11 @@ export class QuestionEditFormComponent {
         const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
             'Save the question?', SimpleModalType.DANGER, modalContent);
         modalRef.result.then(() => {
+          this.formModelChange.emit(this.unsavedModel);
           this.saveExistingQuestionEvent.emit();
         }, () => {});
-      } else if (this.model.isQuestionDetailsChanged) {
+
+      } else if (this.unsavedModel.isQuestionDetailsChanged) {
         // alert user that editing question may result in deletion of responses
         const modalContent: string = `
             <p>Editing question settings in a way that potentially affects the validity of existing responses <b> may
@@ -350,9 +352,11 @@ export class QuestionEditFormComponent {
         const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
             'Save the question?', SimpleModalType.DANGER, modalContent);
         modalRef.result.then(() => {
+          this.formModelChange.emit(this.unsavedModel);
           this.saveExistingQuestionEvent.emit();
         }, () => {});
-      } else if (this.model.isVisibilityChanged) {
+
+      } else if (this.unsavedModel.isVisibilityChanged) {
         // alert user that editing visibility options will not delete responses
         const modalContent: string = `
             <p>You seem to have changed the visibility settings of this question. Please note that <b>the existing
@@ -362,12 +366,14 @@ export class QuestionEditFormComponent {
         const modalRef: NgbModalRef = this.simpleModalService.openConfirmationModal(
             'Save the question?', SimpleModalType.WARNING, modalContent);
         modalRef.result.then(() => {
+          this.formModelChange.emit(this.unsavedModel);
           this.saveExistingQuestionEvent.emit();
         }, () => {});
       }
     }
 
     if (this.formMode === QuestionEditFormMode.ADD) {
+      this.formModelChange.emit(this.unsavedModel);
       this.createNewQuestionEvent.emit();
     }
   }

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -84,7 +84,7 @@ export class VisibilityPanelComponent {
   customVisibilitySetting: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @Output()
-  triggerModelChangeBatch: EventEmitter<Partial<QuestionEditFormModel>> =
+  triggerUnsavedModelChangeBatch: EventEmitter<Partial<QuestionEditFormModel>> =
     new EventEmitter<Partial<QuestionEditFormModel>>();
 
   @Output()
@@ -105,6 +105,25 @@ export class VisibilityPanelComponent {
   ]);
 
   triggerCustomVisibilitySetting(): void {
+    for(var visibilityTypeStr in FeedbackVisibilityType) {
+      const visibilityType = visibilityTypeStr as FeedbackVisibilityType;
+      if(!this.visibilityStateMachine.isVisibilityTypeApplicable(visibilityType)) {
+        continue;
+      }
+
+      for(var visibilityControlStr in VisibilityControl) {
+        const visibilityControl = visibilityControlStr as VisibilityControl;
+        if(!this.visibilityStateMachine.isCellEditable(visibilityType, visibilityControl) 
+        || !this.model.isEditable) {
+          continue;
+        }
+        if(!this.visibilityStateMachine.isVisible(visibilityType, visibilityControl)) {
+          continue;
+        }
+        this.modifyVisibilityControl(true, visibilityType, visibilityControl);
+      }
+    }
+    
     this.customVisibilitySetting.emit(true);
   }
 
@@ -118,7 +137,7 @@ export class VisibilityPanelComponent {
    * Applies the common visibility setting.
    */
   applyCommonVisibilitySettings(commonSettings: CommonVisibilitySetting): void {
-    this.triggerModelChangeBatch.emit({
+    this.triggerUnsavedModelChangeBatch.emit({
       showResponsesTo: commonSettings.visibilitySettings.SHOW_RESPONSE,
       showGiverNameTo: commonSettings.visibilitySettings.SHOW_GIVER_NAME,
       showRecipientNameTo: commonSettings.visibilitySettings.SHOW_RECIPIENT_NAME,
@@ -139,7 +158,7 @@ export class VisibilityPanelComponent {
       this.visibilityStateMachine.disallowToSee(visibilityType, visibilityControl);
       this.visibilityStateMachineChange.emit(this.visibilityStateMachine);
     }
-    this.triggerModelChangeBatch.emit({
+    this.triggerUnsavedModelChangeBatch.emit({
       showResponsesTo:
           this.visibilityStateMachine.getVisibilityTypesUnderVisibilityControl(VisibilityControl.SHOW_RESPONSE),
       showGiverNameTo:

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -105,25 +105,25 @@ export class VisibilityPanelComponent {
   ]);
 
   triggerCustomVisibilitySetting(): void {
-    for(var visibilityTypeStr in FeedbackVisibilityType) {
+    for (const visibilityTypeStr of Object.keys(FeedbackVisibilityType)) {
       const visibilityType = visibilityTypeStr as FeedbackVisibilityType;
-      if(!this.visibilityStateMachine.isVisibilityTypeApplicable(visibilityType)) {
+      if (!this.visibilityStateMachine.isVisibilityTypeApplicable(visibilityType)) {
         continue;
       }
 
-      for(var visibilityControlStr in VisibilityControl) {
+      for (const visibilityControlStr of Object.keys(VisibilityControl)) {
         const visibilityControl = visibilityControlStr as VisibilityControl;
-        if(!this.visibilityStateMachine.isCellEditable(visibilityType, visibilityControl) 
+        if (!this.visibilityStateMachine.isCellEditable(visibilityType, visibilityControl)
         || !this.model.isEditable) {
           continue;
         }
-        if(!this.visibilityStateMachine.isVisible(visibilityType, visibilityControl)) {
+        if (!this.visibilityStateMachine.isVisible(visibilityType, visibilityControl)) {
           continue;
         }
         this.modifyVisibilityControl(true, visibilityType, visibilityControl);
       }
     }
-    
+
     this.customVisibilitySetting.emit(true);
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -74,6 +74,11 @@ export const EXAMPLE_ESSAY_QUESTION_MODEL: QuestionEditFormModel = {
   showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
   showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
 };
+
+export const EXAMPLE_ESSAY_QUESTION_MODEL_WITH_RESPONSES: QuestionEditFormModel = {
+  ...EXAMPLE_ESSAY_QUESTION_MODEL,
+  isQuestionHasResponses: true,
+};
 /**
  * Structure for example of numerical scale question model
  */

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -4760,6 +4760,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                 </button>
                 <button
                   class="btn btn-success"
+                  disabled=""
                 >
                   <span
                     id="btn-save-new"


### PR DESCRIPTION
Fixes #7678

Approach:
- In `question-edit-form`, all changes are immediately propagated to `component.model` and its parent components
- So even if a change is reverted, there is no original copy to compare with and signal that no change was made in the end

Solution:
- Have another `unsavedModel` that stores all unsaved changes first
- Before save button is clicked, compare `unsavedModel` with the original `model` to check for any changes 
- Warning modal will only be shown if the 2 models are different
(in terms of feedback path, visibility or question details)

Not sure if this is the right approach, or if there is a better approach? Also do E2E tests need to be added?