### PR TITLE
[#12048] Update restoreDeletedFeedbackSession to save updated entity to db

### DIFF
--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -127,6 +127,7 @@ public final class FeedbackSessionsDb extends EntitiesDb {
         }
 
         sessionEntity.setDeletedAt(null);
+        merge(sessionEntity);
     }
 
     /**


### PR DESCRIPTION
Part of #12048 

Previously, `restoreDeletedFeedbackSession()` in `FeedbackSessionsDb.java` did not save the changes to db

**Outline of Solution**

Save updated entity to db
