### PR TITLE
[#12508] Update: Give respondents a way to reset a rubric question submission

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
@@ -47,3 +47,5 @@
     </div>
   </div>
 </div>
+<button class="btn btn-success" (click)="resetRubricQuestion()">Reset rubric question</button>
+

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
@@ -6,14 +6,26 @@
   background-color: #D9EDF7 !important;
 }
 
+button.btn {
+  margin: 20px 0;
+}
+
+
 @media (max-width: 768px) {
   .desktop-view {
     display: none;
+  }
+
+  .mobile-view {
+    display: block;
   }
 }
 
 @media (min-width: 768px) {
   .mobile-view {
     display: none;
+  }
+  .desktop-view {
+    display: block;
   }
 }

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
@@ -71,4 +71,11 @@ export class RubricQuestionEditAnswerFormComponent extends QuestionEditAnswerFor
   getInputId(id: String, row: Number, col: Number, platform: String): String {
     return `${id}-row${row}-col${col}-${platform}`;
   }
+
+  resetRubricQuestion() {
+    let newAnswer: number[] = [];
+    newAnswer = Array(this.questionDetails.rubricSubQuestions.length).fill(RUBRIC_ANSWER_NOT_CHOSEN);
+    this.triggerResponseDetailsChange('answer', newAnswer);
+  }
+
 }


### PR DESCRIPTION

<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12508

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
Added a new reset button connected to a function resetRubricQuestion() changing the currently shown answers to the empty question state (not automatically saved in backend).
Changed the media queries, because if the window size was changed more than once, at the with of 768px, the rubric questions were not shown anymore.


Different behavior shown in the video (resetting the question without saving, resetting the question with saving)
https://github.com/TEAMMATES/teammates/assets/90850610/a07e7b65-d2ae-472a-8f9a-10b00c202a18

