### PR TITLE
#000 Fixes Security risk in session cookie.

### DIFF
--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -62,6 +62,7 @@ class GetAuthInfoAction extends Action {
             return new JsonResult(output);
         }
         Cookie csrfTokenCookie = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, csrfToken);
+        csrfTokenCookie.setSecure(true)
         csrfTokenCookie.setPath("/");
         List<Cookie> cookieList = Collections.singletonList(csrfTokenCookie);
         return new JsonResult(output, cookieList);


### PR DESCRIPTION
Fixes Security risk in session cookie.

Using the sonarcloud tool, it can be verified that the cookie created to validate the session is not encrypted, which allows a breach for a man-in-the-middle attack. With this configuration, sensitive cookies like this will not be sent in an HTTP request
