### PR TITLE
[#12507] Instructor Home Page: Page Loads Forever when Copy Feedback Session Fails 

### DIFF
--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -499,7 +499,9 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
     const requestList: Observable<FeedbackSession>[] = this.createSessionCopyRequestsFromRowModel(
         this.courseTabModels[tabIndex].sessionsTableRowModels[result.sessionToCopyRowIndex], result);
     if (requestList.length === 1) {
-      this.copySingleSession(requestList[0], this.modifiedTimestampsModal);
+      this.copySingleSession(requestList[0].pipe(finalize(() => {
+        this.isCopyLoading = false;
+      })), this.modifiedTimestampsModal);
     }
     if (requestList.length > 1) {
       forkJoin(requestList).pipe(finalize(() => {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12507 

**Outline of Solution**
Upon investigating the issue, it turns out that the boolean `isCopyLoading` which determines whether to show the spinner is not set back to `false` after the method `copySingleSession` finished executing. 
This does not affect the scenario where user can successfully copy the feedback session because if it is successfully, the user would be redirected to another page rather than staying on the instructor home page. 
This only affects the scenario where user fails to copy the feedback session as the page will not be re-rendered. 

To fix this issue, I used a `pipe` with `finalize` to set the `isCopyLoading` boolean to false after the `copySingleSession` finish execution. 

**Video demo before the fix**

https://github.com/TEAMMATES/teammates/assets/66376253/c1f9244c-07df-4927-bb85-ab0b0fc24ff4

**Video demo after the fix**

https://github.com/TEAMMATES/teammates/assets/66376253/78a309b2-6979-4763-829f-d13889364b4c


<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
