### PR TITLE
[#12480] Add a trigger for good first issues

### DIFF
--- a/.github/workflows/comment-goodfirstissue.yml
+++ b/.github/workflows/comment-goodfirstissue.yml
@@ -1,0 +1,37 @@
+name: Comment on Good First Issue
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if labeled as "good first issue"
+        id: check_label
+        run: |
+          echo ::set-output name=is_good_first_issue::${{ contains(github.event.issue.labels.*.name, 'good first issue') }}
+
+      - name: Add comment
+        if: steps.check_label.outputs.is_good_first_issue == 'true'
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const message = '**Good First Issue - Notes for Contributors**
+
+This issue is for **first-time contributors only**. If you are new to TEAMMATES, feel free to submit a PR for this issue. *Please note that we allow only one `good first issue` per contributor.* 
+
+If you have already made a prior contribution to TEAMMATES, you may wish to take a look at issues with the `help wanted` tag instead. **We do not assign issues to contributors**. 
+
+If you would like to pick up this issue, do post a comment below to express your interest and check if there is anyone else who is already working on the issue. We will do our best to reply and give you the go-ahead, but if we don't, feel free to submit a PR as long as there is no one else working on it.
+
+**To get started**, do read through our [contributing guidelines](https://teammates.github.io/teammates/contributing-doc.html) carefully, and [set up a development environment on your local machine](https://teammates.github.io/teammates/setting-up.html) before making a PR.
+
+If you need any clarifications on our [developer guide](https://teammates.github.io/teammates/index.html), or are facing issues that are not found in our [troubleshooting guide](https://teammates.github.io/teammates/troubleshooting-guide.html), please [post a message in our discussion forum](https://github.com/TEAMMATES/teammates/discussions).';
+            
+            const comment = context.issue({ body: message });
+            return github.issues.createComment(comment);


### PR DESCRIPTION
Fixes #12480 

**Outline of Solution**

I added a yml file inside the .github/workflows directory that will add a comment every time a new issue is labeled as a "*good first issue*". I changed the initial comment based on the feedback from the TEAMMATES team so that it is more specific and helpful.

***Please note*** that the trigger will work only on new issues and will not add a comment in already existing issues.

In my forked repo, I do not have any issues so I couldn't test the trigger. Please let me know if everything is okay.
