### PR TITLE
[#12048] Migrate FeedbackSessionOpeningSoonRemindersAction

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionOpeningSoonRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionOpeningSoonRemindersActionIT.java
@@ -97,7 +97,7 @@ public class FeedbackSessionOpeningSoonRemindersActionIT extends BaseActionIT<Fe
             assertEquals(
                     String.format(emailSubjectFormat, courseName, sessionName),
                     email.getSubject());
-                
+
         }
     }
 

--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionOpeningSoonRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionOpeningSoonRemindersActionIT.java
@@ -1,0 +1,149 @@
+package teammates.it.ui.webapi;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.EmailWrapper;
+import teammates.common.util.HibernateUtil;
+import teammates.common.util.TaskWrapper;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.request.SendEmailRequest;
+import teammates.ui.webapi.FeedbackSessionOpeningSoonRemindersAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link FeedbackSessionOpeningSoonRemindersAction}.
+ */
+public class FeedbackSessionOpeningSoonRemindersActionIT extends BaseActionIT<FeedbackSessionOpeningSoonRemindersAction> {
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    String getActionUri() {
+        return Const.CronJobURIs.AUTOMATED_FEEDBACK_OPENING_SOON_REMINDERS;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        Course course = typicalBundle.courses.get("course1");
+        verifyOnlyAdminCanAccess(course);
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+        loginAsAdmin();
+
+        ______TS("Typical Success Case 1: Add 1 email task for 1 opening-soon session with only 1 co-owner");
+        textExecute_typicalSuccess1();
+
+        ______TS("Typical Success Case 2: No email task queued -- opening soon email already sent");
+        textExecute_typicalSuccess2();
+
+        ______TS("Typical Success Case 3: No email task queued -- feedback session not opening soon");
+        textExecute_typicalSuccess3();
+    }
+
+    private void textExecute_typicalSuccess1() {
+        long oneDay = 60 * 60 * 24;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setOpeningSoonEmailSent(false);
+        session.setStartTime(now.plusSeconds(oneDay));
+        session.setEndTime(now.plusSeconds(oneDay * 3));
+        session.setGracePeriod(noGracePeriod);
+
+        String[] params = {};
+
+        FeedbackSessionOpeningSoonRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(session.isOpeningSoonEmailSent());
+
+        // Notify only co-owner (1 instructor only for session1InCourse1)
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
+
+        List<TaskWrapper> tasksAdded = mockTaskQueuer.getTasksAdded();
+        String emailSubjectFormat = EmailType.FEEDBACK_OPENING_SOON.getSubject();
+        String courseName = session.getCourse().getName();
+        String sessionName = session.getName();
+        for (TaskWrapper task : tasksAdded) {
+            SendEmailRequest requestBody = (SendEmailRequest) task.getRequestBody();
+            EmailWrapper email = requestBody.getEmail();
+            assertEquals(
+                    String.format(emailSubjectFormat, courseName, sessionName),
+                    email.getSubject());
+                
+        }
+    }
+
+    private void textExecute_typicalSuccess2() {
+        long oneDay = 60 * 60 * 24;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setOpeningSoonEmailSent(true);
+        session.setStartTime(now.plusSeconds(oneDay));
+        session.setEndTime(now.plusSeconds(oneDay * 3));
+        session.setGracePeriod(noGracePeriod);
+
+        String[] params = {};
+
+        FeedbackSessionOpeningSoonRemindersAction action = getAction(params);
+        JsonResult actionOutput = getJsonResult(action);
+        MessageOutput response = (MessageOutput) actionOutput.getOutput();
+
+        assertEquals("Successful", response.getMessage());
+        assertTrue(session.isOpeningSoonEmailSent());
+
+        verifyNoTasksAdded();
+    }
+
+    private void textExecute_typicalSuccess3() {
+        long oneDay = 60 * 60 * 24;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setOpeningSoonEmailSent(false);
+        session.setStartTime(now.plusSeconds(oneDay + 60));
+        session.setEndTime(now.plusSeconds(oneDay * 3));
+        session.setGracePeriod(noGracePeriod);
+
+        String[] params = {};
+
+        FeedbackSessionOpeningSoonRemindersAction action = getAction(params);
+        JsonResult actionOutput = getJsonResult(action);
+        MessageOutput response = (MessageOutput) actionOutput.getOutput();
+
+        assertEquals("Successful", response.getMessage());
+        assertFalse(session.isOpeningSoonEmailSent());
+
+        verifyNoTasksAdded();
+    }
+}

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1324,4 +1324,11 @@ public class Logic {
 
         return accountRequestLogic.searchAccountRequestsInWholeSystem(queryString);
     }
