### PR TITLE
[#12048] Migrate join course action

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
@@ -4,20 +4,32 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
+import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.FieldValidator;
+import teammates.common.util.HibernateUtil;
+import teammates.common.util.StringHelper;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.AccountsLogic;
+import teammates.sqllogic.core.CoursesLogic;
 import teammates.sqllogic.core.NotificationsLogic;
+import teammates.sqllogic.core.UsersLogic;
 import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
+import teammates.storage.sqlentity.Student;
+import teammates.test.AssertHelper;
 
 /**
  * SUT: {@link AccountsLogic}.
@@ -26,8 +38,28 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     private AccountsLogic accountsLogic = AccountsLogic.inst();
     private NotificationsLogic notificationsLogic = NotificationsLogic.inst();
+    private UsersLogic usersLogic = UsersLogic.inst();
+    private CoursesLogic coursesLogic = CoursesLogic.inst();
 
     private AccountsDb accountsDb = AccountsDb.inst();
+
+    private SqlDataBundle typicalDataBundle;
+
+    @Override
+    @BeforeClass
+    public void setupClass() {
+        super.setupClass();
+        typicalDataBundle = getTypicalSqlDataBundle();
+    }
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalDataBundle);
+        HibernateUtil.flushSession();
+        HibernateUtil.clearSession();
+    }
 
     @Test
     public void testUpdateReadNotifications()
@@ -49,5 +81,152 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertEquals(1, accountReadNotifications.size());
         assertSame(actualAccount, accountReadNotifications.get(0).getAccount());
         assertSame(notification, accountReadNotifications.get(0).getNotification());
+    }
+
+    @Test
+    public void testJoinCourseForStudent()
+            throws EntityAlreadyExistsException, InvalidParametersException, EntityDoesNotExistException {
+
+        Student student1YetToJoinCourse = typicalDataBundle.students.get("student1YetToJoinCourse1");
+        Student student2YetToJoinCourse = typicalDataBundle.students.get("student2YetToJoinCourse1");
+        Student studentInCourse = typicalDataBundle.students.get("student1InCourse1");
+
+        String loggedInGoogleId = "AccLogicT.student.id";
+
+        ______TS("failure: wrong key");
+
+        String wrongKey = StringHelper.encrypt("wrongkey");
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsLogic.joinCourseForStudent(wrongKey, loggedInGoogleId));
+        assertEquals("No student with given registration key: " + wrongKey, ednee.getMessage());
+
+        ______TS("failure: invalid parameters");
+
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), "wrong student"));
+        AssertHelper.assertContains(FieldValidator.REASON_INCORRECT_FORMAT, ipe.getMessage());
+
+        ______TS("failure: googleID belongs to an existing student in the course");
+
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(),
+                studentInCourse.getGoogleId()));
+        assertEquals("Student has already joined course", eaee.getMessage());
+
+        ______TS("success: with encryption and new account to be created");
+
+        accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), loggedInGoogleId);
+        Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
+
+        assertEquals(loggedInGoogleId, usersLogic.getStudentForEmail(
+                student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail()).getGoogleId());
+        assertNotNull(accountCreated);
+
+        ______TS("success: student joined but account already exists");
+
+        String existingAccountId = "existingAccountId";
+        Account existingAccount = new Account(existingAccountId, "accountName", student2YetToJoinCourse.getEmail());
+        accountsDb.createAccount(existingAccount);
+
+        accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), existingAccountId);
+
+        assertEquals(existingAccountId, usersLogic.getStudentForEmail(
+                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId());
+
+        ______TS("failure: already joined");
+
+        eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), loggedInGoogleId));
+        assertEquals("Student has already joined course", eaee.getMessage());
+
+        ______TS("failure: course is deleted");
+
+        Course originalCourse = usersLogic.getStudentForEmail(
+                student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail()).getCourse();
+        coursesLogic.moveCourseToRecycleBin(originalCourse.getId());
+
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(),
+                        loggedInGoogleId));
+        assertEquals("The course you are trying to join has been deleted by an instructor", ednee.getMessage());
+    }
+
+    @Test
+    public void testJoinCourseForInstructor() throws Exception {
+        String instructorIdAlreadyJoinedCourse = "instructor1";
+        Instructor instructor1YetToJoinCourse = typicalDataBundle.instructors.get("instructor1YetToJoinCourse3");
+        Instructor instructor2YetToJoinCourse = typicalDataBundle.instructors.get("instructor2YetToJoinCourse3");
+
+        String loggedInGoogleId = "AccLogicT.instr.id";
+        String[] key = new String[] {
+                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail()),
+                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()),
+        };
+
+        ______TS("failure: googleID belongs to an existing instructor in the course");
+
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> accountsLogic.joinCourseForInstructor(
+                        key[0], instructorIdAlreadyJoinedCourse));
+        assertEquals("Instructor has already joined course", eaee.getMessage());
+
+        ______TS("success: instructor joined and new account be created");
+
+        accountsLogic.joinCourseForInstructor(key[0], loggedInGoogleId);
+
+        Instructor joinedInstructor = usersLogic.getInstructorForEmail(
+                        instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail());
+        assertEquals(loggedInGoogleId, joinedInstructor.getGoogleId());
+
+        Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
+        assertNotNull(accountCreated);
+
+        ______TS("success: instructor joined but account already exists");
+
+        String existingAccountId = "existingAccountId";
+        Account existingAccount = new Account(existingAccountId, "accountName", instructor2YetToJoinCourse.getEmail());
+        accountsDb.createAccount(existingAccount);
+
+        accountsLogic.joinCourseForInstructor(key[1], existingAccount.getGoogleId());
+
+        joinedInstructor = usersLogic.getInstructorForEmail(
+                        instructor2YetToJoinCourse.getCourseId(), existingAccount.getEmail());
+        assertEquals(existingAccountId, joinedInstructor.getGoogleId());
+
+        ______TS("failure: instructor already joined");
+
+        eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> accountsLogic.joinCourseForInstructor(key[0], loggedInGoogleId));
+        assertEquals("Instructor has already joined course", eaee.getMessage());
+
+        ______TS("failure: key belongs to a different user");
+
+        eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> accountsLogic.joinCourseForInstructor(key[0], "otherUserId"));
+        assertEquals("Instructor has already joined course", eaee.getMessage());
+
+        ______TS("failure: invalid key");
+
+        String invalidKey = StringHelper.encrypt("invalidKey");
+
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsLogic.joinCourseForInstructor(invalidKey, loggedInGoogleId));
+        assertEquals("No instructor with given registration key: " + invalidKey,
+                ednee.getMessage());
+
+        ______TS("failure: course deleted");
+
+        Course originalCourse = usersLogic.getInstructorForEmail(
+                instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail()).getCourse();
+        coursesLogic.moveCourseToRecycleBin(originalCourse.getId());
+
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsLogic.joinCourseForInstructor(instructor1YetToJoinCourse.getRegKey(),
+                    instructor1YetToJoinCourse.getGoogleId()));
+        assertEquals("The course you are trying to join has been deleted by an instructor", ednee.getMessage());
+    }
+
+    private String getRegKeyForInstructor(String courseId, String email) {
+        return usersLogic.getInstructorForEmail(courseId, email).getRegKey();
     }
 }

--- a/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
@@ -87,8 +87,8 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
     public void testJoinCourseForStudent()
             throws EntityAlreadyExistsException, InvalidParametersException, EntityDoesNotExistException {
 
-        Student student1YetToJoinCourse = typicalDataBundle.students.get("student1YetToJoinCourse1");
-        Student student2YetToJoinCourse = typicalDataBundle.students.get("student2YetToJoinCourse1");
+        Student student2YetToJoinCourse = typicalDataBundle.students.get("student2YetToJoinCourse4");
+        Student student3YetToJoinCourse = typicalDataBundle.students.get("student3YetToJoinCourse4");
         Student studentInCourse = typicalDataBundle.students.get("student1InCourse1");
 
         String loggedInGoogleId = "AccLogicT.student.id";
@@ -103,50 +103,50 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("failure: invalid parameters");
 
         InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
-                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), "wrong student"));
+                () -> accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), "wrong student"));
         AssertHelper.assertContains(FieldValidator.REASON_INCORRECT_FORMAT, ipe.getMessage());
 
         ______TS("failure: googleID belongs to an existing student in the course");
 
         EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
-                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(),
+                () -> accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(),
                 studentInCourse.getGoogleId()));
         assertEquals("Student has already joined course", eaee.getMessage());
 
         ______TS("success: with encryption and new account to be created");
 
-        accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), loggedInGoogleId);
+        accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), loggedInGoogleId);
         Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
 
         assertEquals(loggedInGoogleId, usersLogic.getStudentForEmail(
-                student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail()).getGoogleId());
+                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId());
         assertNotNull(accountCreated);
 
         ______TS("success: student joined but account already exists");
 
         String existingAccountId = "existingAccountId";
-        Account existingAccount = new Account(existingAccountId, "accountName", student2YetToJoinCourse.getEmail());
+        Account existingAccount = new Account(existingAccountId, "accountName", student3YetToJoinCourse.getEmail());
         accountsDb.createAccount(existingAccount);
 
-        accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), existingAccountId);
+        accountsLogic.joinCourseForStudent(student3YetToJoinCourse.getRegKey(), existingAccountId);
 
         assertEquals(existingAccountId, usersLogic.getStudentForEmail(
-                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId());
+                student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getGoogleId());
 
         ______TS("failure: already joined");
 
         eaee = assertThrows(EntityAlreadyExistsException.class,
-                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(), loggedInGoogleId));
+                () -> accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), loggedInGoogleId));
         assertEquals("Student has already joined course", eaee.getMessage());
 
         ______TS("failure: course is deleted");
 
         Course originalCourse = usersLogic.getStudentForEmail(
-                student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail()).getCourse();
+                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getCourse();
         coursesLogic.moveCourseToRecycleBin(originalCourse.getId());
 
         ednee = assertThrows(EntityDoesNotExistException.class,
-                () -> accountsLogic.joinCourseForStudent(student1YetToJoinCourse.getRegKey(),
+                () -> accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(),
                         loggedInGoogleId));
         assertEquals("The course you are trying to join has been deleted by an instructor", ednee.getMessage());
     }
@@ -154,13 +154,13 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
     @Test
     public void testJoinCourseForInstructor() throws Exception {
         String instructorIdAlreadyJoinedCourse = "instructor1";
-        Instructor instructor1YetToJoinCourse = typicalDataBundle.instructors.get("instructor1YetToJoinCourse3");
-        Instructor instructor2YetToJoinCourse = typicalDataBundle.instructors.get("instructor2YetToJoinCourse3");
+        Instructor instructor2YetToJoinCourse = typicalDataBundle.instructors.get("instructor2YetToJoinCourse4");
+        Instructor instructor3YetToJoinCourse = typicalDataBundle.instructors.get("instructor3YetToJoinCourse4");
 
         String loggedInGoogleId = "AccLogicT.instr.id";
         String[] key = new String[] {
-                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail()),
-                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()),
+                getRegKeyForInstructor(instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()),
+                getRegKeyForInstructor(instructor2YetToJoinCourse.getCourseId(), instructor3YetToJoinCourse.getEmail()),
         };
 
         ______TS("failure: googleID belongs to an existing instructor in the course");
@@ -175,7 +175,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         accountsLogic.joinCourseForInstructor(key[0], loggedInGoogleId);
 
         Instructor joinedInstructor = usersLogic.getInstructorForEmail(
-                        instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail());
+                        instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail());
         assertEquals(loggedInGoogleId, joinedInstructor.getGoogleId());
 
         Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
@@ -184,13 +184,13 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: instructor joined but account already exists");
 
         String existingAccountId = "existingAccountId";
-        Account existingAccount = new Account(existingAccountId, "accountName", instructor2YetToJoinCourse.getEmail());
+        Account existingAccount = new Account(existingAccountId, "accountName", instructor3YetToJoinCourse.getEmail());
         accountsDb.createAccount(existingAccount);
 
         accountsLogic.joinCourseForInstructor(key[1], existingAccount.getGoogleId());
 
         joinedInstructor = usersLogic.getInstructorForEmail(
-                        instructor2YetToJoinCourse.getCourseId(), existingAccount.getEmail());
+                        instructor3YetToJoinCourse.getCourseId(), existingAccount.getEmail());
         assertEquals(existingAccountId, joinedInstructor.getGoogleId());
 
         ______TS("failure: instructor already joined");
@@ -217,12 +217,12 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("failure: course deleted");
 
         Course originalCourse = usersLogic.getInstructorForEmail(
-                instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail()).getCourse();
+                instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()).getCourse();
         coursesLogic.moveCourseToRecycleBin(originalCourse.getId());
 
         ednee = assertThrows(EntityDoesNotExistException.class,
-                () -> accountsLogic.joinCourseForInstructor(instructor1YetToJoinCourse.getRegKey(),
-                    instructor1YetToJoinCourse.getGoogleId()));
+                () -> accountsLogic.joinCourseForInstructor(instructor2YetToJoinCourse.getRegKey(),
+                    instructor2YetToJoinCourse.getGoogleId()));
         assertEquals("The course you are trying to join has been deleted by an instructor", ednee.getMessage());
     }
 

--- a/src/it/java/teammates/it/storage/sqlsearch/InstructorSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/InstructorSearchIT.java
@@ -68,7 +68,6 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: search for instructors in whole system; query string should be case-insensitive");
 
         results = usersDb.searchInstructorsInWholeSystem("\"InStRuCtOr 2\"");
-        System.out.println("🌕🌕🌕🌕🌕🌕🌕🌕" + results.size());
         verifySearchResults(results, ins2InCourse1, ins2InCourse4);
 
         ______TS("success: search for instructors in whole system; instructors in archived courses should be included");
@@ -179,8 +178,6 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
      */
     private static void verifySearchResults(List<Instructor> actual,
             Instructor... expected) {
-        System.out.println("😡" + actual.size());
-        System.out.println("😡" + expected.length);
         assertEquals(expected.length, actual.size());
         AssertHelper.assertSameContentIgnoreOrder(Arrays.asList(expected), actual);
     }

--- a/src/it/java/teammates/it/storage/sqlsearch/InstructorSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/InstructorSearchIT.java
@@ -41,6 +41,9 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         Instructor ins1InCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor ins2InCourse1 = typicalBundle.instructors.get("instructor2OfCourse1");
+        Instructor ins1InCourse4 = typicalBundle.instructors.get("instructor1OfCourse4");
+        Instructor ins2InCourse4 = typicalBundle.instructors.get("instructor2YetToJoinCourse4");
+        Instructor ins3InCourse4 = typicalBundle.instructors.get("instructor3YetToJoinCourse4");
         Instructor insInArchivedCourse = typicalBundle.instructors.get("instructorOfArchivedCourse");
         Instructor insInUnregCourse = typicalBundle.instructors.get("instructorOfUnregisteredCourse");
         Instructor insUniqueDisplayName = typicalBundle.instructors.get("instructorOfCourse2WithUniqueDisplayName");
@@ -65,7 +68,8 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: search for instructors in whole system; query string should be case-insensitive");
 
         results = usersDb.searchInstructorsInWholeSystem("\"InStRuCtOr 2\"");
-        verifySearchResults(results, ins2InCourse1);
+        System.out.println("🌕🌕🌕🌕🌕🌕🌕🌕" + results.size());
+        verifySearchResults(results, ins2InCourse1, ins2InCourse4);
 
         ______TS("success: search for instructors in whole system; instructors in archived courses should be included");
 
@@ -96,12 +100,13 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: search for instructors in whole system; instructors should be searchable by their email");
 
         results = usersDb.searchInstructorsInWholeSystem("instr2@teammates.tmt");
-        verifySearchResults(results, ins2InCourse1);
+        verifySearchResults(results, ins2InCourse1, ins2InCourse4);
 
         ______TS("success: search for instructors in whole system; instructors should be searchable by their role");
         results = usersDb.searchInstructorsInWholeSystem("\"Co-owner\"");
         verifySearchResults(results, ins1InCourse1, insInArchivedCourse,
-                insInUnregCourse, insUniqueDisplayName, ins1InCourse3);
+                insInUnregCourse, insUniqueDisplayName, ins1InCourse3,
+                ins1InCourse4, ins2InCourse4, ins3InCourse4);
 
         ______TS("success: search for instructors in whole system; instructors should be searchable by displayed name");
 
