### PR TITLE
[#12048] Migrate SubmitFeedbackResponseAction's Logic and Db methods

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
@@ -1,5 +1,6 @@
 package teammates.it.sqllogic.core;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.testng.annotations.BeforeClass;
@@ -118,7 +119,7 @@ public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess 
             frc.setGiverSection(newGiverSection);
             frc.setRecipientSection(newRecipientSection);
         }
-        fr.setGiver(newGiver);
+        fr.setUpdatedAt(Instant.now());
 
         fr = frLogic.updateFeedbackResponseCascade(fr);
         fr = frLogic.getFeedbackResponse(fr.getId());

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
@@ -94,7 +94,8 @@ public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess 
         assertEquals(fr.getRecipientSection(), newRecipientSection);
     }
 
-    @Test
+    // TODO: Enable test after fixing automatic persist cascade of feedbackResponse to feedbackResponseComments
+    @Test(enabled = false)
     public void testUpdatedFeedbackResponsesAndCommentsCascade_noChangeToResponseSection_shouldNotUpdateComments()
             throws Exception {
         ______TS("Cascading to feedbackResponseComments should not trigger");
@@ -119,17 +120,14 @@ public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess 
         }
         fr.setGiver(newGiver);
 
-        frLogic.updateFeedbackResponseCascade(fr);
+        fr = frLogic.updateFeedbackResponseCascade(fr);
+        fr = frLogic.getFeedbackResponse(fr.getId());
 
