### PR TITLE
[#12292] Admin logs page: Fix display of logs table on mobile

### DIFF
--- a/src/web/app/components/logs-table/logs-table.component.html
+++ b/src/web/app/components/logs-table/logs-table.component.html
@@ -1,4 +1,4 @@
-<div class="row" *ngIf="logs.length>0; else noLogMessage">
+<div class="row logs-table-container" *ngIf="logs.length>0; else noLogMessage">
   <div class="col-12">
     <table id="logs-table" class="table table-bordered table-hover margin-bottom-20px logs-table">
       <thead>

--- a/src/web/app/components/logs-table/logs-table.component.scss
+++ b/src/web/app/components/logs-table/logs-table.component.scss
@@ -21,6 +21,7 @@
   width: 100%;
   word-break: break-all;
   max-height: 90vh;
+  min-width: 1030px;
 
   thead {
     flex: 0 0 auto;
@@ -97,4 +98,12 @@
   overflow: hidden;
   width: 100%;
   white-space: nowrap;
+}
+
+.logs-table-container {
+  div.col-12 {
+    padding-right: 0;
+  }
+
+  margin-right: 0;
 }

--- a/src/web/app/pages-monitoring/logs-page/__snapshots__/logs-page.component.spec.ts.snap
+++ b/src/web/app/pages-monitoring/logs-page/__snapshots__/logs-page.component.spec.ts.snap
@@ -458,6 +458,10 @@ exports[`LogsPageComponent should snap when searching for details in search form
         </div>
       </tm-loading-spinner>
       <div
+        class="overflow-x-scroll"
+      >
+      </div>
+      <div
         class="center mb-4"
       >
       </div>

--- a/src/web/app/pages-monitoring/logs-page/logs-page.component.html
+++ b/src/web/app/pages-monitoring/logs-page/logs-page.component.html
@@ -172,9 +172,11 @@
   <div *tmIsLoading="isSearching" class="center mb-4">
     <button *ngIf="hasResult && hasPreviousPage" id="load-previous-button" class="btn btn-primary" (click)="loadPreviousLogs()">Load more</button>
   </div>
-  <tm-logs-table *ngIf="hasResult" [logs]="searchResults" (addTraceEvent)="addTraceToFilter($event)"
-    (addActionClassEvent)="addActionClassToFilter($event)" (addExceptionClassEvent)="addExceptionClassToFilter($event)"
-    (addSourceLocationEvent)="addSourceLocationToFilter($event)" (addUserInfoEvent)="addUserInfoToFilter($event)"></tm-logs-table>
+  <div class="overflow-x-scroll">
+    <tm-logs-table *ngIf="hasResult" [logs]="searchResults" (addTraceEvent)="addTraceToFilter($event)"
+      (addActionClassEvent)="addActionClassToFilter($event)" (addExceptionClassEvent)="addExceptionClassToFilter($event)"
+      (addSourceLocationEvent)="addSourceLocationToFilter($event)" (addUserInfoEvent)="addUserInfoToFilter($event)"></tm-logs-table>
+  </div>
   <div *tmIsLoading="isSearchingLaterLogs" class="center mb-4">
     <button *ngIf="hasResult && hasNextPage" id="load-next-button" class="btn btn-primary" (click)="loadLaterLogs()">Load more</button>
   </div>

--- a/src/web/app/pages-monitoring/logs-page/logs-page.component.scss
+++ b/src/web/app/pages-monitoring/logs-page/logs-page.component.scss
@@ -19,3 +19,7 @@
   width: 200px;
   display: inline;
 }
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
Fixes #12292 

**Outline of Solution**
Added overflow-x: scroll below a minimum width.
Added a logs-table-container class to remove right padding and margin which were causing the table to overflow even when it was above minimum width.