### PR TITLE
[#12048] Migrate search account requests action

### DIFF
--- a/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
@@ -1,0 +1,167 @@
+package teammates.it.storage.sqlsearch;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.exception.SearchServiceException;
+import teammates.common.util.HibernateUtil;
+import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
+import teammates.storage.sqlapi.AccountRequestsDb;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.test.AssertHelper;
+import teammates.test.TestProperties;
+
+/**
+ * SUT: {@link AccountRequestsDb},
+ *      {@link teammates.storage.search.AccountRequestSearchDocument}.
+ */
+public class AccountRequestSearchIT extends BaseTestCaseWithSqlDatabaseAccess {
+
+    private final SqlDataBundle typicalBundle = getTypicalSqlDataBundle();
+    private final AccountRequestsDb accountRequestsDb = AccountRequestsDb.inst();
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        putDocuments(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Test
+    public void allTests() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        AccountRequest ins1General = typicalBundle.accountRequests.get("instructor1");
+        AccountRequest ins2General = typicalBundle.accountRequests.get("instructor2");
+        AccountRequest ins1InCourse1 = typicalBundle.accountRequests.get("instructor1OfCourse1");
+        AccountRequest ins2InCourse1 = typicalBundle.accountRequests.get("instructor2OfCourse1");
+        AccountRequest ins1InCourse2 = typicalBundle.accountRequests.get("instructor1OfCourse2");
+        AccountRequest ins2InCourse2 = typicalBundle.accountRequests.get("instructor2OfCourse2");
+        AccountRequest ins1InCourse3 = typicalBundle.accountRequests.get("instructor1OfCourse3");
+        AccountRequest ins2InCourse3 = typicalBundle.accountRequests.get("instructor2OfCourse3");
+        AccountRequest insInUnregCourse = typicalBundle.accountRequests.get("instructor3");
+        AccountRequest unregisteredInstructor1 =
+                typicalBundle.accountRequests.get("unregisteredInstructor1");
+        AccountRequest unregisteredInstructor2 =
+                typicalBundle.accountRequests.get("unregisteredInstructor2");
+
+        ______TS("success: search for account requests; query string does not match anyone");
+
+        List<AccountRequest> results =
+                accountRequestsDb.searchAccountRequestsInWholeSystem("non-existent");
+        verifySearchResults(results);
+
+        ______TS("success: search for account requests; empty query string does not match anyone");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("");
+        verifySearchResults(results);
+
+        ______TS("success: search for account requests; query string matches some account requests");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"Instructor 1\"");
+        verifySearchResults(results, ins1InCourse1, ins1InCourse2, ins1InCourse3, unregisteredInstructor1, ins1General);
+
+        ______TS("success: search for account requests; query string should be case-insensitive");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"InStRuCtOr 2\"");
+        verifySearchResults(results, ins2InCourse1, ins2InCourse2, ins2InCourse3, unregisteredInstructor2, ins2General);
+
+        ______TS("success: search for account requests; account requests should be searchable by their name");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"Instructor 3 of CourseNoRegister\"");
+        verifySearchResults(results, insInUnregCourse);
+
+        ______TS("success: search for account requests; account requests should be searchable by their email");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("instr2@course2.tmt");
+        verifySearchResults(results, ins2InCourse2);
+
+        ______TS("success: search for account requests; account requests should be searchable by their institute");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"TEAMMATES Test Institute 2\"");
+        verifySearchResults(results, unregisteredInstructor2);
+
+        ______TS("success: search for account requests; unregistered account requests should be searchable");
+
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"unregisteredinstructor1@gmail.tmt\"");
+        verifySearchResults(results, unregisteredInstructor1);
+
+        ______TS("success: search for account requests; deleted account requests no longer searchable");
+
+        accountRequestsDb.deleteAccountRequest(ins1InCourse1);
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"instructor 1\"");
+        verifySearchResults(results, ins1InCourse2, ins1InCourse3, unregisteredInstructor1, ins1General);
+
+        ______TS("success: search for account requests; account requests created without searchability unsearchable");
+
+        accountRequestsDb.createAccountRequest(ins1InCourse1);
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"instructor 1\"");
+        verifySearchResults(results, ins1InCourse2, ins1InCourse3, unregisteredInstructor1, ins1General);
+
+        ______TS("success: search for account requests; deleting account request without deleting document:"
+                + "document deleted during search, account request unsearchable");
+
+        accountRequestsDb.deleteAccountRequest(ins2InCourse1);
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"instructor 2\"");
+        verifySearchResults(results, ins2InCourse2, ins2InCourse3, unregisteredInstructor2, ins2General);
+    }
+
+    @Test
+    public void testSearchAccountRequest_deleteAfterSearch_shouldNotBeSearchable() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        AccountRequest ins1InCourse2 = typicalBundle.accountRequests.get("instructor1OfCourse2");
+        AccountRequest ins2InCourse2 = typicalBundle.accountRequests.get("instructor2OfCourse2");
+
+        // there is search result before deletion
+        List<AccountRequest> results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"of Course 2\"");
+        verifySearchResults(results, ins1InCourse2, ins2InCourse2);
+
+        // delete an account request
+        accountRequestsDb.deleteAccountRequest(ins1InCourse2);
+
+        // the search result will change
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"of Course 2\"");
+        verifySearchResults(results, ins2InCourse2);
+
+        // delete all account requests
+        accountRequestsDb.deleteAccountRequest(ins2InCourse2);
+
+        // there should be no search result
+        results = accountRequestsDb.searchAccountRequestsInWholeSystem("\"of Course 2\"");
+        verifySearchResults(results);
+    }
+
+    @Test
+    public void testSearchAccountRequest_noSearchService_shouldThrowException() {
+        if (TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        assertThrows(SearchServiceException.class,
+                () -> accountRequestsDb.searchAccountRequestsInWholeSystem("anything"));
+    }
+
+    /**
+     * Verifies that search results match with expected output.
+     *
+     * @param actual the results from the search query.
+     * @param expected the expected results for the search query.
+     */
+    private static void verifySearchResults(List<AccountRequest> actual,
+            AccountRequest... expected) {
+        assertEquals(expected.length, actual.size());
+        AssertHelper.assertSameContentIgnoreOrder(Arrays.asList(expected), actual);
+    }
+
+}

