### PR TITLE
[#12048] Migrate Session Links Recovery Action

### DIFF
--- a/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
@@ -1,8 +1,6 @@
 package teammates.it.sqllogic.api;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.testng.annotations.BeforeClass;
@@ -11,7 +9,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
@@ -75,10 +72,10 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testGenerateSessionLinksRecoveryEmail() throws Exception {
-        
+
         // To remove after migrating to postgres
         String nonExistentStudent = null;
-        Map<CourseAttributes, StringBuilder> emptyFragmentList = new HashMap<CourseAttributes, StringBuilder>();
+        Map<CourseAttributes, StringBuilder> emptyFragmentList = new HashMap<>();
         ______TS("invalid email address");
 
         EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(

--- a/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
@@ -120,7 +120,6 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         verifyEmail(email, student1InCourse4.getEmail(), subject,
                 "/sessionLinksRecoveryOpenedOrClosedAndpublishedSessions.html");
 
-        ______TS("Migration test: students from both postgres and datastore are fetched");
     }
 
     private void verifyEmail(EmailWrapper email, String recipient, String subject, String emailContentFilePath)

--- a/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
@@ -1,10 +1,14 @@
 package teammates.it.sqllogic.api;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
@@ -69,10 +73,11 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
     @Test
     public void testGenerateSessionLinksRecoveryEmail() throws Exception {
 
+        List<StudentAttributes> emptyList = new ArrayList<StudentAttributes>();
         ______TS("invalid email address");
 
         EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                "non-existing-student");
+                "non-existing-student", emptyList);
         String subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, "non-existing-student", subject,
@@ -83,7 +88,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse1 = dataBundle.students.get("student1InCourse1");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse1.getEmail());
+                student1InCourse1.getEmail(), emptyList);
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, student1InCourse1.getEmail(), subject,
@@ -94,7 +99,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse3 = dataBundle.students.get("student1InCourse3");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse3.getEmail());
+                student1InCourse3.getEmail(), emptyList);
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
@@ -106,7 +111,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse4 = dataBundle.students.get("student1InCourse4");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse4.getEmail());
+                student1InCourse4.getEmail(), emptyList);
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 

--- a/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
@@ -74,7 +74,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
     public void testGenerateSessionLinksRecoveryEmail() throws Exception {
 
         // To remove after migrating to postgres
-        String nonExistentStudent = null;
+        String nonExistentStudent = "";
         Map<CourseAttributes, StringBuilder> emptyFragmentList = new HashMap<>();
         ______TS("invalid email address");
 

--- a/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/sqllogic/api/EmailGeneratorTestIT.java
@@ -1,13 +1,16 @@
 package teammates.it.sqllogic.api;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.EmailType;
@@ -72,12 +75,14 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testGenerateSessionLinksRecoveryEmail() throws Exception {
-
-        List<StudentAttributes> emptyList = new ArrayList<StudentAttributes>();
+        
+        // To remove after migrating to postgres
+        String nonExistentStudent = null;
+        Map<CourseAttributes, StringBuilder> emptyFragmentList = new HashMap<CourseAttributes, StringBuilder>();
         ______TS("invalid email address");
 
         EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                "non-existing-student", emptyList);
+                "non-existing-student", nonExistentStudent, emptyFragmentList);
         String subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, "non-existing-student", subject,
@@ -88,7 +93,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse1 = dataBundle.students.get("student1InCourse1");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse1.getEmail(), emptyList);
+                student1InCourse1.getEmail(), nonExistentStudent, emptyFragmentList);
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, student1InCourse1.getEmail(), subject,
@@ -99,7 +104,7 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse3 = dataBundle.students.get("student1InCourse3");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse3.getEmail(), emptyList);
+                student1InCourse3.getEmail(), nonExistentStudent, emptyFragmentList);
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
@@ -111,12 +116,14 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student student1InCourse4 = dataBundle.students.get("student1InCourse4");
 
         email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(
-                student1InCourse4.getEmail(), emptyList);
+                student1InCourse4.getEmail(), nonExistentStudent, emptyFragmentList);
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, student1InCourse4.getEmail(), subject,
                 "/sessionLinksRecoveryOpenedOrClosedAndpublishedSessions.html");
+
+        ______TS("Migration test: students from both postgres and datastore are fetched");
     }
 
     private void verifyEmail(EmailWrapper email, String recipient, String subject, String emailContentFilePath)

