### PR TITLE
[#12665]  Instructor's Student Records Page: Misleading name for canceling of comment edit

### DIFF
--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
@@ -53,4 +53,4 @@
 
 <button type="button" class="btn btn-light btn-sm float-end"
         (click)="triggerCloseCommentBoxEvent()" *ngIf="!shouldHideClosingButton" [disabled]="isDisabled"><i class="fas fa-times"></i>
-  {{ mode === CommentRowMode.EDIT ? 'Discard' : 'Cancel' }}</button>
+  Cancel</button>


### PR DESCRIPTION
Fixes #12665 
This pull request addresses misleading name for canceling of comment edit reported in #12665 .
The changes include changing the button that conditionally displays "Discard" or "Cancel " to only display "Cancel"

