### PR TITLE
Part of [#12283] Instructor view session results (course-wide): Add separate button to download results by question

### DIFF
--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.html
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.html
@@ -1,8 +1,8 @@
 <span class="d-flex flex-column flex-sm-row align-items-sm-center">
   <h2 *ngIf="shouldShowDownloadQuestionResult" class="question-number">
-    <button ngbTooltip="Download Question Results" type="button" class="btn btn-link p-0" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
+    <div class="question">
       Question {{ questionNumber }}:
-    </button>
+    </div>
   </h2>
   <h2 *ngIf="!shouldShowDownloadQuestionResult" class="question-number">
     Question {{ questionNumber }}:
@@ -11,6 +11,11 @@
   <button class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary" (click)="additionalInfoIsExpanded = !additionalInfoIsExpanded;$event.stopPropagation()" *ngIf="hasAdditionalInfo(questionDetails)">
     [{{ additionalInfoIsExpanded ? 'less' : 'more' }}]
   </button>
+  <div class="space">
+    <button ngbTooltip="Download Question Results" type="button" class="btn btn-primary btn-sm button" (click)="downloadQuestionResultEvent.emit(); $event.stopPropagation();">
+      Download Question Results
+    </button>
+  </div>
 </span>
 
 <div class="additional-info info-font-size" *ngIf="hasAdditionalInfo(questionDetails) && additionalInfoIsExpanded">

--- a/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
+++ b/src/web/app/components/question-text-with-info/question-text-with-info.component.scss
@@ -3,3 +3,17 @@
   margin: 0;
   font-weight: bold;
 }
+
+.span-divs {
+  width: 1100px;
+  float: left;
+}
+
+.question {
+  font-weight: light;
+  width: 85px;
+}
+
+.space {
+  margin-left: 5px;
+}


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Refactor: I refactored the button to be after the less/more button in the span and copied all functionality to the button
Replace: I replace the button with a simple div which holds the question number
Styling: I added some styling to the question-text-with-infor.component.scss file in order to copy the styling from before into the new additions.

This shows the changes in UI:

![image](https://user-images.githubusercontent.com/73842589/232855281-4d66913c-bf84-43a5-bb71-7f22e91adf70.png)
