### PR TITLE
[#12048] Support for twin db for search + replace datastore test

### DIFF
--- a/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
@@ -3,33 +3,68 @@ package teammates.ui.webapi;
 import java.util.ArrayList;
 import java.util.List;
 
+import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.InstructorData;
 import teammates.ui.output.InstructorsData;
 
-/**
+/** 
  * Searches for instructors.
  */
 public class SearchInstructorsAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute() {
+        // Search for sql db
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.SEARCH_KEY);
         List<Instructor> instructors;
         try {
             instructors = sqlLogic.searchInstructorsInWholeSystem(searchKey);
         } catch (SearchServiceException e) {
             return new JsonResult(e.getMessage(), e.getStatusCode());
+        } catch (NullPointerException e) {
+            // Solr search service is not active
+            instructors = new ArrayList<>();
+        }
+
+        // Catching of NullPointerException for both Solr searches below is necessary for running of tests.
+        // Tests extend from a base test case class, that only registers one of the search managers.
+        // Hence, for tests, the other search manager is not registered and will throw a NullPointerException.
+        // This should not be a problem in production, because the method to register the search manager
+        // will be invoked by Jetty at application startup.
+
+        // Search for datastore
+        List<InstructorAttributes> instructorsDatastore;
+        try {
+            instructorsDatastore = logic.searchInstructorsInWholeSystem(searchKey);
+        } catch (SearchServiceException e) {
+            return new JsonResult(e.getMessage(), e.getStatusCode());
+        } catch (NullPointerException e) {
+            // Solr search service is not active
+            instructorsDatastore = new ArrayList<>();
         }
 
         List<InstructorData> instructorDataList = new ArrayList<>();
+
+        // Add instructors from sql db
         for (Instructor instructor : instructors) {
             InstructorData instructorData = new InstructorData(instructor);
             instructorData.addAdditionalInformationForAdminSearch(
                     instructor.getRegKey(),
                     sqlLogic.getCourse(instructor.getCourseId()).getInstitute(),
+                    instructor.getGoogleId());
+
+            instructorDataList.add(instructorData);
+        }
+
+        // Add instructors from datastore
+        for (InstructorAttributes instructor : instructorsDatastore) {
+            InstructorData instructorData = new InstructorData(instructor);
+            instructorData.addAdditionalInformationForAdminSearch(
+                    instructor.getKey(),
+                    logic.getCourseInstitute(instructor.getCourseId()),
                     instructor.getGoogleId());
 
             instructorDataList.add(instructorData);

--- a/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
@@ -67,6 +67,11 @@ public class SearchInstructorsAction extends AdminOnlyAction {
                     logic.getCourseInstitute(instructor.getCourseId()),
                     instructor.getGoogleId());
 
+            // If the instructor is already in the list, do not add it again
+            if (instructorDataList.contains(instructorData)) {
+                continue;
+            }
+
             instructorDataList.add(instructorData);
         }
 

--- a/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
@@ -71,8 +71,8 @@ public class SearchInstructorsAction extends AdminOnlyAction {
                     logic.getCourseInstitute(instructor.getCourseId()),
                     instructor.getGoogleId());
 
-            // If the instructor is already in the list, do not add it again
-            if (instructorDataList.contains(instructorData)) {
+            // If the course has been migrated, then the instructor would have been added already
+            if (isCourseMigrated(instructorData.getCourseId())) {
                 continue;
             }
 

--- a/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchInstructorsAction.java
@@ -10,11 +10,12 @@ import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.InstructorData;
 import teammates.ui.output.InstructorsData;
 
-/** 
+/**
  * Searches for instructors.
  */
 public class SearchInstructorsAction extends AdminOnlyAction {
 
+    @SuppressWarnings("PMD.AvoidCatchingNPE") // See comment chunk below
     @Override
     public JsonResult execute() {
         // Search for sql db
@@ -32,7 +33,10 @@ public class SearchInstructorsAction extends AdminOnlyAction {
         // Catching of NullPointerException for both Solr searches below is necessary for running of tests.
         // Tests extend from a base test case class, that only registers one of the search managers.
         // Hence, for tests, the other search manager is not registered and will throw a NullPointerException.
-        // This should not be a problem in production, because the method to register the search manager
+        // It is possible to get around catching the NullPointerException, but that would require quite a bit
+        // of editing of other files.
+        // Since we will phase out the use of datastore, I think this approach is better.
+        // This also should not be a problem in production, because the method to register the search manager
         // will be invoked by Jetty at application startup.
 
         // Search for datastore

--- a/src/test/java/teammates/ui/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SearchInstructorsActionTest.java
@@ -1,0 +1,176 @@
+package teammates.ui.webapi;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.test.TestProperties;
+import teammates.ui.output.InstructorsData;
+import teammates.ui.output.MessageOutput;
+
+/**
+ * SUT: {@link SearchInstructorsAction}.
+ */
+public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructorsAction> {
+
+    private final InstructorAttributes acc = typicalBundle.instructors.get("instructor1OfCourse1");
+
+    @Override
+    protected void prepareTestData() {
+        DataBundle dataBundle = getTypicalDataBundle();
+        removeAndRestoreDataBundle(dataBundle);
+        putDocuments(dataBundle);
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SEARCH_INSTRUCTORS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Override
+    protected void testExecute() {
+        // See test cases below.
+    }
+
+    @Test
+    protected void testExecute_notEnoughParameters_shouldFail() {
+        loginAsAdmin();
+        verifyHttpParameterFailure();
+    }
+
+    @Test
+    protected void testExecute_searchCourseId_shouldSucceed() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, acc.getCourseId() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchDisplayedName_shouldSucceed() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, acc.getDisplayedName() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchEmail_shouldSucceed() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, acc.getEmail() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
+    }
+
+    @Test
+    protected void testExecute_searchGoogleId_shouldSucceed() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, acc.getGoogleId() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
+    }
+
+    @Test
+    protected void testExecute_searchName_shouldSucceed() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, acc.getName() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
+    }
+
+    @Test
+    protected void testExecute_searchNoMatch_shouldBeEmpty() {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, "noMatch" };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        InstructorsData response = (InstructorsData) result.getOutput();
+        assertEquals(0, response.getInstructors().size());
+    }
+
+    @Test
+    public void testExecute_noSearchService_shouldReturn501() {
+        if (TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        loginAsAdmin();
+        String[] params = new String[] {
+                Const.ParamsNames.SEARCH_KEY, "anything",
+        };
+        SearchInstructorsAction a = getAction(params);
+        JsonResult result = getJsonResult(a, HttpStatus.SC_NOT_IMPLEMENTED);
+        MessageOutput output = (MessageOutput) result.getOutput();
+
+        assertEquals("Full-text search is not available.", output.getMessage());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() {
+        verifyOnlyAdminCanAccess();
+    }
+
+}


### PR DESCRIPTION
Part of #12048 

Reworking some code from #12340:
- Previously, the `SearchInstructorsActionTest` was failing because the `SearchInstructorsAction` only uses the new `sqlsearch`
- However, this leads to 2 issues: we lack the original test for searching in datastore, and we are also unable to support search for twin db

Solution:
- Add back in the original search and concatenate the results
- Add back the original test, now that we have the ability to search both
- Currently unable to test both together since we would need to somehow initialise both search managers at once...