--- a/src/it/java/teammates/it/storage/sqlsearch/StudentSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/StudentSearchIT.java
@@ -45,6 +45,7 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         Student stu3InCourse1 = typicalBundle.students.get("student3InCourse1");
         Student stu1InCourse2 = typicalBundle.students.get("student1InCourse2");
         Student unregisteredStuInCourse1 = typicalBundle.students.get("unregisteredStudentInCourse1");
+        Student stu1InCourse3 = typicalBundle.students.get("student1InCourse3");
         Student stu1InCourse4 = typicalBundle.students.get("student1InCourse4");
         Student stuOfArchivedCourse = typicalBundle.students.get("studentOfArchivedCourse");
 
@@ -64,12 +65,12 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: search for students in whole system; query string matches some students");
 
         results = usersDb.searchStudentsInWholeSystem("\"student1\"");
-        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
         ______TS("success: search for students in whole system; query string should be case-insensitive");
 
         results = usersDb.searchStudentsInWholeSystem("\"sTuDeNt1\"");
-        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
         ______TS("success: search for students in whole system; students in archived courses should be included");
 
@@ -94,7 +95,7 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: search for students in whole system; students should be searchable by their email");
 
         results = usersDb.searchStudentsInWholeSystem("student1@teammates.tmt");
-        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(results, stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
         ______TS("success: search for students; query string matches some students; results restricted "
                  + "based on instructor's privilege");
@@ -114,7 +115,7 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         usersDb.deleteUser(stu1InCourse1);
         results = usersDb.searchStudentsInWholeSystem("\"student1\"");
-        verifySearchResults(results, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(results, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
     }
 
@@ -126,12 +127,13 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         Student stu1InCourse1 = typicalBundle.students.get("student1InCourse1");
         Student stu1InCourse2 = typicalBundle.students.get("student1InCourse2");
+        Student stu1InCourse3 = typicalBundle.students.get("student1InCourse3");
         Student stu1InCourse4 = typicalBundle.students.get("student1InCourse4");
 
         List<Student> studentList = usersDb.searchStudentsInWholeSystem("student1");
 
         // there is search result before deletion
-        verifySearchResults(studentList, stu1InCourse1, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(studentList, stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
         // delete a student
         usersDb.deleteUser(stu1InCourse1);
@@ -139,7 +141,7 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         // the search result will change
         studentList = usersDb.searchStudentsInWholeSystem("student1");
 
-        verifySearchResults(studentList, stu1InCourse2, stu1InCourse4);
+        verifySearchResults(studentList, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
         // delete all students in course 2
         usersDb.deleteUser(stu1InCourse2);
@@ -147,7 +149,7 @@ public class StudentSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         // the search result will change
         studentList = usersDb.searchStudentsInWholeSystem("student1");
 
-        verifySearchResults(studentList, stu1InCourse4);
+        verifySearchResults(studentList, stu1InCourse3, stu1InCourse4);
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/SearchStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchStudentsActionIT.java
@@ -96,7 +96,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
         JsonResult result = getJsonResult(a);
         StudentsData response = (StudentsData) result.getOutput();
 
-        assertEquals(9, response.getStudents().size());
+        assertEquals(10, response.getStudents().size());
     }
 
     @Test
@@ -114,7 +114,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
         JsonResult result = getJsonResult(a);
         StudentsData response = (StudentsData) result.getOutput();
 
-        assertEquals(9, response.getStudents().size());
+        assertEquals(10, response.getStudents().size());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
         JsonResult result = getJsonResult(a);
         StudentsData response = (StudentsData) result.getOutput();
 
-        assertEquals(3, response.getStudents().size());
+        assertEquals(4, response.getStudents().size());
     }
 
     @Test
@@ -169,7 +169,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
         SearchStudentsAction a = getAction(googleIdParams);
         JsonResult result = getJsonResult(a);
         StudentsData response = (StudentsData) result.getOutput();
-        assertEquals(2, response.getStudents().size());
+        assertEquals(3, response.getStudents().size());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
@@ -1,0 +1,132 @@
+package teammates.it.ui.webapi;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.SessionLinksRecoveryResponseData;
+import teammates.ui.webapi.InvalidHttpParameterException;
+import teammates.ui.webapi.JsonResult;
+import teammates.ui.webapi.SessionLinksRecoveryAction;
+
+public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksRecoveryAction> {
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.SESSION_LINKS_RECOVERY;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return POST;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+
+        ______TS("Not enough parameters");
+        // no params
+        verifyHttpParameterFailure();
+    
+        ______TS("Failure: email address is not valid");
+        String[] invalidEmailParam = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, "invalid-email-address",
+        };
+
+        InvalidHttpParameterException ihpe = verifyHttpParameterFailure(invalidEmailParam);
+        assertEquals("Invalid email address: invalid-email-address", ihpe.getMessage());
+
+        ______TS("Typical case: non-existent email address");
+
+        String[] nonExistingParam = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, "non-existent@abc.com",
+        };
+
+        SessionLinksRecoveryAction a = getAction(nonExistingParam);
+        JsonResult result = getJsonResult(a);
+
+        SessionLinksRecoveryResponseData output = (SessionLinksRecoveryResponseData) result.getOutput();
+
+        assertEquals("The recovery links for your feedback sessions have been sent to "
+                + "the specified email address: non-existent@abc.com", output.getMessage());
+        verifyNumberOfEmailsSent(1);
+
+        EmailWrapper emailSent = getEmailsSent().get(0);
+        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
+        assertEquals("non-existent@abc.com", emailSent.getRecipient());
+
+        ______TS("Typical case: successfully sent recovery link email: No feedback sessions found");
+        Student student1InCourse2 = typicalBundle.students.get("student1InCourse2");
+
+        String[] param = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse2.getEmail(),
+        };
+
+        a = getAction(param);
+        result = getJsonResult(a);
+
+        output = (SessionLinksRecoveryResponseData) result.getOutput();
+
+        assertEquals("The recovery links for your feedback sessions have been sent to the "
+                        + "specified email address: " + student1InCourse2.getEmail(),
+                output.getMessage());
+        verifyNumberOfEmailsSent(1);
+
+        emailSent = getEmailsSent().get(0);
+        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
+        assertEquals(student1InCourse2.getEmail(), emailSent.getRecipient());
+    
+        ______TS("Typical case test 1: successfully sent recovery link email: opened session and unpublished feedback, "
+                + "closed session and unpublished feedback.");
+        Student student1InCourse3 = typicalBundle.students.get("student1InCourse3");
+
+        param = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse3.getEmail(),
+        };
+
+        a = getAction(param);
+        result = getJsonResult(a);
+
+        output = (SessionLinksRecoveryResponseData) result.getOutput();
+
+        assertEquals("The recovery links for your feedback sessions have been "
+                        + "sent to the specified email address: " + student1InCourse3.getEmail(),
+                output.getMessage());
+        verifyNumberOfEmailsSent(1);
+
+        emailSent = getEmailsSent().get(0);
+        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
+        assertEquals(student1InCourse3.getEmail(), emailSent.getRecipient());
+
+        ______TS("Typical case test 2: successfully sent recovery link email: opened and published, "
+                + "closed and published.");
+        Student student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+
+        param = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getEmail(),
+        };
+
+        a = getAction(param);
+        result = getJsonResult(a);
+
+        output = (SessionLinksRecoveryResponseData) result.getOutput();
+
+        assertEquals("The recovery links for your feedback sessions have been sent "
+                        + "to the specified email address: " + student1InCourse1.getEmail(),
+                output.getMessage());
+        verifyNumberOfEmailsSent(1);
+
+        emailSent = getEmailsSent().get(0);
+        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
+        assertEquals(student1InCourse1.getEmail(), emailSent.getRecipient());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() {
+        verifyAnyUserCanAccess();
+    }
+}

