### PR TITLE
[#10920] Add test for restoreCourse in Instructor Courses Page

### DIFF
--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -384,7 +384,7 @@ describe('InstructorCoursesPageComponent', () => {
     expect(component.activeCourses.length).toEqual(1);
     expect(component.activeCourses[0].course.courseId).toEqual('CS1231');
   });
-    
+
   it('should restore a soft deleted course', () => {
     component.softDeletedCourses = [courseModelCS1231];
     expect(component.softDeletedCourses.length).toEqual(1);
@@ -393,15 +393,15 @@ describe('InstructorCoursesPageComponent', () => {
       .mockReturnValue(of(courseModelCS1231));
     jest.spyOn(simpleModalService, 'openConfirmationModal')
       .mockReturnValue(createMockNgbModalRef());
-    
+
     component.onRestore('CS1231');
 
     expect(courseSpy).toHaveBeenCalledTimes(1);
     expect(courseSpy).toHaveBeenNthCalledWith(1, 'CS1231');
 
     expect(component.archivedCourses.length).toEqual(0);
-    expect(component.softDeletedCourses.length).toEqual(0);    
-  });
+    expect(component.softDeletedCourses.length).toEqual(0);
+});
 
   it('should soft delete a course', async () => {
     component.activeCourses = [courseModelCS1231];

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -384,6 +384,24 @@ describe('InstructorCoursesPageComponent', () => {
     expect(component.activeCourses.length).toEqual(1);
     expect(component.activeCourses[0].course.courseId).toEqual('CS1231');
   });
+    
+  it('should restore a soft deleted course', () => {
+    component.softDeletedCourses = [courseModelCS1231];
+    expect(component.softDeletedCourses.length).toEqual(1);
+
+    const courseSpy: SpyInstance = jest.spyOn(courseService, 'restoreCourse')
+      .mockReturnValue(of(courseModelCS1231));
+    jest.spyOn(simpleModalService, 'openConfirmationModal')
+      .mockReturnValue(createMockNgbModalRef());
+    
+    component.onRestore('CS1231');
+
+    expect(courseSpy).toHaveBeenCalledTimes(1);
+    expect(courseSpy).toHaveBeenNthCalledWith(1, 'CS1231');
+
+    expect(component.archivedCourses.length).toEqual(0);
+    expect(component.softDeletedCourses.length).toEqual(0);    
+  });
 
   it('should soft delete a course', async () => {
     component.activeCourses = [courseModelCS1231];


### PR DESCRIPTION
Part of #10920 

Outline of Solution

Added a test case for onRestore(), used to restore a course that had previously been deleted on the Instructor Course Page
