### PR TITLE
[#12048] Remove typical data bundle from feedbackquestionlogic test

### DIFF
--- a/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
@@ -3,17 +3,18 @@ package teammates.sqllogic.core;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.SqlCourseRoster;
-import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackQuestionsDb;
+import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Student;
@@ -30,13 +31,6 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
 
     private UsersLogic usersLogic;
 
-    private SqlDataBundle typicalDataBundle;
-
-    @BeforeClass
-    public void setUpClass() {
-        typicalDataBundle = getTypicalSqlDataBundle();
-    }
-
     @BeforeMethod
     public void setUpMethod() {
         fqDb = mock(FeedbackQuestionsDb.class);
@@ -47,16 +41,23 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         fqLogic.initLogicDependencies(fqDb, coursesLogic, frLogic, usersLogic, feedbackSessionsLogic);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testGetFeedbackQuestionsForSession_questionNumbersInOrder_success() {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
 
-        List<FeedbackQuestion> questions = List.of(fq1, fq2, fq3, fq4, fq5);
+        fq1.setQuestionNumber(1);
+        fq2.setQuestionNumber(2);
+        fq3.setQuestionNumber(3);
+        fq4.setQuestionNumber(4);
+        fq5.setQuestionNumber(5);
+
+        ArrayList<FeedbackQuestion> questions = new ArrayList<>(List.of(fq2, fq4, fq3, fq1, fq5));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questions);
 
@@ -66,16 +67,23 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         assertTrue(questions.containsAll(actualQuestions));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testGetFeedbackQuestionsForSession_questionNumbersOutOfOrder_success() {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
 
-        List<FeedbackQuestion> questions = List.of(fq2, fq4, fq3, fq1, fq5);
+        fq1.setQuestionNumber(1);
+        fq2.setQuestionNumber(2);
+        fq3.setQuestionNumber(3);
+        fq4.setQuestionNumber(4);
+        fq5.setQuestionNumber(5);
+
+        ArrayList<FeedbackQuestion> questions = new ArrayList<>(List.of(fq2, fq4, fq3, fq1, fq5));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questions);
 
@@ -85,42 +93,53 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         assertTrue(questions.containsAll(actualQuestions));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testCreateFeedbackQuestion_questionNumbersAreConsistent_canCreateFeedbackQuestion()
             throws InvalidParametersException {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
 
-        List<FeedbackQuestion> questionsBefore = List.of(fq1, fq2, fq3, fq4);
+        fq1.setQuestionNumber(1);
+        fq2.setQuestionNumber(2);
+        fq3.setQuestionNumber(3);
+        fq4.setQuestionNumber(4);
+        fq5.setQuestionNumber(5);
+
+        ArrayList<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
+
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
+        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
 
         FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(fq5);
 
         assertEquals(fq5, createdQuestion);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testCreateFeedbackQuestion_questionNumbersAreInconsistent_canCreateFeedbackQuestion()
             throws InvalidParametersException {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
         fq1.setQuestionNumber(2);
         fq2.setQuestionNumber(3);
         fq3.setQuestionNumber(4);
         fq4.setQuestionNumber(5);
 
-        List<FeedbackQuestion> questionsBefore = List.of(fq1, fq2, fq3, fq4);
+        ArrayList<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
+        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
 
         FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(fq5);
 
@@ -130,20 +149,23 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
     @Test(enabled = false)
     public void testCreateFeedbackQuestion_oldQuestionNumberLargerThanNewQuestionNumber_adjustQuestionNumberCorrectly()
             throws InvalidParametersException {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
         fq1.setQuestionNumber(2);
         fq2.setQuestionNumber(3);
         fq3.setQuestionNumber(4);
         fq4.setQuestionNumber(5);
+        fq5.setQuestionNumber(1);
 
-        List<FeedbackQuestion> questionsBefore = List.of(fq1, fq2, fq3, fq4);
+        ArrayList<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
+        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
 
         fqLogic.createFeedbackQuestion(fq5);
 
@@ -156,20 +178,22 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
     @Test(enabled = false)
     public void testCreateFeedbackQuestion_oldQuestionNumberSmallerThanNewQuestionNumber_adjustQuestionNumberCorrectly()
             throws InvalidParametersException {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
         fq1.setQuestionNumber(0);
         fq2.setQuestionNumber(1);
         fq3.setQuestionNumber(2);
         fq4.setQuestionNumber(3);
 
-        List<FeedbackQuestion> questionsBefore = List.of(fq1, fq2, fq3, fq4);
+        ArrayList<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
+        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
 
         fqLogic.createFeedbackQuestion(fq5);
 
@@ -179,13 +203,22 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         assertEquals(4, fq4.getQuestionNumber().intValue());
     }
 
-    @Test(enabled = false)
-    public void testGetFeedbackQuestionsForStudents() {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq1 = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion fq2 = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
+    @Test
+    public void testGetFeedbackQuestionsForStudents_success() {
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
 
-        List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2);
+        List<FeedbackQuestion> questionsSelf = List.of(fq1, fq2);
+        List<FeedbackQuestion> questionsStudent = List.of(fq3, fq4);
+
+        List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2, fq3, fq4);
+
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.SELF)).thenReturn(questionsSelf);
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.STUDENTS)).thenReturn(questionsStudent);
 
         List<FeedbackQuestion> actualQuestions = fqLogic.getFeedbackQuestionsForStudents(fs);
 
@@ -193,16 +226,47 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         assertTrue(actualQuestions.containsAll(actualQuestions));
     }
 
