### PR TITLE
[#12314] Popover appears in front of modal blocking buttons

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -215,7 +215,7 @@
           <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
                   ngbTooltip="You can save your responses for this question at any time and come back later to continue."
                   #tooltip="ngbTooltip" (mouseenter)="tooltip.open()"
-                   (click)="saveFeedbackResponses(); tooltip.close();"[disabled]="isSavingResponses || isSubmissionDisabled">
+                  (click)="saveFeedbackResponses(); tooltip.close();"[disabled]="isSavingResponses || isSubmissionDisabled">
             <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
             <span>{{ isQuestionCountOne ? "Submit Response" : "Submit Response for Question " + model.questionNumber }}</span>
           </button>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -214,7 +214,8 @@
         <div class="col-12 text-center">
           <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"
                   ngbTooltip="You can save your responses for this question at any time and come back later to continue."
-                  (click)="saveFeedbackResponses()" [disabled]="isSavingResponses || isSubmissionDisabled">
+                  #tooltip="ngbTooltip" (mouseenter)="tooltip.open()"
+                   (click)="saveFeedbackResponses(); tooltip.close();"[disabled]="isSavingResponses || isSubmissionDisabled">
             <tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>
             <span>{{ isQuestionCountOne ? "Submit Response" : "Submit Response for Question " + model.questionNumber }}</span>
           </button>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -114,8 +114,7 @@
       <div class="col-12 text-center">
         <button id="btn-submit" type="submit" class="btn btn-success"
                 ngbTooltip="You can save your responses at any time and come back later to continue."
-                #tooltip="ngbTooltip" (mouseenter)="tooltip.open()"
-                (click)="saveFeedbackResponses(questionSubmissionForms); tooltip.close();" [disabled]="isSavingResponses || isSubmissionFormsDisabled"
+                (click)="saveFeedbackResponses(questionSubmissionForms)" [disabled]="isSavingResponses || isSubmissionFormsDisabled"
         ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>Submit Responses for All Questions</button>
       </div>
     </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -114,7 +114,8 @@
       <div class="col-12 text-center">
         <button id="btn-submit" type="submit" class="btn btn-success"
                 ngbTooltip="You can save your responses at any time and come back later to continue."
-                (click)="saveFeedbackResponses(questionSubmissionForms)" [disabled]="isSavingResponses || isSubmissionFormsDisabled"
+                #tooltip="ngbTooltip" (mouseenter)="tooltip.open()"
+                (click)="saveFeedbackResponses(questionSubmissionForms); tooltip.close();" [disabled]="isSavingResponses || isSubmissionFormsDisabled"
         ><tm-ajax-loading *ngIf="isSavingResponses"></tm-ajax-loading>Submit Responses for All Questions</button>
       </div>
     </div>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12314

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
- add mouse enter event to enable the tooltip
- close tooltip when the button to save the responses is clicked

**Laptop size:**
<img width="1241" alt="Bildschirmfoto 2023-09-04 um 02 13 40" src="https://github.com/TEAMMATES/teammates/assets/90850610/788db777-0720-41be-8acf-e1a5f2579fc9">
<img width="1219" alt="Bildschirmfoto 2023-09-04 um 02 13 54" src="https://github.com/TEAMMATES/teammates/assets/90850610/38d582d2-82f2-45f5-bcec-e7284f494cf9">

**Mobile size:**
<img width="468" alt="Bildschirmfoto 2023-09-04 um 02 14 16" src="https://github.com/TEAMMATES/teammates/assets/90850610/37928c70-1b81-46fa-a85e-17a1ea181cb0">
<img width="478" alt="Bildschirmfoto 2023-09-04 um 02 14 27" src="https://github.com/TEAMMATES/teammates/assets/90850610/94e25074-eac9-4cb6-9fa6-03c075e799e8">
