### PR TITLE
[#12647] Fix accessibility tests

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -467,13 +467,12 @@ public class FeedbackResultsPage extends AppPage {
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {
         WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
-        List<WebElement> givenResponses = questionResponsesSection.findElements(By.className("given-responses"));
-        for (int i = 0; i < givenResponses.size(); i++) {
-            List<WebElement> recipients = givenResponses.get(i).findElements(By.className("response-recipient"));
-            for (int j = 0; j < recipients.size(); j++) {
-                if (recipients.get(j).getText().split("To: ")[1].equals(receiver)) {
-                    return givenResponses.get(i).findElements(By.tagName("tm-single-response")).get(j);
-                }
+        WebElement givenResponses = questionResponsesSection.findElement(By.className("given-responses"));
+
+        List<WebElement> recipients = givenResponses.findElements(By.className("response-recipient"));
+        for (int i = 0; i < recipients.size(); i++) {
+            if (recipients.get(i).getText().split("To: ")[1].equals(receiver)) {
+                return givenResponses.findElements(By.tagName("tm-single-response")).get(i);
             }
             // List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
             // for (int j = 0; j < responseComponents.size(); j++) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -469,15 +469,21 @@ public class FeedbackResultsPage extends AppPage {
         WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
         List<WebElement> givenResponses = questionResponsesSection.findElements(By.className("given-responses"));
         for (int i = 0; i < givenResponses.size(); i++) {
-            List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
-            for (int j = 0; j < responseComponents.size(); j++) {
-                List<WebElement> recipients = responseComponents.get(j).findElements(By.className("response-recipient"));
-                for (WebElement recipient : recipients) {     
-                    if (recipient.getText().split("To: ")[1].equals(receiver)) {
-                        return responseComponents.get(j);
-                    }
+            List<WebElement> recipients = givenResponses.get(i).findElements(By.className("response-recipient"));
+            for (int j = 0; j < recipients.size(); j++) {
+                if (recipients.get(j).getText().split("To: ")[1].equals(receiver)) {
+                    return givenResponses.get(i).findElements(By.tagName("tm-single-response")).get(j);
                 }
             }
+            // List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
+            // for (int j = 0; j < responseComponents.size(); j++) {
+            //     List<WebElement> recipients = responseComponents.get(j).findElements(By.className("response-recipient"));
+            //     for (WebElement recipient : recipients) {     
+            //         if (recipient.getText().split("To: ")[1].equals(receiver)) {
+            //             return responseComponents.get(j);
+            //         }
+            //     }
+            // }
         }
         throw new AssertionError("Recipient not found: " + receiver);
 

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -612,7 +612,8 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private int getRecipientIndex(int questionNum, String recipient) {
-        List<WebElement> recipients = getQuestionResponsesSection(questionNum).findElements(By.className("response-recipient"));
+        List<WebElement> recipients = 
+                getQuestionResponsesSection(questionNum).findElements(By.className("response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
             if (recipients.get(i).getText().split("To: ")[1].equals(recipient)) {
                 return i;

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -251,7 +251,7 @@ public class FeedbackResultsPage extends AppPage {
                                              List<FeedbackResponseAttributes> expectedResponses,
                                              boolean isGiverVisible) {
         List<WebElement> anonymousViews = getAllResponseViews(question.getQuestionNumber()).stream()
-                .filter(v -> isAnonymous(v.findElement(By.id("response-recipient")).getText()))
+                .filter(v -> isAnonymous(v.findElement(By.className("response-recipient")).getText()))
                 .collect(Collectors.toList());
         if (anonymousViews.isEmpty()) {
             fail("No anonymous views found");
@@ -309,7 +309,7 @@ public class FeedbackResultsPage extends AppPage {
 
     private boolean isAnyAnonymousResponseEqual(FeedbackQuestionAttributes question, WebElement responseView,
                                                 FeedbackResponseAttributes response) {
-        List<WebElement> giverNames = responseView.findElements(By.id("response-giver"));
+        List<WebElement> giverNames = responseView.findElements(By.className("response-giver"));
         List<WebElement> responseFields = getAllResponseFields(responseView);
         for (int i = 0; i < giverNames.size(); i++) {
             if (isAnonymous(giverNames.get(i).getText()) && isResponseEqual(question, responseFields.get(i), response)) {
@@ -468,13 +468,13 @@ public class FeedbackResultsPage extends AppPage {
     private WebElement getGivenResponseField(int questionNum, String receiver) {
         int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
         return getQuestionResponsesSection(questionNum)
-                .findElements(By.cssSelector("#given-responses tm-single-response"))
+                .findElements(By.cssSelector(".given-responses tm-single-response"))
                 .get(recipientIndex);
     }
 
     private int getGivenRecipientIndex(int questionNum, String recipient) {
         List<WebElement> recipients = getQuestionResponsesSection(questionNum)
-                .findElements(By.cssSelector("#given-responses #response-recipient"));
+                .findElements(By.cssSelector(".given-responses .response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
             if (recipients.get(i).getText().split("To: ")[1].equals(recipient)) {
                 return i;
@@ -584,7 +584,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private String getCommentGiver(WebElement commentField) {
-        String commentGiverDescription = commentField.findElement(By.id("comment-giver-name")).getText();
+        String commentGiverDescription = commentField.findElement(By.className("comment-giver-name")).getText();
         return commentGiverDescription.split(" commented")[0];
     }
 
@@ -608,7 +608,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private int getGiverIndex(WebElement response, String giver) {
-        List<WebElement> givers = response.findElements(By.id("response-giver"));
+        List<WebElement> givers = response.findElements(By.className("response-giver"));
         for (int i = 0; i < givers.size(); i++) {
             if (givers.get(i).getText().contains(giver)) {
                 return i;
@@ -618,7 +618,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private int getRecipientIndex(int questionNum, String recipient) {
-        List<WebElement> recipients = getQuestionResponsesSection(questionNum).findElements(By.id("response-recipient"));
+        List<WebElement> recipients = getQuestionResponsesSection(questionNum).findElements(By.className("response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
             if (recipients.get(i).getText().split("To: ")[1].equals(recipient)) {
                 return i;

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -466,13 +466,39 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {
-        int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
-        return getQuestionResponsesSection(questionNum)
-                .findElements(By.cssSelector(".given-responses tm-single-response"))
-                .get(recipientIndex);
+        WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
+        List<WebElement> givenResponses = questionResponsesSection.findElements(By.className("given-responses"));
+        for (int i = 0; i < givenResponses.size(); i++) {
+            List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
+            for (int j = 0; j < responseComponents.size(); j++) {
+                WebElement recipient = responseComponents.get(j).findElement(By.className("response-recipient"));
+                if (recipient.getText().split("To: ")[1].equals(receiver)) {
+                    return responseComponents.get(j);
+                }
+            }
+        }
+        throw new AssertionError("Recipient not found: " + receiver);
+
+        // int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
+        // return getQuestionResponsesSection(questionNum)
+        //         .findElements(By.cssSelector(".given-responses tm-single-response"))
+        //         .get(recipientIndex);
     }
 
+    /*
     private int getGivenRecipientIndex(int questionNum, String recipient) {
+        // WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
+        // List<WebElement> responses = questionResponsesSection.findElements(By.className("given-responses"));
+        // for (int i = 0; i < responses.size(); i++) {
+        //     List<WebElement> recipients = responses.get(i).findElements(By.className("response-recipient"));
+        //     for (int j = 0; j < recipients.size(); j++) {
+        //         if (recipients.get(j).getText().split("To: ")[1].equals(recipient)) {
+        //             return j;
+        //         }
+        //     }
+        // }
+        // throw new AssertionError("Recipient not found: " + recipient);
+         
         List<WebElement> recipients = getQuestionResponsesSection(questionNum)
                 .findElements(By.cssSelector(".given-responses .response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
@@ -482,6 +508,7 @@ public class FeedbackResultsPage extends AppPage {
         }
         throw new AssertionError("Recipient not found: " + recipient);
     }
+    */
 
     private String getAdditionalInfoString(FeedbackQuestionAttributes question) {
         switch (question.getQuestionType()) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -467,59 +467,15 @@ public class FeedbackResultsPage extends AppPage {
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {
         WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
-        // throw new AssertionError("Recipient not found: " + questionResponsesSection.getText());
-
-        
         WebElement givenResponses = questionResponsesSection.findElement(By.className("given-responses"));
-
         List<WebElement> recipients = givenResponses.findElements(By.className("response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
             if (recipients.get(i).getText().split("To: ")[1].equals(receiver)) {
                 return givenResponses.findElements(By.tagName("tm-single-response")).get(i);
             }
-            // List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
-            // for (int j = 0; j < responseComponents.size(); j++) {
-            //     List<WebElement> recipients = responseComponents.get(j).findElements(By.className("response-recipient"));
-            //     for (WebElement recipient : recipients) {     
-            //         if (recipient.getText().split("To: ")[1].equals(receiver)) {
-            //             return responseComponents.get(j);
-            //         }
-            //     }
-            // }
         }
         throw new AssertionError("Recipient not found: " + receiver);
-        
-
-        // int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
-        // return getQuestionResponsesSection(questionNum)
-        //         .findElements(By.cssSelector(".given-responses tm-single-response"))
-        //         .get(recipientIndex);
     }
-
-    /*
-    private int getGivenRecipientIndex(int questionNum, String recipient) {
-        // WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
-        // List<WebElement> responses = questionResponsesSection.findElements(By.className("given-responses"));
-        // for (int i = 0; i < responses.size(); i++) {
-        //     List<WebElement> recipients = responses.get(i).findElements(By.className("response-recipient"));
-        //     for (int j = 0; j < recipients.size(); j++) {
-        //         if (recipients.get(j).getText().split("To: ")[1].equals(recipient)) {
-        //             return j;
-        //         }
-        //     }
-        // }
-        // throw new AssertionError("Recipient not found: " + recipient);
-         
-        List<WebElement> recipients = getQuestionResponsesSection(questionNum)
-                .findElements(By.cssSelector(".given-responses .response-recipient"));
-        for (int i = 0; i < recipients.size(); i++) {
-            if (recipients.get(i).getText().split("To: ")[1].equals(recipient)) {
-                return i;
-            }
-        }
-        throw new AssertionError("Recipient not found: " + recipient);
-    }
-    */
 
     private String getAdditionalInfoString(FeedbackQuestionAttributes question) {
         switch (question.getQuestionType()) {

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -471,9 +471,11 @@ public class FeedbackResultsPage extends AppPage {
         for (int i = 0; i < givenResponses.size(); i++) {
             List<WebElement> responseComponents = givenResponses.get(i).findElements(By.tagName("tm-single-response"));
             for (int j = 0; j < responseComponents.size(); j++) {
-                WebElement recipient = responseComponents.get(j).findElement(By.className("response-recipient"));
-                if (recipient.getText().split("To: ")[1].equals(receiver)) {
-                    return responseComponents.get(j);
+                List<WebElement> recipients = responseComponents.get(j).findElements(By.className("response-recipient"));
+                for (WebElement recipient : recipients) {     
+                    if (recipient.getText().split("To: ")[1].equals(receiver)) {
+                        return responseComponents.get(j);
+                    }
                 }
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -293,7 +293,8 @@ public class FeedbackResultsPage extends AppPage {
         FeedbackRubricResponseDetails responseDetails = (FeedbackRubricResponseDetails) response.getResponseDetailsCopy();
         List<Integer> answers = responseDetails.getAnswer();
         for (int i = 0; i < answers.size(); i++) {
-            WebElement rubricRow = responseField.findElements(By.cssSelector("#rubric-answers tr")).get(i);
+            WebElement rubricTableBody = responseField.findElement(By.className("rubric-answers"));
+            WebElement rubricRow = rubricTableBody.findElements(By.cssSelector("tr")).get(i);
             WebElement rubricCell = rubricRow.findElements(By.tagName("td")).get(answers.get(i) + 1);
             if (rubricCell.findElements(By.className("fa-check")).size() == 0) {
                 return false;

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -467,9 +467,9 @@ public class FeedbackResultsPage extends AppPage {
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {
         WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
-        throw new AssertionError("Recipient not found: " + questionResponsesSection.getText());
+        // throw new AssertionError("Recipient not found: " + questionResponsesSection.getText());
 
-        /*
+        
         WebElement givenResponses = questionResponsesSection.findElement(By.className("given-responses"));
 
         List<WebElement> recipients = givenResponses.findElements(By.className("response-recipient"));
@@ -488,7 +488,7 @@ public class FeedbackResultsPage extends AppPage {
             // }
         }
         throw new AssertionError("Recipient not found: " + receiver);
-        */
+        
 
         // int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
         // return getQuestionResponsesSection(questionNum)

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -467,6 +467,9 @@ public class FeedbackResultsPage extends AppPage {
 
     private WebElement getGivenResponseField(int questionNum, String receiver) {
         WebElement questionResponsesSection = getQuestionResponsesSection(questionNum);
+        throw new AssertionError("Recipient not found: " + questionResponsesSection.getText());
+
+        /*
         WebElement givenResponses = questionResponsesSection.findElement(By.className("given-responses"));
 
         List<WebElement> recipients = givenResponses.findElements(By.className("response-recipient"));
@@ -485,6 +488,7 @@ public class FeedbackResultsPage extends AppPage {
             // }
         }
         throw new AssertionError("Recipient not found: " + receiver);
+        */
 
         // int recipientIndex = getGivenRecipientIndex(questionNum, receiver);
         // return getQuestionResponsesSection(questionNum)

--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackResultsPage.java
@@ -612,7 +612,7 @@ public class FeedbackResultsPage extends AppPage {
     }
 
     private int getRecipientIndex(int questionNum, String recipient) {
-        List<WebElement> recipients = 
+        List<WebElement> recipients =
                 getQuestionResponsesSection(questionNum).findElements(By.className("response-recipient"));
         for (int i = 0; i < recipients.size(); i++) {
             if (recipients.get(i).getText().split("To: ")[1].equals(recipient)) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1019,7 +1019,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     private String getCommentGiver(WebElement commentField) {
-        String commentGiverDescription = commentField.findElement(By.id("comment-giver-name")).getText();
+        String commentGiverDescription = commentField.findElement(By.className("comment-giver-name")).getText();
         return commentGiverDescription.split(" commented")[0];
     }
 

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -20,7 +20,7 @@
           Comment by response giver.
         </span>
         <span class="text-secondary" *ngIf="!isFeedbackParticipantComment">
-          <span id="comment-giver-name">{{ model.commentGiverName ? model.commentGiverName : model.originalComment.commentGiver }} commented at </span>
+          <span class="comment-giver-name">{{ model.commentGiverName ? model.commentGiverName : model.originalComment.commentGiver }} commented at </span>
           <span class="ngb-tooltip-class" style="margin-right: .25rem;" [ngbTooltip]="model.originalComment.createdAt | formatDateDetail: model.timezone!">
             {{ model.originalComment.createdAt | formatDateBrief: model.timezone! }}</span>
           <ng-container *ngIf="model.originalComment.lastEditedAt && model.originalComment.lastEditedAt !== model.originalComment.createdAt">

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -60,7 +60,6 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -74,7 +73,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -92,7 +91,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -165,7 +164,6 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -179,7 +177,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -197,7 +195,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -226,7 +224,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -244,7 +242,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -317,7 +315,6 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -331,7 +328,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -349,7 +346,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -392,7 +389,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                                                   class="text-secondary"
                                                 >
                                                   <span
-                                                    id="comment-giver-name"
+                                                    class="comment-giver-name"
                                                   >
                                                     comment-giver-1 commented at 
                                                   </span>
@@ -497,7 +494,6 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -511,7 +507,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -529,7 +525,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -558,7 +554,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -576,7 +572,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -605,7 +601,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -623,7 +619,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -691,7 +687,6 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -705,7 +700,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -723,7 +718,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -868,7 +863,6 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -882,7 +876,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -900,7 +894,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:
@@ -943,7 +937,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                                                   class="text-secondary"
                                                 >
                                                   <span
-                                                    id="comment-giver-name"
+                                                    class="comment-giver-name"
                                                   >
                                                     comment-giver-1 commented at 
                                                   </span>
@@ -1033,7 +1027,6 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
             </div>
             <div
               class="mt-4"
-              id="given-responses"
             >
               <strong>
                 Your own responses (to others):
@@ -1047,7 +1040,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                       class="card-header bg-info"
                     >
                       <span
-                        id="response-recipient"
+                        class="response-recipient"
                       >
                         <b>
                           To:
@@ -1065,7 +1058,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                         <tbody>
                           <tr>
                             <td
-                              id="response-giver"
+                              class="response-giver"
                             >
                               <strong>
                                 From:

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -59,7 +59,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -163,7 +163,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -314,7 +314,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -493,7 +493,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -686,7 +686,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -862,7 +862,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
               Responses are not visible to you. 
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):
@@ -1026,7 +1026,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
               </div>
             </div>
             <div
-              class="mt-4"
+              class="given-responses mt-4"
             >
               <strong>
                 Your own responses (to others):

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -35,7 +35,7 @@
               <strong>Other responses (to you): </strong>Responses are not visible to you.
             </div>
           </ng-template>
-          <div id="given-responses" class="mt-4" *ngIf="question.responsesFromSelf.length">
+          <div class="given-responses" class="mt-4" *ngIf="question.responsesFromSelf.length">
             <strong>Your own responses (to others):</strong>
             <div *ngFor="let responseFromSelf of question.responsesFromSelf">
               <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone" [statistics]="question.questionStatistics"></tm-student-view-responses>

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -35,7 +35,7 @@
               <strong>Other responses (to you): </strong>Responses are not visible to you.
             </div>
           </ng-template>
-          <div class="given-responses" class="mt-4" *ngIf="question.responsesFromSelf.length">
+          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length">
             <strong>Your own responses (to others):</strong>
             <div *ngFor="let responseFromSelf of question.responsesFromSelf">
               <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone" [statistics]="question.questionStatistics"></tm-student-view-responses>

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -1,13 +1,13 @@
 <div class="card border-{{ isSelfResponses ? 'info' : 'primary' }} mt-4">
   <div class="card-header bg-{{ isSelfResponses ? 'info' : 'primary' }}" [ngClass]="{ 'text-white': !isSelfResponses }">
-    <span id="response-recipient"><b>To:</b> {{ recipient }}</span>
+    <span class="response-recipient"><b>To:</b> {{ recipient }}</span>
   </div>
   <div class="card-body table-responsive" style="padding: 0;">
     <table class="table">
       <tbody>
         <ng-container *ngFor="let response of responses">
           <tr>
-            <td id="response-giver">
+            <td class="response-giver">
               <strong>From:</strong> {{ response.giver }}
             </td>
           </tr>

--- a/src/web/app/components/question-types/question-response/rubric-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/rubric-question-response.component.html
@@ -6,7 +6,7 @@
         <th class="text-center" *ngFor="let choice of questionDetails.rubricChoices">{{ choice }}</th>
       </tr>
     </thead>
-    <tbody id="rubric-answers">
+    <tbody class="rubric-answers">
       <tr *ngFor="let answer of answers; let i = index">
         <td>{{ questionDetails.rubricSubQuestions[i] }}</td>
         <td class="text-center" *ngFor="let choice of questionDetails.rubricChoices">

--- a/src/web/app/components/question-types/question-response/rubric-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/rubric-question-response.component.html
@@ -10,7 +10,10 @@
       <tr *ngFor="let answer of answers; let i = index">
         <td>{{ questionDetails.rubricSubQuestions[i] }}</td>
         <td class="text-center" *ngFor="let choice of questionDetails.rubricChoices">
-          <i *ngIf="answer.answer === choice" aria-label="selected" class="fas fa-check"></i>
+          <span [attr.aria-label]="answer.answer === choice ? 'selected' : 'unselected'">
+            <i *ngIf="answer.answer === choice" class="fas fa-check"></i>
+          </span>
+          <!-- <i *ngIf="answer.answer === choice" aria-label="selected" class="fas fa-check"></i> -->
         </td>
       </tr>
     </tbody>

--- a/src/web/app/components/question-types/question-response/rubric-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/rubric-question-response.component.html
@@ -13,7 +13,6 @@
           <span [attr.aria-label]="answer.answer === choice ? 'selected' : 'unselected'" role="img">
             <i *ngIf="answer.answer === choice" class="fas fa-check"></i>
           </span>
-          <!-- <i *ngIf="answer.answer === choice" aria-label="selected" class="fas fa-check"></i> -->
         </td>
       </tr>
     </tbody>

--- a/src/web/app/components/question-types/question-response/rubric-question-response.component.html
+++ b/src/web/app/components/question-types/question-response/rubric-question-response.component.html
@@ -10,7 +10,7 @@
       <tr *ngFor="let answer of answers; let i = index">
         <td>{{ questionDetails.rubricSubQuestions[i] }}</td>
         <td class="text-center" *ngFor="let choice of questionDetails.rubricChoices">
-          <span [attr.aria-label]="answer.answer === choice ? 'selected' : 'unselected'">
+          <span [attr.aria-label]="answer.answer === choice ? 'selected' : 'unselected'" role="img">
             <i *ngIf="answer.answer === choice" class="fas fa-check"></i>
           </span>
           <!-- <i *ngIf="answer.answer === choice" aria-label="selected" class="fas fa-check"></i> -->


### PR DESCRIPTION
Fixes #12647 

Change `id`s to `class` and edit E2E tests accordingly. Also merged 2 methods into `getGivenResponseField` method because the previous method for getting the index first wasn't really improving readability - with the merged method, now it's clear that the response field being returned is the one tied to the receiver we're looking for.

Added a `span` into the rubric question response as well and edited the aria label so that the unticked table cell wouldn't just be read as "blank"