### PR TITLE
[#12262] Features page: Enlarge pictures on mobile

### DIFF
--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -12,7 +12,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Team peer evaluations</h2>
       <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer feedback to team members.
           <br><br>
@@ -28,7 +28,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Flexible feedback paths</h2>
       <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           There are many other feedback paths available. Some examples:<br>
           a) feedback between teams<br>
@@ -45,7 +45,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Powerful visibility control</h2>
       <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can see the<br>
           (i) response text,<br>
@@ -62,7 +62,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Reports and statistics</h2>
       <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
           <br><br>
@@ -78,7 +78,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Fine-grain access control</h2>
       <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different access levels.
           <br><br>
@@ -94,7 +94,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Different question types</h2>
       <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number of points among options' questions, questions measuring contribution in team projects, and more choices coming soon...
           <br><br>
@@ -110,7 +110,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Reuse past questions</h2>
       <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           Once you have a perfect set of questions configured for a session, you can reuse those questions later, without needing to configure the same questions from scratch again.
           <br><br>
@@ -126,7 +126,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">No signup required for students</h2>
       <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to log in or sign up.
           <br><br>
@@ -142,7 +142,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Downloadable data</h2>
       <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           You can download the collected responses (and statistics) as spreadsheets.
           <br><br>
@@ -158,7 +158,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Shareable comments</h2>
       <img src="assets/images/feature-sharablecomments.png" alt="Sharable">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           You can add comments about responses collected. You can even share these comments with students/instructors.
           <br><br>
@@ -175,7 +175,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Powerful search</h2>
       <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           TEAMMATES has a powerful search feature to locate details about students.
           <br><br>
@@ -191,7 +191,7 @@
     <div class="inner-content">
       <h2 class="color-orange col-xs-12">Support for big courses</h2>
       <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses">
-      <div class="col-xs-9 col-sm-9">
+      <div class="col-lg-9">
         <div>
           TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into sections of no more than 100 students.
           There is no limit on the number of courses or sessions you could have either.

--- a/src/web/app/pages-static/features-page/features-page.component.scss
+++ b/src/web/app/pages-static/features-page/features-page.component.scss
@@ -6,3 +6,14 @@ img {
 .inner-content {
   margin: 0 20px;
 }
+
+@media (max-width: 991px){
+  img{
+    margin: 0;
+    max-width: 100%;
+  }
+
+  .inner-content{
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Fixes #12262

I added a new media query for mobile screen sizes (with the value 991 taken from page.component styles to be consistent). In this query, I remove the extra margins and make the images fill the width of the screen. I also changed the bootstrap class in the html for the text to be able to fill out the whole width of the image on mobile.

Result:

![Enlarge pictures on mobile](https://user-images.githubusercontent.com/71296308/234222068-6a77d7d2-3ed6-40ce-a567-087c4bcab3c6.png)