--- a/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
@@ -11,6 +11,9 @@ import teammates.ui.webapi.InvalidHttpParameterException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.SessionLinksRecoveryAction;
 
+/**
+ * SUT: {@link SessionLinksRecoveryActionTestIT}.
+ */
 public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksRecoveryAction> {
 
     @Override
@@ -30,7 +33,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
         ______TS("Not enough parameters");
         // no params
         verifyHttpParameterFailure();
-    
+
         ______TS("Failure: email address is not valid");
         String[] invalidEmailParam = new String[] {
                 Const.ParamsNames.STUDENT_EMAIL, "invalid-email-address",
@@ -78,7 +81,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
         emailSent = getEmailsSent().get(0);
         assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
         assertEquals(student1InCourse2.getEmail(), emailSent.getRecipient());
-    
+
         ______TS("Typical case test 1: successfully sent recovery link email: opened session and unpublished feedback, "
                 + "closed session and unpublished feedback.");
         Student student1InCourse3 = typicalBundle.students.get("student1InCourse3");

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -201,7 +201,14 @@
         "id": "course-1"
       },
       "name": "Section 3"
-    }
+    },
+    "section1InCourse3": {
+        "id": "00000000-0000-4000-8000-000000000204",
+        "course": {
+          "id": "course-3"
+        },
+        "name": "Section 1"
+      }
   },
   "teams": {
     "team1InCourse1": {
@@ -224,7 +231,14 @@
         "id": "00000000-0000-4000-8000-000000000203"
       },
       "name": "Team 3"
-    }
+    },
+    "team1InCourse3": {
+        "id": "00000000-0000-4000-8000-000000000304",
+        "section": {
+          "id": "00000000-0000-4000-8000-000000000204"
+        },
+        "name": "Team 1"
+      }
   },
   "deadlineExtensions": {
     "student1InCourse1Session1": {
@@ -585,8 +599,20 @@
       "name": "student1 In Course2",
       "comments": ""
     },
+    "student1InCourse3": {
+        "id": "00000000-0000-4000-8000-000000000605",
+        "email": "student1@teammates.tmt",
+        "course": {
+            "id": "course-3"
+        },
+        "team": {
+            "id": "00000000-0000-4000-8000-000000000304"
+        },
+        "name": "student1 In Course3</td></div>'\"",
+        "comments": "comment for student1InCourse3</td></div>'\""
+    },
     "unregisteredStudentInCourse1": {
-      "id": "00000000-0000-4000-8000-000000000605",
+      "id": "00000000-0000-4000-8000-000000000606",
       "course": {
         "id": "course-1"
       },
@@ -598,7 +624,7 @@
       "comments": ""
     },
     "student1InCourse4": {
-      "id": "00000000-0000-4000-8000-000000000606",
+      "id": "00000000-0000-4000-8000-000000000607",
       "account": {
         "id": "00000000-0000-4000-8000-000000000101"
       },
@@ -613,7 +639,7 @@
       "comments": "comment for student1Course1"
     },
     "student2YetToJoinCourse4": {
-      "id": "00000000-0000-4000-8000-000000000607",
+      "id": "00000000-0000-4000-8000-000000000608",
       "course": {
         "id": "course-4"
       },
@@ -625,7 +651,7 @@
       "comments": ""
     },
     "student3YetToJoinCourse4": {
-      "id": "00000000-0000-4000-8000-000000000608",
+      "id": "00000000-0000-4000-8000-000000000609",
       "course": {
         "id": "course-4"
       },
@@ -637,7 +663,7 @@
       "comments": ""
     },
     "studentOfArchivedCourse": {
-      "id": "00000000-0000-4000-8000-000000000608",
+      "id": "00000000-0000-4000-8000-000000000610",
       "course": {
         "id": "archived-course"
       },
@@ -813,7 +839,7 @@
       "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
-      "endTime": "2012-01-26T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
       "sessionVisibleFromTime": "2012-01-19T22:00:00Z",
       "resultsVisibleFromTime": "2012-02-02T22:00:00Z",
       "gracePeriod": 10,

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -419,7 +419,7 @@ public final class EmailGenerator {
         return email;
     }
 
-    private Map<CourseAttributes, StringBuilder> generateLinkFragmentsMap(List<StudentAttributes> studentsForEmail) {
+    public Map<CourseAttributes, StringBuilder> generateLinkFragmentsMap(List<StudentAttributes> studentsForEmail) {
         var searchStartTime = TimeHelper.getInstantDaysOffsetBeforeNow(SESSION_LINK_RECOVERY_DURATION_IN_DAYS);
         Map<CourseAttributes, StringBuilder> linkFragmentsMap = new HashMap<>();
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -419,6 +419,12 @@ public final class EmailGenerator {
         return email;
     }
 
+    /**
+     * This method was private but was made public to be used in the SQLEmailGenerator for migration.
+     *
+     * @param studentsForEmail - Student to generate link fragment map
+     * @return Course to link fragments used in generating an email
+     */
     public Map<CourseAttributes, StringBuilder> generateLinkFragmentsMap(List<StudentAttributes> studentsForEmail) {
         var searchStartTime = TimeHelper.getInstantDaysOffsetBeforeNow(SESSION_LINK_RECOVERY_DURATION_IN_DAYS);
         Map<CourseAttributes, StringBuilder> linkFragmentsMap = new HashMap<>();

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -638,6 +638,17 @@ public class Logic {
 
     /**
      * Preconditions: <br>
+     * * All parameters are non-null
+     * 
+     * @return Empty list if not match found
+     */
+    public List<StudentAttributes> getAllStudentsForEmail(String email) {
+        assert email != null;
+        return studentsLogic.getAllStudentsForEmail(email);
+    }
+
+    /**
+     * Preconditions: <br>
      * * All parameters are non-null.
      * @return Empty list if none found.
      */

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -638,8 +638,8 @@ public class Logic {
 
     /**
      * Preconditions: <br>
-     * * All parameters are non-null
-     * 
+     * * All parameters are non-null.
+     *
      * @return Empty list if not match found
      */
     public List<StudentAttributes> getAllStudentsForEmail(String email) {

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -364,10 +364,12 @@ public final class SqlEmailGenerator {
             String studentNameFromDatastore, Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap) {
 
         // Datastore attributes should be removed once migration is completed
+        String emptyName = "";
+        boolean noDataStoreStudent = studentNameFromDatastore.equals(emptyName); // student name cannot be empty
 
         List<Student> studentsForEmail = usersLogic.getAllStudentsForEmail(recoveryEmailAddress);
 
-        if (studentsForEmail.isEmpty() && studentNameFromDatastore == null) {
+        if (studentsForEmail.isEmpty() && noDataStoreStudent) {
             return generateSessionLinksRecoveryEmailForNonExistentStudent(recoveryEmailAddress);
         } else {
             return generateSessionLinksRecoveryEmailForExistingStudent(recoveryEmailAddress, studentsForEmail,

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.ErrorLogEntry;
 import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
@@ -360,12 +359,12 @@ public final class SqlEmailGenerator {
      * under {@code recoveryEmailAddress} in the past 180 days. If no student with {@code recoveryEmailAddress} is
      * found, generate an email stating that there is no such student in the system. If no feedback sessions are found,
      * generate an email stating no feedback sessions found.
-     * 
-     * Datastore attributes will be removed once migration is completed
-     * @param datastoreStudents Students from datastore associated with the recovery email address
      */
     public EmailWrapper generateSessionLinksRecoveryEmailForStudent(String recoveryEmailAddress,
             String studentNameFromDatastore, Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap) {
+
+        // Datastore attributes should be removed once migration is completed
+
         List<Student> studentsForEmail = usersLogic.getAllStudentsForEmail(recoveryEmailAddress);
 
         if (studentsForEmail.isEmpty() && studentNameFromDatastore == null) {
@@ -392,21 +391,21 @@ public final class SqlEmailGenerator {
     }
 
     private EmailWrapper generateSessionLinksRecoveryEmailForExistingStudent(String recoveryEmailAddress,
-            List<Student> studentsForEmail, String studentNameFromDatastore, Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap) {
-        assert (!studentsForEmail.isEmpty() || studentNameFromDatastore != null);
-        int first_student_idx = 0;
-        
-        // TODO generate link map for datastudents
+            List<Student> studentsForEmail, String studentNameFromDatastore,
+            Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap) {
+        assert !studentsForEmail.isEmpty() || studentNameFromDatastore != null;
+        int firstStudentIdx = 0;
+
         Map<Course, StringBuilder> linkFragmentsMap = generateLinkFragmentsMap(studentsForEmail);
 
         String emailBody;
-        
+
         String studentName;
 
-        if (studentsForEmail.size() > 0) {
-            studentName = studentsForEmail.get(first_student_idx).getName();
-        } else {
+        if (studentsForEmail.isEmpty()) {
             studentName = studentNameFromDatastore;
+        } else {
+            studentName = studentsForEmail.get(firstStudentIdx).getName();
         }
 
         var recoveryUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSIONS_LINK_RECOVERY_PAGE).toAbsoluteString();
@@ -424,7 +423,7 @@ public final class SqlEmailGenerator {
                 String courseBody = Templates.populateTemplate(
                         EmailTemplates.FRAGMENT_SESSION_LINKS_RECOVERY_ACCESS_LINKS_BY_COURSE,
                         "${sessionFragment}", linksFragments.toString(),
-                        "${courseName}",course.getName());
+                        "${courseName}", course.getName());
                 courseFragments.append(courseBody);
             });
 
@@ -433,7 +432,7 @@ public final class SqlEmailGenerator {
                 String courseBody = Templates.populateTemplate(
                         EmailTemplates.FRAGMENT_SESSION_LINKS_RECOVERY_ACCESS_LINKS_BY_COURSE,
                         "${sessionFragment}", linksFragments.toString(),
-                        "${courseName}",course.getName());
+                        "${courseName}", course.getName());
                 courseFragments.append(courseBody);
             });
             emailBody = Templates.populateTemplate(

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.ErrorLogEntry;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
@@ -358,11 +359,16 @@ public final class SqlEmailGenerator {
      * under {@code recoveryEmailAddress} in the past 180 days. If no student with {@code recoveryEmailAddress} is
      * found, generate an email stating that there is no such student in the system. If no feedback sessions are found,
      * generate an email stating no feedback sessions found.
+     * 
+     * Datastore attributes will be removed once migration is completed
+     * @param datastoreStudents Students from datastore associated with the recovery email address
      */
-    public EmailWrapper generateSessionLinksRecoveryEmailForStudent(String recoveryEmailAddress) {
+    public EmailWrapper generateSessionLinksRecoveryEmailForStudent(String recoveryEmailAddress,
+            List<StudentAttributes> datastoreStudents) {
+        assert datastoreStudents != null;
         List<Student> studentsForEmail = usersLogic.getAllStudentsForEmail(recoveryEmailAddress);
 
-        if (studentsForEmail.isEmpty()) {
+        if (studentsForEmail.isEmpty() && datastoreStudents.isEmpty()) {
             return generateSessionLinksRecoveryEmailForNonExistentStudent(recoveryEmailAddress);
         } else {
             return generateSessionLinksRecoveryEmailForExistingStudent(recoveryEmailAddress, studentsForEmail);

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -37,7 +37,7 @@ class SessionLinksRecoveryAction extends Action {
                     + "the reCAPTCHA verification. Please try again."));
         }
 
-        EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
+        EmailWrapper email = sqlEmailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
         EmailSendingStatus status = emailSender.sendEmail(email);
 
         if (status.isSuccess()) {

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -43,13 +43,14 @@ public class SessionLinksRecoveryAction extends Action {
         }
 
         int firstStudentIdx = 0;
+        String noStudentName = "";
         List<StudentAttributes> studentFromDataStore = logic.getAllStudentsForEmail(recoveryEmailAddress);
 
         Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap =
                 emailGenerator.generateLinkFragmentsMap(studentFromDataStore);
 
         String studentNameFromDatastore = (studentFromDataStore.isEmpty())
-                ? null
+                ? noStudentName
                 : studentFromDataStore.get(firstStudentIdx).getName();
 
         EmailWrapper email = sqlEmailGenerator

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -2,6 +2,9 @@ package teammates.ui.webapi;
 
 import static teammates.common.util.FieldValidator.REGEX_EMAIL;
 
+import java.util.List;
+
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailWrapper;
@@ -37,7 +40,12 @@ class SessionLinksRecoveryAction extends Action {
                     + "the reCAPTCHA verification. Please try again."));
         }
 
-        EmailWrapper email = sqlEmailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
+        List<StudentAttributes> datastoreStudents = logic.getAllStudentsForEmail(recoveryEmailAddress);
+        EmailWrapper email = sqlEmailGenerator
+            .generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress,
+                datastoreStudents);
+        
+        System.out.println(email);
         EmailSendingStatus status = emailSender.sendEmail(email);
 
         if (status.isSuccess()) {

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -41,16 +41,21 @@ public class SessionLinksRecoveryAction extends Action {
             return new JsonResult(new SessionLinksRecoveryResponseData(false, "Something went wrong with "
                     + "the reCAPTCHA verification. Please try again."));
         }
-        
-        int first_student_idx = 0;
+
+        int firstStudentIdx = 0;
         List<StudentAttributes> studentFromDataStore = logic.getAllStudentsForEmail(recoveryEmailAddress);
-        Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap = emailGenerator.generateLinkFragmentsMap(studentFromDataStore);
-        String studentNameFromDatastore = (studentFromDataStore.isEmpty()) ? null : studentFromDataStore.get(first_student_idx).getName();
-        
+
+        Map<CourseAttributes, StringBuilder> dataStoreLinkFragmentMap =
+                emailGenerator.generateLinkFragmentsMap(studentFromDataStore);
+
+        String studentNameFromDatastore = (studentFromDataStore.isEmpty())
+                ? null
+                : studentFromDataStore.get(firstStudentIdx).getName();
+
         EmailWrapper email = sqlEmailGenerator
-            .generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress,
+                .generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress,
                 studentNameFromDatastore, dataStoreLinkFragmentMap);
-        
+
         EmailSendingStatus status = emailSender.sendEmail(email);
 
         if (status.isSuccess()) {


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
Using the refactored email generator (#12723), the links of feedback sessions which students are in are fetched from data store and Postgres server and are combined into a single email to be sent to students (this should be removed after migration)