-    @Test(enabled = false)
-    public void testGetFeedbackQuestionsForInstructors() {
-        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackQuestion fq3 = typicalDataBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        FeedbackQuestion fq4 = typicalDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-        FeedbackQuestion fq5 = typicalDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
+    @Test
+    public void testGetFeedbackQuestionsForInstructors_instructorIsCreator_success() {
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        fs.setCreatorEmail("instr1@teammates.tmt");
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
 
-        List<FeedbackQuestion> expectedQuestions = List.of(fq3, fq4, fq5);
+        List<FeedbackQuestion> questionsInstructors = List.of(fq1, fq2);
+        List<FeedbackQuestion> questionsSelf = List.of(fq3, fq4);
 
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS)).thenReturn(questionsInstructors);
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.SELF)).thenReturn(questionsSelf);
+
+        List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2, fq3, fq4);
         List<FeedbackQuestion> actualQuestions = fqLogic.getFeedbackQuestionsForInstructors(fs, "instr1@teammates.tmt");
+
+        assertEquals(expectedQuestions.size(), actualQuestions.size());
+        assertTrue(actualQuestions.containsAll(actualQuestions));
+    }
+
+    @Test
+    public void testGetFeedbackQuestionsForInstructors_instructorIsNotCreator_success() {
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        fs.setCreatorEmail("instr1@teammates.tmt");
+        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
+
+        List<FeedbackQuestion> questionsInstructors = List.of(fq1, fq2);
+        List<FeedbackQuestion> questionsSelf = List.of(fq3, fq4);
+
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS)).thenReturn(questionsInstructors);
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.SELF)).thenReturn(questionsSelf);
+
+        List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2);
+        List<FeedbackQuestion> actualQuestions = fqLogic.getFeedbackQuestionsForInstructors(fs, "instr2@teammates.tmt");
 
         assertEquals(expectedQuestions.size(), actualQuestions.size());
         assertTrue(actualQuestions.containsAll(actualQuestions));
@@ -210,10 +274,12 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
 
     @Test(enabled = false)
     public void testGetRecipientsOfQuestion_giverTypeStudents() {
-        FeedbackQuestion fq = typicalDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
+        Course c = getTypicalCourse();
+        FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
+        FeedbackQuestion fq = getTypicalFeedbackQuestionForSession(fs);
 
-        Student s1 = typicalDataBundle.students.get("student1InCourse1");
-        Student s2 = typicalDataBundle.students.get("student2InCourse1");
+        Student s1 = getTypicalStudent();
+        Student s2 = getTypicalStudent();
         List<Student> studentsInCourse = List.of(s1, s2);
 
         SqlCourseRoster courseRoster = new SqlCourseRoster(studentsInCourse, null);

--- a/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
@@ -45,19 +45,8 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
     public void testGetFeedbackQuestionsForSession_questionNumbersInOrder_success() {
         Course c = getTypicalCourse();
         FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
-        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
 
-        fq1.setQuestionNumber(1);
-        fq2.setQuestionNumber(2);
-        fq3.setQuestionNumber(3);
-        fq4.setQuestionNumber(4);
-        fq5.setQuestionNumber(5);
-
-        ArrayList<FeedbackQuestion> questions = new ArrayList<>(List.of(fq2, fq4, fq3, fq1, fq5));
+        List<FeedbackQuestion> questions = createQuestionList(fs, 5);
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questions);
 
@@ -98,27 +87,17 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
             throws InvalidParametersException {
         Course c = getTypicalCourse();
         FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
-        FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq4 = getTypicalFeedbackQuestionForSession(fs);
-        FeedbackQuestion fq5 = getTypicalFeedbackQuestionForSession(fs);
+        FeedbackQuestion newQuestion = getTypicalFeedbackQuestionForSession(fs);
 
-        fq1.setQuestionNumber(1);
-        fq2.setQuestionNumber(2);
-        fq3.setQuestionNumber(3);
-        fq4.setQuestionNumber(4);
-        fq5.setQuestionNumber(5);
-
-        ArrayList<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
+        newQuestion.setQuestionNumber(5);
+        List<FeedbackQuestion> questionsBefore = createQuestionList(fs, 4);
 
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
-        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
+        when(fqDb.createFeedbackQuestion(newQuestion)).thenReturn(newQuestion);
 
-        FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(fq5);
-
-        assertEquals(fq5, createdQuestion);
+        FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(newQuestion);
+        assertEquals(newQuestion, createdQuestion);
     }
 
     @Test
@@ -292,5 +271,15 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         assertEquals(fqLogic.getRecipientsOfQuestion(fq, null, s2, null).size(), studentsInCourse.size() - 1);
         assertEquals(fqLogic.getRecipientsOfQuestion(fq, null, s2, courseRoster).size(), studentsInCourse.size() - 1);
 
+    }
+
+    private List<FeedbackQuestion> createQuestionList(FeedbackSession fs, int numOfQuestions) {
+        ArrayList<FeedbackQuestion> questions = new ArrayList<>();
+        for (int i = 1; i <= numOfQuestions; i++) {
+            FeedbackQuestion fq = getTypicalFeedbackQuestionForSession(fs);
+            fq.setQuestionNumber(i);
+            questions.add(fq);
+        }
+        return questions;
     }
 }