@@ -126,7 +131,7 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         usersDb.deleteUser(ins1InCourse3);
         results = usersDb.searchInstructorsInWholeSystem("\"Instructor 1\"");
-        verifySearchResults(results, ins1InCourse1);
+        verifySearchResults(results, ins1InCourse1, ins1InCourse4);
     }
 
     @Test
@@ -174,6 +179,8 @@ public class InstructorSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
      */
     private static void verifySearchResults(List<Instructor> actual,
             Instructor... expected) {
+        System.out.println("😡" + actual.size());
+        System.out.println("😡" + expected.length);
         assertEquals(expected.length, actual.size());
         AssertHelper.assertSameContentIgnoreOrder(Arrays.asList(expected), actual);
     }

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -247,6 +247,10 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
         } else if (entity instanceof AccountRequest) {
             AccountRequest accountRequest = (AccountRequest) entity;
             return logic.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+        } else if (entity instanceof Instructor) {
+            return logic.getInstructor(((Instructor) entity).getId());
+        } else if (entity instanceof Student) {
+            return logic.getStudent(((Student) entity).getId());
         } else {
             throw new RuntimeException("Unknown entity type");
         }

--- a/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
@@ -1,0 +1,148 @@
+package teammates.it.ui.webapi;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.EmailWrapper;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.webapi.InvalidOperationException;
+import teammates.ui.webapi.JoinCourseAction;
+
+/**
+ * SUT: {@link JoinCourseAction}.
+ */
+public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.JOIN;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return PUT;
+    }
+
+    @Override
+    @Test
+    protected void testExecute() throws Exception {
+        Student student1YetToJoinCourse = typicalBundle.students.get("student1YetToJoinCourse1");
+        String student1RegKey =
+                getRegKeyForStudent(student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail());
+        String loggedInGoogleIdStu = "AccLogicT.student.id";
+
+        Instructor instructor1YetToJoinCourse = typicalBundle.instructors.get("instructor1YetToJoinCourse3");
+        String instructor1RegKey =
+                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail());
+
+        String loggedInGoogleIdInst = "AccLogicT.instr.id";
+
+        ______TS("success: student joins course");
+
+        loginAsUnregistered(loggedInGoogleIdStu);
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, student1RegKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
+        };
+
+        JoinCourseAction joinCourseAction = getAction(submissionParams);
+        getJsonResult(joinCourseAction);
+
+        verifyNumberOfEmailsSent(1);
+        EmailWrapper email = mockEmailSender.getEmailsSent().get(0);
+        assertEquals(
+                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 1", "course-1"),
+                email.getSubject());
+
+        ______TS("failure: student is already registered");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, student1RegKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
+        };
+
+        InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
+        assertEquals("Student has already joined course", ioe.getMessage());
+
+        verifyNoEmailsSent();
+
+        ______TS("success: instructor joins course");
+
+        loginAsUnregistered(loggedInGoogleIdInst);
+
+        submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, instructor1RegKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
+        };
+
+        joinCourseAction = getAction(submissionParams);
+        getJsonResult(joinCourseAction);
+
+        verifyNumberOfEmailsSent(1);
+        email = mockEmailSender.getEmailsSent().get(0);
+        assertEquals(
+                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 3", "course-3"),
+                email.getSubject());
+
+        ______TS("failure: instructor is already registered");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, instructor1RegKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
+        };
+
+        ioe = verifyInvalidOperation(submissionParams);
+        assertEquals("Instructor has already joined course", ioe.getMessage());
+
+        verifyNoEmailsSent();
+
+        ______TS("failure: invalid regkey");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, "ANXKJZNZXNJCZXKJDNKSDA",
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
+        };
+
+        verifyEntityNotFound(submissionParams);
+
+        verifyNoEmailsSent();
+
+        ______TS("failure: invalid entity type");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.REGKEY, student1RegKey,
+                Const.ParamsNames.ENTITY_TYPE, "invalid_entity_type",
+        };
+
+        verifyHttpParameterFailure(submissionParams);
+
+        verifyNoEmailsSent();
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws Exception {
+        verifyAnyLoggedInUserCanAccess();
+    }
+
+    private String getRegKeyForStudent(String courseId, String email) {
+        return logic.getStudentForEmail(courseId, email).getRegKey();
+    }
+
+    private String getRegKeyForInstructor(String courseId, String email) {
+        return logic.getInstructorForEmail(courseId, email).getRegKey();
+    }
+}

