### PR TITLE
[#12653] Copy course modal: Mandatory fields not highlighted

### DIFF
--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.html
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.html
@@ -13,14 +13,22 @@
       </div>
       <div class="form-group">
         <label>Course ID:</label>
-        <input [class.invalid]="newCourseIdIsConflicting" id="copy-course-id" type="text" class="form-control" placeholder="e.g. CS3215-2013Semester1"
-          [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false">
-        <span>{{ COURSE_ID_MAX_LENGTH - newCourseId.length }} characters left</span>
+        <input [class.invalid]="newCourseIdIsConflicting" id="copy-course-id" name="courseId" type="text" class="form-control" placeholder="e.g. CS3215-2013Semester1"
+          #courseId="ngModel" [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false" required>
+          <div [hidden]="courseId.valid || (courseId.pristine && courseId.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course ID should not be empty.
+          </div>
+          <span>{{ COURSE_ID_MAX_LENGTH - newCourseId.length }} characters left</span>
       </div>
       <div class="form-group">
         <label>Course Name:</label>
-        <input id="copy-course-name" class="form-control" type="text" placeholder="e.g. Software Engineering" [(ngModel)]="newCourseName"
-          [maxlength]="COURSE_NAME_MAX_LENGTH"/>
+        <input id="copy-course-name" name="courseName" class="form-control" type="text" placeholder="e.g. Software Engineering" [(ngModel)]="newCourseName"
+          [maxlength]="COURSE_NAME_MAX_LENGTH" #courseName="ngModel" required/>
+          <div [hidden]="courseName.valid || (courseName.pristine && courseName.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course Name should not be empty.
+          </div>
         <span>{{ COURSE_NAME_MAX_LENGTH - newCourseName.length }} characters left</span>
       </div>
       <div class="form-group">

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
@@ -7,3 +7,8 @@ hr.solid-divider {
 .invalid {
   border: red 1px solid;
 }
+
+.invalid-field {
+  padding-top: 5px;
+  color: #B50000;
+}


### PR DESCRIPTION
Fixes #12653  

**Added validations for mandatory fields in copy-course-modal**

1. Display a red warning with an exclamation mark, stating "The field Course Id should not be empty," when the instructor clicks the Course Id field but leaves it empty.
2. Display a red warning with an exclamation mark, stating "The field Course Name should not be empty," when the instructor clicks the Course Name field but leaves it empty.

**screenshots**
 
![Screenshot (18)](https://github.com/TEAMMATES/teammates/assets/78807238/a9dd34d5-0d72-4c67-adf0-c7be06b7110b)

