### PR TITLE
[#12267] Instructor getting started page: Fix scroll to top #12267

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -47,7 +47,7 @@
     </ol>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -100,7 +100,7 @@
     </ol>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -152,7 +152,7 @@
     </p>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -175,7 +175,7 @@
       <li>
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Use the <button class="btn btn-light btn-sm dropdown-toggle">Remind</button> button of the session from the <span class="ui-text">Home</span> or <span class="ui-text">Sessions</span> page.
       </li>
-      <li>
+      <li>other-actions
         <a [tmRouterLink]="instructorHelpPath" [queryParams]="{questionId: SessionsSectionQuestions.SUBMIT_FOR_STUDENT, section: Sections.sessions}">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
@@ -193,7 +193,7 @@
     </ul>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -219,7 +219,7 @@
     </ul>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -233,6 +233,6 @@
     </p>
   </div>
   <p align="right">
-    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
+    <button type="button" class="btn btn-info" (click)="jumpToTop('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
 </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -52,4 +52,31 @@ export class InstructorHelpGettingStartedComponent {
     return false;
   }
 
+  /**
+   * To scroll to top of page in a visually pleasing way
+   */
+  jumpToTop(target: string): boolean {
+    const scrollDuration = 300; // Duration of the scrolling animation in milliseconds
+    const targetElement = document.getElementById(target);
+  
+    if (targetElement) {
+      const targetOffset = targetElement.getBoundingClientRect().top + window.scrollY;
+      const scrollStep = (targetOffset - window.scrollY) / (scrollDuration / 15); // Distance to scroll each step in pixels
+  
+      // Define the animation function
+      function scrollToTarget() {
+        if (Math.abs(window.scrollY - targetOffset) > 1) {
+          window.scrollBy(0, scrollStep);
+          setTimeout(scrollToTarget, 15);
+        } else {
+          window.scrollTo(0, targetOffset);
+        }
+      }
+  
+      // Call the animation function
+      scrollToTarget();
+    }
+  
+    return false;
+  }
 }


### PR DESCRIPTION
Fixes #12267 

I implemented a gradual scrolling to the top of the page by creating a new method that runs a lot like the jumpTo() method in instructor-help-getting-started.components.ts that uses window.scrollBy instead of window.scrollTo and uses a scroll duration of 300ms to gradually scroll upwards to the target (in this case 'top') instead of jumping to the target. It does this by computing the pixels to scroll each step and then executing these steps in a gradual way.