### PR TITLE
[#12048] Migrate StudentSearchIndexingWorkerAction

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
@@ -12,6 +12,7 @@ import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlsearch.SearchManagerFactory;
 import teammates.test.TestProperties;
 import teammates.ui.webapi.StudentSearchIndexingWorkerAction;
 
@@ -28,6 +29,7 @@ public class StudentSearchIndexingWorkerActionIT extends BaseActionIT<StudentSea
         super.setUp();
         persistDataBundle(typicalBundle);
         HibernateUtil.flushSession();
+        SearchManagerFactory.getStudentSearchManager().resetCollections();
     }
 
     @Override

--- a/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
@@ -1,0 +1,84 @@
+package teammates.it.ui.webapi;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const.ParamsNames;
+import teammates.common.util.Const.TaskQueue;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Student;
+import teammates.test.TestProperties;
+import teammates.ui.webapi.StudentSearchIndexingWorkerAction;
+
+/**
+ * SUT: {@link StudentSearchIndexingWorkerAction}.
+ */
+public class StudentSearchIndexingWorkerActionIT extends BaseActionIT<StudentSearchIndexingWorkerAction> {
+
+    private final Student student = typicalBundle.students.get("student1InCourse1");
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    protected String getActionUri() {
+        return TaskQueue.STUDENT_SEARCH_INDEXING_WORKER_URL;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return POST;
+    }
+
+    @Override
+    protected void testExecute() throws Exception {
+        // See test cases below
+    }
+
+    @Test
+    protected void testExecute_studentNotYetIndexed_isNotSearchable() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        List<Student> studentList = logic.searchStudentsInWholeSystem(student.getEmail());
+        assertEquals(0, studentList.size());
+    }
+
+    @Test
+    protected void testExecute_studentIndexed_isSearchable() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
+        String[] submissionParams = new String[] {
+                ParamsNames.COURSE_ID, student.getCourseId(),
+                ParamsNames.STUDENT_EMAIL, student.getEmail(),
+        };
+
+        StudentSearchIndexingWorkerAction action = getAction(submissionParams);
+        getJsonResult(action);
+
+        List<Student> studentList = logic.searchStudentsInWholeSystem(student.getEmail());
+        assertEquals(1, studentList.size());
+        assertEquals(student.getName(), studentList.get(0).getName());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws InvalidParametersException, EntityAlreadyExistsException {
+        Course course = typicalBundle.courses.get("course1");
+        verifyOnlyAdminCanAccess(course);
+    }
+}

--- a/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
@@ -48,7 +48,7 @@ public class StudentSearchIndexingWorkerActionIT extends BaseActionIT<StudentSea
     }
 
     @Test
-    protected void testExecute_studentNotYetIndexed_isNotSearchable() throws Exception {
+    protected void testExecute_studentNotYetIndexed_shouldNotBeSearchable() throws Exception {
         if (!TestProperties.isSearchServiceActive()) {
             return;
         }
@@ -58,7 +58,7 @@ public class StudentSearchIndexingWorkerActionIT extends BaseActionIT<StudentSea
     }
 
     @Test
-    protected void testExecute_studentIndexed_isSearchable() throws Exception {
+    protected void testExecute_studentIndexed_shouldBeSearchable() throws Exception {
         if (!TestProperties.isSearchServiceActive()) {
             return;
         }

--- a/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/StudentSearchIndexingWorkerActionIT.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const.ParamsNames;

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -8,12 +8,10 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackQuestionRecipient;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SqlDataBundle;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -21,7 +19,6 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.exception.StudentUpdateException;
-import teammates.logic.core.StudentsLogic;
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1319,7 +1319,7 @@ public class Logic {
     /**
      * Creates or updates search document for the given student.
      *
-     * @see StudentsLogic#putStudentDocument(Student)
+     * @see UsersLogic#putStudentDocument(Student)
      */
     public void putStudentDocument(Student student) throws SearchServiceException {
         usersLogic.putStudentDocument(student);

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -8,10 +8,12 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackQuestionRecipient;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -19,6 +21,7 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.exception.StudentUpdateException;
+import teammates.logic.core.StudentsLogic;
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
@@ -1311,5 +1314,14 @@ public class Logic {
     public FeedbackQuestion updateFeedbackQuestionCascade(UUID questionId, FeedbackQuestionUpdateRequest updateRequest)
             throws InvalidParametersException, EntityDoesNotExistException {
         return feedbackQuestionsLogic.updateFeedbackQuestionCascade(questionId, updateRequest);
+    }
+
+    /**
+     * Creates or updates search document for the given student.
+     *
+     * @see StudentsLogic#putStudentDocument(Student)
+     */
+    public void putStudentDocument(Student student) throws SearchServiceException {
+        usersLogic.putStudentDocument(student);
     }
 }

--- a/src/main/java/teammates/ui/webapi/StudentSearchIndexingWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/StudentSearchIndexingWorkerAction.java
@@ -22,7 +22,7 @@ public class StudentSearchIndexingWorkerAction extends AdminOnlyAction {
         } else {
             return executeWithDataStore(courseId, email);
         }
-        
+
     }
 
     private ActionResult executeWithDataStore(String courseId, String email) {

--- a/src/main/java/teammates/ui/webapi/StudentSearchIndexingWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/StudentSearchIndexingWorkerAction.java
@@ -5,6 +5,7 @@ import org.apache.http.HttpStatus;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Const.ParamsNames;
+import teammates.storage.sqlentity.Student;
 
 /**
  * Task queue worker action: performs student search indexing.
@@ -16,14 +17,27 @@ public class StudentSearchIndexingWorkerAction extends AdminOnlyAction {
         String courseId = getNonNullRequestParamValue(ParamsNames.COURSE_ID);
         String email = getNonNullRequestParamValue(ParamsNames.STUDENT_EMAIL);
 
-        StudentAttributes student = logic.getStudentForEmail(courseId, email);
-        try {
-            logic.putStudentDocument(student);
-        } catch (SearchServiceException e) {
-            // Set an arbitrary retry code outside of the range 200-299 to trigger automatic retry
-            return new JsonResult("Failure", HttpStatus.SC_BAD_GATEWAY);
+        if (isCourseMigrated(courseId)) {
+            Student student = sqlLogic.getStudentForEmail(courseId, email);
+            try {
+                sqlLogic.putStudentDocument(student);
+            } catch (SearchServiceException e) {
+                // Set an arbitrary retry code outside of the range 200-299 to trigger automatic retry
+                return new JsonResult("Failure", HttpStatus.SC_BAD_GATEWAY);
+            }
+    
+            return new JsonResult("Successful");
+        } else {
+            StudentAttributes student = logic.getStudentForEmail(courseId, email);
+            try {
+                logic.putStudentDocument(student);
+            } catch (SearchServiceException e) {
+                // Set an arbitrary retry code outside of the range 200-299 to trigger automatic retry
+                return new JsonResult("Failure", HttpStatus.SC_BAD_GATEWAY);
+            }
+    
+            return new JsonResult("Successful");
         }
-
-        return new JsonResult("Successful");
+        
     }
 }


### PR DESCRIPTION
Part of #12048

**Changes**
* Use SQL logic for StudentSearchIndexingWorkerAction execution if course is migrated
* Add IT for StudentSearchIndexingWorkerAction

Note:
~~As the test relies on Logic::searchStudentsInWholeSystem which is to be implemented in #12735, that PR should be merged first~~ (#12735 has been merged)