### PR TITLE
[#12663] Instructor's Student Records Page: Tooltips for comments 

### DIFF
--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -19,7 +19,7 @@
         <span class="by-response-giver text-secondary" *ngIf="isFeedbackParticipantComment">
           Comment by response giver.
         </span>
-        <span class="text-secondary" *ngIf="!isFeedbackParticipantComment">
+        <ng-container class="text-secondary" *ngIf="!isFeedbackParticipantComment">
           <span class="comment-giver-name">{{ model.commentGiverName ? model.commentGiverName : model.originalComment.commentGiver }} commented at </span>
           <span class="ngb-tooltip-class" style="margin-right: .25rem;" [ngbTooltip]="model.originalComment.createdAt | formatDateDetail: model.timezone!">
             {{ model.originalComment.createdAt | formatDateBrief: model.timezone! }}</span>
@@ -28,7 +28,7 @@
             <span id="last-editor-name" style="margin-right: .25rem;" class="ngb-tooltip-class"
                   [ngbTooltip]="model.originalComment.lastEditedAt | formatDateDetail: model.timezone!">edited by {{ model.lastEditorName ? model.lastEditorName : model.originalComment.lastEditorEmail }}</span>
           </ng-container>
-        </span>
+        </ng-container>
 
         <i class="fa fa-eye" aria-hidden="true" ngbTooltip="This response comment is visible to {{ visibilityStateMachine.getVisibilityTypesUnderVisibilityControl(CommentVisibilityControl.SHOW_COMMENT) | commentVisibilityTypesJointName }}"></i>
 

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -386,19 +386,15 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
                                                 class="col-12"
                                               >
                                                 <span
-                                                  class="text-secondary"
+                                                  class="comment-giver-name"
                                                 >
-                                                  <span
-                                                    class="comment-giver-name"
-                                                  >
-                                                    comment-giver-1 commented at 
-                                                  </span>
-                                                  <span
-                                                    class="ngb-tooltip-class"
-                                                    style="margin-right: .25rem;"
-                                                  >
-                                                     17 Jan 1:09 PM
-                                                  </span>
+                                                  comment-giver-1 commented at 
+                                                </span>
+                                                <span
+                                                  class="ngb-tooltip-class"
+                                                  style="margin-right: .25rem;"
+                                                >
+                                                   17 Jan 1:09 PM
                                                 </span>
                                                 <i
                                                   aria-hidden="true"
@@ -934,19 +930,15 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
                                                 class="col-12"
                                               >
                                                 <span
-                                                  class="text-secondary"
+                                                  class="comment-giver-name"
                                                 >
-                                                  <span
-                                                    class="comment-giver-name"
-                                                  >
-                                                    comment-giver-1 commented at 
-                                                  </span>
-                                                  <span
-                                                    class="ngb-tooltip-class"
-                                                    style="margin-right: .25rem;"
-                                                  >
-                                                     17 Jan 1:09 PM
-                                                  </span>
+                                                  comment-giver-1 commented at 
+                                                </span>
+                                                <span
+                                                  class="ngb-tooltip-class"
+                                                  style="margin-right: .25rem;"
+                                                >
+                                                   17 Jan 1:09 PM
                                                 </span>
                                                 <i
                                                   aria-hidden="true"


### PR DESCRIPTION
Fixes #12663

**Outline of Solution**
The tooltip for comment/edit time causes the rest of the text to go into the next line is because comment/edit time's parent element is a `<span>`. The tooltip window element created when hovering over the comment/edit time will be a a child element of this `<span>`. Changing it to a block element `<ng-container>` fixes the issue.

Alternative:
An alternative is to set `container="body"` so that the tooltip will be attached as a last child of the <body> element ([doc](https://ng-bootstrap.github.io/#/guides/positioning#api)) this makes sure that the tooltip window is outside of the `<span>` element.

**Screenshots:**
<img width="567" alt="Screenshot 2023-12-22 at 10 06 16 PM" src="https://github.com/TEAMMATES/teammates/assets/52706394/dfc38476-46f4-491e-b88e-1e0a6f928b99">
<img width="502" alt="Screenshot 2023-12-22 at 10 06 24 PM" src="https://github.com/TEAMMATES/teammates/assets/52706394/d1d54d43-3cc4-4f62-bdcc-9ab28fa255c1">