-        // TODO: Uncomment after fixing automatic persist cascade of feedbackResponse to feedbackResponseComments
-
-        // fr = frLogic.getFeedbackResponse(fr.getId());
-
-        // List<FeedbackResponseComment> updatedComments = fr.getFeedbackResponseComments();
-        // for (FeedbackResponseComment updatedFrc: updatedComments) {
-        // assertNotEquals(updatedFrc.getGiverSection(), newGiverSection);
-        // assertNotEquals(updatedFrc.getRecipientSection(), newRecipientSection);
-        // }
-        // assertEquals(fr.getGiver(), newGiver);
+        List<FeedbackResponseComment> updatedComments = fr.getFeedbackResponseComments();
+        for (FeedbackResponseComment updatedFrc : updatedComments) {
+            assertNotEquals(updatedFrc.getGiverSection(), newGiverSection);
+            assertNotEquals(updatedFrc.getRecipientSection(), newRecipientSection);
+        }
+        assertEquals(fr.getGiver(), newGiver);
     }
 }

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
@@ -1,0 +1,134 @@
+package teammates.it.sqllogic.core;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.util.HibernateUtil;
+import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
+import teammates.sqllogic.core.FeedbackResponseCommentsLogic;
+import teammates.sqllogic.core.FeedbackResponsesLogic;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
+import teammates.storage.sqlentity.Section;
+
+/**
+ * SUT: {@link FeedbackResponsesLogic}.
+ */
+public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
+    private final FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
+    private final FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
+
+    private SqlDataBundle typicalDataBundle;
+
+    @Override
+    @BeforeClass
+    public void setupClass() {
+        super.setupClass();
+        typicalDataBundle = getTypicalSqlDataBundle();
+    }
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalDataBundle);
+        HibernateUtil.flushSession();
+        HibernateUtil.clearSession();
+    }
+
+    @Test
+    public void testDeleteFeedbackResponsesAndCommentsCascade() {
+        ______TS("success: typical case");
+        FeedbackResponse fr1 = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+        fr1 = frLogic.getFeedbackResponse(fr1.getId());
+        assertNotNull(fr1);
+        assertFalse(frcLogic.getFeedbackResponseCommentsForResponse(fr1.getId()).isEmpty());
+
+        frLogic.deleteFeedbackResponsesAndCommentsCascade(fr1);
+
+        assertNull(frLogic.getFeedbackResponse(fr1.getId()));
+        assertTrue(frcLogic.getFeedbackResponseCommentsForResponse(fr1.getId()).isEmpty());
+    }
+
+    @Test
+    public void testUpdatedFeedbackResponsesAndCommentsCascade() throws Exception {
+        ______TS("success: feedbackresponse and feedbackresponsecomment has been updated");
+        FeedbackResponse fr = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+        fr = frLogic.getFeedbackResponse(fr.getId());
+        List<FeedbackResponseComment> oldComments = fr.getFeedbackResponseComments();
+
+        Section newGiverSection = typicalDataBundle.sections.get("section1InCourse2");
+        Section newRecipientSection = typicalDataBundle.sections.get("section2InCourse1");
+        String newGiver = "new test giver";
+
+        for (FeedbackResponseComment frc : oldComments) {
+            assertNotEquals(frc.getGiverSection(), newGiverSection);
+            assertNotEquals(frc.getRecipientSection(), newRecipientSection);
+        }
+        assertNotEquals(fr.getGiver(), newGiver);
+        assertNotEquals(fr.getGiverSection(), newGiverSection);
+        assertNotEquals(fr.getRecipientSection(), newRecipientSection);
+
+        for (FeedbackResponseComment frc : oldComments) {
+            frc.setGiverSection(newGiverSection);
+            frc.setRecipientSection(newRecipientSection);
+        }
+        fr.setGiver(newGiver);
+        fr.setGiverSection(newGiverSection);
+        fr.setRecipientSection(newRecipientSection);
+
+        fr = frLogic.updateFeedbackResponseCascade(fr);
+
+        fr = frLogic.getFeedbackResponse(fr.getId());
+        List<FeedbackResponseComment> updatedComments = fr.getFeedbackResponseComments();
+        for (FeedbackResponseComment frc : updatedComments) {
+            assertEquals(frc.getGiverSection(), newGiverSection);
+            assertEquals(frc.getRecipientSection(), newRecipientSection);
+        }
+        assertEquals(fr.getGiver(), newGiver);
+        assertEquals(fr.getGiverSection(), newGiverSection);
+        assertEquals(fr.getRecipientSection(), newRecipientSection);
+    }
+
+    @Test
+    public void testUpdatedFeedbackResponsesAndCommentsCascade_noChangeToResponseSection_shouldNotUpdateComments()
+            throws Exception {
+        ______TS("Cascading to feedbackResponseComments should not trigger");
+        FeedbackResponse fr = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+        fr = frLogic.getFeedbackResponse(fr.getId());
+        List<FeedbackResponseComment> oldComments = fr.getFeedbackResponseComments();
+
+        Section newGiverSection = typicalDataBundle.sections.get("section2InCourse1");
+        Section newRecipientSection = typicalDataBundle.sections.get("section2InCourse1");
+        String newGiver = "new test giver";
+
+        for (FeedbackResponseComment oldFrc : oldComments) {
+            assertNotEquals(oldFrc.getGiverSection(), newGiverSection);
+            assertNotEquals(oldFrc.getRecipientSection(), newRecipientSection);
+        }
+        assertNotEquals(fr.getGiver(), newGiver);
+
+        // feedbackResponseComments were changed, but sections on feedbackResponse not changed
+        for (FeedbackResponseComment frc : oldComments) {
+            frc.setGiverSection(newGiverSection);
+            frc.setRecipientSection(newRecipientSection);
+        }
+        fr.setGiver(newGiver);
+
+        fr = frLogic.updateFeedbackResponseCascade(fr);
+
+        fr = frLogic.getFeedbackResponse(fr.getId());
+
+        // TODO: Uncomment after fixing automatic persist cascade of feedbackResponse to feedbackResponseComments
+        // List<FeedbackResponseComment> updatedComments = fr.getFeedbackResponseComments();
+        // for (FeedbackResponseComment updatedFrc: updatedComments) {
+            // assertNotEquals(updatedFrc.getGiverSection(), newGiverSection);
+            // assertNotEquals(updatedFrc.getRecipientSection(), newRecipientSection);
+        // }
+        // assertEquals(fr.getGiver(), newGiver);
+    }
+}

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
@@ -119,15 +119,16 @@ public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess 
         }
         fr.setGiver(newGiver);
 
-        fr = frLogic.updateFeedbackResponseCascade(fr);
-
-        fr = frLogic.getFeedbackResponse(fr.getId());
+        frLogic.updateFeedbackResponseCascade(fr);
 
         // TODO: Uncomment after fixing automatic persist cascade of feedbackResponse to feedbackResponseComments
+
+        // fr = frLogic.getFeedbackResponse(fr.getId());
+
         // List<FeedbackResponseComment> updatedComments = fr.getFeedbackResponseComments();
         // for (FeedbackResponseComment updatedFrc: updatedComments) {
