### PR TITLE
[#12269] Instructor edit sessions page: Fix add question button overflow

### DIFF
--- a/src/web/app/components/adding-question-panel/adding-question-panel.component.html
+++ b/src/web/app/components/adding-question-panel/adding-question-panel.component.html
@@ -24,7 +24,7 @@
     tmRouterLink="/web/instructor/help" [queryParams]="{questionId: 'questions', section: 'questions'}" aria-label="Help for questions">
     <i class="fas fa-info-circle"></i>
   </a>
-  <a type="button" class="btn btn-link" *ngIf="isLinkDisabled"><i class="fas fa-info-circle"></i></a>
+  <a type="button" id="btn-icon" class="btn btn-link" *ngIf="isLinkDisabled"><i class="fas fa-info-circle"></i></a>
   <button id="btn-copy-question" class="btn btn-primary" (click)="copyQuestionsFromOtherSessionsHandler()"
     [disabled]="isCopyingQuestion"><tm-ajax-loading *ngIf="isCopyingQuestion"></tm-ajax-loading>Copy Question</button>
 </div>

--- a/src/web/app/components/adding-question-panel/adding-question-panel.component.scss
+++ b/src/web/app/components/adding-question-panel/adding-question-panel.component.scss
@@ -1,3 +1,17 @@
 .background-color-light-blue {
   background-color: #EAEFF5;
 }
+
+@media (max-width: 480px) {
+  #btn-new-question {
+    padding: 0 0.25rem 0 0.25rem;
+  }
+
+  #btn-copy-question {
+    padding: 0 0.25rem 0 0.25rem;
+  }
+
+  #btn-icon {
+    padding: 0 0.25rem 0 0.25rem;
+  }
+}


### PR DESCRIPTION
[#12269] Instructor edit sessions page: Fix add question button overflow
Fixes #12269

**Outline of Solution**

Fixed the issue by adding dynamic padding to the modal. That way, when screen sizes are 480px wide or smaller, the padding will change on the buttons to make them all fit in one line versus overflowing to the next line.
