### PR TITLE
[#12333] Instructor students page: accessibility issue for course summary headers

### DIFF
--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -52,7 +52,7 @@
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body fw-bold fs-5" id="num-teams">
-                          {{courseTab.stats.numOfTeams}} teams 
+                          {{courseTab.stats.numOfTeams}} teams
                         </div>
                       </div>
                     </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -37,22 +37,22 @@
                   <div class="row text-center text-sm-start" *ngIf="courseTab.stats">
                     <div class="col-md-4">
                       <div class="card">
-                        <div class="card-body" id="num-students" >
-                          <p class="card-title inline"><font size="4"> {{courseTab.stats.numOfStudents}}  students </font></p>
+                        <div class="card-body fw-bold fs-5" id="num-students">
+                          {{courseTab.stats.numOfStudents}}  students
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
-                        <div class="card-body" id="num-sections">
-                          <p class="card-title inline"> <font size="4">{{courseTab.stats.numOfSections}} sections </font> </p>
+                        <div class="card-body fw-bold fs-5" id="num-sections">
+                          {{courseTab.stats.numOfSections}} sections
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
-                        <div class="card-body" id="num-teams">
-                          <p class="card-title inline"> <font size="4">{{courseTab.stats.numOfTeams}} teams </font> </p>
+                        <div class="card-body fw-bold fs-5" id="num-teams">
+                          {{courseTab.stats.numOfTeams}} teams 
                         </div>
                       </div>
                     </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -38,21 +38,21 @@
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body" id="num-students" >
-                          <h3 class="card-title inline">{{courseTab.stats.numOfStudents}} <font size="4"> students </font> </h3>
+                          <p class="card-title inline"><font size="4"> {{courseTab.stats.numOfStudents}}  students </font></p>
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body" id="num-sections">
-                          <h3 class="card-title inline">{{courseTab.stats.numOfSections}} <font size="4"> sections </font> </h3>
+                          <p class="card-title inline"> <font size="4">{{courseTab.stats.numOfSections}} sections </font> </p>
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body" id="num-teams">
-                          <h3 class="card-title inline">{{courseTab.stats.numOfTeams}} <font size="4"> teams </font> </h3>
+                          <p class="card-title inline"> <font size="4">{{courseTab.stats.numOfTeams}} teams </font> </p>
                         </div>
                       </div>
                     </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -38,7 +38,7 @@
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body fw-bold fs-5" id="num-students">
-                          {{courseTab.stats.numOfStudents}}  students
+                          {{courseTab.stats.numOfStudents}} students
                         </div>
                       </div>
                     </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.html
@@ -37,25 +37,22 @@
                   <div class="row text-center text-sm-start" *ngIf="courseTab.stats">
                     <div class="col-md-4">
                       <div class="card">
-                        <div class="card-body" id="num-students">
-                          <h3 class="card-title inline">{{courseTab.stats.numOfStudents}}</h3>
-                          <h4 class="card-text inline"> students</h4>
+                        <div class="card-body" id="num-students" >
+                          <h3 class="card-title inline">{{courseTab.stats.numOfStudents}} <font size="4"> students </font> </h3>
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body" id="num-sections">
-                          <h3 class="card-title inline">{{courseTab.stats.numOfSections}}</h3>
-                          <h4 class="card-text inline"> sections</h4>
+                          <h3 class="card-title inline">{{courseTab.stats.numOfSections}} <font size="4"> sections </font> </h3>
                         </div>
                       </div>
                     </div>
                     <div class="col-md-4">
                       <div class="card">
                         <div class="card-body" id="num-teams">
-                          <h3 class="card-title inline">{{courseTab.stats.numOfTeams}}</h3>
-                          <h4 class="card-text inline"> teams</h4>
+                          <h3 class="card-title inline">{{courseTab.stats.numOfTeams}} <font size="4"> teams </font> </h3>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Fixes #12333

**Outline of Solution**

Fixed the issue by merging the two tags into one 'div' tag. 
Removed the unnecessary classes and fixed style by using Bootstrap 
("fw-bold fs-5" for making the text bold and changing the font size).

Here is the updated UI 

![pr1](https://user-images.githubusercontent.com/95168947/233801948-f03e31e4-e918-4255-a2cf-982f710f71ca.png)

