### PR TITLE
[#12699] Replace ng command in setting-up.md

### DIFF
--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -54,7 +54,7 @@ If you want to develop front-end, you need to install the following:
    ```sh
    npm install -g @angular/cli@14
    ```
-   **Verification:** Run `ng` and you should see a list of available Angular CLI commands.
+   **Verification:** Run `ng --help` and you should see a list of available Angular CLI commands.
 
 ## Step 3: Set up project-specific settings and dependencies
 


### PR DESCRIPTION
## Description: 
Fixes #12699  

## Outline of Solution: 
Replace the command `ng` with `ng --help` in the setting-up.md in the `/docs` directory