### PR TITLE
[#12464] Add verification step for Docker instance of Datastore in docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -210,6 +210,7 @@ We have a Docker compose definition to run dependent services, including local D
 docker-compose run -p 8484:8484 datastore
 ```
 
+**Verification:** Should receive an "Ok" response in the browser at `http://localhost:8484`.
 </panel>
 
 <panel header="**Using Cloud SDK**">


### PR DESCRIPTION
Fixes #12464

**Outline of Solution**

Add verification step to docs, tested on local Markbind server
![image](https://github.com/TEAMMATES/teammates/assets/25302138/b4e62b0f-9907-4102-84bd-ccf494a7b38b)