### PR TITLE
[#12048] Move getTypicalEntity functions to BaseTestCase

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -3,7 +3,6 @@ package teammates.it.sqllogic.core;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -141,27 +140,4 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
                 Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
     }
-
-    private Course getTypicalCourse() {
-        return new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "teammates");
-    }
-
-    private Student getTypicalStudent() {
-        return new Student(course, "student-name", "valid-student@email.tmt", "comments");
-    }
-
-    private Instructor getTypicalInstructor() {
-        InstructorPrivileges instructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        InstructorPermissionRole role = InstructorPermissionRole
-                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-
-        return new Instructor(course, "instructor-name", "valid-instructor@email.tmt",
-                true, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
-    }
-
-    private Account getTypicalAccount() {
-        return new Account("google-id", "name", "email@teammates.com");
-    }
-
 }

--- a/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
@@ -89,8 +89,4 @@ public class AccountsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         Account actual = accountsDb.getAccount(account.getId());
         assertNull(actual);
     }
-
-    private Account getTypicalAccount() {
-        return new Account("google-id", "name", "email@teammates.com");
-    }
 }

--- a/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.common.util.Const;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.CoursesDb;
 import teammates.storage.sqlentity.Course;
@@ -124,9 +123,5 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         List<Team> actualTeams = coursesDb.getTeamsForCourse(course.getId());
         assertEquals(expectedTeams.size(), actualTeams.size());
         assertTrue(expectedTeams.containsAll(actualTeams));
-    }
-
-    private Course getTypicalCourse() {
-        return new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "teammates");
     }
 }

--- a/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
@@ -47,12 +47,14 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         Account instructorAccount = new Account("instructor-account", "instructor-name", "valid-instructor@email.tmt");
         accountsDb.createAccount(instructorAccount);
         instructor = getTypicalInstructor();
+        instructor.setCourse(course);
         usersDb.createInstructor(instructor);
         instructor.setAccount(instructorAccount);
 
         Account studentAccount = new Account("student-account", "student-name", "valid-student@email.tmt");
         accountsDb.createAccount(studentAccount);
         student = getTypicalStudent();
+        student.setCourse(course);
         usersDb.createStudent(student);
         student.setAccount(studentAccount);
 

--- a/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
@@ -6,8 +6,6 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -275,19 +273,5 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         assertEquals(expectedStudents.size(), actualStudents.size());
         assertTrue(expectedStudents.containsAll(actualStudents));
