### PR TITLE
[#12048] Migrate FeedbackSessionClosingRemindersAction

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingRemindersActionIT.java
@@ -1,0 +1,242 @@
+package teammates.it.ui.webapi;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.DeadlineExtension;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.webapi.FeedbackSessionClosingRemindersAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link FeedbackSessionClosingRemindersAction}.
+ */
+public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<FeedbackSessionClosingRemindersAction> {
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+        prepareSession();
+    }
+
+    private void prepareSession() {
+        // DEADLINE EXTENSIONS
+        String[] deKeys = {"student1InCourse1Session1", "instructor1InCourse1Session1"};
+        List<DeadlineExtension> exts = new ArrayList<>();
+        for (String deKey : deKeys) {
+            exts.add(typicalBundle.deadlineExtensions.get(deKey));
+        }
+
+        // FEEDBACK QUESTIONS
+        String[] fqKeys = {
+            "qn1InSession1InCourse1", 
+            "qn2InSession1InCourse1",
+            "qn3InSession1InCourse1", 
+            "qn4InSession1InCourse1",
+            "qn5InSession1InCourse1", 
+            "qn6InSession1InCourse1NoResponses",
+        };
+        List<FeedbackQuestion> qns = new ArrayList<>();
+        for (String fqKey : fqKeys) {
+            qns.add(typicalBundle.feedbackQuestions.get(fqKey));
+        }
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setDeadlineExtensions(exts);
+        session.setFeedbackQuestions(qns);
+    }
+
+    @Override
+    String getActionUri() {
+        return Const.CronJobURIs.AUTOMATED_FEEDBACK_CLOSING_REMINDERS;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        Course course = typicalBundle.courses.get("course1");
+        verifyOnlyAdminCanAccess(course);
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+        loginAsAdmin();
+
+        ______TS("Typical Success Case 1: email tasks added for 1 all users of 1 session");
+        textExecute_typicalSuccess1();
+
+        ______TS("Typical Success Case 2: email tasks added for 1 all users of 1 session and 1 deadline extension");
+        textExecute_typicalSuccess2();
+
+        ______TS("Typical Success Case 3: Only 1 email task queued -- " + 
+                "0 for session: already sent, " +
+                "1 for deadline extension: closing-soon not sent yet");
+        textExecute_typicalSuccess3();
+
+        ______TS("Typical Success Case 4: No tasks queued -- both session and deadline extensions have already sent closing-soon emails");
+        textExecute_typicalSuccess4();
+
+        ______TS("Typical Success Case 5: No tasks queued -- session's closing-soon email disabled");
+        textExecute_typicalSuccess5();
+    }
+
+    private void textExecute_typicalSuccess1() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingSoonEmailSent(false);
+        session.setEndTime(now.plusSeconds((oneHour * 23) + 60));
+        session.setGracePeriod(noGracePeriod);
+
+        String[] params = {};
+
+        FeedbackSessionClosingRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(session.isClosingSoonEmailSent());
+        assertTrue(session.getDeadlineExtensions().stream().allMatch(de -> !de.isClosingSoonEmailSent()));
+
+        // 6 email tasks queued: 
+        // 1 co-owner, 4 students and 3 instructors,
+        // but 1 student and 1 instructor have deadline extensions (should not receive email)
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 6);
+    }
+
+    private void textExecute_typicalSuccess2() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingSoonEmailSent(false);
+        session.setEndTime(now.plusSeconds((oneHour * 23) + 60));
+        session.setGracePeriod(noGracePeriod);
+
+        DeadlineExtension de = session.getDeadlineExtensions().get(0);
+        de.setEndTime(now.plusSeconds(oneHour * 16));
+
+        String[] params = {};
+
+        FeedbackSessionClosingRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(session.isClosingSoonEmailSent());
+        assertTrue(de.isClosingSoonEmailSent());
+
+        // 7 email tasks queued: 
+        // - 6 emails: 1 co-owner, 4 students and 3 instructors,
+        //             but 1 student and 1 instructor have deadline extensions (should not receive email)
+        // - 1 email:  1 student deadline extension
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 7);
+    }
+
+    private void textExecute_typicalSuccess3() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingSoonEmailSent(true);
+        session.setEndTime(now.plusSeconds((oneHour * 23) + 60));
+        session.setGracePeriod(noGracePeriod);
+
+        DeadlineExtension de = session.getDeadlineExtensions().get(0);
+        de.setEndTime(now.plusSeconds(oneHour * 16));
+        de.setClosingSoonEmailSent(false);
+
+        String[] params = {};
+
+        FeedbackSessionClosingRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(session.isClosingSoonEmailSent());
+        assertTrue(de.isClosingSoonEmailSent());
+
+        // 1 email tasks queued: 
+        // - 0 emails: session already sent closing-soon emails
+        // - 1 email:  1 student deadline extension where closing-soon email not sent yet
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
+    }
+
+    private void textExecute_typicalSuccess4() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingSoonEmailSent(true);
+        session.setEndTime(now.plusSeconds((oneHour * 23) + 60));
+        session.setGracePeriod(noGracePeriod);
+
+        DeadlineExtension de = session.getDeadlineExtensions().get(0);
+        de.setEndTime(now.plusSeconds(oneHour * 16));
+        de.setClosingSoonEmailSent(true);
+
+        String[] params = {};
+
+        FeedbackSessionClosingRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(session.isClosingSoonEmailSent());
+        assertTrue(de.isClosingSoonEmailSent());
+
+        verifyNoTasksAdded();
+    }
+    
+    private void textExecute_typicalSuccess5() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingEmailEnabled(false);
+        session.setClosingSoonEmailSent(false);
+        session.setEndTime(now.plusSeconds((oneHour * 23) + 60));
+        session.setGracePeriod(noGracePeriod);
+
+        DeadlineExtension de = session.getDeadlineExtensions().get(0);
+        de.setEndTime(now.plusSeconds(oneHour * 16));
+        de.setClosingSoonEmailSent(false);
+
+        String[] params = {};
+
+        FeedbackSessionClosingRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertTrue(!session.isClosingSoonEmailSent());
+        assertTrue(!de.isClosingSoonEmailSent());
+
+        verifyNoTasksAdded();
+    }
+}

