### PR TITLE
[#12530] Allow header dropdown to be opened with enter key

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -9,7 +9,8 @@
     <ul class="nav navbar-nav flex-nowrap me-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>
-          <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ navItem.display }}</a>
+          <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+                  data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ navItem.display }}</button>
           <div class="dropdown-menu" ngbDropdownMenu>
             <a *ngFor="let childItem of navItem.children" class="dropdown-item" [tmRouterLink]="childItem.url" (click)="toggleCollapse();closeModal()">{{ childItem.display}}</a>
           </div>
@@ -22,21 +23,23 @@
     <ul class="nav navbar-nav me-auto" *ngIf="!isValidUser"></ul>
     <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="!user">
-        <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>Login</a>
+        <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+           data-toggle="dropdown" tabindex="0" ngbDropdownToggle>Login</button>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" id="student-login-btn" [href]="studentLoginUrl">Student Login</a>
           <a class="dropdown-item" id="instructor-login-btn" [href]="instructorLoginUrl">Instructor Login</a>
         </div>
       </li>
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="user">
-        <a class="nav-link dropdown-toggle" data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ user }}</a>
+        <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+                data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ user }}</button>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" tmRouterLink="/web/student" *ngIf="isStudent" (click)="closeModal()">To student pages</a>
           <a class="dropdown-item" tmRouterLink="/web/instructor" *ngIf="isInstructor" (click)="closeModal()">To instructor pages</a>
           <a class="dropdown-item" tmRouterLink="/web/admin" *ngIf="isAdmin" (click)="closeModal()">To admin pages</a>
           <a class="dropdown-item" tmRouterLink="/web/maintainer" *ngIf="isMaintainer" (click)="closeModal()">To maintainer pages</a>
           <div class="dropdown-divider" *ngIf="isStudent || isInstructor || isAdmin || isMaintainer"></div>
-          <a class="dropdown-item" id="logout-btn" style="cursor: pointer;" (click)="logout()">Log Out</a>
+          <a class="dropdown-item" tmRouterLink="/web/front/home" id="logout-btn" tabindex="0" style="cursor: pointer;" (click)="logout()">Log Out</a>
         </div>
       </li>
     </ul>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -9,7 +9,7 @@
     <ul class="nav navbar-nav flex-nowrap me-auto" *ngIf="isValidUser">
       <ng-template ngFor let-navItem [ngForOf]="navItems">
         <li *ngIf="navItem.children" class="nav-item dropdown" ngbDropdown>
-          <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+          <button class="bg-transparent btn btn-link nav-link dropdown-toggle"
                   data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ navItem.display }}</button>
           <div class="dropdown-menu" ngbDropdownMenu>
             <a *ngFor="let childItem of navItem.children" class="dropdown-item" [tmRouterLink]="childItem.url" (click)="toggleCollapse();closeModal()">{{ childItem.display}}</a>
@@ -23,7 +23,7 @@
     <ul class="nav navbar-nav me-auto" *ngIf="!isValidUser"></ul>
     <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="!user">
-        <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+        <button class="bg-transparent btn btn-link nav-link dropdown-toggle"
            data-toggle="dropdown" tabindex="0" ngbDropdownToggle>Login</button>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" id="student-login-btn" [href]="studentLoginUrl">Student Login</a>
@@ -31,7 +31,7 @@
         </div>
       </li>
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="user">
-        <button class="bg-transparent btn btn-link nav-link dropdown-toggle" 
+        <button class="bg-transparent btn btn-link nav-link dropdown-toggle"
                 data-toggle="dropdown" tabindex="0" ngbDropdownToggle>{{ user }}</button>
         <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" tmRouterLink="/web/student" *ngIf="isStudent" (click)="closeModal()">To student pages</a>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -39,7 +39,7 @@
           <a class="dropdown-item" tmRouterLink="/web/admin" *ngIf="isAdmin" (click)="closeModal()">To admin pages</a>
           <a class="dropdown-item" tmRouterLink="/web/maintainer" *ngIf="isMaintainer" (click)="closeModal()">To maintainer pages</a>
           <div class="dropdown-divider" *ngIf="isStudent || isInstructor || isAdmin || isMaintainer"></div>
-          <a class="dropdown-item" tmRouterLink="/web/front/home" id="logout-btn" tabindex="0" style="cursor: pointer;" (click)="logout()">Log Out</a>
+          <a class="dropdown-item" tmRouterLink="/web/front/home" id="logout-btn" style="cursor: pointer;" (click)="logout()">Log Out</a>
         </div>
       </li>
     </ul>

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -133,3 +133,7 @@ nav {
 .dropdown-menu-right {
   margin-bottom: .5rem;
 }
+
+button.bg-transparent.btn.btn-link.nav-link:active {
+  color : white !important;
+}

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -135,5 +135,5 @@ nav {
 }
 
 button.bg-transparent.btn.btn-link.nav-link:active {
-  color : white !important;
+  color: white !important;
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12530

**Outline of Solution**
The current dropdown toggle on the header is created using `<a>` tags, so currently, the dropdown can actually be toggled  using the arrow down key. 

This PR changes those `<a>` tags to use `<button>`tags also with added classes to reduce any change in the visual appearance. This change will now allow the dropdown to be toggled with the Enter key instead of the arrow key.

This PR also allows tabbing to the Log Out button and fixes #12531 by adding `tabindex=0` to the element

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
