### PR TITLE
[#12048] Migrate PutDataBundleDocumentsAction

### DIFF
--- a/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import org.apache.http.HttpStatus;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Config;
@@ -26,8 +27,10 @@ class PutDataBundleDocumentsAction extends Action {
 
     @Override
     public JsonResult execute() {
+        DataBundle dataBundle = JsonUtils.fromJson(getRequestBody(), DataBundle.class);
         SqlDataBundle sqlDataBundle = JsonUtils.fromJson(getRequestBody(), SqlDataBundle.class);
         try {
+            logic.putDocuments(dataBundle);
             sqlLogic.putDocuments(sqlDataBundle);
         } catch (SearchServiceException e) {
             return new JsonResult("Failed to add data bundle documents.", HttpStatus.SC_BAD_GATEWAY);

--- a/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import org.apache.http.HttpStatus;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
@@ -26,9 +27,9 @@ class PutDataBundleDocumentsAction extends Action {
 
     @Override
     public JsonResult execute() {
-        DataBundle dataBundle = JsonUtils.fromJson(getRequestBody(), DataBundle.class);
+        SqlDataBundle sqlDataBundle = JsonUtils.fromJson(getRequestBody(), SqlDataBundle.class);
         try {
-            logic.putDocuments(dataBundle);
+            sqlLogic.putDocuments(sqlDataBundle);
         } catch (SearchServiceException e) {
             return new JsonResult("Failed to add data bundle documents.", HttpStatus.SC_BAD_GATEWAY);
         }

--- a/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleDocumentsAction.java
@@ -2,7 +2,6 @@ package teammates.ui.webapi;
 
 import org.apache.http.HttpStatus;
 
-import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.Config;

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -31,6 +31,7 @@ import org.apache.http.message.BasicNameValuePair;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.AccountRequestAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -285,12 +286,31 @@ public abstract class AbstractBackDoor {
         return output.getMessage();
     }
 
+    // TODO: remove params after migration
     /**
      * Puts searchable documents in data bundle into the database.
      */
     public String putDocuments(DataBundle dataBundle) throws HttpRequestFailedException {
+        Map<String, String> params = new HashMap<>();
+        params.put("databundletype", "datastore");
         ResponseBodyAndCode putRequestOutput =
-                executePutRequest(Const.ResourceURIs.DATABUNDLE_DOCUMENTS, null, JsonUtils.toJson(dataBundle));
+                executePutRequest(Const.ResourceURIs.DATABUNDLE_DOCUMENTS, params, JsonUtils.toJson(dataBundle));
+        if (putRequestOutput.responseCode != HttpStatus.SC_OK) {
+            throw new HttpRequestFailedException("Request failed: [" + putRequestOutput.responseCode + "] "
+                    + putRequestOutput.responseBody);
+        }
+        return putRequestOutput.responseBody;
+    }
+
+    // TODO: remove method after migration
+    /**
+     * Puts searchable documents in data bundle into the SQL database.
+     */
+    public String putSqlDocuments(SqlDataBundle dataBundle) throws HttpRequestFailedException {
+        Map<String, String> params = new HashMap<>();
+        params.put("databundletype", "sql");
+        ResponseBodyAndCode putRequestOutput =
+                executePutRequest(Const.ResourceURIs.DATABUNDLE_DOCUMENTS, params, JsonUtils.toJson(dataBundle));
         if (putRequestOutput.responseCode != HttpStatus.SC_OK) {
             throw new HttpRequestFailedException("Request failed: [" + putRequestOutput.responseCode + "] "
                     + putRequestOutput.responseBody);


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

The documents are added for both datastore and SQL.
This should allow for tests that rely solely on datastore or SQL to be executed.
This should also allow testing for dual-db search behaviors where one entry might exist in both the datastore and SQL database