--- a/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
@@ -38,14 +38,14 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
     @Override
     @Test
     protected void testExecute() throws Exception {
-        Student student1YetToJoinCourse = typicalBundle.students.get("student1YetToJoinCourse1");
+        Student studentYetToJoinCourse = typicalBundle.students.get("student2YetToJoinCourse4");
         String student1RegKey =
-                getRegKeyForStudent(student1YetToJoinCourse.getCourseId(), student1YetToJoinCourse.getEmail());
+                getRegKeyForStudent(studentYetToJoinCourse.getCourseId(), studentYetToJoinCourse.getEmail());
         String loggedInGoogleIdStu = "AccLogicT.student.id";
 
-        Instructor instructor1YetToJoinCourse = typicalBundle.instructors.get("instructor1YetToJoinCourse3");
+        Instructor instructorYetToJoinCourse = typicalBundle.instructors.get("instructor2YetToJoinCourse4");
         String instructor1RegKey =
-                getRegKeyForInstructor(instructor1YetToJoinCourse.getCourseId(), instructor1YetToJoinCourse.getEmail());
+                getRegKeyForInstructor(instructorYetToJoinCourse.getCourseId(), instructorYetToJoinCourse.getEmail());
 
         String loggedInGoogleIdInst = "AccLogicT.instr.id";
 
@@ -64,7 +64,7 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         verifyNumberOfEmailsSent(1);
         EmailWrapper email = mockEmailSender.getEmailsSent().get(0);
         assertEquals(
-                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 1", "course-1"),
+                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 4", "course-4"),
                 email.getSubject());
 
         ______TS("failure: student is already registered");
@@ -94,7 +94,7 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         verifyNumberOfEmailsSent(1);
         email = mockEmailSender.getEmailsSent().get(0);
         assertEquals(
-                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 3", "course-3"),
+                String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 4", "course-4"),
                 email.getSubject());
 
         ______TS("failure: instructor is already registered");

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -93,6 +93,13 @@
       "institute": "TEAMMATES Test Institute 1",
       "timeZone": "Asia/Singapore"
     },
