### PR TITLE
[#12265] Modify minimum page height to factor in footer height

### DIFF
--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -18,7 +18,13 @@ nav {
   padding: 20px 70px;
 }
 
-@media (max-width: 575px) { 
+@media (max-width: 313px) {
+  .main-content {
+    min-height: calc(100vh - 165px);
+  }
+}
+
+@media (min-width: 314px) and (max-width: 575px) { 
   .main-content {
     min-height: calc(100vh - 144px);
   }

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -18,6 +18,24 @@ nav {
   padding: 20px 70px;
 }
 
+@media (max-width: 575px) { 
+  .main-content {
+    min-height: calc(100vh - 144px);
+  }
+}
+
+@media (min-width: 576px) and (max-width: 589px) { 
+  .main-content {
+    min-height: calc(100vh - 123px);
+  }
+}
+
+@media (min-width: 590px) { 
+  .main-content {
+    min-height: calc(100vh - 102px);
+  }
+}
+
 .footer {
   padding: 5px 70px;
   color: rgba(255, 255, 255, .75);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12265 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

The issue was that as the widths of screen change, the footer dynamically stacks, increasing its height. In some cases where all the contents of the screen can fit, scrolling is still allowed because the min-height css parameter does not take the footer into account. I added some css properties to "/src/web/app/page.component.scss".

Steps I took:

1) I determined which screen widths caused a change in footer height

2) I used media queries to set the correct min-height based on screen width (which affects footer height)
            a) I went with this approach because it seemed the least convoluted

3) I tested using the chrome web inspector to ensure everything worked for every screen size 
            a) Screen sizes greater than 313 pixels- but no modern phone has a screen that small