### PR TITLE
[#11947] Format error toasts

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -363,5 +363,4 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
             return false;
         }
     }
-    
 }

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -363,13 +363,5 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
             return false;
         }
     }
-
-    void waitForSpecifiedTime(int milliseconds) {
-        try {
-            Thread.sleep(milliseconds);
-        } catch (InterruptedException e) {
-            // continue
-        }
-    }
-
+    
 }

--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -364,4 +364,12 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithDatabaseAccess {
         }
     }
 
+    void waitForSpecifiedTime(int milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            // continue
+        }
+    }
+
 }

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
@@ -68,9 +68,9 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
                 .build();
 
         editPage.addInstructor(newInstructor);
-        editPage.verifyStatusMessage("\"The instructor " + newInstructor.getName() + " has been added successfully. "
+        editPage.verifyStatusMessage("The instructor " + newInstructor.getName() + " has been added successfully. "
                 + "An email containing how to 'join' this course will be sent to " + newInstructor.getEmail()
-                + " in a few minutes.\"");
+                + " in a few minutes.");
         editPage.verifyInstructorDetails(newInstructor);
         verifyPresentInDatabase(newInstructor);
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -171,6 +171,8 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         verifyEmailSent(studentToEmail.getEmail(), "TEAMMATES: Feedback session reminder"
                 + " [Course: " + course.getName() + "][Feedback Session: "
                 + feedbackSessionOpen.getFeedbackSessionName() + "]");
+        
+        waitForSpecifiedTime(1000);
 
         ______TS("resend results link");
         homePage.resendResultsLink(courseIndex, sessionIndex, studentToEmail);

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -167,13 +167,10 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
 
         homePage.verifyStatusMessage("Reminder e-mails have been sent out to those students"
                 + " and instructors. Please allow up to 1 hour for all the notification emails to be sent out.");
-
         verifyEmailSent(studentToEmail.getEmail(), "TEAMMATES: Feedback session reminder"
                 + " [Course: " + course.getName() + "][Feedback Session: "
                 + feedbackSessionOpen.getFeedbackSessionName() + "]");
         
-        waitForSpecifiedTime(1000);
-
         ______TS("resend results link");
         homePage.resendResultsLink(courseIndex, sessionIndex, studentToEmail);
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -170,7 +170,6 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         verifyEmailSent(studentToEmail.getEmail(), "TEAMMATES: Feedback session reminder"
                 + " [Course: " + course.getName() + "][Feedback Session: "
                 + feedbackSessionOpen.getFeedbackSessionName() + "]");
-        
         ______TS("resend results link");
         homePage.resendResultsLink(courseIndex, sessionIndex, studentToEmail);
 

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -639,6 +639,7 @@ public abstract class AppPage {
      */
     public void verifyStatusMessage(String expectedMessage) {
         verifyStatusMessageWithLinks(expectedMessage, new String[] {});
+        closeToast();
     }
 
     /**
@@ -665,6 +666,14 @@ public abstract class AppPage {
                 }
             }
         }
+    }
+
+    /**
+     * Closes toast message.
+     */
+    public void closeToast() {
+        WebElement toastCloseButton = waitForElementPresence(By.className("btn-close"));
+        click(toastCloseButton);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -61,7 +61,7 @@ class CreateFeedbackQuestionAction extends Action {
         FeedbackQuestionDetails questionDetails = attributes.getQuestionDetailsCopy();
         List<String> questionDetailsErrors = questionDetails.validateQuestionDetails();
         if (!questionDetailsErrors.isEmpty()) {
-            throw new InvalidHttpRequestBodyException(questionDetailsErrors.toString());
+            throw new InvalidHttpRequestBodyException(String.join("\n", questionDetailsErrors));
         }
 
         try {

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -193,7 +193,7 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
                         .validateResponsesDetails(responseDetails, numRecipients);
 
         if (!questionSpecificErrors.isEmpty()) {
-            throw new InvalidHttpRequestBodyException(questionSpecificErrors.toString());
+            throw new InvalidHttpRequestBodyException(String.join("\n", questionSpecificErrors));
         }
 
         List<String> recipients = submitRequest.getRecipients();

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -67,7 +67,7 @@ class UpdateFeedbackQuestionAction extends Action {
         List<String> questionDetailsErrors = questionDetails.validateQuestionDetails();
 
         if (!questionDetailsErrors.isEmpty()) {
-            throw new InvalidHttpRequestBodyException(questionDetailsErrors.toString());
+            throw new InvalidHttpRequestBodyException(String.join("\n", questionDetailsErrors));
         }
 
         try {

--- a/src/web/app/components/toast/toast.component.scss
+++ b/src/web/app/components/toast/toast.component.scss
@@ -10,7 +10,7 @@
   .toast {
     max-width: 100%;
     width: inherit;
-    white-space: pre-line;
+    white-space: break-spaces;
   }
 }
 

--- a/src/web/app/components/toast/toast.component.scss
+++ b/src/web/app/components/toast/toast.component.scss
@@ -10,6 +10,7 @@
   .toast {
     max-width: 100%;
     width: inherit;
+    white-space: pre-line;
   }
 }
 

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -499,8 +499,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
             newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
 
             this.instructorDetailPanels.push(newDetailPanels);
-            this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully.
-          An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
+            this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully. ` +
+          `An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
 
             this.updatePrivilegeForInstructor(newDetailPanels.originalInstructor, newDetailPanels.editPanel.permission);
 
@@ -779,8 +779,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
         this.statusMessageService.showErrorToast(err.error.message);
       },
       complete: () => {
-        this.statusMessageService.showSuccessToast(`The selected instructor(s) have been added successfully.
-      An email containing how to 'join' this course will be sent to them in a few minutes.`);
+        this.statusMessageService.showSuccessToast(`The selected instructor(s) have been added successfully. ` + 
+          `An email containing how to 'join' this course will be sent to them in a few minutes.`);
       },
     });
   }
