### PR TITLE
[#12407] Sort icons in info table headings are hard to see

### DIFF
--- a/src/web/app/components/student-list/student-list.component.scss
+++ b/src/web/app/components/student-list/student-list.component.scss
@@ -7,6 +7,10 @@
   background-color: #DADADA;
 }
 
+.fa-sort {
+  color: white;
+}
+
 /*
 Allow only mouse hover events for the element.
 !important is required to override Bootstrap .disabled class matches


### PR DESCRIPTION
Fixes #12407 

**Outline of Solution**

I changed the respective scss file and added the white color in all fa-sort elements so that the sort icons have a white color instead of the grey one. 

Here is the updated UI
![sorticons](https://github.com/TEAMMATES/teammates/assets/95168947/66eca869-2b05-49b8-9a1e-9054b17a5643)

Here is the UI when a table is sorted by a specific column 
![sorticons](https://github.com/TEAMMATES/teammates/assets/95168947/05d12340-50ab-44cc-a9df-0071d7f33a4d)


