### PR TITLE
[#12099] Add 'course -> copy' option to the instructor home page

### DIFF
--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -6,6 +6,8 @@ exports[`InstructorHomePageComponent should snap when courses are still loading 
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -18,6 +20,7 @@ exports[`InstructorHomePageComponent should snap when courses are still loading 
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -25,6 +28,7 @@ exports[`InstructorHomePageComponent should snap when courses are still loading 
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -32,6 +36,7 @@ exports[`InstructorHomePageComponent should snap when courses are still loading 
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -75,6 +80,8 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -87,6 +94,7 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -94,6 +102,7 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -101,6 +110,7 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -144,6 +154,8 @@ exports[`InstructorHomePageComponent should snap with one course with error load
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -156,6 +168,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -163,6 +176,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -170,6 +184,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -289,6 +304,8 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -301,6 +318,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -308,6 +326,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -315,6 +334,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -496,6 +516,12 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                     tmrouterlink="/web/instructor/courses/edit"
                   >
                      View / Edit 
+                  </a>
+                  <a
+                    class="btn-copy-course btn btn-light btn-sm dropdown-item"
+                    ngbtooltip="Copy the course and its corresponding sessions"
+                  >
+                     Copy 
                   </a>
                   <a
                     class="btn-delete-course btn btn-light btn-sm dropdown-item"
@@ -795,6 +821,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -807,6 +835,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -814,6 +843,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -821,6 +851,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -1453,6 +1484,8 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -1465,6 +1498,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -1472,6 +1506,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -1479,6 +1514,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -1660,6 +1696,12 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                     tmrouterlink="/web/instructor/courses/edit"
                   >
                      View / Edit 
+                  </a>
+                  <a
+                    class="btn-copy-course btn btn-light btn-sm dropdown-item"
+                    ngbtooltip="Copy the course and its corresponding sessions"
+                  >
+                     Copy 
                   </a>
                   <a
                     class="btn-delete-course btn btn-light btn-sm dropdown-item"
@@ -1693,6 +1735,8 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -1705,6 +1749,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -1712,6 +1757,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -1719,6 +1765,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -1900,6 +1947,12 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                     tmrouterlink="/web/instructor/courses/edit"
                   >
                      View / Edit 
+                  </a>
+                  <a
+                    class="btn-copy-course btn btn-light btn-sm dropdown-item"
+                    ngbtooltip="Copy the course and its corresponding sessions"
+                  >
+                     Copy 
                   </a>
                   <a
                     class="btn-delete-course btn btn-light btn-sm dropdown-item"
@@ -1957,6 +2010,8 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
   SessionsTableHeaderColorScheme={[Function Object]}
   SortBy={[Function Object]}
   __ngContext__={[Function Number]}
+  allCoursesList={[Function Array]}
+  copyProgressPercentage="0"
   courseService={[Function CourseService]}
   courseTabModels={[Function Array]}
   coursesOfModifiedSession={[Function Array]}
@@ -1969,6 +2024,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
   instructorCoursesSortBy={[Function Number]}
   instructorService={[Function InstructorService]}
   isCopyLoading="false"
+  isCopyingCourse="false"
   isNewUser="false"
   isResultActionLoading="false"
   isSendReminderLoading="false"
@@ -1976,6 +2032,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
   modifiedTimestampsModal={[Function TemplateRef2]}
   navigationService={[Function NavigationService]}
   ngbModal={[Function NgbModal]}
+  numberOfSessionsCopied="0"
   progressBarService={[Function ProgressBarService]}
   publishUnpublishRetryAttempts={[Function Number]}
   simpleModalService={[Function SimpleModalService]}
@@ -1983,6 +2040,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
   studentService={[Function StudentService]}
   tableComparatorService={[Function TableComparatorService]}
   timezoneService={[Function TimezoneService]}
+  totalNumberOfSessionsToCopy="0"
 >
   <h1>
     Home
@@ -2164,6 +2222,12 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                     tmrouterlink="/web/instructor/courses/edit"
                   >
                      View / Edit 
+                  </a>
+                  <a
+                    class="btn-copy-course btn btn-light btn-sm dropdown-item"
+                    ngbtooltip="Copy the course and its corresponding sessions"
+                  >
+                     Copy 
                   </a>
                   <a
                     class="btn-delete-course btn btn-light btn-sm dropdown-item"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -29,6 +29,11 @@
   </div>
 </div>
 
+<div *ngIf="isCopyingCourse" class="margin-top-bottom-30px">
+  <p>Copy Progress</p>
+  <tm-progress-bar></tm-progress-bar>
+</div>
+
 <tm-loading-retry [shouldShowRetry]="hasCoursesLoadingFailed" [message]="'Something went wrong'"
   (retryEvent)="loadCourses()">
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
@@ -81,6 +86,12 @@
                 <!--                <a class="btn btn-light btn-sm dropdown-item"-->
                 <!--                   tmRouterLink='/web/instructor/courses/student-activity-logs' [queryParams]="{courseid: courseTabModel.course.courseId}"> View Logs-->
                 <!--                </a>-->
+                <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyCourse">
+                  <a class="btn-copy-course btn btn-light btn-sm dropdown-item"
+                    ngbTooltip="Copy the course and its corresponding sessions"
+                    (click)="!isCopyingCourse && onCopy(courseTabModel.course.courseId, courseTabModel.course.courseName, courseTabModel.course.timeZone)"> Copy
+                  </a>
+                </ng-container>
                 <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyCourse">
                   <a class="btn-delete-course btn btn-light btn-sm dropdown-item"
                     ngbTooltip="Delete the course and its corresponding students and sessions"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -29,7 +29,7 @@
   </div>
 </div>
 
-<div *ngIf="isCopyingCourse" class="margin-top-bottom-30px">
+<div *ngIf="isCopyingCourse" class="mb-4">
   <p>Copy Progress</p>
   <tm-progress-bar></tm-progress-bar>
 </div>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -27,3 +27,8 @@
 .text-color-lightgray {
   color: lightgray;
 }
+
+.margin-top-bottom-30px {
+  margin-top: 30px;
+  margin-bottom: 30px;
+}

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -27,8 +27,3 @@
 .text-color-lightgray {
   color: lightgray;
 }
-
-.margin-top-bottom-30px {
-  margin-top: 30px;
-  margin-bottom: 30px;
-}

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -24,6 +24,8 @@ import {
 } from '../../../types/api-output';
 import { DEFAULT_INSTRUCTOR_PRIVILEGE } from '../../../types/default-instructor-privilege';
 import { SortBy, SortOrder } from '../../../types/sort-properties';
+import { CopyCourseModalResult } from '../../components/copy-course-modal/copy-course-modal-model';
+import { CopyCourseModalComponent } from '../../components/copy-course-modal/copy-course-modal.component';
 import {
   CopySessionResult,
   SessionsTableColumn,
@@ -72,11 +74,17 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
 
   // data
   courseTabModels: CourseTabModel[] = [];
+  allCoursesList: Course[] = [];
 
   hasCoursesLoaded: boolean = false;
   hasCoursesLoadingFailed: boolean = false;
   isNewUser: boolean = false;
   isCopyLoading: boolean = false;
+  isCopyingCourse: boolean = false;
+
+  numberOfSessionsCopied = 0;
+  totalNumberOfSessionsToCopy = 0;
+  copyProgressPercentage = 0;
 
   @ViewChild('modifiedTimestampsModal') modifiedTimestampsModal!: TemplateRef<any>;
 
@@ -117,6 +125,118 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
       return !courseTabModel.isTabExpanded;
     }
     return courseTabModel.isTabExpanded;
+  }
+
+  /**
+   * Initializes course tab model data on load.
+   */
+  initializeCourseTabModule(course: Course): void {
+    const model: CourseTabModel = {
+        course,
+        instructorPrivilege: course.privileges || DEFAULT_INSTRUCTOR_PRIVILEGE(),
+        sessionsTableRowModels: [],
+        isTabExpanded: false,
+        isAjaxSuccess: true,
+        hasPopulated: false,
+        hasLoadingFailed: false,
+        sessionsTableRowModelsSortBy: SortBy.NONE,
+        sessionsTableRowModelsSortOrder: SortOrder.ASC,
+      };
+
+    this.courseTabModels.push(model);
+  }
+
+  /**
+   * Creates a copy of a course including the selected sessions.
+   */
+  onCopy(courseId: string, courseName: string, timeZone: string): void {
+    if (!courseId) {
+      this.statusMessageService.showErrorToast('Course is not found!');
+      return;
+    }
+
+    this.feedbackSessionsService.getFeedbackSessionsForInstructor(courseId).subscribe({
+      next: (response: FeedbackSessions) => {
+        const modalRef: NgbModalRef = this.ngbModal.open(CopyCourseModalComponent);
+        modalRef.componentInstance.oldCourseId = courseId;
+        modalRef.componentInstance.oldCourseName = courseName;
+        modalRef.componentInstance.allCourses = this.allCoursesList;
+        modalRef.componentInstance.newTimeZone = timeZone;
+        modalRef.componentInstance.courseToFeedbackSession[courseId] = response.feedbackSessions;
+        modalRef.componentInstance.selectedFeedbackSessions = new Set(response.feedbackSessions);
+        modalRef.result.then((result: CopyCourseModalResult) => this.createCopiedCourse(result), () => {
+        });
+      },
+      error: (resp: ErrorMessageOutput) => {
+        this.statusMessageService.showErrorToast(resp.error.message);
+      },
+    });
+  }
+
+  /**
+   * Creates a new course with the selected feedback sessions
+   */
+  createCopiedCourse(result: CopyCourseModalResult): void {
+    this.isCopyingCourse = true;
+    this.numberOfSessionsCopied = 0;
+    this.totalNumberOfSessionsToCopy = result.totalNumberOfSessions;
+    this.copyProgressPercentage = 0;
+
+    this.courseService.createCourse(result.newCourseInstitute, {
+      courseName: result.newCourseName,
+      timeZone: result.newTimeZone,
+      courseId: result.newCourseId,
+    })
+    .subscribe({
+      next: () => {
+        // Wrap in a Promise to wait for all feedback sessions to be copied
+        const promise: Promise<void> = new Promise<void>((resolve: () => void) => {
+          if (result.selectedFeedbackSessionList.size === 0) {
+            this.progressBarService.updateProgress(100);
+            resolve();
+
+            return;
+          }
+
+          result.selectedFeedbackSessionList.forEach((session: FeedbackSession) => {
+            this.copyFeedbackSession(session, session.feedbackSessionName, result.newCourseId, result.oldCourseId)
+                .pipe(finalize(() => {
+                  this.numberOfSessionsCopied += 1;
+                  this.copyProgressPercentage =
+                      Math.round(100 * this.numberOfSessionsCopied / this.totalNumberOfSessionsToCopy);
+                  this.progressBarService.updateProgress(this.copyProgressPercentage);
+
+                  if (this.numberOfSessionsCopied === this.totalNumberOfSessionsToCopy) {
+                    resolve();
+                  }
+                }))
+                .subscribe();
+          });
+        });
+
+        promise.then(() => {
+          this.courseService
+              .getCourseAsInstructor(result.newCourseId)
+              .subscribe((course: Course) => {
+                this.allCoursesList.push(course);
+                this.initializeCourseTabModule(course);
+                this.sortCoursesBy(this.instructorCoursesSortBy);
+                this.isCopyingCourse = false;
+                if (Object.keys(this.modifiedSession).length > 0) {
+                  this.simpleModalService.openInformationModal('Note On Modified Session Timings',
+                      SimpleModalType.WARNING, this.modifiedTimestampsModal);
+                } else {
+                  this.statusMessageService.showSuccessToast('The course has been added.');
+                }
+              });
+        });
+      },
+      error: (resp: ErrorMessageOutput) => {
+        this.statusMessageService.showErrorToast(resp.error.message);
+        this.isCopyingCourse = false;
+        this.hasCoursesLoadingFailed = true;
+      },
+    });
   }
 
   /**
@@ -171,6 +291,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
       });
     }, () => {});
   }
+
   /**
    * Loads courses of current instructor.
    */
@@ -185,19 +306,8 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
         .subscribe({
           next: (courses: Courses) => {
             courses.courses.forEach((course: Course) => {
-              const model: CourseTabModel = {
-                course,
-                instructorPrivilege: course.privileges || DEFAULT_INSTRUCTOR_PRIVILEGE(),
-                sessionsTableRowModels: [],
-                isTabExpanded: false,
-                isAjaxSuccess: true,
-                hasPopulated: false,
-                hasLoadingFailed: false,
-                sessionsTableRowModelsSortBy: SortBy.NONE,
-                sessionsTableRowModelsSortOrder: SortOrder.ASC,
-              };
-
-              this.courseTabModels.push(model);
+              this.allCoursesList.push(course);
+              this.initializeCourseTabModule(course);
             });
             this.isNewUser = !courses.courses.some((course: Course) => !/-demo\d*$/.test(course.courseId));
             this.sortCoursesBy(this.instructorCoursesSortBy);
@@ -207,6 +317,24 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
             this.statusMessageService.showErrorToast(resp.error.message);
           },
         });
+    this.courseService.getAllCoursesAsInstructor('archived').subscribe({
+      next: (resp: Courses) => {
+        this.allCoursesList.push(...resp.courses);
+      },
+      error: (resp: ErrorMessageOutput) => {
+        this.hasCoursesLoadingFailed = true;
+        this.statusMessageService.showErrorToast(resp.error.message);
+      },
+    });
+    this.courseService.getAllCoursesAsInstructor('softDeleted').subscribe({
+      next: (resp: Courses) => {
+        this.allCoursesList.push(...resp.courses);
+      },
+      error: (resp: ErrorMessageOutput) => {
+        this.hasCoursesLoadingFailed = true;
+        this.statusMessageService.showErrorToast(resp.error.message);
+      },
+    });
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -178,6 +178,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
    */
   createCopiedCourse(result: CopyCourseModalResult): void {
     this.isCopyingCourse = true;
+    this.modifiedSession = {};
     this.numberOfSessionsCopied = 0;
     this.totalNumberOfSessionsToCopy = result.totalNumberOfSessions;
     this.copyProgressPercentage = 0;
@@ -223,6 +224,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
                 this.sortCoursesBy(this.instructorCoursesSortBy);
                 this.isCopyingCourse = false;
                 if (Object.keys(this.modifiedSession).length > 0) {
+                  this.coursesOfModifiedSession = [];
                   this.simpleModalService.openInformationModal('Note On Modified Session Timings',
                       SimpleModalType.WARNING, this.modifiedTimestampsModal);
                 } else {

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.module.ts
@@ -3,12 +3,14 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { NgbCollapseModule, NgbDropdownModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { CopyCourseModalModule } from '../../components/copy-course-modal/copy-course-modal.module';
 import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
 import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
 import {
   ModifiedTimestampModalModule,
 } from '../../components/modified-timestamps-modal/modified-timestamps-module.module';
 import { PanelChevronModule } from '../../components/panel-chevron/panel-chevron.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
 import { SessionsTableModule } from '../../components/sessions-table/sessions-table.module';
 import { TeammatesRouterModule } from '../../components/teammates-router/teammates-router.module';
 import { InstructorHomePageComponent } from './instructor-home-page.component';
@@ -39,6 +41,8 @@ const routes: Routes = [
     LoadingRetryModule,
     PanelChevronModule,
     TeammatesRouterModule,
+    CopyCourseModalModule,
+    ProgressBarModule,
     ModifiedTimestampModalModule,
   ],
   exports: [


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12099

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->
I've added the course copy element to the html in the instructor home page, added the course copy logic to the typescript files while using functions declared in its ancestor InstructorSessionBasePageComponent, and I also updated the snapshot tests.


![](https://github.com/TEAMMATES/teammates/assets/71296308/f72ea3d4-49b6-4e15-b3f2-11e847e6d127)
