### PR TITLE
[#10976] Document frontend standardizations

### DIFF
--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -43,6 +43,7 @@
   * [UI Design]({{ baseUrl }}/best-practices/ui-design.html)
   * [Accessibility]({{ baseUrl }}/best-practices/accessibility.html)
   * [Mobile-Friendliness]({{ baseUrl }}/best-practices/mobile-friendliness.html)
+  * [Frontend Development]({{ baseUrl }}/best-practices/frontend-development.html)
 * How-to :expanded:
   * [Captcha]({{ baseUrl }}/captcha.html)
   * [Documentation]({{ baseUrl }}/documentation.html)

--- a/docs/best-practices/frontend-development.md
+++ b/docs/best-practices/frontend-development.md
@@ -1,0 +1,37 @@
+<frontmatter>
+  title: "Best Practices: Frontend Development"
+</frontmatter>
+
+# Frontend Development Best Practices
+
+The goal is to establish a standardized style for frontend development on our website. By following these standardizations and best practices, we can ensure consistency in our codebase and make it easier for new contributors to understand and contribute to the project.
+
+## Style Standardizations
+
+* Keep a neutral color scheme across the site.
+* Use built in color schemes to give subtle hints only when necessary.
+  * ex. primary, info, warning, danger
+* Do not use arbitrary colors for buttons, keep them the same color.
+* Button margins are 10px.
+* Darken hover colour of dropdown items.
+* Footer link color should be blue.
+* Try to use [bootstrap styles](https://getbootstrap.com/docs/5.0/utilities/spacing/#margin-and-padding) as much as possible.
+* For checkboxes followed by text:
+  * Use the form-check class on the surrounding div
+
+## HTML Best Practices
+
+* Use semantic HTML tags to improve the accessibility and structure of the website.
+* Inline styling should be avoided and use external css files instead.
+* Avoid the use of nested tables for layout purposes.
+
+## CSS Best Practices
+
+* CSS classes and IDs should be named in a consistent and readable manner.
+* Minimize/avoid the use of global styles.
+
+
+## JavaScript Best Practices
+
+* Use descriptive variable and function names.
+* Use proper indentation and spacing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Here are some documents important for TEAMMATES developers.
 * The [**workflow/process to follow**](process.md) when contributing to TEAMMATES.
 * [**Developer Troubleshooting Guide**](troubleshooting-guide.md)
 * How the [**issue tracker**](issues.md) is used - issue lifecycle, issue labels, etc.
+* [**Frontend style standardizations**](best-practices/frontend-development.md)
 
 ### Supplementary documents
 
@@ -36,6 +37,7 @@ Here are some documents important for TEAMMATES developers.
   * [UI design](best-practices/ui-design.md)
   * [Accessibility](best-practices/accessibility.md)
   * [Mobile-friendliness](best-practices/mobile-friendliness.md)
+  * [Frontend Development](best-practices/frontend-development.md)
 
 * **How-to guides** for:
   * [Static analysis](static-analysis.md): Performing code quality checks


### PR DESCRIPTION
Fixes #10976

Added documentation for frontend development standardizations and best practices. Linked the page in the Introduction page and is included in the side bar under "Best Practices". Having this file to document site-wide standards for frontend development will help keep the site consistent. Document can be updated when necessary whenever new standards are set.

Notes taken from previous issues. Ready to review.