### PR TITLE
[#12407] Sort icons in info table headings are hard to see

### DIFF
--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -59,7 +59,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -75,7 +75,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -91,7 +91,7 @@ exports[`StudentListComponent should snap with default fields 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -153,7 +153,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -169,7 +169,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -185,7 +185,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -201,7 +201,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -217,7 +217,7 @@ exports[`StudentListComponent should snap with enable remind button set to true 
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -515,7 +515,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -531,7 +531,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -547,7 +547,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -563,7 +563,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -579,7 +579,7 @@ exports[`StudentListComponent should snap with enable remind button set to true,
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -871,7 +871,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -887,7 +887,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -903,7 +903,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -919,7 +919,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -935,7 +935,7 @@ exports[`StudentListComponent should snap with some student list data 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1221,7 +1221,7 @@ exports[`StudentListComponent should snap with some student list data and some s
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1237,7 +1237,7 @@ exports[`StudentListComponent should snap with some student list data and some s
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1253,7 +1253,7 @@ exports[`StudentListComponent should snap with some student list data and some s
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1269,7 +1269,7 @@ exports[`StudentListComponent should snap with some student list data and some s
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1285,7 +1285,7 @@ exports[`StudentListComponent should snap with some student list data and some s
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1573,7 +1573,7 @@ exports[`StudentListComponent should snap with some student list data when not a
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1589,7 +1589,7 @@ exports[`StudentListComponent should snap with some student list data when not a
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1605,7 +1605,7 @@ exports[`StudentListComponent should snap with some student list data when not a
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1621,7 +1621,7 @@ exports[`StudentListComponent should snap with some student list data when not a
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1637,7 +1637,7 @@ exports[`StudentListComponent should snap with some student list data when not a
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1923,7 +1923,7 @@ exports[`StudentListComponent should snap with some student list data with no se
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1939,7 +1939,7 @@ exports[`StudentListComponent should snap with some student list data with no se
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1955,7 +1955,7 @@ exports[`StudentListComponent should snap with some student list data with no se
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -1971,7 +1971,7 @@ exports[`StudentListComponent should snap with some student list data with no se
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -2087,7 +2087,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -2103,7 +2103,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -2119,7 +2119,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>
@@ -2135,7 +2135,7 @@ exports[`StudentListComponent should snap with table head set to hidden 1`] = `
                 class="fa-stack"
               >
                 <i
-                  class="fas fa-sort"
+                  class="fas fa-sort fa-bg-white"
                 />
               </span>
             </button>

--- a/src/web/app/components/student-list/student-list.component.html
+++ b/src/web/app/components/student-list/student-list.component.html
@@ -1,15 +1,15 @@
 <div class="table-responsive">
   <table class="table table-bordered table-striped m-0">
     <thead
-        [ngClass]="{'thead-gray': useGrayHeading, 'bg-info fw-bold': !useGrayHeading}"
-        [hidden]="isHideTableHead"
+            [ngClass]="{'thead-gray': useGrayHeading, 'bg-info fw-bold': !useGrayHeading}"
+            [hidden]="isHideTableHead"
     >
     <tr>
       <th class="sortable-header" *ngIf="hasSection()" (click)="sortStudentList(SortBy.SECTION_NAME)" [attr.aria-sort]="getAriaSort(SortBy.SECTION_NAME)">
         <button>
           Section
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.SECTION_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -19,7 +19,7 @@
         <button>
           Team
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.TEAM_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -29,7 +29,7 @@
         <button>
           Student Name
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_NAME && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -39,7 +39,7 @@
         <button>
           Status
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.JOIN_STATUS && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -49,7 +49,7 @@
         <button>
           Email
           <span class="fa-stack" aria-hidden="true">
-            <i class="fas fa-sort"></i>
+            <i class="fas fa-sort fa-bg-white"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.DESC" class="fas fa-sort-down"></i>
             <i *ngIf="tableSortBy === SortBy.RESPONDENT_EMAIL && tableSortOrder === SortOrder.ASC" class="fas fa-sort-up"></i>
           </span>
@@ -94,27 +94,27 @@
           tmRouterLink: '/web/instructor/courses/student/edit',
           queryParams: {courseid: courseId, studentemail: studentModel.student.email}
         }"></ng-container>
-      <ng-container *ngIf="enableRemindButton">
-        <ng-container *ngIf="studentModel.student.joinState === JoinState.NOT_JOINED">
-          <button id="btn-send-invite-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
-            [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
-            [disabled]=!isActionButtonsEnabled
-            [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
+        <ng-container *ngIf="enableRemindButton">
+          <ng-container *ngIf="studentModel.student.joinState === JoinState.NOT_JOINED">
+            <button id="btn-send-invite-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
+                    [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
+                    [disabled]=!isActionButtonsEnabled
+                    [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
             ? 'Email an invitation to the student requesting him/her to join the course using his/her'
             + ' Google Account. Note: Students can use TEAMMATES without \'joining\','
             + ' but a joined student can access extra features e.g. set up a user profile'
             : 'You do not have the permissions to access this feature'"
-            (click)="openRemindModal(studentModel)">Send Invite</button>
+                    (click)="openRemindModal(studentModel)">Send Invite</button>
+          </ng-container>
         </ng-container>
-      </ng-container>
-      <button id="btn-delete-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
-        [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
-        [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
+        <button id="btn-delete-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right"
+                [ngClass]="{'disabled mouse-hover-only': !studentModel.isAllowedToModifyStudent || !isActionButtonsEnabled}"
+                [ngbTooltip]="studentModel.isAllowedToModifyStudent && isActionButtonsEnabled
           ? 'Delete the student and the corresponding submissions from the course'
           : 'You do not have the permissions to access this feature'"
-        [disabled]="!isActionButtonsEnabled"
-        (click)="openDeleteModal(studentModel)">Delete</button>
-      <ng-container *ngTemplateOutlet="actionButton; context: {
+                [disabled]="!isActionButtonsEnabled"
+                (click)="openDeleteModal(studentModel)">Delete</button>
+        <ng-container *ngTemplateOutlet="actionButton; context: {
         id: 'btn-view-records-' + courseId + '-' + idx,
         isEnabled: isActionButtonsEnabled,
         tooltip: 'View all data about this student',

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -415,7 +415,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                         class="fa-stack"
                       >
                         <i
-                          class="fas fa-sort"
+                          class="fas fa-sort fa-bg-white"
                         />
                       </span>
                     </button>
@@ -431,7 +431,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                         class="fa-stack"
                       >
                         <i
-                          class="fas fa-sort"
+                          class="fas fa-sort fa-bg-white"
                         />
                       </span>
                     </button>
@@ -447,7 +447,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                         class="fa-stack"
                       >
                         <i
-                          class="fas fa-sort"
+                          class="fas fa-sort fa-bg-white"
                         />
                       </span>
                     </button>
@@ -463,7 +463,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                         class="fa-stack"
                       >
                         <i
-                          class="fas fa-sort"
+                          class="fas fa-sort fa-bg-white"
                         />
                       </span>
                     </button>
@@ -479,7 +479,7 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
                         class="fa-stack"
                       >
                         <i
-                          class="fas fa-sort"
+                          class="fas fa-sort fa-bg-white"
                         />
                       </span>
                     </button>

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -169,7 +169,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                           class="fa-stack"
                         >
                           <i
-                            class="fas fa-sort"
+                            class="fas fa-sort fa-bg-white"
                           />
                         </span>
                       </button>
@@ -185,7 +185,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                           class="fa-stack"
                         >
                           <i
-                            class="fas fa-sort"
+                            class="fas fa-sort fa-bg-white"
                           />
                         </span>
                       </button>
@@ -201,7 +201,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                           class="fa-stack"
                         >
                           <i
-                            class="fas fa-sort"
+                            class="fas fa-sort fa-bg-white"
                           />
                         </span>
                       </button>
@@ -217,7 +217,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                           class="fa-stack"
                         >
                           <i
-                            class="fas fa-sort"
+                            class="fas fa-sort fa-bg-white"
                           />
                         </span>
                       </button>
@@ -233,7 +233,7 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
                           class="fa-stack"
                         >
                           <i
-                            class="fas fa-sort"
+                            class="fas fa-sort fa-bg-white"
                           />
                         </span>
                       </button>


### PR DESCRIPTION
PR title: [#12407 ] Sort icons in info table headings are hard to see
Fixes #12407 

Outline of Solution
Fixed the sort icon background from gray to white and updated the screenshots
