### PR TITLE
[#12267] Instructor getting started page: Fix scroll to top #12267

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11335,6 +11335,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -30976,6 +30977,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -44,11 +44,12 @@ export class InstructorHelpGettingStartedComponent {
    */
   jumpTo(target: string): boolean {
     const destination: Element | null = document.getElementById(target);
-    if (destination) {
-      destination.scrollIntoView();
-      // to prevent the navbar from covering the text
-      window.scrollTo(0, window.scrollY - 50);
-    }
+  if (destination) {
+    const topHeight = destination.getBoundingClientRect().height;
+    const scrollPosition = window.scrollY;
+    const topOffset = destination.getBoundingClientRect().top;
+      window.scrollTo({top: 0, left: scrollPosition + topOffset - topHeight, behavior: "smooth"});
+  }
     return false;
   }
 


### PR DESCRIPTION


<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12267 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
In this code, topHeight is the height of the h1, scrollPosition is the current scroll position, and topOffset is the distance between the target element and the top of the viewport. The code then scrolls to the position of the target element minus the height of the navbar. This should ensure that the target element is visible and not covered by the h1.
