### PR TITLE
[#12641] Adding coverage to the isResponseOfFeedbackQuestionVisibleToStudent method

### DIFF
--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -34,7 +34,6 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.test.AssertHelper;
 
-
 /**
  * SUT: {@link FeedbackResponsesLogic}.
  */

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -1715,7 +1715,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT1(){
+    public void testResponseVisibleToStudentWhenShownToStudents(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(STUDENTS);
@@ -1728,7 +1728,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT2(){
+    public void testResponseVisibleToStudentWhenReceiverIsStudent(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER);
@@ -1743,7 +1743,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT3(){
+    public void testResponseVisibleToStudentWhenReceiverExcludesSelf(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER);
@@ -1758,7 +1758,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT4(){
+    public void testResponseVisibleToStudentInSameSection(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER);
@@ -1773,7 +1773,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT5(){
+    public void testResponseVisibleToStudentWhenReceiverIsOwnTeamMember(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER);
@@ -1787,7 +1787,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         assertEquals(response, true);
     }
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT6(){
+    public void testResponseVisibleToStudentWhenReceiverIsGiver(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER);
@@ -1802,7 +1802,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT7(){
+    public void testResponseNotVisibleToStudentWhenReceiverTeamMembers(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(RECEIVER_TEAM_MEMBERS);
@@ -1817,7 +1817,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT8(){
+    public void testResponseVisibleToStudentWhenShownToOwnTeamMembers(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(OWN_TEAM_MEMBERS);

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -1715,7 +1715,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentWhenShownToStudents(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.STUDENTS);
 
@@ -1728,7 +1727,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentWhenReceiverIsStudent(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1743,7 +1741,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentWhenReceiverExcludesSelf(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1758,7 +1755,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentInSameSection(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1773,7 +1769,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentWhenReceiverIsOwnTeamMember(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1785,9 +1780,9 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
     }
+
     @Test
     public void testResponseVisibleToStudentWhenReceiverIsGiver(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1802,7 +1797,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseNotVisibleToStudentWhenReceiverTeamMembers(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
 
@@ -1817,7 +1811,6 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     @Test
     public void testResponseVisibleToStudentWhenShownToOwnTeamMembers(){
-
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
 

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -34,6 +34,8 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.test.AssertHelper;
 
+import static teammates.common.datatransfer.FeedbackParticipantType.*;
+
 /**
  * SUT: {@link FeedbackResponsesLogic}.
  */
@@ -523,12 +525,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         fq.setRecipientType(FeedbackParticipantType.TEAMS);
         fq.getShowRecipientNameTo().clear();
-        fq.getShowRecipientNameTo().add(FeedbackParticipantType.RECEIVER);
+        fq.getShowRecipientNameTo().add(RECEIVER);
         fr.setRecipient(student.getTeam());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
 
-        fq.setRecipientType(FeedbackParticipantType.STUDENTS);
+        fq.setRecipientType(STUDENTS);
         fr.setRecipient(student.getEmail());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertFalse(frLogic.isNameVisibleToUser(fq, fr, student2.getEmail(), false, false, roster));
@@ -540,7 +542,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
 
-        fq.setRecipientType(FeedbackParticipantType.STUDENTS);
+        fq.setRecipientType(STUDENTS);
         fr.setRecipient(student.getEmail());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
@@ -565,8 +567,8 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         // Only members of the recipient team should be able to see the recipient name
         fq.setRecipientType(FeedbackParticipantType.TEAMS);
         fq.getShowRecipientNameTo().clear();
-        fq.getShowRecipientNameTo().add(FeedbackParticipantType.RECEIVER);
-        fq.getShowResponsesTo().add(FeedbackParticipantType.STUDENTS);
+        fq.getShowRecipientNameTo().add(RECEIVER);
+        fq.getShowResponsesTo().add(STUDENTS);
         fr.setRecipient("Team 1.1");
         assertFalse(frLogic.isNameVisibleToUser(fq, fr, student5.getEmail(), false, false, roster));
 
@@ -1076,7 +1078,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         FeedbackResponseAttributes fra = getResponseFromDatabase("response3ForQ2S1C1");
         StudentAttributes student2InCourse1 = dataBundle.students.get("student2InCourse1");
         // giver is student
-        assertEquals(FeedbackParticipantType.STUDENTS,
+        assertEquals(STUDENTS,
                 fqLogic.getFeedbackQuestion(fra.getFeedbackQuestionId()).getGiverType());
         // student is the recipient
         assertEquals(fra.getRecipient(), student2InCourse1.getEmail());
@@ -1710,6 +1712,123 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         List<FeedbackResponseAttributes> responseForQuestion =
                 bundle.getQuestionResponseMap().entrySet().iterator().next().getValue();
         assertEquals(4, responseForQuestion.size());
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT1(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(STUDENTS);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT2(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(FeedbackParticipantType.STUDENTS)
+                .withGiverType(STUDENTS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT3(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(FeedbackParticipantType.STUDENTS_EXCLUDING_SELF)
+                .withGiverType(STUDENTS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT4(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(FeedbackParticipantType.STUDENTS_IN_SAME_SECTION)
+                .withGiverType(STUDENTS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT5(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS)
+                .withGiverType(STUDENTS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT6(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(FeedbackParticipantType.GIVER)
+                .withGiverType(STUDENTS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT7(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(RECEIVER_TEAM_MEMBERS);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(NONE)
+                .withGiverType(NONE)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, false);
+    }
+
+    @Test
+    public void testIsResponseOfFeedbackQuestionVisibleToStudentCT8(){
+
+        List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
+        showResponseTo.add(OWN_TEAM_MEMBERS);
+
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withShowResponsesTo(showResponseTo)
+                .withRecipientType(NONE)
+                .withGiverType(TEAMS)
+                .build();
+        boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
+        assertEquals(response, true);
     }
 
     private FeedbackQuestionAttributes getQuestionFromDatabase(DataBundle dataBundle, String jsonId) {

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -34,7 +34,6 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.test.AssertHelper;
 
-import static teammates.common.datatransfer.FeedbackParticipantType.*;
 
 /**
  * SUT: {@link FeedbackResponsesLogic}.
@@ -525,12 +524,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         fq.setRecipientType(FeedbackParticipantType.TEAMS);
         fq.getShowRecipientNameTo().clear();
-        fq.getShowRecipientNameTo().add(RECEIVER);
+        fq.getShowRecipientNameTo().add(FeedbackParticipantType.RECEIVER);
         fr.setRecipient(student.getTeam());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
 
-        fq.setRecipientType(STUDENTS);
+        fq.setRecipientType(FeedbackParticipantType.STUDENTS);
         fr.setRecipient(student.getEmail());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertFalse(frLogic.isNameVisibleToUser(fq, fr, student2.getEmail(), false, false, roster));
@@ -542,7 +541,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
 
-        fq.setRecipientType(STUDENTS);
+        fq.setRecipientType(FeedbackParticipantType.STUDENTS);
         fr.setRecipient(student.getEmail());
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student.getEmail(), false, false, roster));
         assertTrue(frLogic.isNameVisibleToUser(fq, fr, student3.getEmail(), false, false, roster));
@@ -567,8 +566,8 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         // Only members of the recipient team should be able to see the recipient name
         fq.setRecipientType(FeedbackParticipantType.TEAMS);
         fq.getShowRecipientNameTo().clear();
-        fq.getShowRecipientNameTo().add(RECEIVER);
-        fq.getShowResponsesTo().add(STUDENTS);
+        fq.getShowRecipientNameTo().add(FeedbackParticipantType.RECEIVER);
+        fq.getShowResponsesTo().add(FeedbackParticipantType.STUDENTS);
         fr.setRecipient("Team 1.1");
         assertFalse(frLogic.isNameVisibleToUser(fq, fr, student5.getEmail(), false, false, roster));
 
@@ -1078,7 +1077,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         FeedbackResponseAttributes fra = getResponseFromDatabase("response3ForQ2S1C1");
         StudentAttributes student2InCourse1 = dataBundle.students.get("student2InCourse1");
         // giver is student
-        assertEquals(STUDENTS,
+        assertEquals(FeedbackParticipantType.STUDENTS,
                 fqLogic.getFeedbackQuestion(fra.getFeedbackQuestionId()).getGiverType());
         // student is the recipient
         assertEquals(fra.getRecipient(), student2InCourse1.getEmail());
@@ -1718,7 +1717,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenShownToStudents(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(STUDENTS);
+        showResponseTo.add(FeedbackParticipantType.STUDENTS);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
@@ -1731,12 +1730,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenReceiverIsStudent(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
                 .withRecipientType(FeedbackParticipantType.STUDENTS)
-                .withGiverType(STUDENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
@@ -1746,12 +1745,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenReceiverExcludesSelf(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
                 .withRecipientType(FeedbackParticipantType.STUDENTS_EXCLUDING_SELF)
-                .withGiverType(STUDENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
@@ -1761,12 +1760,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentInSameSection(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
                 .withRecipientType(FeedbackParticipantType.STUDENTS_IN_SAME_SECTION)
-                .withGiverType(STUDENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
@@ -1776,12 +1775,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenReceiverIsOwnTeamMember(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
                 .withRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS)
-                .withGiverType(STUDENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
@@ -1790,12 +1789,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenReceiverIsGiver(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
                 .withRecipientType(FeedbackParticipantType.GIVER)
-                .withGiverType(STUDENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);
@@ -1805,12 +1804,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseNotVisibleToStudentWhenReceiverTeamMembers(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(RECEIVER_TEAM_MEMBERS);
+        showResponseTo.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
-                .withRecipientType(NONE)
-                .withGiverType(NONE)
+                .withRecipientType(FeedbackParticipantType.NONE)
+                .withGiverType(FeedbackParticipantType.NONE)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, false);
@@ -1820,12 +1819,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     public void testResponseVisibleToStudentWhenShownToOwnTeamMembers(){
 
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
-        showResponseTo.add(OWN_TEAM_MEMBERS);
+        showResponseTo.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
 
         FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
                 .withShowResponsesTo(showResponseTo)
-                .withRecipientType(NONE)
-                .withGiverType(TEAMS)
+                .withRecipientType(FeedbackParticipantType.NONE)
+                .withGiverType(FeedbackParticipantType.TEAMS)
                 .build();
         boolean response = FeedbackResponsesLogic.inst().isResponseOfFeedbackQuestionVisibleToStudent(question);
         assertEquals(response, true);

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -1714,7 +1714,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenShownToStudents(){
+    public void testResponseVisibleToStudentWhenShownToStudents() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.STUDENTS);
 
@@ -1726,7 +1726,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenReceiverIsStudent(){
+    public void testResponseVisibleToStudentWhenReceiverIsStudent() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1740,7 +1740,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenReceiverExcludesSelf(){
+    public void testResponseVisibleToStudentWhenReceiverExcludesSelf() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1754,7 +1754,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentInSameSection(){
+    public void testResponseVisibleToStudentInSameSection() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1768,7 +1768,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenReceiverIsOwnTeamMember(){
+    public void testResponseVisibleToStudentWhenReceiverIsOwnTeamMember() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1782,7 +1782,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenReceiverIsGiver(){
+    public void testResponseVisibleToStudentWhenReceiverIsGiver() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER);
 
@@ -1796,7 +1796,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseNotVisibleToStudentWhenReceiverTeamMembers(){
+    public void testResponseNotVisibleToStudentWhenReceiverTeamMembers() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
 
@@ -1810,7 +1810,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testResponseVisibleToStudentWhenShownToOwnTeamMembers(){
+    public void testResponseVisibleToStudentWhenShownToOwnTeamMembers() {
         List<FeedbackParticipantType> showResponseTo = new ArrayList<>();
         showResponseTo.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
 


### PR DESCRIPTION
Fixes [#12641]

**Outline of Solution**

This PR adds unit tests for method isResponseOfFeedbackQuestionVisibleToStudent from the FeedbackResponsesLogic class.

testResponseVisibleToStudentWhenShownToOwnTeamMembers
testResponseNotVisibleToStudentWhenReceiverTeamMembers
testResponseVisibleToStudentWhenReceiverIsGiver
testResponseVisibleToStudentWhenReceiverIsOwnTeamMember
testResponseVisibleToStudentInSameSection
testResponseVisibleToStudentWhenReceiverExcludesSelf
testResponseVisibleToStudentWhenReceiverIsStudent
testResponseVisibleToStudentWhenShownToStudents