--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingRemindersActionIT.java
@@ -42,12 +42,12 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
 
         // FEEDBACK QUESTIONS
         String[] fqKeys = {
-            "qn1InSession1InCourse1", 
-            "qn2InSession1InCourse1",
-            "qn3InSession1InCourse1", 
-            "qn4InSession1InCourse1",
-            "qn5InSession1InCourse1", 
-            "qn6InSession1InCourse1NoResponses",
+                "qn1InSession1InCourse1",
+                "qn2InSession1InCourse1",
+                "qn3InSession1InCourse1",
+                "qn4InSession1InCourse1",
+                "qn5InSession1InCourse1",
+                "qn6InSession1InCourse1NoResponses",
         };
         List<FeedbackQuestion> qns = new ArrayList<>();
         for (String fqKey : fqKeys) {
@@ -87,12 +87,13 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
         ______TS("Typical Success Case 2: email tasks added for 1 all users of 1 session and 1 deadline extension");
         textExecute_typicalSuccess2();
 
-        ______TS("Typical Success Case 3: Only 1 email task queued -- " + 
-                "0 for session: already sent, " +
-                "1 for deadline extension: closing-soon not sent yet");
+        ______TS("Typical Success Case 3: Only 1 email task queued -- "
+                + "0 for session: already sent, "
+                + "1 for deadline extension: closing-soon not sent yet");
         textExecute_typicalSuccess3();
 
-        ______TS("Typical Success Case 4: No tasks queued -- both session and deadline extensions have already sent closing-soon emails");
+        ______TS("Typical Success Case 4: No tasks queued -- "
+                + "both session and deadline extensions have already sent closing-soon emails");
         textExecute_typicalSuccess4();
 
         ______TS("Typical Success Case 5: No tasks queued -- session's closing-soon email disabled");
@@ -119,7 +120,7 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
         assertTrue(session.isClosingSoonEmailSent());
         assertTrue(session.getDeadlineExtensions().stream().allMatch(de -> !de.isClosingSoonEmailSent()));
 
-        // 6 email tasks queued: 
+        // 6 email tasks queued:
         // 1 co-owner, 4 students and 3 instructors,
         // but 1 student and 1 instructor have deadline extensions (should not receive email)
         verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 6);