+
+    /**
+     * Returns a list of sessions that are going to open soon.
+     */
+    public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
+        return feedbackSessionsLogic.getFeedbackSessionsOpeningWithinTimeLimit();
+    }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -13,6 +13,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.Logger;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -25,6 +26,8 @@ import teammates.storage.sqlentity.Instructor;
  * @see FeedbackSessionsDb
  */
 public final class FeedbackSessionsLogic {
+
+    private static final Logger log = Logger.getLogger();
 
     private static final String ERROR_NON_EXISTENT_FS_STRING_FORMAT = "Trying to %s a non-existent feedback session: ";
     private static final String ERROR_NON_EXISTENT_FS_UPDATE = String.format(ERROR_NON_EXISTENT_FS_STRING_FORMAT, "update");
@@ -385,5 +388,25 @@ public final class FeedbackSessionsLogic {
         if (session.isPublishedEmailSent()) {
             session.setPublishedEmailSent(session.isPublished());
         }
+    }
+
+    /**
+     * Returns a list of sessions that are going to open in 24 hours.
+     */
+    public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
+        List<FeedbackSession> requiredSessions = new ArrayList<>();
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpeningSoonEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        for (FeedbackSession session : sessions) {
+            if (session.isOpeningWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT)
+                    && session.getCourse().getDeletedAt() == null) {
+                requiredSessions.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
+        return requiredSessions;
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -6,11 +6,13 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.common.util.TimeHelper;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 
@@ -232,6 +234,29 @@ public final class FeedbackSessionsDb extends EntitiesDb {
                 .where(cb.and(
                     cb.greaterThanOrEqualTo(root.get("startTime"), after),
                     cb.equal(courseJoin.get("id"), courseId)));
+
+        return HibernateUtil.createQuery(cr).getResultList();
+    }
+
+    /**
+     * Gets a list of undeleted feedback sessions which open in the future
+     * and possibly need a opening soon email to be sent.
+     */
+    public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingOpeningSoonEmail() {
+        return getFeedbackSessionEntitiesPossiblyNeedingOpeningSoonEmail().stream()
+                .filter(session -> session.getDeletedAt() == null)
+                .collect(Collectors.toList());
+    }
+
+    private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingOpeningSoonEmail() {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
+        Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+
+        cr.select(root)
+                .where(cb.and(
+                    cb.greaterThan(root.get("startTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
+                    cb.equal(root.get("isOpeningSoonEmailSent"), false)));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -558,4 +558,15 @@ public class FeedbackSession extends BaseEntity {
         return this.deletedAt != null;
     }
 
+    /**
+     * Returns true if the feedback session opens after the number of specified hours.
+     */
+    public boolean isOpeningWithinTimeLimit(long hours) {
+        Instant now = Instant.now();
+        Duration difference = Duration.between(now, startTime);
+
+        return now.isBefore(startTime)
+                && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
+                && difference.compareTo(Duration.ofHours(hours)) < 0;
+    }
 }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
@@ -49,7 +49,7 @@ public class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
                 log.severe("Unexpected error", e);
             }
         }
-        
+
         return new JsonResult("Successful");
     }
 }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
@@ -6,17 +6,23 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
 import teammates.common.util.RequestTracer;
+import teammates.storage.sqlentity.FeedbackSession;
 
 /**
  * Cron job: schedules feedback session opening soon emails to be sent.
  */
-class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
+public class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
     private static final Logger log = Logger.getLogger();
 
     @Override
     public JsonResult execute() {
-        List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsOpeningWithinTimeLimit();
-        for (FeedbackSessionAttributes session : sessions) {
+        List<FeedbackSessionAttributes> sessionAttributes = logic.getFeedbackSessionsOpeningWithinTimeLimit();
+        for (FeedbackSessionAttributes session : sessionAttributes) {
+            // If course has been migrated, use sql email logic instead.
+            if (isCourseMigrated(session.getCourseId())) {
+                continue;
+            }
+
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionOpeningSoonEmails(session);
             try {
@@ -31,6 +37,19 @@ class FeedbackSessionOpeningSoonRemindersAction extends AdminOnlyAction {
                 log.severe("Unexpected error", e);
             }
         }
+
+        List<FeedbackSession> sessions = sqlLogic.getFeedbackSessionsOpeningWithinTimeLimit();
+        for (FeedbackSession session : sessions) {
+            RequestTracer.checkRemainingTime();
+            List<EmailWrapper> emailsToBeSent = sqlEmailGenerator.generateFeedbackSessionOpeningSoonEmails(session);
+            try {
+                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                session.setOpeningSoonEmailSent(true);
+            } catch (Exception e) {
+                log.severe("Unexpected error", e);
+            }
+        }
+        
         return new JsonResult("Successful");
     }
 }


### PR DESCRIPTION
Part of #12048.

OpeningSoon emails are only sent to co-owner instructors of a course. 

---

Integration tests for this action have been added.
When referencing the old tests for this class (FeedbackSessionOpeningSoonRemindersActionTest.java), there are tests for emails to or not to be added when feedback session is modified, but I think it makes more sense to add them in UpdateFeedbackSessionActionIT.java instead.