+    "course4": {
+      "createdAt": "2012-04-01T23:59:00Z",
+      "id": "course-4",
+      "name": "Typical Course 4",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Asia/Singapore"
+    },
     "archivedCourse": {
       "id": "archived-course",
       "name": "Archived Course",
@@ -374,13 +381,16 @@
         "sessionLevel": {}
       }
     },
-    "instructor1YetToJoinCourse3": {
+    "instructor1OfCourse4": {
       "id": "00000000-0000-4000-8000-000000000508",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
       "course": {
-        "id": "course-3"
+        "id": "course-4"
       },
       "name": "Instructor 1",
-      "email": "instructor1YetToJoinCourse3@teammates.tmt",
+      "email": "instr1@teammates.tmt",
       "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Instructor",
@@ -399,13 +409,38 @@
         "sessionLevel": {}
       }
     },
-    "instructor2YetToJoinCourse3": {
+    "instructor2YetToJoinCourse4": {
       "id": "00000000-0000-4000-8000-000000000509",
       "course": {
-        "id": "course-3"
+        "id": "course-4"
       },
       "name": "Instructor 2",
-      "email": "instructor2YetToJoinCourse3@teammates.tmt",
+      "email": "instr2@teammates.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor3YetToJoinCourse4": {
+      "id": "00000000-0000-4000-8000-000000000510",
+      "course": {
+        "id": "course-4"
+      },
+      "name": "Instructor 3",
+      "email": "instructor3YetToJoinCourse4@teammates.tmt",
       "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Instructor",
@@ -495,28 +530,43 @@
       "name": "Unregistered Student In Course1",
       "comments": ""
     },
-    "student1YetToJoinCourse1": {
+    "student1InCourse4": {
       "id": "00000000-0000-4000-8000-000000000606",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000101"
+      },
       "course": {
-        "id": "course-1"
+        "id": "course-4"
       },
       "team": {
-        "id": "00000000-0000-4000-8000-000000000302"
+        "id": "00000000-0000-4000-8000-000000000301"
       },
-      "email": "student1YetToJoinCourse@teammates.tmt",
-      "name": "student1YetToJoinCourse In Course1",
-      "comments": ""
+      "email": "student1@teammates.tmt",
+      "name": "student1 In Course4",
+      "comments": "comment for student1Course1"
     },
-    "student2YetToJoinCourse1": {
+    "student2YetToJoinCourse4": {
       "id": "00000000-0000-4000-8000-000000000607",
       "course": {
-        "id": "course-1"
+        "id": "course-4"
       },
       "team": {
         "id": "00000000-0000-4000-8000-000000000302"
       },
-      "email": "student2YetToJoinCourse@teammates.tmt",
-      "name": "student2YetToJoinCourse In Course1",
+      "email": "student2YetToJoinCourse4@teammates.tmt",
+      "name": "student2YetToJoinCourse In Course4",
+      "comments": ""
+    },
+    "student3YetToJoinCourse4": {
+      "id": "00000000-0000-4000-8000-000000000608",
+      "course": {
+        "id": "course-4"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000302"
+      },
+      "email": "student3YetToJoinCourse4@teammates.tmt",
+      "name": "student3YetToJoinCourse In Course4",
       "comments": ""
     }
   },

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -359,6 +359,56 @@
         "sectionLevel": {},
         "sessionLevel": {}
       }
+    },
+    "instructor1YetToJoinCourse3": {
+      "id": "00000000-0000-4000-8000-000000000508",
+      "course": {
+        "id": "course-3"
+      },
+      "name": "Instructor 1",
+      "email": "instructor1YetToJoinCourse3@teammates.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor2YetToJoinCourse3": {
+      "id": "00000000-0000-4000-8000-000000000509",
+      "course": {
+        "id": "course-3"
+      },
+      "name": "Instructor 2",
+      "email": "instructor2YetToJoinCourse3@teammates.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
     }
   },
   "students": {
@@ -429,6 +479,30 @@
       },
       "email": "unregisteredStudentInCourse1@teammates.tmt",
       "name": "Unregistered Student In Course1",
