### PR TITLE
[#12289] Usage statistics and logs page: Improve date/time input on mobile

### DIFF
--- a/src/web/app/pages-monitoring/logs-page/__snapshots__/logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-monitoring/logs-page/__snapshots__/logs-page.component.spec.ts.snap
@@ -127,10 +127,10 @@ exports[`LogsPageComponent should snap when searching for details in search form
             </label>
           </div>
           <div
-            class="col-12 row"
+            class="row"
           >
             <div
-              class="col-md-8"
+              class="col-6"
             >
               <div
                 class="input-group"
@@ -152,7 +152,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
               </div>
             </div>
             <div
-              class="col-md-4"
+              class="col-6"
               id="logs-from-timepicker"
             >
               <ngb-timepicker
@@ -207,10 +207,10 @@ exports[`LogsPageComponent should snap when searching for details in search form
             </label>
           </div>
           <div
-            class="col-12 row"
+            class="row"
           >
             <div
-              class="col-md-8"
+              class="col-6"
             >
               <div
                 class="input-group"
@@ -232,7 +232,7 @@ exports[`LogsPageComponent should snap when searching for details in search form
               </div>
             </div>
             <div
-              class="col-md-4 mb-4"
+              class="col-6"
               id="logs-to-timepicker"
             >
               <ngb-timepicker

--- a/src/web/app/pages-monitoring/logs-page/logs-page.component.html
+++ b/src/web/app/pages-monitoring/logs-page/logs-page.component.html
@@ -11,8 +11,8 @@
         <div class="col-12 mb-1">
           <label for="logs-from-datepicker" class="fw-bold">Search period from</label>
         </div>
-        <div class="col-12 row">
-          <div class="col-md-8">
+        <div class="row">
+          <div class="col-6">
             <div class="input-group">
               <input id="logs-from-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="earliestSearchDate" [maxDate]="dateToday" [(ngModel)]="formModel.logsDateFrom" #logsFromDp="ngbDatepicker"/>
               <button class="btn btn-light input-group-text" (click)="logsFromDp.toggle()" type="button">
@@ -20,15 +20,15 @@
               </button>
             </div>
           </div>
-          <div id="logs-from-timepicker" class="col-md-4">
+          <div id="logs-from-timepicker" class="col-6">
             <ngb-timepicker [(ngModel)]="formModel.logsTimeFrom" [spinners]="false"></ngb-timepicker>
           </div>
         </div>
         <div class="col-12 mb-1 mt-4">
           <label for="logs-to-datepicker" class="fw-bold">Search period until</label>
         </div>
-        <div class="col-12 row">
-          <div class="col-md-8">
+        <div class="row">
+          <div class="col-6">
             <div class="input-group">
               <input id="logs-to-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="earliestSearchDate" [maxDate]="dateToday" [(ngModel)]="formModel.logsDateTo" #logsToDp="ngbDatepicker"/>
               <button class="btn btn-light" (click)="logsToDp.toggle()" type="button">
@@ -36,7 +36,7 @@
               </button>
             </div>
           </div>
-          <div id="logs-to-timepicker" class="col-md-4 mb-4">
+          <div id="logs-to-timepicker" class="col-6">
             <ngb-timepicker [(ngModel)]="formModel.logsTimeTo" [spinners]="false"></ngb-timepicker>
           </div>
         </div>

--- a/src/web/app/pages-monitoring/usage-stats-page/__snapshots__/usage-statistics-page.component.spec.ts.snap
+++ b/src/web/app/pages-monitoring/usage-stats-page/__snapshots__/usage-statistics-page.component.spec.ts.snap
@@ -44,10 +44,10 @@ exports[`UsageStatisticsPageComponent should snap with default fields 1`] = `
             </label>
           </div>
           <div
-            class="col-12 row"
+            class="row"
           >
             <div
-              class="col-md-7"
+              class="col-6"
             >
               <div
                 class="input-group"
@@ -69,7 +69,7 @@ exports[`UsageStatisticsPageComponent should snap with default fields 1`] = `
               </div>
             </div>
             <div
-              class="col-md-5"
+              class="col-6"
             >
               <ngb-timepicker
                 class="ng-untouched ng-pristine ng-valid"
@@ -127,10 +127,10 @@ exports[`UsageStatisticsPageComponent should snap with default fields 1`] = `
             </label>
           </div>
           <div
-            class="col-12 row"
+            class="row"
           >
             <div
-              class="col-md-7"
+              class="col-6"
             >
               <div
                 class="input-group"
@@ -152,7 +152,7 @@ exports[`UsageStatisticsPageComponent should snap with default fields 1`] = `
               </div>
             </div>
             <div
-              class="col-md-5"
+              class="col-6"
             >
               <ngb-timepicker
                 class="ng-untouched ng-pristine ng-valid"

--- a/src/web/app/pages-monitoring/usage-stats-page/usage-statistics-page.component.html
+++ b/src/web/app/pages-monitoring/usage-stats-page/usage-statistics-page.component.html
@@ -6,8 +6,8 @@
         <div class="col-12 mb-1">
           <label for="search-from-datepicker" class="fw-bold">Search period from</label>
         </div>
-        <div class="col-12 row">
-          <div class="col-md-7">
+        <div class="row">
+          <div class="col-6">
             <div class="input-group">
               <input id="search-from-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="earliestSearchDate" [maxDate]="dateToday" [(ngModel)]="formModel.fromDate" #logsFromDp="ngbDatepicker">
               <button class="btn btn-light input-group-text" (click)="logsFromDp.toggle()" type="button">
@@ -15,7 +15,7 @@
               </button>
             </div>
           </div>
-          <div class="col-md-5">
+          <div class="col-6">
             <ngb-timepicker [(ngModel)]="formModel.fromTime" [spinners]="false"></ngb-timepicker>
           </div>
         </div>
@@ -24,8 +24,8 @@
         <div class="col-12 mb-1">
           <label for="search-to-datepicker" class="fw-bold">Search period until</label>
         </div>
-        <div class="col-12 row">
-          <div class="col-md-7">
+        <div class="row">
+          <div class="col-6">
             <div class="input-group">
               <input id="search-to-datepicker" type="text" class="form-control" ngbDatepicker [minDate]="earliestSearchDate" [maxDate]="dateToday" [(ngModel)]="formModel.toDate" #logsToDp="ngbDatepicker"/>
               <button class="btn btn-light input-group-text" (click)="logsToDp.toggle()" type="button">
@@ -33,7 +33,7 @@
               </button>
             </div>
           </div>
-          <div class="col-md-5">
+          <div class="col-6">
             <ngb-timepicker [(ngModel)]="formModel.toTime" [spinners]="false"></ngb-timepicker>
           </div>
         </div>


### PR DESCRIPTION
<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12289

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
I made changes to the following files so that the hour selection is besides the date picker instead of below on mobiles:
- [logs-page.component.html](https://github.com/TEAMMATES/teammates/compare/master...aorlandou:teammates:team-mast?expand=1#diff-ee2477d2f4c61cebb26a8abf3bb8fb690a22ddff913400dfd322f51a01db0a80)
- [usage-statistics-page.component.html](https://github.com/TEAMMATES/teammates/compare/master...aorlandou:teammates:team-mast?expand=1#diff-7f560ba4f7dc66e249b704cb1f6a492222d8dac0fb4fa026a836241c18cff07c)

**Logs page after the changes**
<img width="368" alt="logs after" src="https://user-images.githubusercontent.com/73021053/233104505-7c954682-a505-4c04-b6ba-347cc9c2c2ed.png">

**Usage Statistics page after the changes**
<img width="373" alt="usage statistics after" src="https://user-images.githubusercontent.com/73021053/233104511-6c6e44e1-9df4-4f38-b659-6e7d66a91e7b.png">

