### PR TITLE
[#12671] Remove redundant newline in Development section of Docs 

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,7 +67,6 @@ If you have access to Docker, we have a Docker compose definition to run those s
 
 ```sh
 docker compose up -d
-
 ```
 If the above command does not work, you may not have the updated v2 version of Docker. You may want to try this instead:
 


### PR DESCRIPTION
Remove redundant newline in Development section of Docs #12671
Fixes #12671 

**Outline of Solution**
Updated docs/development.md to remove redundant newline.