--- a/src/it/java/teammates/it/ui/webapi/GetCourseJoinStatusActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetCourseJoinStatusActionIT.java
@@ -131,7 +131,7 @@ public class GetCourseJoinStatusActionIT extends BaseActionIT<GetCourseJoinStatu
 
         ______TS("Normal case: account request not used, instructor has not joined course");
 
-        String accountRequestNotUsedKey = logic.getAccountRequest("unregisteredInstructor@teammates.tmt",
+        String accountRequestNotUsedKey = logic.getAccountRequest("unregisteredinstructor1@gmail.tmt",
                 "TEAMMATES Test Institute 1").getRegistrationKey();
 
         params = new String[] {

--- a/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
@@ -102,7 +102,7 @@ public class SearchAccountRequestsActionIT extends BaseActionIT<SearchAccountReq
         result = getJsonResult(action, 200);
         response = (AccountRequestsData) result.getOutput();
         assertTrue(response.getAccountRequests().get(0).getRegistrationKey() != null);
-        assertEquals(3, response.getAccountRequests().size());
+        assertEquals(11, response.getAccountRequests().size());
 
         ______TS("Search result with 0 matches");
 

--- a/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
@@ -67,7 +67,6 @@ public class SearchAccountRequestsActionIT extends BaseActionIT<SearchAccountReq
         String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, accountRequest.getEmail() };
         SearchAccountRequestsAction action = getAction(submissionParams);
         JsonResult result = getJsonResult(action, 200);
-        // assertEquals(((MessageOutput) result.getOutput()).getMessage(), new JsonResult("null", 503).getOutput());
         AccountRequestsData response = (AccountRequestsData) result.getOutput();
         assertTrue(response.getAccountRequests().stream()
                 .filter(i -> i.getName().equals(accountRequest.getName()))

--- a/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchAccountRequestsActionIT.java
@@ -1,0 +1,116 @@
+package teammates.it.ui.webapi;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.storage.sqlentity.Course;
+import teammates.test.TestProperties;
+import teammates.ui.output.AccountRequestsData;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.webapi.JsonResult;
+import teammates.ui.webapi.SearchAccountRequestsAction;
+
+/**
+ * SUT: {@link SearchAccountRequestsAction}.
+ */
+public class SearchAccountRequestsActionIT extends BaseActionIT<SearchAccountRequestsAction> {
+
+    @Override
+    @Test
+    protected void testAccessControl() throws InvalidParametersException, EntityAlreadyExistsException {
+        Course course = typicalBundle.courses.get("course1");
+        verifyOnlyAdminCanAccess(course);
+    }
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        putDocuments(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SEARCH_ACCOUNT_REQUESTS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws InvalidParametersException, EntityAlreadyExistsException {
+        if (!TestProperties.isSearchServiceActive()) {
+            ______TS("Search with SearchService disabled");
+            String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, "randomString123" };
+            SearchAccountRequestsAction action = getAction(submissionParams);
+            JsonResult result = getJsonResult(action, HttpStatus.SC_NOT_IMPLEMENTED);
+            MessageOutput output = (MessageOutput) result.getOutput();
+            assertEquals("Full-text search is not available.", output.getMessage());
+            return;
+        }
+        AccountRequest accountRequest = typicalBundle.accountRequests.get("instructor1");
+
+        loginAsAdmin();
+
+        ______TS("Search via Email");
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, accountRequest.getEmail() };
+        SearchAccountRequestsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action, 200);
+        // assertEquals(((MessageOutput) result.getOutput()).getMessage(), new JsonResult("null", 503).getOutput());
+        AccountRequestsData response = (AccountRequestsData) result.getOutput();
+        assertTrue(response.getAccountRequests().stream()
+                .filter(i -> i.getName().equals(accountRequest.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getAccountRequests().get(0).getRegistrationKey() != null);
+
+        ______TS("Search via Institute");
+        submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, accountRequest.getInstitute() };
+        action = getAction(submissionParams);
+        result = getJsonResult(action, 200);
+        response = (AccountRequestsData) result.getOutput();
+        assertTrue(response.getAccountRequests().stream()
+                .filter(i -> i.getName().equals(accountRequest.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getAccountRequests().get(0).getRegistrationKey() != null);
+
+        ______TS("Search via Name");
+        submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, accountRequest.getName() };
+        action = getAction(submissionParams);
+        result = getJsonResult(action, 200);
+        response = (AccountRequestsData) result.getOutput();
+        assertTrue(response.getAccountRequests().stream()
+                .filter(i -> i.getName().equals(accountRequest.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getAccountRequests().get(0).getRegistrationKey() != null);
+
+        ______TS("Search Duplicate Name");
+        submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, "Instructor" };
+        action = getAction(submissionParams);
+        result = getJsonResult(action, 200);
+        response = (AccountRequestsData) result.getOutput();
+        assertTrue(response.getAccountRequests().get(0).getRegistrationKey() != null);
+        assertEquals(3, response.getAccountRequests().size());
+
+        ______TS("Search result with 0 matches");
+
+        submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, "randomString123" };
+        action = getAction(submissionParams);
+        result = getJsonResult(action, 200);
+        response = (AccountRequestsData) result.getOutput();
+        assertEquals(0, response.getAccountRequests().size());
+    }
+}

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -64,11 +64,66 @@
       "institute": "TEAMMATES Test Institute 1",
       "registeredAt": "2015-02-14T00:00:00Z"
     },
-    "unregisteredInstructor": {
-      "id": "00000000-0000-4000-8000-000000000103",
-      "name": "Unregistered Instructor",
-      "email": "unregisteredInstructor@teammates.tmt",
-      "institute": "TEAMMATES Test Institute 1"
+    "instructor3": {
+      "name": "Instructor 3 of CourseNoRegister",
+      "email": "instr3@teammates.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor1OfCourse1": {
+      "name": "Instructor 1 of Course 1",
+      "email": "instr1@course1.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor2OfCourse1": {
+      "name": "Instructor 2 of Course 1",
+      "email": "instr2@course1.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor1OfCourse2": {
+      "name": "Instructor 1 of Course 2",
+      "email": "instr1@course2.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor2OfCourse2": {
+      "name": "Instructor 2 of Course 2",
+      "email": "instr2@course2.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor1OfCourse3": {
+      "name": "Instructor 1 of Course 3",
+      "email": "instr1@course3.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "instructor2OfCourse3": {
+      "name": "Instructor 2 of Course 3",
+      "email": "instr2@course3.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "unregisteredInstructor1": {
+      "name": "Unregistered Instructor 1",
+      "email": "unregisteredinstructor1@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2011-01-01T00:00:00Z"
+    },
+    "unregisteredInstructor2": {
+      "name": "Unregistered Instructor 2",
+      "email": "unregisteredinstructor2@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 2",
+      "createdAt": "2011-01-01T00:00:00Z"
     }
   },
   "courses": {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1280,4 +1280,16 @@ public class Logic {
             throws InvalidParametersException, EntityDoesNotExistException {
         return feedbackQuestionsLogic.updateFeedbackQuestionCascade(questionId, updateRequest);
     }
+
+    /**
+     * This is used by admin to search account requests in the whole system.
+     *
+     * @return A list of {@link AccountRequest} or {@code null} if no match found.
+     */
+    public List<AccountRequest> searchAccountRequestsInWholeSystem(String queryString)
+            throws SearchServiceException {
+        assert queryString != null;
+
+        return accountRequestLogic.searchAccountRequestsInWholeSystem(queryString);
+    }
 }

--- a/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
@@ -1,5 +1,7 @@
 package teammates.sqllogic.core;
 
+import java.util.List;
+
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -106,5 +108,15 @@ public final class AccountRequestsLogic {
         AccountRequest toDelete = accountRequestDb.getAccountRequest(email, institute);
 
         accountRequestDb.deleteAccountRequest(toDelete);
+    }
+
+    /**
+     * Searches for account requests in the whole system.
+     *
+     * @return A list of {@link AccountRequest} or {@code null} if no match found.
+     */
+    public List<AccountRequest> searchAccountRequestsInWholeSystem(String queryString)
+            throws SearchServiceException {
+        return accountRequestDb.searchAccountRequestsInWholeSystem(queryString);
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
@@ -4,11 +4,13 @@ import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.SearchServiceException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlsearch.AccountRequestSearchManager;
@@ -128,5 +130,20 @@ public final class AccountRequestsDb extends EntitiesDb {
         if (accountRequest != null) {
             delete(accountRequest);
         }
+    }
+
+    /**
+     * Searches all account requests in the system.
+     *
+     * <p>This is used by admin to search account requests in the whole system.
+     */
+    public List<AccountRequest> searchAccountRequestsInWholeSystem(String queryString)
+            throws SearchServiceException {
+
+        if (queryString.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return getSearchManager().searchAccountRequests(queryString);
     }
 }

--- a/src/main/java/teammates/ui/webapi/SearchAccountRequestsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchAccountRequestsAction.java
@@ -3,29 +3,30 @@ package teammates.ui.webapi;
 import java.util.ArrayList;
 import java.util.List;
 
-import teammates.common.datatransfer.attributes.AccountRequestAttributes;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.AccountRequest;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.output.AccountRequestsData;
 
 /**
  * Searches for account requests.
  */
-class SearchAccountRequestsAction extends AdminOnlyAction {
+public class SearchAccountRequestsAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.SEARCH_KEY);
-        List<AccountRequestAttributes> accountRequests;
+
+        List<AccountRequest> accountRequests;
         try {
-            accountRequests = logic.searchAccountRequestsInWholeSystem(searchKey);
+            accountRequests = sqlLogic.searchAccountRequestsInWholeSystem(searchKey);
         } catch (SearchServiceException e) {
             return new JsonResult(e.getMessage(), e.getStatusCode());
         }
 
         List<AccountRequestData> accountRequestDataList = new ArrayList<>();
-        for (AccountRequestAttributes accountRequest : accountRequests) {
+        for (AccountRequest accountRequest : accountRequests) {
             AccountRequestData accountRequestData = new AccountRequestData(accountRequest);
             accountRequestDataList.add(accountRequestData);
         }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**
- Change `SearchAccountRequestsAction` to handle search on both datastore and SQL db
- Created necessary functions in `AccountRequestsLogic` and `AccountRequestsDb`
- Add in tests for search on SQL db for this action
- Support for twin db implemented similarly to #12728 

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
