### PR TITLE
[#12345] Instructor courses page: other actions dropdown cut off

### DIFF
--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -313,3 +313,8 @@ label {
   --bs-navbar-color: rgba(255, 255, 255, .75);
   --bs-navbar-hover-color: white;
 }
+
+// overrides default table-responsive scrolling
+.table-responsive {
+  -webkit-overflow-scrolling: auto;
+}


### PR DESCRIPTION
Fixes #12345 

**Outline of Solution**

- The issue causing this is the IOS specific property of smooth touching scrolling.
- I fixed it by changing the overflow-scrolling property of the responsive table from touch to auto.

**The below screenshot is before I fixed it:**

![bug](https://github.com/TEAMMATES/teammates/assets/115834409/3b564717-4adf-46a5-99a1-aa2aab32a248)

**The below screenshot is after I fixed it:**

![fixed](https://github.com/TEAMMATES/teammates/assets/115834409/9c3fed3c-ee24-4bd1-ada9-e6834f4c1052)

