### PR TITLE
[#12430] Include student email in 'distribute points' type question summary table CSV

### DIFF
--- a/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
+++ b/src/web/services/__snapshots__/session-result-csv.service.spec.ts.snap
@@ -42,9 +42,9 @@ Team 1.2,student5 In Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Co
 Question 2,Split points among the teams
 
 Summary Statistics
-Team,Recipient,Total Points,Average Points,Points Received
-,\\"Team 1.1</td></div>'\\"\\"\\",80,80,80
-,Team 1.2,20,20,20
+Team,Recipient,Recipient Email,Total Points,Average Points,Points Received
+,\\"Team 1.1</td></div>'\\"\\"\\",\\"Team 1.1</td></div>'\\"\\"\\",80,80,80
+,Team 1.2,Team 1.2,20,20,20
 
 
 Team,Giver's Name,Giver's Email,Recipient's Team,Recipient's Name,Recipient's Email,Feedback
@@ -55,12 +55,12 @@ Instructors,Instructor1 Course1,instructor1@course1.tmt,Team 1.2,Team 1.2,,20
 Question 3,How much has each student worked?
 
 Summary Statistics
-Team,Recipient,Total Points,Average Points,Points Received
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",30,30,30
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,20,20,20
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,30,30,30
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,10,10,10
-Team 1.2,student5 In Course1,10,10,10
+Team,Recipient,Recipient Email,Total Points,Average Points,Points Received
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,30,30,30
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,20,20,20
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,30,30,30
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,10,10,10
+Team 1.2,student5 In Course1,student5InCourse1@gmail.tmt,10,10,10
 
 
 Team,Giver's Name,Giver's Email,Recipient's Team,Recipient's Name,Recipient's Email,Feedback
@@ -279,9 +279,9 @@ exports[`SessionResultCsvService should generate results for NUMSCALE question 1
 Question 1,Rate our product.
 
 Summary Statistics
-Team,Recipient,Average,Minimum,Maximum
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",3.5,3.5,3.5
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,2,2,2
+Team,Recipient,Recipient Email,Average,Minimum,Maximum
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,3.5,3.5,3.5
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,2,2,2
 
 
 Team,Giver's Name,Giver's Email,Recipient's Team,Recipient's Name,Recipient's Email,Feedback
@@ -295,9 +295,9 @@ Team 1.2,student5 In Course1,student5InCourse1@gmail.tmt,Team 1.2,student5 In Co
 Question 2,Rate our product.
 
 Summary Statistics
-Team,Recipient,Average,Minimum,Maximum
-Instructors,Instructor1 Course1,4.5,4.5,4.5
-Instructors,Instructor2 Course1,1,1,1
+Team,Recipient,Recipient Email,Average,Minimum,Maximum
+Instructors,Instructor1 Course1,instructor1@course1.tmt,4.5,4.5,4.5
+Instructors,Instructor2 Course1,instructor2@course1.tmt,1,1,1
 
 
 Team,Giver's Name,Giver's Email,Recipient's Team,Recipient's Name,Recipient's Email,Feedback
@@ -314,11 +314,11 @@ exports[`SessionResultCsvService should generate results for RANK question 1`] =
 Question 1,Rank the other students.
 
 Summary Statistics
-Team,Recipient,Self Rank,Overall Rank,Overall Rank Excluding Self,Team Rank,Team Rank Excluding Self,Ranks Received
-\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",4,4,-,-,-,4
-\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,2,1,3,-,-,2,3
-\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,3,1,1,-,-,2,3
-\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,3,3,2,-,-,1,3,4
+Team,Recipient,Recipient Email,Self Rank,Overall Rank,Overall Rank Excluding Self,Team Rank,Team Rank Excluding Self,Ranks Received
+\\"Team 1.1</td></div>'\\"\\"\\",\\"student1 In Course1</td></div>'\\"\\"\\",student1InCourse1@gmail.tmt,4,4,-,-,-,4
+\\"Team 1.1</td></div>'\\"\\"\\",student2 In Course1,student2InCourse1@gmail.tmt,2,1,3,-,-,2,3
+\\"Team 1.1</td></div>'\\"\\"\\",student3 In Course1,student3InCourse1@gmail.tmt,3,1,1,-,-,2,3
+\\"Team 1.1</td></div>'\\"\\"\\",student4 In Course1,student4InCourse1@gmail.tmt,3,3,2,-,-,1,3,4
 
 
 Team,Giver's Name,Giver's Email,Recipient's Team,Recipient's Name,Recipient's Email,Feedback

--- a/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-constsum-recipient-question-details.impl.ts
@@ -49,12 +49,13 @@ export class FeedbackConstantSumRecipientsQuestionDetailsImpl extends AbstractFe
     }
     statsCalculation.calculateStatistics();
 
-    statsRows.push(['Team', 'Recipient', 'Total Points', 'Average Points', 'Points Received']);
+    statsRows.push(['Team', 'Recipient', 'Recipient Email', 'Total Points', 'Average Points', 'Points Received']);
 
     Object.keys(statsCalculation.pointsPerOption).sort().forEach((recipient: string) => {
       statsRows.push([
         statsCalculation.emailToTeamName[recipient],
         statsCalculation.emailToName[recipient],
+        recipient,
         String(statsCalculation.totalPointsPerOption[recipient]),
         String(statsCalculation.averagePointsPerOption[recipient]),
         ...statsCalculation.pointsPerOption[recipient].map(String),

--- a/src/web/types/question-details-impl/feedback-num-scale-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-num-scale-question-details.impl.ts
@@ -38,7 +38,7 @@ export class FeedbackNumericalScaleQuestionDetailsImpl extends AbstractFeedbackQ
     }
     statsCalculation.calculateStatistics();
 
-    const header: string[] = ['Team', 'Recipient', 'Average', 'Minimum', 'Maximum'];
+    const header: string[] = ['Team', 'Recipient', 'Recipient Email', 'Average', 'Minimum', 'Maximum'];
     const shouldShowAvgExcludingSelf: boolean =
         this.shouldShowAverageExcludingSelfInCsvStats(question, statsCalculation);
     if (shouldShowAvgExcludingSelf) {
@@ -52,6 +52,7 @@ export class FeedbackNumericalScaleQuestionDetailsImpl extends AbstractFeedbackQ
         const currRow: string[] = [
           team,
           recipient,
+          statsCalculation.recipientEmails[recipient],
           String(stats.average),
           String(stats.min),
           String(stats.max),

--- a/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rank-recipients-question-details.impl.ts
@@ -44,6 +44,7 @@ export class FeedbackRankRecipientsQuestionDetailsImpl extends AbstractFeedbackQ
     statsRows.push([
       'Team',
       'Recipient',
+      'Recipient Email',
       'Self Rank',
       'Overall Rank',
       'Overall Rank Excluding Self',
@@ -56,6 +57,7 @@ export class FeedbackRankRecipientsQuestionDetailsImpl extends AbstractFeedbackQ
       statsRows.push([
         statsCalculation.emailToTeamName[recipient],
         statsCalculation.emailToName[recipient],
+        recipient,
         statsCalculation.selfRankPerOption[recipient]
             ? String(statsCalculation.selfRankPerOption[recipient]) : emptyStr,
         statsCalculation.rankPerOption[recipient] ? String(statsCalculation.rankPerOption[recipient]) : emptyStr,


### PR DESCRIPTION
Fixes #12430 Include student email in 'distribute points' type question summary table CSV

I changed the method which generated the csv file. Added one more columnfor the email stat.

For distribute points type question
![emailAdd](https://github.com/TEAMMATES/teammates/assets/48171184/bd421116-d8b8-42d6-afc5-2d47d9b7a048)

For rank participants type question  
![rank](https://github.com/TEAMMATES/teammates/assets/48171184/1140c928-b5e2-41a7-adad-ac2ce2408951)

For Numerical-scale type question:
![numscale](https://github.com/TEAMMATES/teammates/assets/48171184/50a1929d-0d03-4ca7-b4a3-96c3b52e61e0)
