### PR TITLE
[#12654] Instructor Edit Session Page: Bug in Grace Period Tooltip

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -177,8 +177,8 @@
           </div>
           <div class="col-md-4 border-left-gray">
             <div class="row text-center">
-              <div class="ngb-tooltip-class col-12 text-md-start ms-md-2" ngbTooltip="Amount of time the system will continue accepting submissions after the specified deadline.">
-                <label for="grace-period" class="control-label font-bold">
+              <div class="col-12 text-md-start ms-md-2">
+                <label for="grace-period" class="ngb-tooltip-class control-label font-bold" ngbTooltip="Amount of time the system will continue accepting submissions after the specified deadline.">
                   Grace period
                 </label>
               </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1141,12 +1141,12 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                     class="row text-center"
                   >
                     <div
-                      class="ngb-tooltip-class col-12 text-md-start ms-md-2"
-                      ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
+                      class="col-12 text-md-start ms-md-2"
                     >
                       <label
-                        class="control-label font-bold"
+                        class="ngb-tooltip-class control-label font-bold"
                         for="grace-period"
+                        ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
                       >
                          Grace period 
                       </label>
@@ -3825,12 +3825,12 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                     class="row text-center"
                   >
                     <div
-                      class="ngb-tooltip-class col-12 text-md-start ms-md-2"
-                      ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
+                      class="col-12 text-md-start ms-md-2"
                     >
                       <label
-                        class="control-label font-bold"
+                        class="ngb-tooltip-class control-label font-bold"
                         for="grace-period"
+                        ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
                       >
                          Grace period 
                       </label>

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -1078,12 +1078,12 @@ exports[`InstructorSessionsPageComponent should snap when new session form is ex
                       class="row text-center"
                     >
                       <div
-                        class="ngb-tooltip-class col-12 text-md-start ms-md-2"
-                        ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
+                        class="col-12 text-md-start ms-md-2"
                       >
                         <label
-                          class="control-label font-bold"
+                          class="ngb-tooltip-class control-label font-bold"
                           for="grace-period"
+                          ngbtooltip="Amount of time the system will continue accepting submissions after the specified deadline."
                         >
                            Grace period 
                         </label>


### PR DESCRIPTION
Fixes #12654

**Outline of Solution**

* Move the tooltip target from the wrapping div of `Grace period` label to the label itself.
* Apply the class `ngb-tooltip-class` to the label, to apply the underline styling.

![image](https://github.com/TEAMMATES/teammates/assets/87511888/308ffe22-59b0-4f46-9fe2-1c0f55f43a2b)
