### PR TITLE
[#1501] Add tests cases to FeedbackRankOptionsQuestionDetails

### DIFF
--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
@@ -86,6 +86,16 @@ public class FeedbackRankOptionsQuestionDetailsTest extends BaseTestCase {
         feedbackQuestionDetails.setOptions(Arrays.asList("1", "2", "3", "4", "5"));
         errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_INVALID_MIN_OPTIONS_ENABLED);
         assertEquals(errorResponse, feedbackQuestionDetails.validateQuestionDetails());
+        errorResponse.clear();
+
+        feedbackQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackQuestionDetails.setMaxOptionsToBeRanked(0);
+        feedbackQuestionDetails.setMinOptionsToBeRanked(0);
+        errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_INVALID_MAX_OPTIONS_ENABLED);
+        errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_INVALID_MIN_OPTIONS_ENABLED);
+        errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_NOT_ENOUGH_OPTIONS
+                + FeedbackRankOptionsQuestionDetails.MIN_NUM_OF_OPTIONS + ".");
+        assertEquals(errorResponse, feedbackQuestionDetails.validateQuestionDetails());
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetailsTest.java
@@ -78,6 +78,14 @@ public class FeedbackRankOptionsQuestionDetailsTest extends BaseTestCase {
         errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_MAX_OPTIONS_ENABLED_MORE_THAN_CHOICES);
         feedbackQuestionDetails.setOptions(Arrays.asList("1", "2", "3"));
         assertEquals(errorResponse, feedbackQuestionDetails.validateQuestionDetails());
+        errorResponse.clear();
+
+        feedbackQuestionDetails = new FeedbackRankOptionsQuestionDetails();
+        feedbackQuestionDetails.setMinOptionsToBeRanked(5);
+        feedbackQuestionDetails.setMaxOptionsToBeRanked(3);
+        feedbackQuestionDetails.setOptions(Arrays.asList("1", "2", "3", "4", "5"));
+        errorResponse.add(FeedbackRankOptionsQuestionDetails.ERROR_INVALID_MIN_OPTIONS_ENABLED);
+        assertEquals(errorResponse, feedbackQuestionDetails.validateQuestionDetails());
     }
 
     @Test


### PR DESCRIPTION
Part of #1501

**Outline of Solution**

Approach:
- Based on jacoco reports and the coverage of the method validateQuestionDetails
- I applied mulitple-conditions white-box test 
- And added 2 tests cases to cover 100% of the method 
- In the test method testValidateQuestionDetails_invalidMaxMinOptions_errorReturned 