@@ -801,8 +801,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
         const emailSet: Set<string> = new Set();
         for (const instructor of allInstructorsAfterCopy) {
           if (emailSet.has(instructor.email)) {
-            this.statusMessageService.showErrorToast(`An instructor with email address ${instructor.email} 
-            already exists in the course and/or you have selected more than one instructor with this email address.`);
+            this.statusMessageService.showErrorToast(`An instructor with email address ${instructor.email} ` + 
+            `already exists in the course and/or you have selected more than one instructor with this email address.`);
             return false;
           }
           emailSet.add(instructor.email);

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -499,8 +499,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
             newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
 
             this.instructorDetailPanels.push(newDetailPanels);
-            this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully. ` +
-          `An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
+            this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully. `
+            + `An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
 
             this.updatePrivilegeForInstructor(newDetailPanels.originalInstructor, newDetailPanels.editPanel.permission);
 
@@ -779,8 +779,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
         this.statusMessageService.showErrorToast(err.error.message);
       },
       complete: () => {
-        this.statusMessageService.showSuccessToast(`The selected instructor(s) have been added successfully. ` + 
-          `An email containing how to 'join' this course will be sent to them in a few minutes.`);
+        this.statusMessageService.showSuccessToast('The selected instructor(s) have been added successfully. '
+        + 'An email containing how to \'join\' this course will be sent to them in a few minutes.');
       },
     });
   }
@@ -801,8 +801,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
         const emailSet: Set<string> = new Set();
         for (const instructor of allInstructorsAfterCopy) {
           if (emailSet.has(instructor.email)) {
-            this.statusMessageService.showErrorToast(`An instructor with email address ${instructor.email} ` + 
-            `already exists in the course and/or you have selected more than one instructor with this email address.`);
+            this.statusMessageService.showErrorToast(`An instructor with email address ${instructor.email} already `
+            + 'exists in the course and/or you have selected more than one instructor with this email address.');
             return false;
           }
           emailSet.add(instructor.email);

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -499,8 +499,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
             newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
 
             this.instructorDetailPanels.push(newDetailPanels);
-            this.statusMessageService.showSuccessToast(`"The instructor ${resp.name} has been added successfully. `
-            + `An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes."`);
+            this.statusMessageService.showSuccessToast(`The instructor ${resp.name} has been added successfully. `
+            + `An email containing how to 'join' this course will be sent to ${resp.email} in a few minutes.`);
 
             this.updatePrivilegeForInstructor(newDetailPanels.originalInstructor, newDetailPanels.editPanel.permission);
 

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -260,8 +260,8 @@ export class InstructorCoursesPageComponent implements OnInit {
       next: (courseArchive: CourseArchive) => {
         if (courseArchive.isArchived) {
           this.changeModelFromActiveToArchived(courseId);
-          this.statusMessageService.showSuccessToast(`The course ${courseId} has been archived.
-          It will not appear on the home page anymore.`);
+          this.statusMessageService.showSuccessToast(`The course ${courseId} has been archived. ` + 
+          `It will not appear on the home page anymore.`);
         } else {
           this.changeModelFromArchivedToActive(courseId);
           this.statusMessageService.showSuccessToast('The course has been unarchived.');

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -260,8 +260,8 @@ export class InstructorCoursesPageComponent implements OnInit {
       next: (courseArchive: CourseArchive) => {
         if (courseArchive.isArchived) {
           this.changeModelFromActiveToArchived(courseId);
-          this.statusMessageService.showSuccessToast(`The course ${courseId} has been archived. ` + 
-          `It will not appear on the home page anymore.`);
+          this.statusMessageService.showSuccessToast(`The course ${courseId} has been archived. `
+          + 'It will not appear on the home page anymore.');
         } else {
           this.changeModelFromArchivedToActive(courseId);
           this.statusMessageService.showSuccessToast('The course has been unarchived.');

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -259,8 +259,8 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
           this.courseTabModels = this.courseTabModels.filter((model: CourseTabModel) => {
             return model.course.courseId !== courseId;
           });
-          this.statusMessageService.showSuccessToast(`The course ${courseArchive.courseId} has been archived.
-            You can retrieve it from the Courses page.`);
+          this.statusMessageService.showSuccessToast(`The course ${courseArchive.courseId} has been archived.`
+             + 'You can retrieve it from the Courses page.');
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -259,7 +259,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
           this.courseTabModels = this.courseTabModels.filter((model: CourseTabModel) => {
             return model.course.courseId !== courseId;
           });
-          this.statusMessageService.showSuccessToast(`The course ${courseArchive.courseId} has been archived.`
+          this.statusMessageService.showSuccessToast(`The course ${courseArchive.courseId} has been archived. `
              + 'You can retrieve it from the Courses page.');
         },
         error: (resp: ErrorMessageOutput) => {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #11947

**Outline of Solution**

This PR improves the appearance of error toasts by formatting them to separate each error into a new line, by adjusting the `whitespace` CSS property on the toast component. 

Additionally, due to the adjustment of this property, some of the status messages within the toasts turn up with odd spaces and line breaks. This PR also adds the necessary fixes for those messages.

Lastly, due to the modification, some E2E tests also fail with the odd errors unrelated to toast itself. I found that adding a fixed timeout and closing the toast popup after verification of the message fixes this issue. These changes are also within this PR.

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
