### PR TITLE
 [#12460] Set character limit on question description

### DIFF
--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
@@ -15,7 +15,7 @@
       </pre>
     </div>
     <div class="col-md-10">
-      <tm-rich-text-editor [richText]="description" (richTextChange)="triggerDescriptionChange($event)" [isDisabled]="isDescriptionDisabled" minHeightInPx="100" [placeholderText]="'More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;'"></tm-rich-text-editor>
+      <tm-rich-text-editor [richText]="description" (richTextChange)="triggerDescriptionChange($event)" [isDisabled]="isDescriptionDisabled" minHeightInPx="100" [hasCharacterLimit]="true" [placeholderText]="'More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;'"></tm-rich-text-editor>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #12460 

**Outline of Solution**

Added the [hasCharacterLimit]="true" attribute to the question edit component.

![image](https://github.com/TEAMMATES/teammates/assets/13874024/c2339f4a-d230-4b4b-918c-95518bbc87d2)
![image](https://github.com/TEAMMATES/teammates/assets/13874024/14e689a0-469d-40d1-801b-03a8a4304ac6)