### PR TITLE
[#12481] Fix running of component tests using Windows Powershell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -439,9 +439,8 @@ def afterTestClosure = { descriptor, result ->
             def process = "${diffCommand} ${expectedFileName} ${actualFileName}".execute()
             println process.getText()
             process.waitFor()
-            def deleteCommand = isWindows ? "del" : "rm"
-            "${deleteCommand} ${expectedFileName}".execute()
-            "${deleteCommand} ${actualFileName}".execute()
+            delete expectedFileName
+            delete actualFileName
         } else {
             println "${result.exception.getClass().getName()}: ${result.exception.getMessage()}"
         }


### PR DESCRIPTION
The previous strategy of choosing the command for deleting temporary files relied on the Windows CMD command `del`. This command does not exist in PowerShell, so the task fails.

Thankfully, there is a `delete` method we can use. This method takes care of platform differences for us.

Fixes #12481 

**Outline of Solution**

Using gradle's [`delete`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#delete-java.lang.Object...-) method fixes the problem and takes care of all other platform issues (I hope).