### PR TITLE
[#12279]  Instructor home page: Improve display of card header on mobile

### DIFF
--- a/src/web/app/components/panel-chevron/panel-chevron.component.html
+++ b/src/web/app/components/panel-chevron/panel-chevron.component.html
@@ -1,4 +1,4 @@
-<button type="button" class="chevron btn-course btn btn-primary btn-sm" aria-label="Open table with sessions for this course" [attr.aria-expanded]=isExpanded>
+<button type="button" class="chevron btn-course btn btn-primary btn-sm" aria-label="Expand panel" [attr.aria-expanded]=isExpanded>
   <i class="fas fa-chevron-down" *ngIf="!isExpanded"></i>
   <i class="fas fa-chevron-up" *ngIf="isExpanded"></i>
 </button>

--- a/src/web/app/components/panel-chevron/panel-chevron.component.html
+++ b/src/web/app/components/panel-chevron/panel-chevron.component.html
@@ -1,4 +1,4 @@
-<button class="chevron btn-course btn btn-primary btn-sm" aria-label="Open table with sessions for this course" [attr.aria-expanded]=isExpanded>
+<button type="button" class="chevron btn-course btn btn-primary btn-sm" aria-label="Open table with sessions for this course" [attr.aria-expanded]=isExpanded>
   <i class="fas fa-chevron-down" *ngIf="!isExpanded"></i>
   <i class="fas fa-chevron-up" *ngIf="isExpanded"></i>
 </button>

--- a/src/web/app/components/panel-chevron/panel-chevron.component.html
+++ b/src/web/app/components/panel-chevron/panel-chevron.component.html
@@ -1,4 +1,4 @@
-<div class="chevron">
+<button class="chevron btn-course btn btn-primary btn-sm" aria-label="Open table with sessions for this course" [attr.aria-expanded]=isExpanded>
   <i class="fas fa-chevron-down" *ngIf="!isExpanded"></i>
   <i class="fas fa-chevron-up" *ngIf="isExpanded"></i>
-</div>
+</button>

--- a/src/web/app/components/panel-chevron/panel-chevron.component.scss
+++ b/src/web/app/components/panel-chevron/panel-chevron.component.scss
@@ -1,4 +1,6 @@
-.chevron {
+button.chevron {
   display: inline-flex;
   vertical-align: middle;
+  background-color: inherit;
+  border-width: 0;
 }

--- a/src/web/app/components/panel-chevron/panel-chevron.component.scss
+++ b/src/web/app/components/panel-chevron/panel-chevron.component.scss
@@ -4,3 +4,7 @@ button.chevron {
   background-color: inherit;
   border-width: 0;
 }
+
+button.chevron:active {
+  background-color: inherit;
+}

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -39,13 +39,16 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
         class="collapse-caret"
       >
         <tm-panel-chevron>
-          <div
-            class="chevron"
+          <button
+            aria-expanded="true"
+            aria-label="Open table with sessions for this course"
+            class="chevron btn-course btn btn-primary btn-sm"
+            type="button"
           >
             <i
               class="fas fa-chevron-up"
             />
-          </div>
+          </button>
         </tm-panel-chevron>
       </div>
       <div

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -41,7 +41,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
         <tm-panel-chevron>
           <button
             aria-expanded="true"
-            aria-label="Open table with sessions for this course"
+            aria-label="Expand panel"
             class="chevron btn-course btn btn-primary btn-sm"
             type="button"
           >

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,6 +1,6 @@
 <div id="question-submission-form-qn-{{ model.questionNumber }}" class="card">
   <div class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="toggleQuestionTab();"
-    [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
+    [ngClass]="isSaved ? 'bg-success' : 'bg-primary'">
     <div class="collapse-caret">
       <tm-panel-chevron [isExpanded]="model.isTabExpanded"></tm-panel-chevron>
     </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -1,12 +1,12 @@
 <div id="question-submission-form-qn-{{ model.questionNumber }}" class="card">
-  <button class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="toggleQuestionTab();"
+  <div class="card-header bg-primary text-white question-header cursor-pointer border-0" (click)="toggleQuestionTab();"
     [ngClass]="isSaved ? 'bg-success' : 'bg-primary'" [attr.aria-expanded]="this.model.isTabExpanded">
     <div class="collapse-caret">
-      <tm-panel-chevron [isExpanded]="model.isTabExpanded" aria-hidden="true"></tm-panel-chevron>
+      <tm-panel-chevron [isExpanded]="model.isTabExpanded"></tm-panel-chevron>
     </div>
     <i class="fas fa-check me-2" *ngIf="isSaved" aria-hidden="true"></i>
     <h2 class="question-details"><b>Question {{ model.questionNumber }}: </b>{{ model.questionBrief }}</h2>
-  </button>
+  </div>
 
   <div *ngIf="model.isTabExpanded" @collapseAnim>
     <div class="card-body" *tmIsLoading="model.isLoading">

--- a/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
@@ -1,7 +1,7 @@
 <div class="plain-text-area" *ngIf="!questionDetails.shouldAllowRichText">
   <textarea [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [attr.aria-label]="getAriaLabel()" [disabled]="isDisabled"></textarea>
 </div>
-<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [attr.aria-label]="getAriaLabel()" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
+<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
 <div class="margin-top-7px text-secondary text-end">
   <div id="recommended-length" *ngIf="questionDetails.recommendedLength">
     Recommended length for the answer: {{ questionDetails.recommendedLength }} words

--- a/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
@@ -1,7 +1,7 @@
 <div class="plain-text-area" *ngIf="!questionDetails.shouldAllowRichText">
   <textarea [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [attr.aria-label]="getAriaLabel()" [disabled]="isDisabled"></textarea>
 </div>
-<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
+<tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" role="textbox" [attr.aria-label]="getAriaLabel()" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
 <div class="margin-top-7px text-secondary text-end">
   <div id="recommended-length" *ngIf="questionDetails.recommendedLength">
     Recommended length for the answer: {{ questionDetails.recommendedLength }} words

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -80,13 +80,16 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="false"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-down"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -109,13 +112,16 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="false"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-down"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -253,13 +259,16 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -307,13 +316,16 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -430,13 +442,16 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -484,13 +499,16 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -607,13 +625,16 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -661,13 +682,16 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -82,7 +82,7 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
               <tm-panel-chevron>
                 <button
                   aria-expanded="false"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -114,7 +114,7 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
               <tm-panel-chevron>
                 <button
                   aria-expanded="false"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -261,7 +261,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -318,7 +318,7 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -444,7 +444,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -501,7 +501,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -627,7 +627,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -684,7 +684,7 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
@@ -81,13 +81,16 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when feedback
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -218,13 +221,16 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -478,13 +484,16 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -612,13 +621,16 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with courses 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="false"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-down"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -640,13 +652,16 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with courses 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="false"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-down"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
@@ -83,7 +83,7 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when feedback
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -223,7 +223,7 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -486,7 +486,7 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -623,7 +623,7 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with courses 
             <tm-panel-chevron>
               <button
                 aria-expanded="false"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -654,7 +654,7 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with courses 
             <tm-panel-chevron>
               <button
                 aria-expanded="false"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -261,24 +261,15 @@ exports[`InstructorHomePageComponent should snap with one course with error load
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-up"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -415,8 +406,8 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
@@ -434,6 +425,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Students 
                 </button>
@@ -465,6 +457,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Instructors 
                 </button>
@@ -489,6 +482,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Sessions 
                 </button>
@@ -513,6 +507,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Course 
                 </button>
@@ -553,17 +548,17 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                   </a>
                 </div>
               </span>
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
             </div>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-up"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1005,8 +1000,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
@@ -1024,6 +1019,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Students 
                 </button>
@@ -1048,6 +1044,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Instructors 
                 </button>
@@ -1072,6 +1069,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Sessions 
                 </button>
@@ -1096,6 +1094,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   aria-expanded="false"
                   class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Course 
                 </button>
@@ -1120,17 +1119,17 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                   </a>
                 </div>
               </span>
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
             </div>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-up"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1752,8 +1751,8 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
@@ -1771,6 +1770,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Students 
                 </button>
@@ -1802,6 +1802,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Instructors 
                 </button>
@@ -1826,6 +1827,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Sessions 
                 </button>
@@ -1850,6 +1852,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   aria-expanded="false"
                   class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Course 
                 </button>
@@ -1890,17 +1893,17 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                   </a>
                 </div>
               </span>
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-down"
+                  />
+                </div>
+              </tm-panel-chevron>
             </div>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-down"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -2013,8 +2016,8 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
@@ -2032,6 +2035,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Students 
                 </button>
@@ -2063,6 +2067,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Instructors 
                 </button>
@@ -2087,6 +2092,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Sessions 
                 </button>
@@ -2111,6 +2117,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   aria-expanded="false"
                   class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Course 
                 </button>
@@ -2151,17 +2158,17 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                   </a>
                 </div>
               </span>
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
             </div>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-up"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -2298,8 +2305,8 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
           class="card"
           id="course-tab-0"
         >
-          <div
-            class="card-header bg-primary text-white cursor-pointer"
+          <button
+            class="card-header bg-primary text-white cursor-pointer border-0"
           >
             <b
               class="course-details text-break"
@@ -2317,6 +2324,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Students 
                 </button>
@@ -2348,6 +2356,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Instructors 
                 </button>
@@ -2372,6 +2381,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   aria-expanded="false"
                   class="dropdown-toggle btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Sessions 
                 </button>
@@ -2396,6 +2406,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   aria-expanded="false"
                   class="dropdown-toggle btn-course btn btn-primary btn-sm"
                   ngbdropdowntoggle=""
+                  type="button"
                 >
                    Course 
                 </button>
@@ -2436,17 +2447,17 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                   </a>
                 </div>
               </span>
+              <tm-panel-chevron>
+                <div
+                  class="chevron"
+                >
+                  <i
+                    class="fas fa-chevron-up"
+                  />
+                </div>
+              </tm-panel-chevron>
             </div>
-            <tm-panel-chevron>
-              <div
-                class="chevron"
-              >
-                <i
-                  class="fas fa-chevron-up"
-                />
-              </div>
-            </tm-panel-chevron>
-          </div>
+          </button>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -551,7 +551,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1125,7 +1125,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1902,7 +1902,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
               <tm-panel-chevron>
                 <button
                   aria-expanded="false"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -2170,7 +2170,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -2462,7 +2462,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -261,15 +261,15 @@ exports[`InstructorHomePageComponent should snap with one course with error load
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
             >
               [CS3281]: Thematic Systems I
             </b>
-          </button>
+          </div>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -406,8 +406,8 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -558,7 +558,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                 </div>
               </tm-panel-chevron>
             </div>
-          </button>
+          </div>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1000,8 +1000,8 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -1129,7 +1129,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                 </div>
               </tm-panel-chevron>
             </div>
-          </button>
+          </div>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1751,8 +1751,8 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -1903,7 +1903,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                 </div>
               </tm-panel-chevron>
             </div>
-          </button>
+          </div>
         </div>
       </div>
     </div>
@@ -2016,8 +2016,8 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -2168,7 +2168,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                 </div>
               </tm-panel-chevron>
             </div>
-          </button>
+          </div>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -2305,8 +2305,8 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
           class="card"
           id="course-tab-0"
         >
-          <button
-            class="card-header bg-primary text-white cursor-pointer border-0"
+          <div
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -2457,7 +2457,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                 </div>
               </tm-panel-chevron>
             </div>
-          </button>
+          </div>
           <div
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -549,13 +549,16 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                 </div>
               </span>
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -1120,13 +1123,16 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                 </div>
               </span>
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -1894,13 +1900,16 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
                 </div>
               </span>
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="false"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-down"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -2159,13 +2168,16 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
                 </div>
               </span>
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -2448,13 +2460,16 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
                 </div>
               </span>
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,7 +39,7 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div class="card-header bg-primary text-white cursor-pointer"
+        <button class="card-header bg-primary text-white cursor-pointer border-0"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
@@ -102,7 +102,7 @@
             </span>
           </div>
           <tm-panel-chevron [isExpanded]="courseTabModel.isTabExpanded"></tm-panel-chevron>
-        </div>
+        </button>
         <div class="card-body padding-0 table-responsive" *ngIf="courseTabModel.isTabExpanded" @collapseAnim>
           <tm-loading-retry [shouldShowRetry]="courseTabModel.hasLoadingFailed"
             [message]="'Error loading feedback sessions'" (retryEvent)="loadFeedbackSessions(idx)">

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,13 +39,13 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div class="card-header bg-primary text-white cursor-pointer"
+        <button class="card-header bg-primary text-white cursor-pointer border-0"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
           <div class="card-header-btn-toolbar flex-lg-shrink-0" *ngIf="courseTabModel.isAjaxSuccess">
             <span ngbDropdown>
-              <button class="btn btn-primary btn-sm" ngbDropdownToggle> Students </button>
+              <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Students </button>
               <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyStudent">
                   <a class="btn btn-info btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/enroll"
@@ -58,7 +58,7 @@
               </div>
             </span>
             <span ngbDropdown>
-              <button class="btn btn-primary btn-sm" ngbDropdownToggle> Instructors </button>
+              <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Instructors </button>
               <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/edit"
                   [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
@@ -66,7 +66,7 @@
               </div>
             </span>
             <span ngbDropdown>
-              <button class="btn btn-primary btn-sm" ngbDropdownToggle> Sessions </button>
+              <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Sessions </button>
               <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/sessions"
                   [queryParams]="{courseid: courseTabModel.course.courseId}"> Add
@@ -74,7 +74,7 @@
               </div>
             </span>
             <span ngbDropdown>
-              <button class="btn-course btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
+              <button type="button" class="btn-course btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
               <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn-archive-course btn btn-light btn-sm dropdown-item"
                   ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
@@ -100,9 +100,9 @@
                 </ng-container>
               </div>
             </span>
+            <tm-panel-chevron [isExpanded]="courseTabModel.isTabExpanded"></tm-panel-chevron>
           </div>
-          <tm-panel-chevron [isExpanded]="courseTabModel.isTabExpanded"></tm-panel-chevron>
-        </div>
+        </button>
         <div class="card-body padding-0 table-responsive" *ngIf="courseTabModel.isTabExpanded" @collapseAnim>
           <tm-loading-retry [shouldShowRetry]="courseTabModel.hasLoadingFailed"
             [message]="'Error loading feedback sessions'" (retryEvent)="loadFeedbackSessions(idx)">

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,7 +39,7 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <button class="card-header bg-primary text-white cursor-pointer border-0"
+        <div class="card-header bg-primary text-white cursor-pointer border-0"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
@@ -102,7 +102,7 @@
             </span>
           </div>
           <tm-panel-chevron [isExpanded]="courseTabModel.isTabExpanded"></tm-panel-chevron>
-        </button>
+        </div>
         <div class="card-body padding-0 table-responsive" *ngIf="courseTabModel.isTabExpanded" @collapseAnim>
           <tm-loading-retry [shouldShowRetry]="courseTabModel.hasLoadingFailed"
             [message]="'Error loading feedback sessions'" (retryEvent)="loadFeedbackSessions(idx)">

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,7 +39,7 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div class="card-header bg-primary text-white cursor-pointer border-0"
+        <div class="card-header bg-primary text-white cursor-pointer"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,7 +39,7 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <button class="card-header bg-primary text-white cursor-pointer border-0"
+        <div class="card-header bg-primary text-white cursor-pointer"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
@@ -102,7 +102,7 @@
             </span>
             <tm-panel-chevron [isExpanded]="courseTabModel.isTabExpanded"></tm-panel-chevron>
           </div>
-        </button>
+        </div>
         <div class="card-body padding-0 table-responsive" *ngIf="courseTabModel.isTabExpanded" @collapseAnim>
           <tm-loading-retry [shouldShowRetry]="courseTabModel.hasLoadingFailed"
             [message]="'Error loading feedback sessions'" (retryEvent)="loadFeedbackSessions(idx)">

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -40,6 +40,7 @@
     justify-content: flex-start;
     flex-wrap: wrap;
   }
+
   tm-panel-chevron {
     margin-left: auto;
   }

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -27,3 +27,16 @@
 .text-color-lightgray {
   color: lightgray;
 }
+
+@media (max-width: 450px) {
+  .card-header {
+    display:block;
+  }
+  .card-header-btn-toolbar {
+    text-align: right;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -30,8 +30,9 @@
 
 @media (max-width: 450px) {
   .card-header {
-    display:block;
+    display: block;
   }
+
   .card-header-btn-toolbar {
     text-align: right;
     display: flex;

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -35,9 +35,12 @@
 
   .card-header-btn-toolbar {
     text-align: right;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: flex-start;
     flex-wrap: wrap;
+  }
+  tm-panel-chevron {
+    margin-left: auto;
   }
 }

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1298,13 +1298,16 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 class="collapse-caret"
               >
                 <tm-panel-chevron>
-                  <div
-                    class="chevron"
+                  <button
+                    aria-expanded="true"
+                    aria-label="Open table with sessions for this course"
+                    class="chevron btn-course btn btn-primary btn-sm"
+                    type="button"
                   >
                     <i
                       class="fas fa-chevron-up"
                     />
-                  </div>
+                  </button>
                 </tm-panel-chevron>
               </div>
               <div
@@ -2021,13 +2024,16 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 class="collapse-caret"
               >
                 <tm-panel-chevron>
-                  <div
-                    class="chevron"
+                  <button
+                    aria-expanded="true"
+                    aria-label="Open table with sessions for this course"
+                    class="chevron btn-course btn btn-primary btn-sm"
+                    type="button"
                   >
                     <i
                       class="fas fa-chevron-up"
                     />
-                  </div>
+                  </button>
                 </tm-panel-chevron>
               </div>
               <div
@@ -3956,13 +3962,16 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
             class="collapse-caret"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
           <div

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1300,7 +1300,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 <tm-panel-chevron>
                   <button
                     aria-expanded="true"
-                    aria-label="Open table with sessions for this course"
+                    aria-label="Expand panel"
                     class="chevron btn-course btn btn-primary btn-sm"
                     type="button"
                   >
@@ -2026,7 +2026,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                 <tm-panel-chevron>
                   <button
                     aria-expanded="true"
-                    aria-label="Open table with sessions for this course"
+                    aria-label="Expand panel"
                     class="chevron btn-course btn btn-primary btn-sm"
                     type="button"
                   >
@@ -3964,7 +3964,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
@@ -82,7 +82,7 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -293,7 +293,7 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -428,7 +428,7 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -649,7 +649,7 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap with feedback 
             <tm-panel-chevron>
               <button
                 aria-expanded="false"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >
@@ -682,7 +682,7 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap with feedback 
             <tm-panel-chevron>
               <button
                 aria-expanded="false"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
@@ -80,13 +80,16 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -288,13 +291,16 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -420,13 +426,16 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -638,13 +647,16 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap with feedback 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="false"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-down"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>
@@ -668,13 +680,16 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap with feedback 
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="false"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-down"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
@@ -1251,7 +1251,7 @@ exports[`InstructorStudentActivityLogsComponent should snap with results of a se
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1436,7 +1436,7 @@ exports[`InstructorStudentActivityLogsComponent should snap with results of a se
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
@@ -1249,13 +1249,16 @@ exports[`InstructorStudentActivityLogsComponent should snap with results of a se
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>
@@ -1431,13 +1434,16 @@ exports[`InstructorStudentActivityLogsComponent should snap with results of a se
               class="card-header-btn-toolbar"
             >
               <tm-panel-chevron>
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
           </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
@@ -86,13 +86,16 @@ exports[`InstructorStudentListPageComponent should snap with a course with stude
             class="card-header-btn-toolbar"
           >
             <tm-panel-chevron>
-              <div
-                class="chevron"
+              <button
+                aria-expanded="true"
+                aria-label="Open table with sessions for this course"
+                class="chevron btn-course btn btn-primary btn-sm"
+                type="button"
               >
                 <i
                   class="fas fa-chevron-up"
                 />
-              </div>
+              </button>
             </tm-panel-chevron>
           </div>
         </div>

--- a/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
@@ -88,7 +88,7 @@ exports[`InstructorStudentListPageComponent should snap with a course with stude
             <tm-panel-chevron>
               <button
                 aria-expanded="true"
-                aria-label="Open table with sessions for this course"
+                aria-label="Expand panel"
                 class="chevron btn-course btn btn-primary btn-sm"
                 type="button"
               >

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -901,13 +901,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -1167,13 +1170,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -1385,13 +1391,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <h2
@@ -1492,13 +1501,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -1792,13 +1804,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -2002,13 +2017,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -2226,13 +2244,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -2680,13 +2701,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -3019,13 +3043,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -3296,13 +3323,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -3737,13 +3767,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -4008,13 +4041,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -4227,13 +4263,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <h2
@@ -4334,13 +4373,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -4640,13 +4682,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -4852,13 +4897,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -5078,13 +5126,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -5534,13 +5585,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -5883,13 +5937,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i
@@ -6162,13 +6219,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron
                 aria-hidden="true"
               >
-                <div
-                  class="chevron"
+                <button
+                  aria-expanded="true"
+                  aria-label="Open table with sessions for this course"
+                  class="chevron btn-course btn btn-primary btn-sm"
+                  type="button"
                 >
                   <i
                     class="fas fa-chevron-up"
                   />
-                </div>
+                </button>
               </tm-panel-chevron>
             </div>
             <i

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -892,7 +892,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-1"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -1159,7 +1158,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-3"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -1378,7 +1376,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-2"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
@@ -1486,7 +1483,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-4"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -1787,7 +1783,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-5"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -1998,7 +1993,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-6"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -2223,7 +2217,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-7"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -2678,7 +2671,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-8"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -3018,7 +3010,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-9"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -3296,7 +3287,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-10"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -3738,7 +3728,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-1"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -4010,7 +3999,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-3"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -4230,7 +4218,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-2"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
@@ -4338,7 +4325,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-4"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -4645,7 +4631,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-5"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -4858,7 +4843,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-6"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -5085,7 +5069,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-7"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -5542,7 +5525,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-8"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -5892,7 +5874,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-9"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
@@ -6172,7 +6153,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           id="question-submission-form-qn-10"
         >
           <div
-            aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -900,7 +900,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1166,7 +1166,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1384,7 +1384,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1491,7 +1491,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -1791,7 +1791,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -2001,7 +2001,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -2225,7 +2225,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -2679,7 +2679,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -3018,7 +3018,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -3295,7 +3295,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -3736,7 +3736,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -4007,7 +4007,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -4226,7 +4226,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -4333,7 +4333,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -4639,7 +4639,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -4851,7 +4851,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -5077,7 +5077,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -5533,7 +5533,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -5882,7 +5882,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >
@@ -6161,7 +6161,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               <tm-panel-chevron>
                 <button
                   aria-expanded="true"
-                  aria-label="Open table with sessions for this course"
+                  aria-label="Expand panel"
                   class="chevron btn-course btn btn-primary btn-sm"
                   type="button"
                 >

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -891,16 +891,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-1"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -925,7 +923,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1160,16 +1158,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-3"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -1194,7 +1190,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1381,16 +1377,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-2"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -1411,7 +1405,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1491,16 +1485,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-4"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -1525,7 +1517,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               MSQ question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -1794,16 +1786,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-5"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -1828,7 +1818,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               numerical scale question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -2007,16 +1997,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-6"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -2041,7 +2029,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               constant sum question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -2234,16 +2222,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-7"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -2268,7 +2254,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               contribution question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -2691,16 +2677,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-8"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -2725,7 +2709,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -3033,16 +3017,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-9"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -3067,7 +3049,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -3313,16 +3295,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-10"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -3347,7 +3327,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -3757,16 +3737,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-1"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -3791,7 +3769,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -4031,16 +4009,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-3"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -4065,7 +4041,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -4253,16 +4229,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-2"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -4283,7 +4257,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -4363,16 +4337,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-4"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -4397,7 +4369,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               MSQ question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -4672,16 +4644,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-5"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -4706,7 +4676,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               numerical scale question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -4887,16 +4857,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-6"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -4921,7 +4889,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               constant sum question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -5116,16 +5084,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-7"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -5150,7 +5116,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               contribution question
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -5575,16 +5541,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-8"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -5609,7 +5573,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -5927,16 +5891,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-9"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -5961,7 +5923,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""
@@ -6209,16 +6171,14 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           class="card"
           id="question-submission-form-qn-10"
         >
-          <button
+          <div
             aria-expanded="true"
             class="card-header bg-primary text-white question-header cursor-pointer border-0 bg-success"
           >
             <div
               class="collapse-caret"
             >
-              <tm-panel-chevron
-                aria-hidden="true"
-              >
+              <tm-panel-chevron>
                 <button
                   aria-expanded="true"
                   aria-label="Open table with sessions for this course"
@@ -6243,7 +6203,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </b>
               question brief
             </h2>
-          </button>
+          </div>
           <div
             class="ng-trigger ng-trigger-collapseAnim ng-animating"
             style=""

--- a/src/web/data/developers.json
+++ b/src/web/data/developers.json
@@ -1266,6 +1266,9 @@
       "username": "mesternefeld"
     },
     {
+      "username": "mariemllr"
+    },
+    {
       "name": "Marlon Calvo",
       "username": "marloncalvo"
     },
@@ -1490,6 +1493,11 @@
       "username": "Olle251"
     },
     {
+      "multiple": true,
+      "name": "Ong Han Wei",
+      "username": "rexong"
+    },
+    {
       "name": "Ong Jun Xiong",
       "username": "ong6"
     },
@@ -1651,6 +1659,10 @@
       "username": "srajat"
     },
     {
+      "name": "Rajdeep Pal",
+      "username": "Rajdeep1311"
+    },
+    {
       "name": "Rajiv Jha",
       "username": "rjrajivjha"
     },
@@ -1770,6 +1782,9 @@
     },
     {
       "username": "SetsunaS"
+    },
+    {
+      "username": "sgadkar2"
     },
     {
       "multiple": true,
@@ -2088,6 +2103,9 @@
     {
       "multiple": true,
       "name": "Teo Yock Swee Terence"
+    },
+    {
+      "username": "theKelvincode"
     },
     {
       "multiple": true,


### PR DESCRIPTION
Fixes #12279 

Card-header-toolbar changed to display as flex-container on mobile screens (see screenshots below) and changed from div-element to button element for screenreader compatibility.
An other option would be with using grid to create a 2X2 grid with all 4 buttons. I also think the panel-chevron component  (drop-down icon) could be positioned to the right instead of below. 
Any opinions?

Screen-size of 450px
<img width="435" src="https://github.com/TEAMMATES/teammates/assets/90850610/caa1ea89-87bb-42a5-97f1-5547a828095e">

Screen-size of 320px 
<img width="305" src="https://github.com/TEAMMATES/teammates/assets/90850610/96535371-a067-4c85-b7e5-5cfb0766c07f">

Screen-size of 768px
<img width="754" src="https://github.com/TEAMMATES/teammates/assets/90850610/d1aee346-3b7e-473a-96a2-e2bb93cdf78e">