-    }
-
-    private Student getTypicalStudent() {
-        return new Student(course, "student-name", "valid-student@email.tmt", "comments");
-    }
-
-    private Instructor getTypicalInstructor() {
-        InstructorPrivileges instructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        InstructorPermissionRole role = InstructorPermissionRole
-                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-
-        return new Instructor(course, "instructor-name", "valid-instructor@email.tmt",
-                true, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
     }
 }

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -13,8 +13,6 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.NotificationStyle;
-import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.AccountsDb;
@@ -49,7 +47,7 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testDeleteAccount_accountExists_success() {
-        Account account = generateTypicalAccount();
+        Account account = getTypicalAccount();
         String googleId = account.getGoogleId();
 
         when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
@@ -61,7 +59,7 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testDeleteAccountCascade_googleIdExists_success() {
-        Account account = generateTypicalAccount();
+        Account account = getTypicalAccount();
         String googleId = account.getGoogleId();
         List<User> users = new ArrayList<>();
 
@@ -84,8 +82,8 @@ public class AccountsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateReadNotifications_shouldReturnCorrectReadNotificationId_success()
             throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = generateTypicalAccount();
-        Notification notification = generateTypicalNotification();
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
         String googleId = account.getGoogleId();
         UUID notificationId = notification.getId();
 
@@ -105,8 +103,8 @@ public class AccountsLogicTest extends BaseTestCase {
     @Test
     public void testUpdateReadNotifications_shouldAddReadNotificationToAccount_success()
             throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = generateTypicalAccount();
-        Notification notification = generateTypicalNotification();
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
         String googleId = account.getGoogleId();
         UUID notificationId = notification.getId();
 
@@ -127,8 +125,8 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testUpdateReadNotifications_accountDoesNotExist_throwEntityDoesNotExistException() {
-        Account account = generateTypicalAccount();
-        Notification notification = generateTypicalNotification();
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
         String googleId = account.getGoogleId();
         UUID notificationId = notification.getId();
 
@@ -142,8 +140,8 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testUpdateReadNotifications_notificationDoesNotExist_throwEntityDoesNotExistException() {
-        Account account = generateTypicalAccount();
-        Notification notification = generateTypicalNotification();
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
         String googleId = account.getGoogleId();
         UUID notificationId = notification.getId();
 
@@ -157,8 +155,8 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testUpdateReadNotifications_markExpiredNotificationAsRead_throwInvalidParametersException() {
-        Account account = generateTypicalAccount();
-        Notification notification = generateTypicalNotification();
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
         notification.setEndTime(Instant.parse("2012-01-01T00:00:00Z"));
         String googleId = account.getGoogleId();
         UUID notificationId = notification.getId();
@@ -173,7 +171,7 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testGetReadNotificationsId_doesNotHaveReadNotifications_success() {
-        Account account = generateTypicalAccount();
+        Account account = getTypicalAccount();
         String googleId = account.getGoogleId();
         when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
 
@@ -184,10 +182,10 @@ public class AccountsLogicTest extends BaseTestCase {
 
     @Test
     public void testGetReadNotificationsId_hasReadNotifications_success() {
-        Account account = generateTypicalAccount();
+        Account account = getTypicalAccount();
         List<ReadNotification> readNotifications = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Notification notification = generateTypicalNotification();
+            Notification notification = getTypicalNotificationWithId();
             ReadNotification readNotification = new ReadNotification(account, notification);
             readNotifications.add(readNotification);
         }
@@ -204,19 +202,5 @@ public class AccountsLogicTest extends BaseTestCase {
             assertEquals(readNotifications.get(i).getNotification().getId(),
                     actualReadNotifications.get(i));
         }
-    }
-
-    private Account generateTypicalAccount() {
-        return new Account("test-googleId", "test-name", "test@test.com");
-    }
-
-    private Notification generateTypicalNotification() {
-        return new Notification(
-                Instant.parse("2011-01-01T00:00:00Z"),
-                Instant.parse("2099-01-01T00:00:00Z"),
-                NotificationStyle.DANGER,
-                NotificationTargetUser.GENERAL,
-                "A deprecation note",
-                "<p>Deprecation happens in three minutes</p>");
     }
 }

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -13,20 +13,14 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.common.util.Const;
 import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
-import teammates.storage.sqlentity.Course;
-import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
-import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.User;
 import teammates.test.BaseTestCase;
 
@@ -45,16 +39,12 @@ public class AccountsLogicTest extends BaseTestCase {
 
     private CoursesLogic coursesLogic;
 
-    private Course course;
-
     @BeforeMethod
     public void setUpMethod() {
         accountsDb = mock(AccountsDb.class);
         notificationsLogic = mock(NotificationsLogic.class);
         usersLogic = mock(UsersLogic.class);
         accountsLogic.initLogicDependencies(accountsDb, notificationsLogic, usersLogic, coursesLogic);
-
-        course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
     }
 
     @Test
@@ -228,19 +218,5 @@ public class AccountsLogicTest extends BaseTestCase {
                 NotificationTargetUser.GENERAL,
                 "A deprecation note",
                 "<p>Deprecation happens in three minutes</p>");
-    }
-
-    private Instructor getTypicalInstructor() {
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges(
-                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        InstructorPermissionRole role = InstructorPermissionRole
-                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-
-        return new Instructor(course, "instructor-name", "valid-instructor@email.tmt",
-                true, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
-    }
-
-    private Student getTypicalStudent() {
-        return new Student(course, "student-name", "valid-student@email.tmt", "comments");
     }
 }

--- a/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
@@ -38,7 +38,7 @@ public class CoursesLogicTest extends BaseTestCase {
     @Test
     public void testMoveCourseToRecycleBin_shouldReturnBinnedCourse_success()
             throws EntityDoesNotExistException {
-        Course course = generateTypicalCourse();
+        Course course = getTypicalCourse();
         String courseId = course.getId();
 
         when(coursesDb.getCourse(courseId)).thenReturn(course);
@@ -51,7 +51,7 @@ public class CoursesLogicTest extends BaseTestCase {
 
     @Test
     public void testMoveCourseToRecycleBin_courseDoesNotExist_throwEntityDoesNotExistException() {
-        String courseId = generateTypicalCourse().getId();
+        String courseId = getTypicalCourse().getId();
 
         when(coursesDb.getCourse(courseId)).thenReturn(null);
 
@@ -64,7 +64,7 @@ public class CoursesLogicTest extends BaseTestCase {
     @Test
     public void testRestoreCourseFromRecycleBin_shouldSetDeletedAtToNull_success()
             throws EntityDoesNotExistException {
-        Course course = generateTypicalCourse();
+        Course course = getTypicalCourse();
         String courseId = course.getId();
         course.setDeletedAt(Instant.parse("2021-01-01T00:00:00Z"));
 
@@ -78,7 +78,7 @@ public class CoursesLogicTest extends BaseTestCase {
 
     @Test
     public void testRestoreCourseFromRecycleBin_courseDoesNotExist_throwEntityDoesNotExistException() {
-        String courseId = generateTypicalCourse().getId();
+        String courseId = getTypicalCourse().getId();
 
         when(coursesDb.getCourse(courseId)).thenReturn(null);
 
@@ -90,9 +90,20 @@ public class CoursesLogicTest extends BaseTestCase {
 
     @Test
     public void testGetSectionNamesForCourse_shouldReturnListOfSectionNames_success() throws EntityDoesNotExistException {
-        Course course = generateTypicalCourse();
+        Course course = getTypicalCourse();
         String courseId = course.getId();
-        course.setSections(generateTypicalSections());
+
+        Section s1 = getTypicalSection();
+        s1.setName("test-sectionName1");
+
+        Section s2 = getTypicalSection();
+        s2.setName("test-sectionName2");
+
+        List<Section> sections = new ArrayList<>();
+        sections.add(s1);
+        sections.add(s2);
+
+        course.setSections(sections);
 
         when(coursesDb.getCourse(courseId)).thenReturn(course);
 
@@ -102,13 +113,13 @@ public class CoursesLogicTest extends BaseTestCase {
 
         List<String> expectedSectionNames = List.of("test-sectionName1", "test-sectionName2");
 
-        assertEquals(sectionNames, expectedSectionNames);
+        assertEquals(expectedSectionNames, sectionNames);
     }
 
     @Test
     public void testGetSectionNamesForCourse_courseDoesNotExist_throwEntityDoesNotExistException()
             throws EntityDoesNotExistException {
-        String courseId = generateTypicalCourse().getId();
+        String courseId = getTypicalCourse().getId();
 
         when(coursesDb.getCourse(courseId)).thenReturn(null);
 
@@ -116,18 +127,5 @@ public class CoursesLogicTest extends BaseTestCase {
                 () -> coursesLogic.getSectionNamesForCourse(courseId));
 
         assertEquals("Trying to get section names for a non-existent course.", ex.getMessage());
-    }
-
-    private Course generateTypicalCourse() {
-        return new Course("test-courseId", "test-courseName", "test-courseTimeZone", "test-courseInstitute");
-    }
-
-    private List<Section> generateTypicalSections() {
-        List<Section> sections = new ArrayList<>();
-
-        sections.add(new Section(generateTypicalCourse(), "test-sectionName1"));
-        sections.add(new Section(generateTypicalCourse(), "test-sectionName2"));
-
-        return sections;
     }
 }

--- a/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
@@ -126,16 +126,4 @@ public class NotificationsLogicTest extends BaseTestCase {
 
         assertEquals("Trying to update non-existent Entity: " + Notification.class, ex.getMessage());
     }
-
-    private Notification getTypicalNotificationWithId() {
-        Notification notification = new Notification(
-                Instant.parse("2011-01-01T00:00:00Z"),
-                Instant.parse("2099-01-01T00:00:00Z"),
-                NotificationStyle.DANGER,
-                NotificationTargetUser.GENERAL,
-                "A deprecation note",
-                "<p>Deprecation happens in three minutes</p>");
-        notification.setId(UUID.fromString("00000001-0000-1000-0000-000000000000"));
-        return notification;
-    }
 }

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
@@ -58,7 +57,7 @@ public class UsersLogicTest extends BaseTestCase {
         course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
         instructor = getTypicalInstructor();
         student = getTypicalStudent();
-        account = generateTypicalAccount();
+        account = getTypicalAccount();
 
         instructor.setAccount(account);
         student.setAccount(account);
@@ -165,24 +164,6 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
                 Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
-    }
-
-    private Instructor getTypicalInstructor() {
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges(
-                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        InstructorPermissionRole role = InstructorPermissionRole
-                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-
-        return new Instructor(course, "instructor-name", "valid-instructor@email.tmt",
-                true, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
-    }
-
-    private Student getTypicalStudent() {
-        return new Student(course, "student-name", "valid-student@email.tmt", "comments");
-    }
-
-    private Account generateTypicalAccount() {
-        return new Account("test-googleId", "test-name", "test@test.com");
     }
 
 }

--- a/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
@@ -159,8 +159,4 @@ public class AccountsDbTest extends BaseTestCase {
 
         mockHibernateUtil.verify(() -> HibernateUtil.remove(account));
     }
-
-    private Account getTypicalAccount() {
-        return new Account("google-id", "name", "email@teammates.com");
-    }
 }

--- a/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
@@ -83,7 +83,7 @@ public class NotificationsDbTest extends BaseTestCase {
 
     @Test
     public void testGetNotification_success() {
-        Notification notification = generateTypicalNotificationWithId();
+        Notification notification = getTypicalNotificationWithId();
         mockHibernateUtil.when(() ->
                 HibernateUtil.get(Notification.class, notification.getId())).thenReturn(notification);
 
@@ -106,7 +106,7 @@ public class NotificationsDbTest extends BaseTestCase {
 
     @Test
     public void testDeleteNotification_entityExists_success() {
-        Notification notification = generateTypicalNotificationWithId();
+        Notification notification = getTypicalNotificationWithId();
         notificationsDb.deleteNotification(notification);
         mockHibernateUtil.verify(() -> HibernateUtil.remove(notification));
     }

--- a/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/NotificationsDbTest.java
@@ -117,12 +117,4 @@ public class NotificationsDbTest extends BaseTestCase {
         mockHibernateUtil.verify(() -> HibernateUtil.remove(any()), never());
     }
 
-    private Notification generateTypicalNotificationWithId() {
-        Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
-                Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
-                "A deprecation note", "<p>Deprecation happens in three minutes</p>");
-        notification.setId(UUID.randomUUID());
-        return notification;
-    }
-
 }

--- a/src/test/java/teammates/storage/sqlapi/UsersDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/UsersDbTest.java
@@ -13,14 +13,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
-import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
@@ -45,33 +41,6 @@ public class UsersDbTest extends BaseTestCase {
     @AfterMethod
     public void teardown() {
         mockHibernateUtil.close();
-    }
-
-    private Instructor getTypicalInstructor() {
-        Course course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
-        InstructorPrivileges instructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-        InstructorPermissionRole role = InstructorPermissionRole
-                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
-
-        return new Instructor(course, "instructor-name", "valid@teammates.tmt",
-                false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
-    }
-
-    private Student getTypicalStudent() {
-        Course course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
-        return new Student(course, "student-name", "valid@teammates.tmt", "comments");
-    }
-
-    private Section getTypicalSection() {
-        Course course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
-        return new Section(course, "test-section");
-    }
-
-    private Team getTypicalTeam() {
-        Course course = new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "institute");
-        Section section = new Section(course, "test-section");
-        return new Team(section, "test-team");
     }
 
     @Test

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -2,18 +2,32 @@ package teammates.test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.InstructorPermissionRole;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.NotificationStyle;
+import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.JsonUtils;
 import teammates.sqllogic.core.DataBundleLogic;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.Team;
 
 /**
  * Base class for all test cases.
@@ -83,6 +97,48 @@ public class BaseTestCase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected Account getTypicalAccount() {
+        return new Account("google-id", "name", "email@teammates.com");
+    }
+
+    protected Notification generateTypicalNotificationWithId() {
+        Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
+                Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
+                "A deprecation note", "<p>Deprecation happens in three minutes</p>");
+        notification.setId(UUID.randomUUID());
+        return notification;
+    }
+
+    protected Instructor getTypicalInstructor() {
+        Course course = getTypicalCourse();
+        InstructorPrivileges instructorPrivileges =
+                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+        InstructorPermissionRole role = InstructorPermissionRole
+                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+
+        return new Instructor(course, "instructor-name", "valid@teammates.tmt",
+                false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, role, instructorPrivileges);
+    }
+
+    protected Course getTypicalCourse() {
+        return new Course("course-id", "course-name", Const.DEFAULT_TIME_ZONE, "teammates");
+    }
+
+    protected Student getTypicalStudent() {
+        Course course = getTypicalCourse();
+        return new Student(course, "student-name", "valid@teammates.tmt", "comments");
+    }
+
+    protected Section getTypicalSection() {
+        Course course = getTypicalCourse();
+        return new Section(course, "test-section");
+    }
+
+    protected Team getTypicalTeam() {
+        Section section = getTypicalSection();
+        return new Team(section, "test-team");
     }
 
     /**
@@ -279,5 +335,4 @@ public class BaseTestCase {
         // CHECKSTYLE.ON:IllegalThrows
 
     }
-
 }

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -128,7 +128,7 @@ public class BaseTestCase {
 
     protected Student getTypicalStudent() {
         Course course = getTypicalCourse();
-        return new Student(course, "student-name", "valid@teammates.tmt", "comments");
+        return new Student(course, "student-name", "validstudent@teammates.tmt", "comments");
     }
 
     protected Section getTypicalSection() {

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -99,11 +99,23 @@ public class BaseTestCase {
         }
     }
 
+    /**
+     * These getTypicalX functions are used to generate typical entities for tests.
+     * The entity fields can be changed using setter methods if needed.
+     * New entity generator functions for tests should be added here, and follow the
+     * same naming convention.
+     *
+     * <p>Example usage:
+     * Account account = getTypicalAccount();
+     * Student student = getTypicalStudent();
+     * account.setEmail("newemail@teammates.com");
+     * student.setName("New Student Name");
+     */
     protected Account getTypicalAccount() {
         return new Account("google-id", "name", "email@teammates.com");
     }
 
-    protected Notification generateTypicalNotificationWithId() {
+    protected Notification getTypicalNotificationWithId() {
         Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
                 Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**
Moves the getTypicalX functionality to BaseTestCase

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