@@ -148,7 +149,7 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
         assertTrue(session.isClosingSoonEmailSent());
         assertTrue(de.isClosingSoonEmailSent());
 
-        // 7 email tasks queued: 
+        // 7 email tasks queued:
         // - 6 emails: 1 co-owner, 4 students and 3 instructors,
         //             but 1 student and 1 instructor have deadline extensions (should not receive email)
         // - 1 email:  1 student deadline extension
@@ -179,7 +180,7 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
         assertTrue(session.isClosingSoonEmailSent());
         assertTrue(de.isClosingSoonEmailSent());
 
-        // 1 email tasks queued: 
+        // 1 email tasks queued:
         // - 0 emails: session already sent closing-soon emails
         // - 1 email:  1 student deadline extension where closing-soon email not sent yet
         verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
@@ -211,7 +212,7 @@ public class FeedbackSessionClosingRemindersActionIT extends BaseActionIT<Feedba
 
         verifyNoTasksAdded();
     }
-    
+
     private void textExecute_typicalSuccess5() {
         long oneHour = 60 * 60;
         Instant now = Instant.now();

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -398,6 +398,14 @@ public class Logic {
     }
 
     /**
+     * Gets a list of deadline extensions with endTime coming up soon
+     * and possibly need a closing email to be sent.
+     */
+    public List<DeadlineExtension> getDeadlineExtensionsPossiblyNeedingClosingEmail() {
+        return deadlineExtensionsLogic.getDeadlineExtensionsPossiblyNeedingClosingEmail();
+    }
+
+    /**
      * Gets a feedback session.
      *
      * @return null if not found.
@@ -1323,5 +1331,12 @@ public class Logic {
         assert queryString != null;
 
         return accountRequestLogic.searchAccountRequestsInWholeSystem(queryString);
+    }
+
+    /**
+     * Returns a list of sessions that are going to close soon.
+     */
+    public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
+        return feedbackSessionsLogic.getFeedbackSessionsClosingWithinTimeLimit();
     }
 }

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -104,12 +104,12 @@ public final class SqlEmailGenerator {
 
             // student.
             students = students.stream()
-                    .filter(x -> userIds.contains(x.getId()))
+                    .filter(x -> !userIds.contains(x.getId()))
                     .collect(Collectors.toList());
 
             // instructor.
             instructors = instructors.stream()
-                    .filter(x -> userIds.contains(x.getId()))
+                    .filter(x -> !userIds.contains(x.getId()))
                     .collect(Collectors.toList());
         }
 

