### PR TITLE
[#12658] Instructor Home Page: Dropdown buttons on mobile

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -126,7 +126,7 @@ public class InstructorHomePage extends AppPage {
     public void deleteCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.cssSelector("a.btn-delete-course")));
+        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div > a.btn-delete-course.btn")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -119,14 +119,14 @@ public class InstructorHomePage extends AppPage {
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.className("btn-archive-course")));
+        clickAndConfirm(courseTab.findElement(By.className("a.btn-archive-course")));
         waitUntilAnimationFinish();
     }
 
     public void deleteCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.className("btn-delete-course")));
+        clickAndConfirm(courseTab.findElement(By.className("a.btn-delete-course")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -119,7 +119,7 @@ public class InstructorHomePage extends AppPage {
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.cssSelector("body > div > div >a.btn-archive-course.btn")));
+        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div >a.btn-archive-course.btn")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -119,14 +119,14 @@ public class InstructorHomePage extends AppPage {
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div >a.btn-archive-course.btn")));
+        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div > .btn-archive-course")));
         waitUntilAnimationFinish();
     }
 
     public void deleteCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div > a.btn-delete-course.btn")));
+        clickAndConfirm(browser.driver.findElement(By.cssSelector("body > div > div > .btn-delete-course")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -119,7 +119,7 @@ public class InstructorHomePage extends AppPage {
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.className("a.btn-archive-course")));
+        clickAndConfirm(courseTab.findElement(By.cssSelector("a.btn-archive-course.btn.btn-light.btn-sm.dropdown-item.ng-tns-c164-1")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -119,7 +119,7 @@ public class InstructorHomePage extends AppPage {
     public void archiveCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.cssSelector("a.btn-archive-course.btn.btn-light.btn-sm.dropdown-item.ng-tns-c164-1")));
+        clickAndConfirm(courseTab.findElement(By.cssSelector("body > div > div >a.btn-archive-course.btn")));
         waitUntilAnimationFinish();
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePage.java
@@ -126,7 +126,7 @@ public class InstructorHomePage extends AppPage {
     public void deleteCourse(int courseTabIndex) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-course")));
-        clickAndConfirm(courseTab.findElement(By.className("a.btn-delete-course")));
+        clickAndConfirm(courseTab.findElement(By.cssSelector("a.btn-delete-course")));
         waitUntilAnimationFinish();
     }
 

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -262,7 +262,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -407,7 +407,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -1009,7 +1009,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -1768,7 +1768,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -2041,7 +2041,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"
@@ -2338,7 +2338,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+            class="card-header bg-primary text-white cursor-pointer"
           >
             <b
               class="course-details text-break"

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -262,7 +262,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -407,7 +407,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -419,6 +419,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
             >
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -451,6 +452,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -476,6 +478,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -501,6 +504,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1005,7 +1009,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -1017,6 +1021,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
             >
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1042,6 +1047,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1067,6 +1073,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1092,6 +1099,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1760,7 +1768,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -1772,6 +1780,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
             >
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1804,6 +1813,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1829,6 +1839,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -1854,6 +1865,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2029,7 +2041,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -2041,6 +2053,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
             >
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2073,6 +2086,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2098,6 +2112,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2123,6 +2138,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2322,7 +2338,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
           id="course-tab-0"
         >
           <div
-            class="card-header bg-primary text-white cursor-pointer"
+            class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           >
             <b
               class="course-details text-break"
@@ -2334,6 +2350,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
             >
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2366,6 +2383,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2391,6 +2409,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button
@@ -2416,6 +2435,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
               </span>
               <span
                 class="dropdown"
+                container="body"
                 ngbdropdown=""
               >
                 <button

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,14 +39,14 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div class="card-header bg-primary text-white cursor-pointer overflow-hidden"
+        <div class="card-header bg-primary text-white cursor-pointer"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
           <div class="card-header-btn-toolbar flex-lg-shrink-0" *ngIf="courseTabModel.isAjaxSuccess">
             <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Students </button>
-              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyStudent">
                   <a class="btn btn-info btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/enroll"
                     [queryParams]="{courseid: courseTabModel.course.courseId}"> Enroll
@@ -59,15 +59,15 @@
             </span>
             <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Instructors </button>
-              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/edit"
-                   [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
+                  [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
                 </a>
               </div>
             </span>
             <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Sessions </button>
-              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/sessions"
                   [queryParams]="{courseid: courseTabModel.course.courseId}"> Add
                 </a>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -39,14 +39,14 @@
   <div *tmIsLoading="!hasCoursesLoaded || isCopyLoading">
     <div *ngIf="courseTabModels.length > 0">
       <div id="course-tab-{{ idx }}" class="card" *ngFor="let courseTabModel of courseTabModels; let idx = index">
-        <div class="card-header bg-primary text-white cursor-pointer"
+        <div class="card-header bg-primary text-white cursor-pointer overflow-hidden"
           (click)="courseTabModel.isTabExpanded = handleClick($event, courseTabModel); this.loadFeedbackSessions(idx);">
           <b class="course-details text-break">[{{ courseTabModel.course.courseId }}]: {{
             courseTabModel.course.courseName }}</b>
           <div class="card-header-btn-toolbar flex-lg-shrink-0" *ngIf="courseTabModel.isAjaxSuccess">
-            <span ngbDropdown>
+            <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Students </button>
-              <div ngbDropdownMenu (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
                 <ng-container *ngIf="courseTabModel.instructorPrivilege.canModifyStudent">
                   <a class="btn btn-info btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/enroll"
                     [queryParams]="{courseid: courseTabModel.course.courseId}"> Enroll
@@ -57,25 +57,25 @@
                 </a>
               </div>
             </span>
-            <span ngbDropdown>
+            <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Instructors </button>
-              <div ngbDropdownMenu (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/courses/edit"
-                  [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
+                   [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
                 </a>
               </div>
             </span>
-            <span ngbDropdown>
+            <span ngbDropdown container="body">
               <button type="button" class="btn btn-primary btn-sm" ngbDropdownToggle> Sessions </button>
-              <div ngbDropdownMenu (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
                 <a class="btn btn-light btn-sm dropdown-item" tmRouterLink="/web/instructor/sessions"
                   [queryParams]="{courseid: courseTabModel.course.courseId}"> Add
                 </a>
               </div>
             </span>
-            <span ngbDropdown>
+            <span ngbDropdown container="body">
               <button type="button" class="btn-course btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
-              <div ngbDropdownMenu (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
                 <a class="btn-archive-course btn btn-light btn-sm dropdown-item"
                   ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   (click)="archiveCourse(courseTabModel.course.courseId)"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -75,7 +75,7 @@
             </span>
             <span ngbDropdown container="body">
               <button type="button" class="btn-course btn btn-primary btn-sm" ngbDropdownToggle> Course </button>
-              <div ngbDropdownMenu  (click)="$event.stopPropagation()">
+              <div ngbDropdownMenu (click)="$event.stopPropagation()">
                 <a class="btn-archive-course btn btn-light btn-sm dropdown-item"
                   ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                   (click)="archiveCourse(courseTabModel.course.courseId)"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -205,13 +205,8 @@ describe('InstructorHomePageComponent', () => {
 
     const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const archiveButton: any = document.querySelector('body > div > div >a.btn-archive-course.btn ');
-    // Checking archiveButton
-    if (archiveButton) {
-      archiveButton.click();
-    } else {
-      console.error('Archive button not found');
-    }
+    const archiveButton: any = document.querySelector('body > div > div > .btn-archive-course');
+    archiveButton.click();
 
     expect(component.courseTabModels.length).toEqual(1);
     expect(component.courseTabModels[0].course.courseId).toEqual('CS3281');
@@ -238,13 +233,8 @@ describe('InstructorHomePageComponent', () => {
 
     const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const deleteButton: any = document.querySelector('body > div > div > a.btn-delete-course.btn');
-      // Checking deleteButton
-      if (deleteButton) {
-        deleteButton.click();
-      } else {
-        console.error('Delete button not found');
-      }
+    const deleteButton: any = document.querySelector('body > div > div > .btn-delete-course');
+    deleteButton.click();
 
     expect(component.courseTabModels.length).toEqual(1);
     expect(component.courseTabModels[0].course.courseId).toEqual('CS3281');

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -205,8 +205,13 @@ describe('InstructorHomePageComponent', () => {
 
     const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('.btn-archive-course');
-    archiveButton.click();
+    const archiveButton: any = document.querySelector('body > div > div >a.btn-archive-course.btn ');
+    // Checking archiveButton
+    if (archiveButton) {
+      archiveButton.click();
+    } else {
+      console.error('Archive button not found');
+    }
 
     expect(component.courseTabModels.length).toEqual(1);
     expect(component.courseTabModels[0].course.courseId).toEqual('CS3281');
@@ -233,8 +238,13 @@ describe('InstructorHomePageComponent', () => {
 
     const courseButton: any = fixture.debugElement.nativeElement.querySelector('.btn-course');
     courseButton.click();
-    const archiveButton: any = fixture.debugElement.nativeElement.querySelector('.btn-delete-course');
-    archiveButton.click();
+    const deleteButton: any = document.querySelector('body > div > div > a.btn-delete-course.btn');
+      // Checking deleteButton
+      if (deleteButton) {
+        deleteButton.click();
+      } else {
+        console.error('Delete button not found');
+      }
 
     expect(component.courseTabModels.length).toEqual(1);
     expect(component.courseTabModels[0].course.courseId).toEqual('CS3281');


### PR DESCRIPTION

Fixes #12658 

**Outline of Solution**
**Made  Responsive Drop-down Menu for the Instructor Home Page**
### Before there was an Overflow of the drop-down buttons on the home page

![Screenshot 2023-12-16 113322-instructor](https://github.com/TEAMMATES/teammates/assets/153512661/7caa0485-e3dd-47b7-94cf-24c4bfeeab65)
![Screenshot 2023-12-16 113409-sessions](https://github.com/TEAMMATES/teammates/assets/153512661/49aff6e9-d76a-4493-8bd4-eaf66647f8cf)
### After making it Responsive according to the size of the screen, I am able to fix the overflow(spilling out) issue
**Modified Screens**
![Screenshot 2023-12-16 113640](https://github.com/TEAMMATES/teammates/assets/153512661/a7e0d3e4-149b-48ce-a078-ca437a45e77d)
![Screenshot 2023-12-16 113720](https://github.com/TEAMMATES/teammates/assets/153512661/9613f457-c7a7-48fd-933a-52bf47c47f1e)

- Tested with all screen widths.
- Run all the test cases including  lint cases & passed


