### PR TITLE
[#12407] Sort icons in info table headings are hard to see

### DIFF
--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -9,7 +9,7 @@
         <button>
           Section
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -19,7 +19,7 @@
         <button>
           Team
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -29,7 +29,7 @@
         <button>
           Student Name
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -39,7 +39,7 @@
         <button>
           Status
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -49,7 +49,7 @@
         <button>
           Email
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>


### PR DESCRIPTION
 PR title: [#12407] Sort icons in info table headings are hard to see
Fixes #12407

**Outline of Solution**

Fixed the sort icon background from gray to white
