### PR TITLE
[#12517] Instructors creating sessions: response visible time should be 'not now' by default

### DIFF
--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -125,6 +125,8 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
       ...this.sessionEditFormModel,
       isEditable: true,
       gracePeriod: 15,
+      responseVisibleSetting: ResponseVisibleSetting.LATER,
+      instructions: 'Please answer all the given questions.',
     };
   }
 


### PR DESCRIPTION
Fixes #12517 

**Outline of Solution**

Overwrite default attributes inherited from base class.