+      "comments": ""
+    },
+    "student1YetToJoinCourse1": {
+      "id": "00000000-0000-4000-8000-000000000606",
+      "course": {
+        "id": "course-1"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000302"
+      },
+      "email": "student1YetToJoinCourse@teammates.tmt",
+      "name": "student1YetToJoinCourse In Course1",
+      "comments": ""
+    },
+    "student2YetToJoinCourse1": {
+      "id": "00000000-0000-4000-8000-000000000607",
+      "course": {
+        "id": "course-1"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000302"
+      },
+      "email": "student2YetToJoinCourse@teammates.tmt",
+      "name": "student2YetToJoinCourse In Course1",
       "comments": ""
     }
   },

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -750,6 +750,21 @@ public class Logic {
     }
 
     /**
+     * Make the instructor join the course, i.e. associate the Google ID to the instructor.<br>
+     * Creates an account for the instructor if no existing account is found.
+     * Preconditions: <br>
+     * * Parameters regkey and googleId are non-null.
+     */
+    public Instructor joinCourseForInstructor(String regkey, String googleId)
+            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+
+        assert googleId != null;
+        assert regkey != null;
+
+        return accountsLogic.joinCourseForInstructor(regkey, googleId);
+    }
+
+    /**
      * Gets student associated with {@code id}.
      *
      * @param id    Id of Student.
@@ -859,6 +874,23 @@ public class Logic {
         assert courseId != null;
 
         usersLogic.deleteStudentsInCourseCascade(courseId);
+    }
+
+    /**
+     * Make the student join the course, i.e. associate the Google ID to the student.<br>
+     * Create an account for the student if no existing account is found.
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * @param key the registration key
+     */
+    public Student joinCourseForStudent(String key, String googleId)
+            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+
+        assert googleId != null;
+        assert key != null;
+
+        return accountsLogic.joinCourseForStudent(key, googleId);
+
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/AccountsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountsLogic.java
@@ -207,12 +207,8 @@ public final class AccountsLogic {
         // Update the googleId of the student entity for the instructor which was created from sample data.
         Student student = usersLogic.getStudentForEmail(instructor.getCourseId(), instructor.getEmail());
         if (student != null) {
-            // TODO: Update the student
-            // student.setGoogleId(googleId);
-            // studentsLogic.updateStudentCascade(
-            //         StudentAttributes.updateOptionsBuilder(student.getCourse(), student.getEmail())
-            //                 .withGoogleId(student.getGoogleId())
-            //                 .build());
+            student.setAccount(account);
+            usersLogic.updateStudentCascade(student);
         }
 
         return instructor;

--- a/src/main/java/teammates/sqllogic/core/AccountsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountsLogic.java
@@ -10,8 +10,11 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
+import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.User;
 
 /**
@@ -30,14 +33,18 @@ public final class AccountsLogic {
 
     private UsersLogic usersLogic;
 
+    private CoursesLogic coursesLogic;
+
     private AccountsLogic() {
         // prevent initialization
     }
 
-    void initLogicDependencies(AccountsDb accountsDb, NotificationsLogic notificationsLogic, UsersLogic usersLogic) {
+    void initLogicDependencies(AccountsDb accountsDb, NotificationsLogic notificationsLogic,
+            UsersLogic usersLogic, CoursesLogic coursesLogic) {
         this.accountsDb = accountsDb;
         this.notificationsLogic = notificationsLogic;
         this.usersLogic = usersLogic;
+        this.coursesLogic = coursesLogic;
     }
 
     public static AccountsLogic inst() {
@@ -155,5 +162,133 @@ public final class AccountsLogic {
         return accountsDb.getAccountByGoogleId(googleId).getReadNotifications().stream()
                 .map(n -> n.getNotification().getId())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Joins the user as a student.
+     */
+    public Student joinCourseForStudent(String registrationKey, String googleId)
+            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+        Student student = validateStudentJoinRequest(registrationKey, googleId);
+
+        Account account = accountsDb.getAccountByGoogleId(googleId);
+        // Create an account if it doesn't exist
+        if (account == null) {
+            account = new Account(googleId, student.getName(), student.getEmail());
+            createAccount(account);
+        }
+
+        if (student.getAccount() == null) {
+            student.setAccount(account);
+        }
+
+        return student;
+    }
+
+    /**
+     * Joins the user as an instructor.
+     */
+    public Instructor joinCourseForInstructor(String key, String googleId)
+            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+        Instructor instructor = validateInstructorJoinRequest(key, googleId);
+
+        Account account = accountsDb.getAccountByGoogleId(googleId);
+        if (account == null) {
+            try {
+                account = new Account(googleId, instructor.getName(), instructor.getEmail());
+                createAccount(account);
+            } catch (EntityAlreadyExistsException e) {
+                assert false : "Account already exists.";
+            }
+        }
+
+        instructor.setAccount(account);
+
+        // Update the googleId of the student entity for the instructor which was created from sample data.
+        Student student = usersLogic.getStudentForEmail(instructor.getCourseId(), instructor.getEmail());
+        if (student != null) {
+            // TODO: Update the student
+            // student.setGoogleId(googleId);
+            // studentsLogic.updateStudentCascade(
+            //         StudentAttributes.updateOptionsBuilder(student.getCourse(), student.getEmail())
+            //                 .withGoogleId(student.getGoogleId())
+            //                 .build());
+        }
+
+        return instructor;
+    }
+
+    private Instructor validateInstructorJoinRequest(String registrationKey, String googleId)
+            throws EntityDoesNotExistException, EntityAlreadyExistsException {
+        Instructor instructorForKey = usersLogic.getInstructorByRegistrationKey(registrationKey);
+
+        if (instructorForKey == null) {
+            throw new EntityDoesNotExistException("No instructor with given registration key: " + registrationKey);
+        }
+
+        Course course = coursesLogic.getCourse(instructorForKey.getCourseId());
+
+        if (course == null) {
+            throw new EntityDoesNotExistException("Course with id " + instructorForKey.getCourseId() + " does not exist");
+        }
+
+        if (course.isCourseDeleted()) {
+            throw new EntityDoesNotExistException("The course you are trying to join has been deleted by an instructor");
+        }
+
+        if (instructorForKey.isRegistered()) {
+            if (instructorForKey.getGoogleId().equals(googleId)) {
+                Account existingAccount = accountsDb.getAccountByGoogleId(googleId);
+                if (existingAccount != null) {
+                    throw new EntityAlreadyExistsException("Instructor has already joined course");
+                }
+            } else {
+                throw new EntityAlreadyExistsException("Instructor has already joined course");
+            }
+        } else {
+            // Check if this Google ID has already joined this course
+            Instructor existingInstructor =
+                    usersLogic.getInstructorByGoogleId(instructorForKey.getCourseId(), googleId);
+
+            if (existingInstructor != null) {
+                throw new EntityAlreadyExistsException("Instructor has already joined course");
+            }
+        }
+
+        return instructorForKey;
+    }
+
+    private Student validateStudentJoinRequest(String registrationKey, String googleId)
+            throws EntityDoesNotExistException, EntityAlreadyExistsException {
+
+        Student studentRole = usersLogic.getStudentByRegistrationKey(registrationKey);
+
+        if (studentRole == null) {
+            throw new EntityDoesNotExistException("No student with given registration key: " + registrationKey);
+        }
+
+        Course course = coursesLogic.getCourse(studentRole.getCourseId());
+
+        if (course == null) {
+            throw new EntityDoesNotExistException("Course with id " + studentRole.getCourseId() + " does not exist");
+        }
+
+        if (course.isCourseDeleted()) {
+            throw new EntityDoesNotExistException("The course you are trying to join has been deleted by an instructor");
+        }
+
+        if (studentRole.isRegistered()) {
+            throw new EntityAlreadyExistsException("Student has already joined course");
+        }
+
+        // Check if this Google ID has already joined this course
+        Student existingStudent =
+                usersLogic.getStudentByGoogleId(studentRole.getCourseId(), googleId);
+
+        if (existingStudent != null) {
+            throw new EntityAlreadyExistsException("Student has already joined course");
+        }
+
+        return studentRole;
     }
 }

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -41,7 +41,7 @@ public class LogicStarter implements ServletContextListener {
         UsersLogic usersLogic = UsersLogic.inst();
 
         accountRequestsLogic.initLogicDependencies(AccountRequestsDb.inst());
-        accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic);
+        accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic, coursesLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic, usersLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,
                 deadlineExtensionsLogic, fsLogic, fqLogic, frLogic, frcLogic,

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -43,6 +43,8 @@ public class AccountsLogicTest extends BaseTestCase {
 
     private UsersLogic usersLogic;
 
+    private CoursesLogic coursesLogic;
+
     private Course course;
 
     @BeforeMethod
@@ -50,7 +52,7 @@ public class AccountsLogicTest extends BaseTestCase {
         accountsDb = mock(AccountsDb.class);
         notificationsLogic = mock(NotificationsLogic.class);
         usersLogic = mock(UsersLogic.class);
-        accountsLogic.initLogicDependencies(accountsDb, notificationsLogic, usersLogic);
+        accountsLogic.initLogicDependencies(accountsDb, notificationsLogic, usersLogic, coursesLogic);
 
         course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
     }


### PR DESCRIPTION
Part of #12048

**Outline of Solution**
- Modified `JoinCourseAction` to use `sqlLogic` when course is migrated
  - Used registration key in the http param to query the DB for `courseId`. 
  - Default to use the result of querying datastore if it is not null. If both are null, default to "not migrated" instead of throwing exception as the logic for checking if registration key is valid is already present in the logic layer.
- Added `joinCourseForStudent` and `joinCourseForInstructor` to`sqllogic.core.AccountsLogic`
- Added integration test for `JoinCourseAction`
- Added test cases for testing the `joinCourseForStudent` and `joinCourseForInstructor` to `AccountsLogicIT.java`