### PR TITLE
Prevent dropdown to open inside table

### DIFF
--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -289,6 +289,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   </div>
                   <div
                     class="d-inline-block dropdown"
+                    container="body"
                     ngbdropdown=""
                     ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                   >
@@ -473,6 +474,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   </div>
                   <div
                     class="d-inline-block dropdown"
+                    container="body"
                     ngbdropdown=""
                     ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                   >
@@ -787,6 +789,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   </div>
                   <div
                     class="d-inline-block dropdown"
+                    container="body"
                     ngbdropdown=""
                     ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                   >
@@ -958,6 +961,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   </div>
                   <div
                     class="d-inline-block dropdown"
+                    container="body"
                     ngbdropdown=""
                     ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                   >

--- a/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
+++ b/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
@@ -153,6 +153,7 @@
   <div
     ngbDropdown
     class="d-inline-block"
+    container="body"
     ngbTooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
   >
     <button

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -839,6 +839,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                 </div>
                                 <div
                                   class="d-inline-block dropdown"
+                                  container="body"
                                   ngbdropdown=""
                                   ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                                 >
@@ -1397,6 +1398,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 </div>
                                 <div
                                   class="d-inline-block dropdown"
+                                  container="body"
                                   ngbdropdown=""
                                   ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                                 >
@@ -1581,6 +1583,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                 </div>
                                 <div
                                   class="d-inline-block dropdown"
+                                  container="body"
                                   ngbdropdown=""
                                   ngbtooltip="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so"
                                 >


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12532 

**Outline of Solution**
I referred to the dropdown box for `Results` and notice that the `Remind` dropdown's `<div>` does not have a container that is set to "body". 
After adding `container="body"`, the dropdown expands outside the table. 

https://github.com/TEAMMATES/teammates/assets/66376253/f9285478-c70e-4bc2-b78b-75865257e349


<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
