### PR TITLE
[#12399] Instructor editing feedback path of a question: unnecessary scrollbars

### DIFF
--- a/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
+++ b/src/web/app/components/feedback-path-panel/feedback-path-panel.component.html
@@ -3,7 +3,7 @@
     <b class="feedback-path-title">Feedback Path</b> (Who is giving feedback about whom?)
   </div>
   <div ngbDropdown #mainMenu="ngbDropdown" class="margin-top-15px w-100" autoClose="outside">
-    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block" ngbDropdownToggle
+    <button id="btn-feedback-path" class="btn btn-light white-space-normal mw-100  d-inline-block" ngbDropdownToggle
             [disabled]="!model.isEditable || commonFeedbackPaths.size === 1" (click)="resetMenu()">
       <span *ngIf="!model.isUsingOtherFeedbackPath" class="text-wrap">
         {{ model.giverType | giverTypeDescription }} will give feedback on <i class="fas fa-arrow-right"></i> {{ model.recipientType | recipientTypeDescription }}

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -256,7 +256,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             >
               <button
                 aria-expanded="false"
-                class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
+                class="dropdown-toggle btn btn-light white-space-normal mw-100 d-inline-block"
                 disabled=""
                 id="btn-feedback-path"
                 ngbdropdowntoggle=""

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1522,7 +1522,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
-                        class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
+                        class="dropdown-toggle btn btn-light white-space-normal mw-100 d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
@@ -2245,7 +2245,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     >
                       <button
                         aria-expanded="false"
-                        class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
+                        class="dropdown-toggle btn btn-light white-space-normal mw-100 d-inline-block"
                         id="btn-feedback-path"
                         ngbdropdowntoggle=""
                       >
@@ -4123,7 +4123,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                 >
                   <button
                     aria-expanded="false"
-                    class="dropdown-toggle btn btn-light white-space-normal mw-100 overflow-scroll d-inline-block"
+                    class="dropdown-toggle btn btn-light white-space-normal mw-100 d-inline-block"
                     id="btn-feedback-path"
                     ngbdropdowntoggle=""
                   >


### PR DESCRIPTION
Fixes #12399 

**Outline of Solution**

Fix the issue by removing "overflow-scroll" which was the reason for the unnecessary scrollbars when an instructor is editing a question of an existing session (feedback path)

Here is the updated UI

![issue1](https://user-images.githubusercontent.com/95168947/233828465-669c62ea-ae4c-4cb9-a89b-c5f64b02ba12.png)
![issue2](https://user-images.githubusercontent.com/95168947/233828472-3b8b506f-8da1-4937-8c07-ddf5f7674c1d.png)

