### PR TITLE
[#12400] Instructor editing questions: warning about visibility is removed if the edit is cancelled. 

### DIFF
--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -756,6 +756,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.feedbackQuestionModels.get(questionEditFormModel.feedbackQuestionId)!;
     this.questionEditFormModels[index] = this.getQuestionEditFormModel(feedbackQuestion);
+    this.questionEditFormModels[index].isQuestionHasResponses = questionEditFormModel.isQuestionHasResponses;
   }
 
   /**


### PR DESCRIPTION
Fixes #12400 

**Outline of Solution**

`isQuestionHasResponses` of `questionEditFormModel` was set back to default when discard action was executed. I simply mutated the new `questionEditFormModel` created with the previous `isQuestionHasResponses` status.

## Demo 

https://github.com/Zxun2/teammates/assets/63457492/d8790667-02f7-4a50-81f5-51fff5e17e60

