### PR TITLE
[#12578] Fix @ issue by using innerHTML tag

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/text-question-edit-answer-form.component.html
@@ -1,5 +1,5 @@
 <div class="plain-text-area" *ngIf="!questionDetails.shouldAllowRichText">
-  <textarea [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [attr.aria-label]="getAriaLabel()" [disabled]="isDisabled"></textarea>
+  <textarea (input)="triggerResponseDetailsChange('answer', $event.target.value)" [attr.aria-label]="getAriaLabel()" [disabled]="isDisabled" [innerHtml]="responseDetails.answer" ></textarea>
 </div>
 <tm-rich-text-editor *ngIf="questionDetails.shouldAllowRichText" [attr.aria-label]="getAriaLabel()" [richText]="responseDetails.answer" (richTextChange)="triggerResponseDetailsChange('answer', $event)" [isDisabled]="isDisabled"></tm-rich-text-editor>
 <div class="margin-top-7px text-secondary text-end">


### PR DESCRIPTION
Fixes #12578 

**Outline of Solution**

I have identified that the backend database stores special characters as HTML-encoded entities, which is sent back to the UI.

My solution is to fix the issue in the UI by decoding the HTML characters and showing them in the UI.
I found two ways to do this. Both have advantages and disadvantages, but both approaches work flawlessly as far as I have tested them. 

The first approach was to use the innerHtml tag, which automatically decodes text, but for this, ngModel should be removed since ngModelChange works with ngModel; it also has to be removed and replaced with input event so that event binding to the variable works.

The second approach its to use approach mentioned here https://www.npmjs.com/package/decode-html-entities.
The second approach is to create another textarea that does the decoding and gets its value to be shown in the UI.

The code for the above approach is simple, but it requires the creation of another texture
transform(value: any, args: any[]): any {
        if (!value) return;
        let txt = document.createElement("textarea");
        txt.innerHTML = value;
        return txt.value;
    }

I went with the first approach rather than creating a new textarea box.