### PR TITLE
[#12048] Migrate GetOngoingSessionsAction for V9

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
@@ -112,6 +112,23 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
     }
 
     @Test
+    public void testGetOngoingSessions_typicalCase_shouldGetOnlyOngoingSessionsWithinRange() {
+        FeedbackSession c1Fs2 = typicalDataBundle.feedbackSessions.get("ongoingSession2InCourse1");
+        FeedbackSession c1Fs3 = typicalDataBundle.feedbackSessions.get("ongoingSession3InCourse1");
+        FeedbackSession c3Fs2 = typicalDataBundle.feedbackSessions.get("ongoingSession2InCourse3");
+        Set<FeedbackSession> expectedUniqueOngoingSessions = new HashSet<>();
+        expectedUniqueOngoingSessions.add(c1Fs2);
+        expectedUniqueOngoingSessions.add(c1Fs3);
+        expectedUniqueOngoingSessions.add(c3Fs2);
+        Instant rangeStart = Instant.parse("2012-01-25T22:00:00Z");
+        Instant rangeEnd = Instant.parse("2012-01-27T22:00:00Z");
+        List<FeedbackSession> actualOngoingSessions = fsLogic.getOngoingSessions(rangeStart, rangeEnd);
+        Set<FeedbackSession> actualUniqueOngoingSessions = new HashSet<>();
+        actualUniqueOngoingSessions.addAll(actualOngoingSessions);
+        assertEquals(expectedUniqueOngoingSessions, actualUniqueOngoingSessions);
+    }
+
+    @Test
     public void testGetSoftDeletedFeedbackSessionsForInstructors() {
         Instructor instructor = typicalDataBundle.instructors.get("instructor1OfCourse1");
         Course course = instructor.getCourse();

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackSessionsDbIT.java
@@ -2,6 +2,9 @@ package teammates.it.storage.sqlapi;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.testng.annotations.Test;
 
@@ -40,6 +43,52 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         FeedbackSession actualFs = fsDb.getFeedbackSession(fs2.getName(), fs2.getCourse().getId());
 
         verifyEquals(fs2, actualFs);
+    }
+
+    @Test
+    public void testGetOngoingSessions_typicalCase_shouldGetOnlyOngoingSessionsWithinRange()
+            throws EntityAlreadyExistsException, InvalidParametersException {
+        Instant instantNow = Instant.now();
+        Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
+        coursesDb.createCourse(course1);
+        FeedbackSession c1Fs1 = new FeedbackSession("name1-1", course1, "test1@test.com", "test-instruction",
+                instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofDays(1L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        fsDb.createFeedbackSession(c1Fs1);
+        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", course1, "test2@test.com", "test-instruction",
+                instantNow, instantNow.plus(Duration.ofDays(7L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        fsDb.createFeedbackSession(c1Fs2);
+        Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
+        coursesDb.createCourse(course2);
+        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", course2, "test3@test.com", "test-instruction",
+                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        fsDb.createFeedbackSession(c2Fs1);
+        FeedbackSession c2Fs2 = new FeedbackSession("name2-2", course2, "test3@test.com", "test-instruction",
+                instantNow.plus(Duration.ofDays(1L)), instantNow.plus(Duration.ofDays(7L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        fsDb.createFeedbackSession(c2Fs2);
+        Course course3 = new Course("test-id3", "test-name3", "UTC", "UCL");
+        coursesDb.createCourse(course3);
+        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", course3, "test4@test.com", "test-instruction",
+                instantNow.minus(Duration.ofDays(7L)), instantNow,
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        fsDb.createFeedbackSession(c3Fs1);
+        Set<FeedbackSession> expectedUniqueOngoingSessions = new HashSet<>();
+        expectedUniqueOngoingSessions.add(c1Fs2);
+        expectedUniqueOngoingSessions.add(c2Fs1);
+        expectedUniqueOngoingSessions.add(c3Fs1);
+        List<FeedbackSession> actualOngoingSessions =
+                fsDb.getOngoingSessions(instantNow.minus(Duration.ofDays(1L)), instantNow.plus(Duration.ofDays(1L)));
+        Set<FeedbackSession> actualUniqueOngoingSessions = new HashSet<>();
+        actualUniqueOngoingSessions.addAll(actualOngoingSessions);
+        assertEquals(expectedUniqueOngoingSessions, actualUniqueOngoingSessions);
     }
 
     @Test

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -455,6 +455,116 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false
+    },
+    "ongoingSession1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000704",
+      "course": {
+        "id": "course-1"
+      },
+      "name": "Ongoing session 1 in course 1",
+      "creatorEmail": "instr1@teammates.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-01-19T22:00:00Z",
+      "endTime": "2012-01-25T22:00:00Z",
+      "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
+      "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": true,
+      "isClosedEmailSent": true,
+      "isPublishedEmailSent": true
+    },
+    "ongoingSession2InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000705",
+      "course": {
+        "id": "course-1"
+      },
+      "name": "Ongoing session 2 in course 1",
+      "creatorEmail": "instr1@teammates.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-01-26T22:00:00Z",
+      "endTime": "2012-02-02T22:00:00Z",
+      "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
+      "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": true,
+      "isClosedEmailSent": true,
+      "isPublishedEmailSent": true
+    },
+    "ongoingSession3InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000706",
+      "course": {
+        "id": "course-1"
+      },
+      "name": "Ongoing session 3 in course 1",
+      "creatorEmail": "instr1@teammates.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-01-26T10:00:00Z",
+      "endTime": "2012-01-27T10:00:00Z",
+      "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
+      "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": true,
+      "isClosedEmailSent": true,
+      "isPublishedEmailSent": true
+    },
+    "ongoingSession1InCourse3": {
+      "id": "00000000-0000-4000-8000-000000000707",
+      "course": {
+        "id": "course-3"
+      },
+      "name": "Ongoing session 1 in course 3",
+      "creatorEmail": "instr1@teammates.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-01-27T22:00:00Z",
+      "endTime": "2012-02-02T22:00:00Z",
+      "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
+      "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": true,
+      "isClosedEmailSent": true,
+      "isPublishedEmailSent": true
+    },
+    "ongoingSession2InCourse3": {
+      "id": "00000000-0000-4000-8000-000000000707",
+      "course": {
+        "id": "course-3"
+      },
+      "name": "Ongoing session 2 in course 3",
+      "creatorEmail": "instr1@teammates.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-01-19T22:00:00Z",
+      "endTime": "2012-01-26T22:00:00Z",
+      "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
+      "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": true,
+      "isOpenEmailSent": true,
+      "isClosingSoonEmailSent": true,
+      "isClosedEmailSent": true,
+      "isPublishedEmailSent": true
     }
   },
   "feedbackQuestions": {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -408,6 +408,13 @@ public class Logic {
     }
 
     /**
+     * Gets all and only the feedback sessions ongoing within a range of time.
+     */
+    public List<FeedbackSession> getOngoingSessions(Instant rangeStart, Instant rangeEnd) {
+        return feedbackSessionsLogic.getOngoingSessions(rangeStart, rangeEnd);
+    }
+
+    /**
      * Gets a set of giver identifiers that has at least one response under a feedback session.
      */
     public Set<String> getGiverSetThatAnsweredFeedbackSession(String feedbackSessionName, String courseId) {

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -149,6 +149,13 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
+     * Gets all and only the feedback sessions ongoing within a range of time.
+     */
+    public List<FeedbackSession> getOngoingSessions(Instant rangeStart, Instant rangeEnd) {
+        return fsDb.getOngoingSessions(rangeStart, rangeEnd);
+    }
+
+    /**
      * Gets a set of giver identifiers that has at least one response under a feedback session.
      */
     public Set<String> getGiverSetThatAnsweredFeedbackSession(String feedbackSessionName, String courseId) {

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -97,6 +97,22 @@ public final class FeedbackSessionsDb extends EntitiesDb {
     }
 
     /**
+     * Gets all and only the feedback sessions ongoing within a range of time.
+     */
+    public List<FeedbackSession> getOngoingSessions(Instant rangeStart, Instant rangeEnd) {
+        assert rangeStart != null;
+        assert rangeEnd != null;
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
+        Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        cr.select(root)
+                .where(cb.and(
+                    cb.greaterThan(root.get("endTime"), rangeStart),
+                    cb.lessThan(root.get("startTime"), rangeEnd)));
+        return HibernateUtil.createQuery(cr).getResultList();
+    }
+
+    /**
      * Restores a specific soft deleted feedback session.
      */
     public void restoreDeletedFeedbackSession(String feedbackSessionName, String courseId)

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -473,6 +473,13 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
+     * Checks if the feedback session has not opened yet.
+     */
+    public boolean isWaitingToOpen() {
+        return Instant.now().isBefore(startTime);
+    }
+
+    /**
      * Checks if the feedback session is opened given the extendedDeadline and grace period.
      */
     public boolean isOpenedGivenExtendedDeadline(Instant extendedDeadline) {

--- a/src/main/java/teammates/ui/output/OngoingSession.java
+++ b/src/main/java/teammates/ui/output/OngoingSession.java
@@ -3,7 +3,6 @@ package teammates.ui.output;
 import java.util.ArrayList;
 import java.util.List;
 
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -22,13 +21,13 @@ public class OngoingSession {
     private final String courseId;
     private final String feedbackSessionName;
 
-    public OngoingSession(FeedbackSessionAttributes fs, AccountAttributes account) {
+    public OngoingSession(FeedbackSessionAttributes fs, String googleId) {
         this.sessionStatus = getSessionStatusForShow(fs);
 
         String instructorHomePageLink = "";
-        if (account != null) {
+        if (googleId != null) {
             instructorHomePageLink = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
-                    .withUserId(account.getGoogleId())
+                    .withUserId(googleId)
                     .toString();
         }
         this.instructorHomePageLink = instructorHomePageLink;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -81,6 +81,13 @@ public abstract class Action {
     /**
      * Inject logic class for use in tests.
      */
+    public void setLogic(teammates.logic.api.Logic logic) {
+        this.logic = logic;
+    }
+
+    /**
+     * Inject logic class for use in tests.
+     */
     public void setLogic(Logic logic) {
         this.sqlLogic = logic;
         // TODO: remove these temporary hacks after migration

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -21,6 +21,10 @@ import teammates.ui.output.OngoingSessionsData;
  */
 class GetOngoingSessionsAction extends AdminOnlyAction {
 
+    private static final String INVALID_START_TIME = "Invalid start time.";
+    private static final String INVALID_END_TIME = "Invalid end time.";
+    private static final String INVALID_RANGE = "The filter range is not valid. End time should be after start time.";
+
     @Override
     public JsonResult execute() {
         String startTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME);
@@ -28,13 +32,13 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         try {
             startTime = Long.parseLong(startTimeString);
         } catch (NumberFormatException e) {
-            throw new InvalidHttpParameterException("Invalid startTime parameter", e);
+            throw new InvalidHttpParameterException(INVALID_START_TIME, e);
         }
         try {
             // test for bounds
             Instant.ofEpochMilli(startTime).minus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
         } catch (ArithmeticException e) {
-            throw new InvalidHttpParameterException("Invalid startTime parameter", e);
+            throw new InvalidHttpParameterException(INVALID_START_TIME, e);
         }
 
         String endTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME);
@@ -42,17 +46,17 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         try {
             endTime = Long.parseLong(endTimeString);
         } catch (NumberFormatException e) {
-            throw new InvalidHttpParameterException("Invalid endTime parameter", e);
+            throw new InvalidHttpParameterException(INVALID_END_TIME, e);
         }
         try {
             // test for bounds
             Instant.ofEpochMilli(endTime).plus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
         } catch (ArithmeticException e) {
-            throw new InvalidHttpParameterException("Invalid endTime parameter", e);
+            throw new InvalidHttpParameterException(INVALID_END_TIME, e);
         }
 
         if (startTime > endTime) {
-            throw new InvalidHttpParameterException("The filter range is not valid. End time should be after start time.");
+            throw new InvalidHttpParameterException(INVALID_RANGE);
         }
 
         List<FeedbackSessionAttributes> allOngoingSessions =

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -33,12 +33,8 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
 
         List<FeedbackSessionAttributes> allOngoingSessions =
                 logic.getAllOngoingSessions(Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime));
-        Map<String, List<FeedbackSessionAttributes>> courseIdToFeedbackSessionsMap = new HashMap<>();
-        for (FeedbackSessionAttributes fs : allOngoingSessions) {
-            String courseId = fs.getCourseId();
-            courseIdToFeedbackSessionsMap.computeIfAbsent(courseId, k -> new ArrayList<>()).add(fs);
-        }
-
+        Map<String, List<FeedbackSessionAttributes>> courseIdToFeedbackSessionsMap =
+                createCourseIdToFeedbackSessionsMap(allOngoingSessions);
         Map<String, List<OngoingSession>> instituteToFeedbackSessionsMap = new HashMap<>();
         for (var courseIdFeedbackSessionList : courseIdToFeedbackSessionsMap.entrySet()) {
             String courseId = courseIdFeedbackSessionList.getKey();
@@ -92,6 +88,16 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         if (startTime > endTime) {
             throw new InvalidHttpParameterException(INVALID_RANGE);
         }
+    }
+
+    private Map<String, List<FeedbackSessionAttributes>> createCourseIdToFeedbackSessionsMap(
+            List<FeedbackSessionAttributes> allOngoingSessions) {
+        Map<String, List<FeedbackSessionAttributes>> courseIdToFeedbackSessionsMap = new HashMap<>();
+        for (FeedbackSessionAttributes fs : allOngoingSessions) {
+            String courseId = fs.getCourseId();
+            courseIdToFeedbackSessionsMap.computeIfAbsent(courseId, k -> new ArrayList<>()).add(fs);
+        }
+        return courseIdToFeedbackSessionsMap;
     }
 
     private OngoingSessionsData createOutput(List<FeedbackSessionAttributes> allOngoingSessions,

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -3,10 +3,8 @@ package teammates.ui.webapi;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -41,7 +39,6 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         int totalClosedSessions = 0;
         int totalAwaitingSessions = 0;
 
-        Set<String> courseIds = new HashSet<>();
         Map<String, List<FeedbackSessionAttributes>> courseIdToFeedbackSessionsMap = new HashMap<>();
         for (FeedbackSessionAttributes fs : allOngoingSessions) {
             if (fs.isOpened()) {
@@ -55,17 +52,18 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
             }
 
             String courseId = fs.getCourseId();
-            courseIds.add(courseId);
             courseIdToFeedbackSessionsMap.computeIfAbsent(courseId, k -> new ArrayList<>()).add(fs);
         }
 
         Map<String, List<OngoingSession>> instituteToFeedbackSessionsMap = new HashMap<>();
-        for (String courseId : courseIds) {
+        for (var courseIdFeedbackSessionList : courseIdToFeedbackSessionsMap.entrySet()) {
+            String courseId = courseIdFeedbackSessionList.getKey();
+            List<FeedbackSessionAttributes> feedbackSessions = courseIdFeedbackSessionList.getValue();
             List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
             AccountAttributes account = getRegisteredInstructorAccountFromInstructors(instructors);
 
             String institute = logic.getCourseInstitute(courseId);
-            List<OngoingSession> sessions = courseIdToFeedbackSessionsMap.get(courseId).stream()
+            List<OngoingSession> sessions = feedbackSessions.stream()
                     .map(session -> new OngoingSession(session, account))
                     .collect(Collectors.toList());
 

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -29,25 +29,9 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
     public JsonResult execute() {
         String startTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME);
         long startTime = parseTimeStringIfValid(startTimeString, INVALID_START_TIME);
-        try {
-            // test for bounds
-            Instant.ofEpochMilli(startTime).minus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
-        } catch (ArithmeticException e) {
-            throw new InvalidHttpParameterException(INVALID_START_TIME, e);
-        }
-
         String endTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME);
         long endTime = parseTimeStringIfValid(endTimeString, INVALID_END_TIME);
-        try {
-            // test for bounds
-            Instant.ofEpochMilli(endTime).plus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
-        } catch (ArithmeticException e) {
-            throw new InvalidHttpParameterException(INVALID_END_TIME, e);
-        }
-
-        if (startTime > endTime) {
-            throw new InvalidHttpParameterException(INVALID_RANGE);
-        }
+        validateTimeParameters(startTime, endTime);
 
         List<FeedbackSessionAttributes> allOngoingSessions =
                 logic.getAllOngoingSessions(Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime));
@@ -120,5 +104,23 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
             throw new InvalidHttpParameterException(exceptionMessageIfInvalid, e);
         }
         return time;
+    }
+
+    private void validateTimeParameters(long startTime, long endTime) {
+        try {
+            // test for bounds
+            Instant.ofEpochMilli(startTime).minus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
+        } catch (ArithmeticException e) {
+            throw new InvalidHttpParameterException(INVALID_START_TIME, e);
+        }
+        try {
+            // test for bounds
+            Instant.ofEpochMilli(endTime).plus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
+        } catch (ArithmeticException e) {
+            throw new InvalidHttpParameterException(INVALID_END_TIME, e);
+        }
+        if (startTime > endTime) {
+            throw new InvalidHttpParameterException(INVALID_RANGE);
+        }
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -28,12 +28,7 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
     @Override
     public JsonResult execute() {
         String startTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME);
-        long startTime;
-        try {
-            startTime = Long.parseLong(startTimeString);
-        } catch (NumberFormatException e) {
-            throw new InvalidHttpParameterException(INVALID_START_TIME, e);
-        }
+        long startTime = parseTimeStringIfValid(startTimeString, INVALID_START_TIME);
         try {
             // test for bounds
             Instant.ofEpochMilli(startTime).minus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
@@ -42,12 +37,7 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         }
 
         String endTimeString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME);
-        long endTime;
-        try {
-            endTime = Long.parseLong(endTimeString);
-        } catch (NumberFormatException e) {
-            throw new InvalidHttpParameterException(INVALID_END_TIME, e);
-        }
+        long endTime = parseTimeStringIfValid(endTimeString, INVALID_END_TIME);
         try {
             // test for bounds
             Instant.ofEpochMilli(endTime).plus(Const.FEEDBACK_SESSIONS_SEARCH_WINDOW).toEpochMilli();
@@ -120,5 +110,15 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
             }
         }
         return null;
+    }
+
+    private long parseTimeStringIfValid(String timeString, String exceptionMessageIfInvalid) {
+        long time;
+        try {
+            time = Long.parseLong(timeString);
+        } catch (NumberFormatException e) {
+            throw new InvalidHttpParameterException(exceptionMessageIfInvalid, e);
+        }
+        return time;
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -49,8 +49,8 @@ public class GetOngoingSessionsAction extends AdminOnlyAction {
             instituteToFeedbackSessionsMap.computeIfAbsent(sqlInstitute, k -> new ArrayList<>())
                     .addAll(sqlFeedbackSessions);
         }
-        OngoingSessionsData output =
-                createOutput(ongoingSqlSessions, allOngoingSessions, instituteToFeedbackSessionsMap);
+        OngoingSessionsData output = createOutput(courseIdToFeedbackSessionsSqlMap, courseIdToFeedbackSessionsMap,
+                instituteToFeedbackSessionsMap);
         return new JsonResult(output);
     }
 
@@ -145,33 +145,39 @@ public class GetOngoingSessionsAction extends AdminOnlyAction {
         return instituteToFeedbackSessionsMap;
     }
 
-    private OngoingSessionsData createOutput(List<FeedbackSession> ongoingSqlSessions,
-            List<FeedbackSessionAttributes> allOngoingSessions,
+    private OngoingSessionsData createOutput(Map<String, List<FeedbackSession>> courseIdToFeedbackSessionsSqlMap,
+            Map<String, List<FeedbackSessionAttributes>> courseIdToFeedbackSessionsMap,
             Map<String, List<OngoingSession>> instituteToFeedbackSessionsMap) {
-        int totalOngoingSessions = ongoingSqlSessions.size() + allOngoingSessions.size();
+        int totalOngoingSessions = 0;
         int totalOpenSessions = 0;
         int totalClosedSessions = 0;
         int totalAwaitingSessions = 0;
-        for (FeedbackSession fs : ongoingSqlSessions) {
-            if (fs.isOpened()) {
-                totalOpenSessions++;
-            }
-            if (fs.isClosed()) {
-                totalClosedSessions++;
-            }
-            if (fs.isWaitingToOpen()) {
-                totalAwaitingSessions++;
+        for (List<FeedbackSession> feedbackSessions : courseIdToFeedbackSessionsSqlMap.values()) {
+            totalOngoingSessions += feedbackSessions.size();
+            for (FeedbackSession fs : feedbackSessions) {
+                if (fs.isOpened()) {
+                    totalOpenSessions++;
+                }
+                if (fs.isClosed()) {
+                    totalClosedSessions++;
+                }
+                if (fs.isWaitingToOpen()) {
+                    totalAwaitingSessions++;
+                }
             }
         }
-        for (FeedbackSessionAttributes fs : allOngoingSessions) {
-            if (fs.isOpened()) {
-                totalOpenSessions++;
-            }
-            if (fs.isClosed()) {
-                totalClosedSessions++;
-            }
-            if (fs.isWaitingToOpen()) {
-                totalAwaitingSessions++;
+        for (List<FeedbackSessionAttributes> feedbackSessions : courseIdToFeedbackSessionsMap.values()) {
+            totalOngoingSessions += feedbackSessions.size();
+            for (FeedbackSessionAttributes fs : feedbackSessions) {
+                if (fs.isOpened()) {
+                    totalOpenSessions++;
+                }
+                if (fs.isClosed()) {
+                    totalClosedSessions++;
+                }
+                if (fs.isWaitingToOpen()) {
+                    totalAwaitingSessions++;
+                }
             }
         }
         long totalInstitutes = instituteToFeedbackSessionsMap.keySet().stream()

--- a/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOngoingSessionsAction.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
@@ -41,10 +40,10 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
         return new JsonResult(output);
     }
 
-    private AccountAttributes getRegisteredInstructorAccountFromInstructors(List<InstructorAttributes> instructors) {
+    private String getRegisteredInstructorGoogleIdFromInstructors(List<InstructorAttributes> instructors) {
         for (InstructorAttributes instructor : instructors) {
             if (instructor.isRegistered()) {
-                return logic.getAccount(instructor.getGoogleId());
+                return instructor.getGoogleId();
             }
         }
         return null;
@@ -95,11 +94,11 @@ class GetOngoingSessionsAction extends AdminOnlyAction {
             String courseId = courseIdFeedbackSessionList.getKey();
             List<FeedbackSessionAttributes> feedbackSessions = courseIdFeedbackSessionList.getValue();
             List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
-            AccountAttributes account = getRegisteredInstructorAccountFromInstructors(instructors);
+            String googleId = getRegisteredInstructorGoogleIdFromInstructors(instructors);
 
             String institute = logic.getCourseInstitute(courseId);
             List<OngoingSession> sessions = feedbackSessions.stream()
-                    .map(session -> new OngoingSession(session, account))
+                    .map(session -> new OngoingSession(session, googleId))
                     .collect(Collectors.toList());
 
             instituteToFeedbackSessionsMap.computeIfAbsent(institute, k -> new ArrayList<>()).addAll(sessions);

--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -56,6 +56,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     static final String DELETE = HttpDelete.METHOD_NAME;
 
     Logic mockLogic = mock(Logic.class);
+    teammates.logic.api.Logic mockDatastoreLogic = mock(teammates.logic.api.Logic.class);
     MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();
     MockEmailSender mockEmailSender = new MockEmailSender();
     MockLogsProcessor mockLogsProcessor = new MockLogsProcessor();
@@ -103,6 +104,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             @SuppressWarnings("unchecked")
             T action = (T) ActionFactory.getAction(req, getRequestMethod());
             action.setLogic(mockLogic);
+            action.setLogic(mockDatastoreLogic);
             action.setTaskQueuer(mockTaskQueuer);
             action.setEmailSender(mockEmailSender);
             action.setLogsProcessor(mockLogsProcessor);

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -146,7 +146,13 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
 
     @Test
     void testExecute_typicalCase_shouldGetOngoingSessionsDataCorrectly() {
+        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
+        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
+        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
+        // mocking a time that is off by an amount of time less than a millisecond.
         Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        Instant end = instantNow.plus(Duration.ofDays(1L));
         Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
         when(mockLogic.getCourse(course1.getId())).thenReturn(course1);
         Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
@@ -183,8 +189,6 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                 instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofHours(12L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true, true);
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        Instant end = instantNow.plus(Duration.ofDays(1L));
         List<FeedbackSession> ongoingSqlSessions = new ArrayList<>();
         ongoingSqlSessions.add(c1Fs2);
         ongoingSqlSessions.add(c2Fs1);
@@ -205,7 +209,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         JsonResult r = getJsonResult(getOngoingSessionsAction);
         OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
 
-        assertEquals(ongoingSqlSessions.size(), response.getTotalOngoingSessions());
+        assertEquals(3, response.getTotalOngoingSessions());
         assertEquals(1, response.getTotalOpenSessions());
         assertEquals(1, response.getTotalClosedSessions());
         assertEquals(1, response.getTotalAwaitingSessions());
@@ -223,6 +227,10 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
 
     @Test
     void testExecute_ongoingSessionsInBothDatastoreAndSql_shouldGetOngoingSessionsDataCorrectly() {
+        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
+        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
+        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
+        // mocking a time that is off by an amount of time less than a millisecond.
         Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         Instant start = instantNow.minus(Duration.ofDays(1L));
         Instant end = instantNow.plus(Duration.ofDays(1L));

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -327,11 +327,9 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         Instant end = instantNow.plus(Duration.ofDays(1L));
         Course sqlCourse2 = new Course("test-id2", "test-name2", "UTC", "MIT");
         when(mockLogic.getCourse(sqlCourse2.getId())).thenReturn(sqlCourse2);
-        // Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
         Instructor sqlInstructor3 = new Instructor(sqlCourse2, "instructor3", "test3@test.com", false, "instructor3",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
-        // instructor3.setAccount(instructor3Account);
         when(mockLogic.getInstructorsByCourse(sqlCourse2.getId())).thenReturn(Collections.singletonList(sqlInstructor3));
         FeedbackSession sqlC2Fs1 = new FeedbackSession("name2-1", sqlCourse2, "test3@test.com", "test-instruction",
                 instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -160,13 +160,13 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         instructor2.setAccount(instructor2Account);
         when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
         Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
-        Instructor instructor3 = new Instructor(course1, "instructor3", "test3@test.com", false, "instructor3",
+        Instructor instructor3 = new Instructor(course2, "instructor3", "test3@test.com", false, "instructor3",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor3.setAccount(instructor3Account);
         when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
         Account instructor4Account = new Account("instructor4", "instructor4", "test4@test.com");
-        Instructor instructor4 = new Instructor(course1, "instructor4", "test4@test.com", false, "instructor4",
+        Instructor instructor4 = new Instructor(course3, "instructor4", "test4@test.com", false, "instructor4",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor4.setAccount(instructor4Account);

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
@@ -311,6 +312,71 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
         OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getGoogleId());
         expectedSessions.put("UCL", Collections.singletonList(expectedOngoingC3Fs1));
+        Map<String, List<OngoingSession>> actualSessions = response.getSessions();
+        assertEqualSessions(expectedSessions, actualSessions);
+    }
+
+    @Test
+    void testExecute_courseMigratedButAccountNotMigrated_shouldGetOngoingSessionsDataCorrectly() {
+        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
+        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
+        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
+        // mocking a time that is off by an amount of time less than a millisecond.
+        Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        Instant end = instantNow.plus(Duration.ofDays(1L));
+        Course sqlCourse2 = new Course("test-id2", "test-name2", "UTC", "MIT");
+        when(mockLogic.getCourse(sqlCourse2.getId())).thenReturn(sqlCourse2);
+        // Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
+        Instructor sqlInstructor3 = new Instructor(sqlCourse2, "instructor3", "test3@test.com", false, "instructor3",
+                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
+        // instructor3.setAccount(instructor3Account);
+        when(mockLogic.getInstructorsByCourse(sqlCourse2.getId())).thenReturn(Collections.singletonList(sqlInstructor3));
+        FeedbackSession sqlC2Fs1 = new FeedbackSession("name2-1", sqlCourse2, "test3@test.com", "test-instruction",
+                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        List<FeedbackSession> ongoingSqlSessions = Collections.singletonList(sqlC2Fs1);
+        when(mockLogic.getOngoingSessions(start, end)).thenReturn(ongoingSqlSessions);
+        CourseAttributes course2 = CourseAttributes.builder("test-id2")
+                .build();
+        when(mockDatastoreLogic.getCourse("test-id2")).thenReturn(course2);
+        InstructorAttributes instructor3 = InstructorAttributes.builder("test-id2", "test3@test.com")
+                .withGoogleId("instructor3")
+                .build();
+        when(mockDatastoreLogic.getInstructorsForCourse("test-id2")).thenReturn(Collections.singletonList(instructor3));
+        FeedbackSessionAttributes c2Fs1 = FeedbackSessionAttributes.builder("name2-1", "test-id2")
+                .withCreatorEmail("test3@test.com")
+                .withStartTime(instantNow.minus(Duration.ofHours(12L)))
+                .withEndTime(instantNow.plus(Duration.ofHours(12L)))
+                .withSessionVisibleFromTime(instantNow.minus(Duration.ofDays(7L)))
+                .withResultsVisibleFromTime(instantNow.plus(Duration.ofDays(7L)))
+                .build();
+        List<FeedbackSessionAttributes> allOngoingSessions = Collections.singletonList(c2Fs1);
+        when(mockDatastoreLogic.getAllOngoingSessions(start, end)).thenReturn(allOngoingSessions);
+
+        long startTime = start.toEpochMilli();
+        long endTime = end.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+
+        GetOngoingSessionsAction getOngoingSessionsAction = getAction(params);
+        JsonResult r = getJsonResult(getOngoingSessionsAction);
+        OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
+
+        assertEquals(1, response.getTotalOngoingSessions());
+        assertEquals(1, response.getTotalOpenSessions());
+        assertEquals(0, response.getTotalClosedSessions());
+        assertEquals(0, response.getTotalAwaitingSessions());
+        assertEquals(1L, response.getTotalInstitutes());
+        Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
+        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(sqlC2Fs1, instructor3.getGoogleId());
+        expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
         Map<String, List<OngoingSession>> actualSessions = response.getSessions();
         assertEqualSessions(expectedSessions, actualSessions);
     }

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -1,0 +1,255 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPermissionRole;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.common.util.Const.InstructorPermissionRoleNames;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
+import teammates.ui.output.OngoingSession;
+import teammates.ui.output.OngoingSessionsData;
+import teammates.ui.webapi.GetOngoingSessionsAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link GetOngoingSessionsAction}.
+ */
+public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessionsAction> {
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.SESSIONS_ONGOING;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    void testExecute_noParameters_shouldThrowInvalidHttpParameterException() {
+        verifyHttpParameterFailure();
+    }
+
+    @Test
+    void testExecute_noStartTimeParameter_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant end = instantNow.plus(Duration.ofDays(1L));
+        long endTime = end.toEpochMilli();
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_noEndTimeParameter_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        long startTime = start.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_nonLongStartTimeParameter_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant end = instantNow.plus(Duration.ofDays(1L));
+        long endTime = end.toEpochMilli();
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, "not_a_long",
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_nonLongEndTimeParameter_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        long startTime = start.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, "not_a_long",
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_startTimeParameterBelowMinimum_shouldThrowInvalidHttpParameterException() {
+        long minStartTime = Long.MIN_VALUE + 30L * 24L * 60L * 60L * 1000L;
+        long belowMinStartTime = minStartTime - 1L;
+        String belowMinStartTimeString = String.valueOf(belowMinStartTime);
+        Instant instantNow = Instant.now();
+        Instant end = instantNow.plus(Duration.ofDays(1L));
+        long endTime = end.toEpochMilli();
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, belowMinStartTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_endTimeParameterAboveMaximum_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        long startTime = start.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        long maxEndTime = Long.MAX_VALUE - 30L * 24L * 60L * 60L * 1000L;
+        long aboveMaxEndTime = maxEndTime + 1L;
+        String aboveMaxEndTimeString = String.valueOf(aboveMaxEndTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, aboveMaxEndTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_endTimeBeforeStartTime_shouldThrowInvalidHttpParameterException() {
+        Instant instantNow = Instant.now();
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        long startTime = start.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        long endTime = startTime - 1;
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_typicalCase_shouldGetOngoingSessionsDataCorrectly() {
+        Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
+        when(mockLogic.getCourse(course1.getId())).thenReturn(course1);
+        Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
+        when(mockLogic.getCourse(course2.getId())).thenReturn(course2);
+        Course course3 = new Course("test-id3", "test-name3", "UTC", "UCL");
+        when(mockLogic.getCourse(course3.getId())).thenReturn(course3);
+        Account instructor2Account = new Account("instructor2", "instructor2", "test2@test.com");
+        Instructor instructor2 = new Instructor(course1, "instructor2", "test2@test.com", false, "instructor2",
+                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
+        instructor2.setAccount(instructor2Account);
+        when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
+        Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
+        Instructor instructor3 = new Instructor(course1, "instructor3", "test3@test.com", false, "instructor3",
+                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
+        instructor3.setAccount(instructor3Account);
+        when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
+        Account instructor4Account = new Account("instructor4", "instructor4", "test4@test.com");
+        Instructor instructor4 = new Instructor(course1, "instructor4", "test4@test.com", false, "instructor4",
+                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
+        instructor4.setAccount(instructor4Account);
+        when(mockLogic.getInstructorsByCourse(course3.getId())).thenReturn(Collections.singletonList(instructor4));
+        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", course1, "test2@test.com", "test-instruction",
+                instantNow.plus(Duration.ofHours(12L)), instantNow.plus(Duration.ofDays(7L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", course2, "test3@test.com", "test-instruction",
+                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", course3, "test4@test.com", "test-instruction",
+                instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofHours(12L)),
+                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                true, true, true);
+        Instant start = instantNow.minus(Duration.ofDays(1L));
+        Instant end = instantNow.plus(Duration.ofDays(1L));
+        List<FeedbackSession> ongoingSqlSessions = new ArrayList<>();
+        ongoingSqlSessions.add(c1Fs2);
+        ongoingSqlSessions.add(c2Fs1);
+        ongoingSqlSessions.add(c3Fs1);
+        when(mockLogic.getOngoingSessions(start, end)).thenReturn(ongoingSqlSessions);
+        when(mockDatastoreLogic.getAllOngoingSessions(start, end)).thenReturn(Collections.emptyList());
+
+        long startTime = start.toEpochMilli();
+        long endTime = end.toEpochMilli();
+        String startTimeString = String.valueOf(startTime);
+        String endTimeString = String.valueOf(endTime);
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+        };
+
+        GetOngoingSessionsAction getOngoingSessionsAction = getAction(params);
+        JsonResult r = getJsonResult(getOngoingSessionsAction);
+        OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
+
+        assertEquals(ongoingSqlSessions.size(), response.getTotalOngoingSessions());
+        assertEquals(1, response.getTotalOpenSessions());
+        assertEquals(1, response.getTotalClosedSessions());
+        assertEquals(1, response.getTotalAwaitingSessions());
+        assertEquals(3L, response.getTotalInstitutes());
+        Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
+        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(c1Fs2, instructor2.getGoogleId());
+        expectedSessions.put("NUS", Collections.singletonList(expectedOngoingC1Fs2));
+        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(c2Fs1, instructor3.getGoogleId());
+        expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
+        OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getGoogleId());
+        expectedSessions.put("UCL", Collections.singletonList(expectedOngoingC3Fs1));
+        Map<String, List<OngoingSession>> actualSessions = response.getSessions();
+        assertEqualSessions(expectedSessions, actualSessions);
+    }
+
+    private void assertEqualSessions(
+            Map<String, List<OngoingSession>> expectedSessions, Map<String, List<OngoingSession>> actualSessions) {
+        assertEquals(expectedSessions.keySet(), actualSessions.keySet());
+        for (Map.Entry<String, List<OngoingSession>> expectedInstituteSessionList : expectedSessions.entrySet()) {
+            String institute = expectedInstituteSessionList.getKey();
+            List<OngoingSession> expectedInstituteSessions = expectedInstituteSessionList.getValue();
+            List<OngoingSession> actualInstituteSessions = actualSessions.get(institute);
+            assertEqualInstituteSessions(expectedInstituteSessions, actualInstituteSessions);
+        }
+    }
+
+    private void assertEqualInstituteSessions(
+            List<OngoingSession> expectedInstituteSessions, List<OngoingSession> actualInstituteSessions) {
+        int expectedSize = expectedInstituteSessions.size();
+        assertEquals(expectedSize, actualInstituteSessions.size());
+        for (int i = 0; i < expectedSize; i++) {
+            OngoingSession expectedOngoingSession = expectedInstituteSessions.get(i);
+            OngoingSession actualOngoingSession = actualInstituteSessions.get(i);
+            assertEqualOngoingSessions(expectedOngoingSession, actualOngoingSession);
+        }
+    }
+
+    private void assertEqualOngoingSessions(OngoingSession expectedOngoingSession,
+            OngoingSession actualOngoingSession) {
+        assertEquals(expectedOngoingSession.getSessionStatus(), actualOngoingSession.getSessionStatus());
+        assertEquals(expectedOngoingSession.getInstructorHomePageLink(),
+                actualOngoingSession.getInstructorHomePageLink());
+        assertEquals(expectedOngoingSession.getStartTime(), actualOngoingSession.getStartTime());
+        assertEquals(expectedOngoingSession.getEndTime(), actualOngoingSession.getEndTime());
+        assertEquals(expectedOngoingSession.getCreatorEmail(), actualOngoingSession.getCreatorEmail());
+        assertEquals(expectedOngoingSession.getCourseId(), actualOngoingSession.getCourseId());
+        assertEquals(expectedOngoingSession.getFeedbackSessionName(), actualOngoingSession.getFeedbackSessionName());
+    }
+}


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

The code was first refactored to make it easier to migrate, and improve readability. This is until the [commit with the message "Remove dependency on account in ongoing session"](https://github.com/TEAMMATES/teammates/commit/f34d1199b68f7b3778fa4cd5823a90afecdf2631). The commits from the [commit with the message "Add method to get ongoing feedback sessions"](https://github.com/TEAMMATES/teammates/commit/66fb6c7a4d609b3aad24937b120159230ad422d0) onwards were for the main migration work.

The main migration work involved adding methods to get ongoing feedback sessions in the SQL logic and SQL storage classes so that they can be called by the action to get ongoing feedback sessions. A mock datastore logic class instance was injected into actions during testing. A minor method to check whether a feedback session is waiting to open was added. A constructor of the ongoing session output data class that accepts the SQL feedback session entity was also added. Finally, the action was updated for migration to SQL.

During the migration, there may be ongoing feedback sessions from both courses that are migrated and courses that are not yet migrated. This means that we need to get ongoing feedback sessions from both the SQL database and the Datastore database. Besides that, we also need the Google IDs of registered instructors for each ongoing session. However, these Google IDs are only available from accounts, which may not be migrated to SQL even if the feedback session was migrated. This means that for migrated feedback sessions, we must query for Google IDs in the SQL database, and if they are not found, we must query for them in the Datastore database.