### PR TITLE
[#1501]  Create Unit Tests for FeedbackMcqQuestionDetailsTest.java

### DIFF
--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetailsTest.java
@@ -225,4 +225,98 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
 
         assertEquals(0, errors.size());
     }
+
+    @Test
+    public void testIsQuestionDropdownEnabled_shouldReturnFalse() {
+        FeedbackMcqQuestionDetails feedbackQuestionDetails = new FeedbackMcqQuestionDetails("test");
+        assertFalse(feedbackQuestionDetails.isQuestionDropdownEnabled());
+        
+    }
+
+    @Test
+    public void testIsQuestionDropdownEnabled_shouldReturnTrue() {
+        FeedbackMcqQuestionDetails feedbackQuestionDetails = new FeedbackMcqQuestionDetails();
+        feedbackQuestionDetails.setQuestionDropdownEnabled(true);
+        assertTrue(feedbackQuestionDetails.isQuestionDropdownEnabled());
+    }
+
+    @Test
+    public void testSetQuestionDropdownEnabled_shouldReturnFalse() {
+        FeedbackMcqQuestionDetails feedbackQuestionDetails = new FeedbackMcqQuestionDetails();
+        feedbackQuestionDetails.setQuestionDropdownEnabled(false);
+        assertFalse(feedbackQuestionDetails.isQuestionDropdownEnabled());
+    }
+    
+    @Test
+    public void testValidateQuestionDetails_weightsNotEnabledButWeightListNotEmpty_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setMcqWeights(Arrays.asList(1.22, -1.55));
+        mcqDetails.setMcqChoices(Arrays.asList("choice 1", "choice 2"));
+        mcqDetails.setHasAssignedWeights(false);
+        
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(FeedbackParticipantType.NONE, mcqDetails.getGenerateOptionsFor());
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
+    }
+
+    @Test
+    public void testValidateQuestionDetails_weightsNotEnabledButOtherWeightNotZero_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setMcqOtherWeight(0.5);
+        mcqDetails.setHasAssignedWeights(false);
+        
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(FeedbackParticipantType.NONE, mcqDetails.getGenerateOptionsFor());
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
+    }
+
+    @Test
+    public void testValidateQuestionDetails_hasAssignedWeightsOtherEnabledNonZeroWeight_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setHasAssignedWeights(true);
+        mcqDetails.setOtherEnabled(true);
+        mcqDetails.setMcqOtherWeight(1.5);
+        mcqDetails.setMcqChoices(Arrays.asList("choice 1", "choice 2"));
+
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_INVALID_WEIGHT, errors.get(0));
+    }
+    
+    @Test
+    public void testValidateQuestionDetails_hasAssignedWeightsOtherEnabledNegativeWeight_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setHasAssignedWeights(true);
+        mcqDetails.setOtherEnabled(true);
+        mcqDetails.setMcqOtherWeight(-1.5);
+
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(2, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_NOT_ENOUGH_CHOICES + FeedbackMcqQuestionDetails.MCQ_MIN_NUM_OF_CHOICES + ".", errors.get(0));
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_INVALID_WEIGHT, errors.get(1));
+    }
+    
+    @Test
+    public void testValidateQuestionDetails_hasAssignedWeightsNonEmptyWeights_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setHasAssignedWeights(true);
+        mcqDetails.setMcqWeights(Collections.singletonList(1.5));
+        
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(2, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_NOT_ENOUGH_CHOICES + FeedbackMcqQuestionDetails.MCQ_MIN_NUM_OF_CHOICES + ".", errors.get(0));
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_INVALID_WEIGHT, errors.get(1));
+    }
+
+    @Test
+    public void testValidateQuestionDetails_generateOptionsForNone_errorReturned() {
+        FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
+        mcqDetails.setGenerateOptionsFor(FeedbackParticipantType.NONE);
+
+        List<String> errors = mcqDetails.validateQuestionDetails();
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMcqQuestionDetails.MCQ_ERROR_NOT_ENOUGH_CHOICES + FeedbackMcqQuestionDetails.MCQ_MIN_NUM_OF_CHOICES + ".", errors.get(0));
+    }
 }


### PR DESCRIPTION
 [#1501] Create Unit Tests for Feedback*QuestionDetails classes

Fixes #1501 

This PR adds unit tests for the FeedbackMcqQuestionDetails class, focusing on methods related to question details and weights. The tests cover scenarios such as enabling/disabling question dropdowns, validating weights, and handling various combinations of weights and question details. 

Current branch coverage of this class is ~80%.  Locally, all tests pass successfully. 