--- a/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackQuestionsLogicTest.java
@@ -239,7 +239,8 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         List<FeedbackQuestion> questionsInstructors = List.of(fq1, fq2);
         List<FeedbackQuestion> questionsSelf = List.of(fq3, fq4);
 
-        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS)).thenReturn(questionsInstructors);
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS))
+                .thenReturn(questionsInstructors);
         when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.SELF)).thenReturn(questionsSelf);
 
         List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2, fq3, fq4);
@@ -262,7 +263,8 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         List<FeedbackQuestion> questionsInstructors = List.of(fq1, fq2);
         List<FeedbackQuestion> questionsSelf = List.of(fq3, fq4);
 
-        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS)).thenReturn(questionsInstructors);
+        when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.INSTRUCTORS))
+                .thenReturn(questionsInstructors);
         when(fqDb.getFeedbackQuestionsForGiverType(fs, FeedbackParticipantType.SELF)).thenReturn(questionsSelf);
 
         List<FeedbackQuestion> expectedQuestions = List.of(fq1, fq2);

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -3,6 +3,7 @@ package teammates.test;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -12,17 +13,21 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.JsonUtils;
 import teammates.sqllogic.core.DataBundleLogic;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.Section;
@@ -151,6 +156,16 @@ public class BaseTestCase {
     protected Team getTypicalTeam() {
         Section section = getTypicalSection();
         return new Team(section, "test-team");
+    }
+
+    protected FeedbackSession getTypicalFeedbackSessionForCourse(Course course) {
+        return new FeedbackSession("test-feedbacksession", course, "testemail", "test-instructions", null, null, null, null, null, false, false, false);
+    }
+
+    protected FeedbackQuestion getTypicalFeedbackQuestionForSession(FeedbackSession session) {
+        return FeedbackQuestion.makeQuestion(session, 1, "test-description",
+                FeedbackParticipantType.SELF, FeedbackParticipantType.SELF, 1, new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(),
+                new ArrayList<FeedbackParticipantType>(), new FeedbackTextQuestionDetails("test question text"));
     }
 
     /**

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -159,13 +159,15 @@ public class BaseTestCase {
     }
 
     protected FeedbackSession getTypicalFeedbackSessionForCourse(Course course) {
-        return new FeedbackSession("test-feedbacksession", course, "testemail", "test-instructions", null, null, null, null, null, false, false, false);
+        return new FeedbackSession("test-feedbacksession", course, "testemail", "test-instructions", null,
+                    null, null, null, null, false, false, false);
     }
 
     protected FeedbackQuestion getTypicalFeedbackQuestionForSession(FeedbackSession session) {
         return FeedbackQuestion.makeQuestion(session, 1, "test-description",
-                FeedbackParticipantType.SELF, FeedbackParticipantType.SELF, 1, new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(),
-                new ArrayList<FeedbackParticipantType>(), new FeedbackTextQuestionDetails("test question text"));
+                FeedbackParticipantType.SELF, FeedbackParticipantType.SELF, 1, new ArrayList<FeedbackParticipantType>(),
+                new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(),
+                new FeedbackTextQuestionDetails("test question text"));
     }
 
     /**


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of  #12048 

**Outline of Solution**
Remove typicalDataBundle from FeedbackQuestionLogicTest as unit tests should not use databundle

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