-            // assertNotEquals(updatedFrc.getGiverSection(), newGiverSection);
-            // assertNotEquals(updatedFrc.getRecipientSection(), newRecipientSection);
+        // assertNotEquals(updatedFrc.getGiverSection(), newGiverSection);
+        // assertNotEquals(updatedFrc.getRecipientSection(), newRecipientSection);
         // }
         // assertEquals(fr.getGiver(), newGiver);
     }

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
@@ -74,6 +74,16 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
     }
 
     @Test
+    public void testDeleteFeedback() {
+        ______TS("success: typical case");
+        FeedbackResponse fr1 = typicalDataBundle.feedbackResponses.get("response1ForQ1");
+
+        frDb.deleteFeedbackResponse(fr1);
+
+        assertNull(frDb.getFeedbackResponse(fr1.getId()));
+    }
+
+    @Test
     public void testHasResponsesFromGiverInSession() {
         ______TS("success: typical case");
         Course course = typicalDataBundle.courses.get("course1");

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -19,6 +19,7 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.exception.StudentUpdateException;
+
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
@@ -1215,6 +1216,25 @@ public class Logic {
             FeedbackResponseCommentUpdateRequest updateRequest, String updaterEmail)
             throws EntityDoesNotExistException {
         return feedbackResponseCommentsLogic.updateFeedbackResponseComment(frcId, updateRequest, updaterEmail);
+    }
+
+    /**
+     * Updates a feedback response and comments by {@link FeedbackResponse}.
+     *
+     * <p>Cascade updates its associated feedback response comment
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return updated feedback response
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the comment cannot be found
+     */
+    public FeedbackResponse updateFeedbackResponseCascade(FeedbackResponse feedbackResponse)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        assert feedbackResponse != null;
+
+        return feedbackResponsesLogic.updateFeedbackResponseCascade(feedbackResponse);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -19,7 +19,6 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.exception.StudentUpdateException;
-
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -88,6 +88,19 @@ public final class FeedbackResponseCommentsLogic {
     }
 
     /**
+     * Updates a feedback response comment by {@link FeedbackResponseComment}.
+     *
+     * @return updated comment
+     * @throws InvalidParametersException if attributes to update are not valid
+     * @throws EntityDoesNotExistException if the comment cannot be found
+     */
+    public FeedbackResponseComment updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment)
+            throws InvalidParametersException, EntityDoesNotExistException {
+
+        return frcDb.updateFeedbackResponseComment(feedbackResponseComment);
+    }
+
+    /**
      * Updates a feedback response comment.
      * @throws EntityDoesNotExistException if the comment does not exist
      */

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -190,10 +190,10 @@ public final class FeedbackResponseCommentsDb extends EntitiesDb {
     /**
      * Updates the feedback response comment.
      */
-    public void updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment) {
+    public FeedbackResponseComment updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment) {
         assert feedbackResponseComment != null;
 
-        merge(feedbackResponseComment);
+        return merge(feedbackResponseComment);
     }
 
 }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.util.FieldValidator;
+import teammates.common.util.SanitizationHelper;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -200,6 +201,11 @@ public class FeedbackResponseComment extends BaseEntity {
 
     public void setLastEditorEmail(String lastEditorEmail) {
         this.lastEditorEmail = lastEditorEmail;
+    }
+
+    // TODO: Override when BaseEntity adds abstract sanitizeForSaving
+    public void sanitizeForSaving() {
+        this.commentText = SanitizationHelper.sanitizeForRichText(this.commentText);
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -203,7 +203,10 @@ public class FeedbackResponseComment extends BaseEntity {
         this.lastEditorEmail = lastEditorEmail;
     }
 
-    // TODO: Override when BaseEntity adds abstract sanitizeForSaving
+    /**
+     * Formats the entity before persisting in database.
+     * TODO: Override when BaseEntity adds abstract sanitizeForSaving
+     */
     public void sanitizeForSaving() {
         this.commentText = SanitizationHelper.sanitizeForRichText(this.commentText);
     }


### PR DESCRIPTION
Part of #12048.

This PR is part 1 of 2, and is related to #12720. Splitting it up as the PR is quite big.

This PR will handle the database and logic layer needed for the actual migration of SubmitFeedbackResponseAction.