### PR TITLE
[#12499] Flickering questions when loading session results

### DIFF
--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -106,11 +106,13 @@ export class QuestionResponsePanelComponent {
           question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
           question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
         }
-        if (question.errorMessage) {
-          this.statusMessageService.showSuccessToast('Question '
-            .concat(question.feedbackQuestion.questionNumber.toString())
-            .concat(' has no responses.'));
-        }
+       else {
+          question.hasResponse = false;
+          if (question.errorMessage) {
+            this.statusMessageService.showSuccessToast('Question '
+              .concat(question.feedbackQuestion.questionNumber.toString())
+              .concat(' has no responses.'));
+          }
       },
       complete: () => {
         question.isLoaded = true;

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -105,8 +105,7 @@ export class QuestionResponsePanelComponent {
           question.responsesToSelf = responses.responsesToSelf;
           question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
           question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
-        }
-       else {
+      } else {
           question.hasResponse = false;
           if (question.errorMessage) {
             this.statusMessageService.showSuccessToast('Question '

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -112,6 +112,7 @@ export class QuestionResponsePanelComponent {
               .concat(question.feedbackQuestion.questionNumber.toString())
               .concat(' has no responses.'));
           }
+        }
       },
       complete: () => {
         question.isLoaded = true;

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -85,7 +85,6 @@ export class QuestionResponsePanelComponent {
       // Do not re-fetch data
       return;
     }
-   
     this.feedbackSessionsService.getFeedbackSessionResults({
       questionId: question.feedbackQuestion.feedbackQuestionId,
       courseId: this.session.courseId,

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -105,12 +105,11 @@ export class QuestionResponsePanelComponent {
           question.responsesToSelf = responses.responsesToSelf;
           question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
           question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
-        } else {
-          if (question.errorMessage) {
-            this.statusMessageService.showSuccessToast('Question '
-              .concat(question.feedbackQuestion.questionNumber.toString())
-              .concat(' has no responses.'));
-          }
+        } 
+        if (question.errorMessage) {
+          this.statusMessageService.showSuccessToast('Question '
+            .concat(question.feedbackQuestion.questionNumber.toString())
+            .concat(' has no responses.'));
         }
       },
       complete: () => {

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -85,6 +85,7 @@ export class QuestionResponsePanelComponent {
       // Do not re-fetch data
       return;
     }
+   
     this.feedbackSessionsService.getFeedbackSessionResults({
       questionId: question.feedbackQuestion.feedbackQuestionId,
       courseId: this.session.courseId,
@@ -96,6 +97,7 @@ export class QuestionResponsePanelComponent {
       next: (sessionResults: SessionResults) => {
         const responses: QuestionOutput = sessionResults.questions[0];
         if (responses) {
+          question.hasResponse = true;
           question.feedbackQuestion = responses.feedbackQuestion;
           question.allResponses = responses.allResponses;
           question.otherResponses = responses.otherResponses;
@@ -105,7 +107,6 @@ export class QuestionResponsePanelComponent {
           question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
           question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
         } else {
-          question.hasResponse = false;
           if (question.errorMessage) {
             this.statusMessageService.showSuccessToast('Question '
               .concat(question.feedbackQuestion.questionNumber.toString())

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -105,7 +105,7 @@ export class QuestionResponsePanelComponent {
           question.responsesToSelf = responses.responsesToSelf;
           question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
           question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
-        } 
+        }
         if (question.errorMessage) {
           this.statusMessageService.showSuccessToast('Question '
             .concat(question.feedbackQuestion.questionNumber.toString())

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -391,7 +391,7 @@ describe('SessionResultPageComponent', () => {
       otherResponses: [],
       isLoading: false,
       isLoaded: false,
-      hasResponse: true,
+      hasResponse: false,
       hasResponseButNotVisibleForPreview: false,
       hasCommentNotVisibleForPreview: false,
     };

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -327,7 +327,7 @@ export class SessionResultPageComponent implements OnInit {
                     otherResponses: [],
                     isLoading: false,
                     isLoaded: false,
-                    hasResponse: true,
+                    hasResponse: false,
                     hasResponseButNotVisibleForPreview: false,
                     hasCommentNotVisibleForPreview: false,
                   });


### PR DESCRIPTION
Fixes #12499

Changed the hasResponse field to be false by default. Now the questions won't show up briefly and then be hidden due to not having responses. 

Previous:
https://user-images.githubusercontent.com/63457492/247068301-1e5b68cc-5bec-4f07-aa57-e3837ec1847b.mp4

New:
https://github.com/TEAMMATES/teammates/assets/83157275/592b008d-9290-4ecb-b6dc-af993ee0f710