--- a/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
@@ -98,6 +98,14 @@ public final class DeadlineExtensionsLogic {
     }
 
     /**
+     * Gets a list of deadline extensions with endTime coming up soon
+     * and possibly need a closing email to be sent.
+     */
+    public List<DeadlineExtension> getDeadlineExtensionsPossiblyNeedingClosingEmail() {
+        return deadlineExtensionsDb.getDeadlineExtensionsPossiblyNeedingClosingEmail();
+    }
+
+    /**
      * Deletes a user's deadline extensions.
      */
     public void deleteDeadlineExtensionsForUser(User user) {

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -400,7 +400,7 @@ public final class FeedbackSessionsLogic {
 
         for (FeedbackSession session : sessions) {
             if (session.isClosingWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
-            && session.getCourse().getDeletedAt() == null) {
+                    && session.getCourse().getDeletedAt() == null) {
                 requiredSessions.add(session);
             }
         }

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -13,6 +13,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.Logger;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -25,6 +26,8 @@ import teammates.storage.sqlentity.Instructor;
  * @see FeedbackSessionsDb
  */
 public final class FeedbackSessionsLogic {
+
+    private static final Logger log = Logger.getLogger();
 
     private static final String ERROR_NON_EXISTENT_FS_STRING_FORMAT = "Trying to %s a non-existent feedback session: ";
     private static final String ERROR_NON_EXISTENT_FS_UPDATE = String.format(ERROR_NON_EXISTENT_FS_STRING_FORMAT, "update");
@@ -385,5 +388,25 @@ public final class FeedbackSessionsLogic {
         if (session.isPublishedEmailSent()) {
             session.setPublishedEmailSent(session.isPublished());
         }
+    }
+
+    /**
+     * Returns a list of sessions that are going to close within the next 24 hours.
+     */
+    public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
+        List<FeedbackSession> requiredSessions = new ArrayList<>();
+        List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingSoonEmail();
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        for (FeedbackSession session : sessions) {
+            if (session.isClosingWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
+                    && session.getCourse().getDeletedAt() == null) {
+                requiredSessions.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                requiredSessions.size()));
+        return requiredSessions;
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -238,7 +238,7 @@ public final class FeedbackSessionsDb extends EntitiesDb {
         return HibernateUtil.createQuery(cr).getResultList();
     }
 
-     /**
+    /**
      * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
      * and possibly need a closing soon email to be sent.
      */

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -6,11 +6,13 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
+import teammates.common.util.TimeHelper;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 
@@ -232,6 +234,32 @@ public final class FeedbackSessionsDb extends EntitiesDb {
                 .where(cb.and(
                     cb.greaterThanOrEqualTo(root.get("startTime"), after),
                     cb.equal(courseJoin.get("id"), courseId)));
+
+        return HibernateUtil.createQuery(cr).getResultList();
+    }
+
+     /**
+     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
+     * and possibly need a closing soon email to be sent.
+     */
+    public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingClosingSoonEmail() {
+        return getFeedbackSessionEntitiesPossiblyNeedingClosingSoonEmail().stream()
+                .filter(session -> session.getDeletedAt() == null)
+                .collect(Collectors.toList());
+    }
+
+    private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosingSoonEmail() {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
+        Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+
+        cr.select(root)
+                .where(cb.and(
+                        cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
+                        cb.and(
+                                cb.equal(root.get("isClosingSoonEmailSent"), false),
+                                cb.equal(root.get("isClosingEmailEnabled"), true))
+               ));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -558,4 +558,17 @@ public class FeedbackSession extends BaseEntity {
         return this.deletedAt != null;
     }
 
+    /**
+     * Returns true if the feedback session is closing (almost closed) after the number of specified hours.
+     */
+    public boolean isClosingWithinTimeLimit(long hours) {
+        Instant now = Instant.now();
+        Duration difference = Duration.between(now, endTime);
+        // If now and start are almost similar, it means the feedback session
+        // is open for only 24 hours.
+        // Hence we do not send a reminder e-mail for feedback session.
+        return now.isAfter(startTime)
+               && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
+               && difference.compareTo(Duration.ofHours(hours)) < 0;
+    }
 }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -76,7 +76,7 @@ public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
             if (isCourseMigrated(session.getCourseId())) {
                 continue;
             }
-            
+
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosingEmails(session);
             try {

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -48,7 +48,7 @@ public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
                     .stream()
                     .collect(Collectors.groupingBy(de -> de.getFeedbackSession()))
                     .values();
-        
+
         for (var deadlineExtensions : groupedDeadlineExtensions) {
             RequestTracer.checkRemainingTime();
 

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -73,6 +73,10 @@ public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
         List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsClosingWithinTimeLimit();
 
         for (FeedbackSessionAttributes session : sessions) {
+            if (isCourseMigrated(session.getCourseId())) {
+                continue;
+            }
+            
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosingEmails(session);
             try {

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -40,7 +40,7 @@ public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
             }
         }
 
-        executeForDatastorExtendedDeadlines();
+        executeForDatastoreExtendedDeadlines();
 
         // Group deadline extensions by feedback sessions
         Collection<List<DeadlineExtension>> groupedDeadlineExtensions =
@@ -88,7 +88,7 @@ public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
         }
     }
 
-    private void executeForDatastorExtendedDeadlines() {
+    private void executeForDatastoreExtendedDeadlines() {
         // group deadline extensions by courseId and feedbackSessionName
         Collection<List<DeadlineExtensionAttributes>> groupedDeadlineExtensionsAttributes =
                 logic.getDeadlineExtensionsPossiblyNeedingClosingEmail()

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingRemindersAction.java
@@ -13,16 +13,63 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
 import teammates.common.util.RequestTracer;
+import teammates.storage.sqlentity.DeadlineExtension;
+import teammates.storage.sqlentity.FeedbackSession;
 
 /**
  * Cron job: schedules feedback session closing emails to be sent.
  */
-class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
+public class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
 
     private static final Logger log = Logger.getLogger();
 
     @Override
     public JsonResult execute() {
+        executeForDatastoreFeedbackSessions();
+
+        List<FeedbackSession> sessions = sqlLogic.getFeedbackSessionsClosingWithinTimeLimit();
+
+        for (FeedbackSession session : sessions) {
+            RequestTracer.checkRemainingTime();
+            List<EmailWrapper> emailsToBeSent = sqlEmailGenerator.generateFeedbackSessionClosingEmails(session);
+            try {
+                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                session.setClosingSoonEmailSent(true);
+            } catch (Exception e) {
+                log.severe("Unexpected error", e);
+            }
+        }
+
+        executeForDatastorExtendedDeadlines();
+
+        // Group deadline extensions by feedback sessions
+        Collection<List<DeadlineExtension>> groupedDeadlineExtensions =
+                sqlLogic.getDeadlineExtensionsPossiblyNeedingClosingEmail()
+                    .stream()
+                    .collect(Collectors.groupingBy(de -> de.getFeedbackSession()))
+                    .values();
+        
+        for (var deadlineExtensions : groupedDeadlineExtensions) {
+            RequestTracer.checkRemainingTime();
+
+            FeedbackSession session = deadlineExtensions.get(0).getFeedbackSession();
+            if (!session.isClosingEmailEnabled()) {
+                continue;
+            }
+
+            List<EmailWrapper> emailsToBeSent = sqlEmailGenerator
+                    .generateFeedbackSessionClosingWithExtensionEmails(session, deadlineExtensions);
+            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+
+            for (var de : deadlineExtensions) {
+                de.setClosingSoonEmailSent(true);
+            }
+        }
+
+        return new JsonResult("Successful");
+    }
+
+    private void executeForDatastoreFeedbackSessions() {
         List<FeedbackSessionAttributes> sessions = logic.getFeedbackSessionsClosingWithinTimeLimit();
 
         for (FeedbackSessionAttributes session : sessions) {
@@ -39,18 +86,24 @@ class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
                 log.severe("Unexpected error", e);
             }
         }
+    }
 
+    private void executeForDatastorExtendedDeadlines() {
         // group deadline extensions by courseId and feedbackSessionName
-        Collection<List<DeadlineExtensionAttributes>> groupedDeadlineExtensions =
+        Collection<List<DeadlineExtensionAttributes>> groupedDeadlineExtensionsAttributes =
                 logic.getDeadlineExtensionsPossiblyNeedingClosingEmail()
                         .stream()
                         .collect(Collectors.groupingBy(de -> de.getCourseId() + "%" + de.getFeedbackSessionName()))
                         .values();
 
-        for (var deadlineExtensions : groupedDeadlineExtensions) {
+        for (var deadlineExtensions : groupedDeadlineExtensionsAttributes) {
+            String courseId = deadlineExtensions.get(0).getCourseId();
+            if (isCourseMigrated(courseId)) {
+                continue;
+            }
+
             RequestTracer.checkRemainingTime();
             String feedbackSessionName = deadlineExtensions.get(0).getFeedbackSessionName();
-            String courseId = deadlineExtensions.get(0).getCourseId();
             FeedbackSessionAttributes feedbackSession = logic.getFeedbackSession(feedbackSessionName, courseId);
             if (feedbackSession == null || !feedbackSession.isClosingEmailEnabled()) {
                 continue;
@@ -75,8 +128,6 @@ class FeedbackSessionClosingRemindersAction extends AdminOnlyAction {
                 log.severe("Unexpected error", e);
             }
         }
-
-        return new JsonResult("Successful");
     }
 
     /**


### PR DESCRIPTION
Part of #12048.

Per session, Closing-soon emails are sent for all co-owners, students and instructors (except students and instructors with deadline extensions).

---

For IT Tests, upon loading from data bundle, feedback sessions don't have association with deadline extension and feedback questions entities (ie: session.getDeadlineExtensions() and session.getFeedbackQuestions() return empty array). `prepareSession` function manually adds this association. 