### PR TITLE
[#12048] Refactor FeedbackResponses and FeedbackResponseComments attributes

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
@@ -254,7 +254,10 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
 
     @Override
     protected FeedbackResponseData getFeedbackResponse(FeedbackResponse fr) {
-        return getFeedbackResponse(fr.getFeedbackQuestion().getId().toString(), fr.getGiver(), fr.getRecipient());
+        return getFeedbackResponse(
+                fr.getFeedbackQuestion().getId().toString(),
+                fr.getGiver().getEmail(),
+                fr.getRecipient().getEmail());
     }
 
     StudentData getStudent(String courseId, String studentEmailAddress) {

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackMcqQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackMcqQuestionE2ETest.java
@@ -134,7 +134,6 @@ public class FeedbackMcqQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
         } else {
             details.setAnswer(answer);
         }
-        return FeedbackResponse.makeResponse(feedbackQuestion, student.getEmail(), null, instructor.getEmail(), null,
-                details);
+        return FeedbackResponse.makeResponse(feedbackQuestion, student, null, instructor, null, details);
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackMsqQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackMsqQuestionE2ETest.java
@@ -144,7 +144,7 @@ public class FeedbackMsqQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
         }
         details.setAnswers(answers);
 
-        return FeedbackResponse.makeResponse(feedbackQuestion, student.getEmail(), student.getSection(),
-                receiver.getEmail(), receiver.getSection(), details);
+        return FeedbackResponse.makeResponse(feedbackQuestion, student, student.getSection(),
+                receiver, receiver.getSection(), details);
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankOptionQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankOptionQuestionE2ETest.java
@@ -123,6 +123,6 @@ public class FeedbackRankOptionQuestionE2ETest extends BaseFeedbackQuestionE2ETe
     private FeedbackResponse getResponse(FeedbackQuestion question, Student receiver, List<Integer> answers) {
         FeedbackRankOptionsResponseDetails details = new FeedbackRankOptionsResponseDetails();
         details.setAnswers(answers);
-        return FeedbackResponse.makeResponse(question, student.getEmail(), null, receiver.getEmail(), null, details);
+        return FeedbackResponse.makeResponse(question, student, null, receiver, null, details);
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackTextQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackTextQuestionE2ETest.java
@@ -106,6 +106,6 @@ public class FeedbackTextQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
     private FeedbackResponse getResponse(FeedbackQuestion feedbackQuestion, Instructor instructor, String answer) {
         FeedbackTextResponseDetails details = new FeedbackTextResponseDetails(answer);
         return FeedbackResponse.makeResponse(
-            feedbackQuestion, student.getEmail(), null, instructor.getEmail(), null, details);
+            feedbackQuestion, student, null, instructor, null, details);
     }
 }

--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -192,8 +192,8 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("verify feedback responses deserialized correctly");
         FeedbackResponse actualResponse1 = dataBundle.feedbackResponses.get("response1ForQ1S1C1");
         FeedbackResponseDetails responseDetails1 = new FeedbackTextResponseDetails("Student 1 self feedback.");
-        FeedbackResponse expectedResponse1 = FeedbackResponse.makeResponse(actualQuestion1, "student1@teammates.tmt",
-                expectedSection, "student1@teammates.tmt", expectedSection, responseDetails1);
+        FeedbackResponse expectedResponse1 = FeedbackResponse.makeResponse(actualQuestion1, actualStudent1,
+                expectedSection, actualStudent1, expectedSection, responseDetails1);
         expectedResponse1.setId(actualResponse1.getId());
         verifyEquals(expectedResponse1, actualResponse1);
 

--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -199,10 +199,11 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("verify feedback response comments deserialized correctly");
         FeedbackResponseComment actualComment1 = dataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
-        FeedbackResponseComment expectedComment1 = new FeedbackResponseComment(expectedResponse1, "instr1@teammates.tmt",
+        Instructor expectedInstructor = dataBundle.instructors.get("instructor1OfTypicalCourse");
+        FeedbackResponseComment expectedComment1 = new FeedbackResponseComment(expectedResponse1, expectedInstructor,
                 FeedbackParticipantType.INSTRUCTORS, expectedSection, expectedSection,
                 "Instructor 1 comment to student 1 self feedback", false, false,
-                new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(), "instr1@teammates.tmt");
+                new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(), expectedInstructor);
         expectedComment1.setId(actualComment1.getId());
         verifyEquals(expectedComment1, actualComment1);
     }

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackResponsesLogicIT.java
@@ -2,6 +2,7 @@ package teammates.it.sqllogic.core;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -15,6 +16,7 @@ import teammates.sqllogic.core.FeedbackResponsesLogic;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.User;
 
 /**
  * SUT: {@link FeedbackResponsesLogic}.
@@ -64,7 +66,9 @@ public class FeedbackResponsesLogicIT extends BaseTestCaseWithSqlDatabaseAccess 
 
         Section newGiverSection = typicalDataBundle.sections.get("section1InCourse2");
         Section newRecipientSection = typicalDataBundle.sections.get("section2InCourse1");
-        String newGiver = "new test giver";
+        User newGiver = typicalDataBundle.students.get("student1InCourse1");
+        // As assertion uses UUID to compare, let's change the UUID.
+        newGiver.setId(UUID.randomUUID());
 
         for (FeedbackResponseComment frc : oldComments) {
             assertNotEquals(frc.getGiverSection(), newGiverSection);

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponseCommentsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponseCommentsDbIT.java
@@ -59,66 +59,6 @@ public class FeedbackResponseCommentsDbIT extends BaseTestCaseWithSqlDatabaseAcc
         assertEquals(expectedComment, actualComment);
     }
 
-    private FeedbackResponseComment prepareSqlInjectionTest() {
-        FeedbackResponseComment frc = testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
-        assertNotNull(frcDb.getFeedbackResponseComment(frc.getId()));
-
-        return frc;
-    }
-
-    private void checkSqlInjectionFailed(FeedbackResponseComment frc) {
-        assertNotNull(frcDb.getFeedbackResponseComment(frc.getId()));
-    }
-
-    @Test
-    public void testSqlInjectionInUpdateGiverEmailOfFeedbackResponseComments() {
-        FeedbackResponseComment frc = prepareSqlInjectionTest();
-
-        String sqli = "'; DELETE FROM feedback_response_comments;--";
-        frcDb.updateGiverEmailOfFeedbackResponseComments(sqli, "", "");
-
-        checkSqlInjectionFailed(frc);
-    }
-
-    @Test
-    public void testSqlInjectionInUpdateLastEditorEmailOfFeedbackResponseComments() {
-        FeedbackResponseComment frc = prepareSqlInjectionTest();
-
-        String sqli = "'; DELETE FROM feedback_response_comments;--";
-        frcDb.updateLastEditorEmailOfFeedbackResponseComments(sqli, "", "");
-
-        checkSqlInjectionFailed(frc);
-    }
-
-    @Test
-    public void testSqlInjectionInCreateFeedbackResponseComment() throws Exception {
-        FeedbackResponseComment frc = prepareSqlInjectionTest();
-
-        FeedbackResponse fr = testDataBundle.feedbackResponses.get("response1ForQ1");
-        Section s = testDataBundle.sections.get("section2InCourse1");
-
-        String sqli = "'');/**/DELETE/**/FROM/**/feedback_response_comments;--@gmail.com";
-        FeedbackResponseComment newFrc = new FeedbackResponseComment(
-                fr, "", FeedbackParticipantType.INSTRUCTORS, s, s, "",
-                false, false,
-                new ArrayList<FeedbackParticipantType>(), new ArrayList<FeedbackParticipantType>(), sqli);
-
-        frcDb.createFeedbackResponseComment(newFrc);
-
-        checkSqlInjectionFailed(frc);
-    }
-
-    @Test
-    public void testSqlInjectionInUpdateFeedbackResponseComment() throws Exception {
-        FeedbackResponseComment frc = prepareSqlInjectionTest();
-
-        String sqli = "'');/**/DELETE/**/FROM/**/feedback_response_comments;--@gmail.com";
-        frc.setLastEditorEmail(sqli);
-        frcDb.updateFeedbackResponseComment(frc);
-
-        checkSqlInjectionFailed(frc);
-    }
-
     @Test
     public void testGetFeedbackResponseCommentsForSession_matchFound_success() {
         Course course = testDataBundle.courses.get("course1");

--- a/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/FeedbackResponsesDbIT.java
@@ -159,7 +159,7 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("SQL Injection test in GetFeedbackResponsesFromGiverForCourse, courseId param");
         String courseId = "'; DELETE FROM feedback_responses;--";
-        frDb.getFeedbackResponsesFromGiverForCourse(courseId, "");
+        frDb.getFeedbackResponsesFromGiverForCourse(courseId, null);
 
         checkSqliFailed(fr);
     }
@@ -170,7 +170,7 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("SQL Injection test in GetFeedbackResponsesForRecipientForCourse, courseId param");
         String courseId = "'; DELETE FROM feedback_responses;--";
-        frDb.getFeedbackResponsesForRecipientForCourse(courseId, "");
+        frDb.getFeedbackResponsesForRecipientForCourse(courseId, null);
 
         checkSqliFailed(fr);
     }
@@ -204,34 +204,6 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("SQL Injection test in HasResponsesForCourse, courseId param");
         String courseId = "'; DELETE FROM feedback_responses;--";
         frDb.hasResponsesForCourse(courseId);
-
-        checkSqliFailed(fr);
-    }
-
-    @Test
-    public void testSqlInjectionInCreateFeedbackResponse() throws Exception {
-        FeedbackResponse fr = prepareSqlInjectionTest();
-
-        FeedbackQuestion fq = testDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        Section s = testDataBundle.sections.get("section1InCourse1");
-        String dummyUuid = "00000000-0000-4000-8000-000000000001";
-        FeedbackResponseDetails frd = new FeedbackTextResponseDetails();
-
-        String sqli = "', " + dummyUuid + ", " + dummyUuid + "); DELETE FROM feedback_responses;--";
-
-        FeedbackResponse newFr = new FeedbackTextResponse(fq, "", s, sqli, s, frd);
-        frDb.createFeedbackResponse(newFr);
-
-        checkSqliFailed(fr);
-    }
-
-    @Test
-    public void testSqlInjectionInCpdateFeedbackResponse() throws Exception {
-        FeedbackResponse fr = prepareSqlInjectionTest();
-
-        String sqli = "''); DELETE FROM feedback_response_comments;--";
-        fr.setGiver(sqli);
-        frDb.updateFeedbackResponse(fr);
 
         checkSqliFailed(fr);
     }

--- a/src/it/java/teammates/it/ui/webapi/CreateFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateFeedbackResponseCommentActionIT.java
@@ -61,7 +61,7 @@ public class CreateFeedbackResponseCommentActionIT extends BaseActionIT<CreateFe
         FeedbackResponseComment comment =
                 logic.getFeedbackResponseCommentForResponseFromParticipant(fr.getId());
         assertEquals(comment.getCommentText(), "Student submission comment");
-        assertEquals(student.getEmail(), comment.getGiver());
+        assertEquals(student.getEmail(), comment.getGiver().getEmail());
         assertTrue(comment.getIsCommentFromFeedbackParticipant());
         assertTrue(comment.getIsVisibilityFollowingFeedbackQuestion());
         assertEquals(FeedbackParticipantType.STUDENTS, comment.getGiverType());

--- a/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
@@ -71,7 +71,7 @@ public class DeleteFeedbackResponseCommentActionIT extends BaseActionIT<DeleteFe
         ______TS("Different instructor of same course cannot delete comment");
 
         Instructor differentInstructorInSameCourse = typicalBundle.instructors.get("instructor2OfCourse1");
-        assertNotEquals(differentInstructorInSameCourse.getEmail(), frc.getGiver());
+        assertNotEquals(differentInstructorInSameCourse.getEmail(), frc.getGiver().getEmail());
         loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
         verifyCannotAccess(submissionParams);
     }

--- a/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
@@ -64,7 +64,7 @@ public class DeleteFeedbackResponseCommentActionIT extends BaseActionIT<DeleteFe
         };
         Instructor instructorWhoGiveComment = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        assertEquals(instructorWhoGiveComment.getEmail(), frc.getGiver());
+        assertEquals(instructorWhoGiveComment.getEmail(), frc.getGiver().getEmail());
         loginAsInstructor(instructorWhoGiveComment.getGoogleId());
         verifyCanAccess(submissionParams);
 

--- a/src/it/java/teammates/it/ui/webapi/EnrollStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/EnrollStudentsActionIT.java
@@ -130,7 +130,7 @@ public class EnrollStudentsActionIT extends BaseActionIT<EnrollStudentsAction> {
             assertEquals(logic.getSection(courseId, "Section 3"), response.getRecipientSection());
             List<FeedbackResponseComment> commentsFromUser = logic.getFeedbackResponseCommentsForResponse(response.getId());
             for (FeedbackResponseComment comment : commentsFromUser) {
-                if (comment.getGiver().equals(giverEmail)) {
+                if (comment.getGiver().getEmail().equals(giverEmail)) {
                     assertEquals(logic.getSection(courseId, "Section 3"), comment.getGiverSection());
                 }
             }

--- a/src/it/java/teammates/it/ui/webapi/UpdateFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateFeedbackResponseCommentActionIT.java
@@ -59,7 +59,7 @@ public class UpdateFeedbackResponseCommentActionIT extends BaseActionIT<UpdateFe
 
         FeedbackResponseComment actualFrc = logic.getFeedbackResponseComment(frc.getId());
         assertEquals(newCommentText, actualFrc.getCommentText());
-        assertEquals(instructor.getEmail(), actualFrc.getLastEditorEmail());
+        assertEquals(instructor.getEmail(), actualFrc.getLastEditor().getEmail());
     }
 
     @Test

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -257,8 +257,14 @@
           "INSTRUCTORS"
         ]
       },
-      "giver": "student1@teammates.tmt",
-      "recipient": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -299,8 +305,14 @@
             "INSTRUCTORS"
           ]
         },
-        "giver": "student1@teammates.tmt",
-        "recipient": "student1@teammates.tmt",
+        "giver": {
+          "id": "00000000-0000-4000-8000-000000000601",
+          "type": "student"
+        },
+        "recipient": {
+          "id": "00000000-0000-4000-8000-000000000601",
+          "type": "student"
+        },
         "giverSection": {
           "id": "00000000-0000-4000-8000-000000000201"
         },

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -324,7 +324,11 @@
           "answer": "Student 1 self feedback."
         }
       },
-      "giver": "instr1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      },
       "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -337,7 +341,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "instr1@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      }
     }
   },
   "notifications": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -209,12 +209,12 @@
       "name": "Section 3"
     },
     "section1InCourse3": {
-        "id": "00000000-0000-4000-8000-000000000204",
-        "course": {
-          "id": "course-3"
-        },
-        "name": "Section 1"
-      }
+      "id": "00000000-0000-4000-8000-000000000204",
+      "course": {
+        "id": "course-3"
+      },
+      "name": "Section 1"
+    }
   },
   "teams": {
     "team1InCourse1": {
@@ -613,16 +613,16 @@
       "comments": ""
     },
     "student1InCourse3": {
-        "id": "00000000-0000-4000-8000-000000000605",
-        "email": "student1@teammates.tmt",
-        "course": {
-            "id": "course-3"
-        },
-        "team": {
-            "id": "00000000-0000-4000-8000-000000000304"
-        },
-        "name": "student1 In Course3</td></div>'\"",
-        "comments": "comment for student1InCourse3</td></div>'\""
+      "id": "00000000-0000-4000-8000-000000000605",
+      "email": "student1@teammates.tmt",
+      "course": {
+        "id": "course-3"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000304"
+      },
+      "name": "student1 In Course3</td></div>'\"",
+      "comments": "comment for student1InCourse3</td></div>'\""
     },
     "unregisteredStudentInCourse1": {
       "id": "00000000-0000-4000-8000-000000000606",
@@ -896,9 +896,15 @@
       "giverType": "STUDENTS",
       "recipientType": "SELF",
       "numOfEntitiesToGiveFeedbackTo": 1,
-      "showResponsesTo": ["INSTRUCTORS"],
-      "showGiverNameTo": ["INSTRUCTORS"],
-      "showRecipientNameTo": ["INSTRUCTORS"]
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
     },
     "qn2InSession1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000802",
@@ -915,9 +921,17 @@
       "giverType": "STUDENTS",
       "recipientType": "STUDENTS_EXCLUDING_SELF",
       "numOfEntitiesToGiveFeedbackTo": 1,
-      "showResponsesTo": ["INSTRUCTORS", "RECEIVER"],
-      "showGiverNameTo": ["INSTRUCTORS"],
-      "showRecipientNameTo": ["INSTRUCTORS", "RECEIVER"]
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
     },
     "qn3InSession1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000803",
@@ -1000,9 +1014,15 @@
       "giverType": "SELF",
       "recipientType": "NONE",
       "numOfEntitiesToGiveFeedbackTo": -100,
-      "showResponsesTo": ["INSTRUCTORS"],
-      "showGiverNameTo": ["INSTRUCTORS"],
-      "showRecipientNameTo": ["INSTRUCTORS"]
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
     },
     "qn6InSession1InCourse1NoResponses": {
       "id": "00000000-0000-4000-8000-000000000806",
@@ -1019,9 +1039,15 @@
       "giverType": "SELF",
       "recipientType": "NONE",
       "numOfEntitiesToGiveFeedbackTo": -100,
-      "showResponsesTo": ["INSTRUCTORS"],
-      "showGiverNameTo": ["INSTRUCTORS"],
-      "showRecipientNameTo": ["INSTRUCTORS"]
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
     },
     "qn1InSession2InCourse1": {
       "id": "00000000-0000-4000-8001-000000000800",
@@ -1032,7 +1058,10 @@
         "hasAssignedWeights": false,
         "mcqWeights": [],
         "mcqOtherWeight": 0.0,
-        "mcqChoices": ["Great", "Perfect"],
+        "mcqChoices": [
+          "Great",
+          "Perfect"
+        ],
         "otherEnabled": false,
         "questionDropdownEnabled": false,
         "generateOptionsFor": "NONE",
@@ -1044,9 +1073,15 @@
       "giverType": "STUDENTS",
       "recipientType": "SELF",
       "numOfEntitiesToGiveFeedbackTo": 1,
-      "showResponsesTo": ["INSTRUCTORS"],
-      "showGiverNameTo": ["INSTRUCTORS"],
-      "showRecipientNameTo": ["INSTRUCTORS"]
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
     }
   },
   "feedbackResponses": {
@@ -1059,8 +1094,16 @@
           "questionText": "What is the best selling point of your product?"
         }
       },
-      "giver": "student1@teammates.tmt",
-      "recipient": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1081,8 +1124,16 @@
           "questionText": "What is the best selling point of your product?"
         }
       },
-      "giver": "student2@teammates.tmt",
-      "recipient": "student2@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000602",
+        "type": "student",
+        "email": "student2@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000602",
+        "type": "student",
+        "email": "student2@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1111,12 +1162,28 @@
         "giverType": "STUDENTS",
         "recipientType": "STUDENTS_EXCLUDING_SELF",
         "numOfEntitiesToGiveFeedbackTo": 1,
-        "showResponsesTo": ["INSTRUCTORS", "RECEIVER"],
-        "showGiverNameTo": ["INSTRUCTORS"],
-        "showRecipientNameTo": ["INSTRUCTORS", "RECEIVER"]
+        "showResponsesTo": [
+          "INSTRUCTORS",
+          "RECEIVER"
+        ],
+        "showGiverNameTo": [
+          "INSTRUCTORS"
+        ],
+        "showRecipientNameTo": [
+          "INSTRUCTORS",
+          "RECEIVER"
+        ]
       },
-      "giver": "student2@teammates.tmt",
-      "recipient": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000602",
+        "type": "student",
+        "email": "student2@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1145,12 +1212,28 @@
         "giverType": "STUDENTS",
         "recipientType": "STUDENTS_EXCLUDING_SELF",
         "numOfEntitiesToGiveFeedbackTo": 1,
-        "showResponsesTo": ["INSTRUCTORS", "RECEIVER"],
-        "showGiverNameTo": ["INSTRUCTORS"],
-        "showRecipientNameTo": ["INSTRUCTORS", "RECEIVER"]
+        "showResponsesTo": [
+          "INSTRUCTORS",
+          "RECEIVER"
+        ],
+        "showGiverNameTo": [
+          "INSTRUCTORS"
+        ],
+        "showRecipientNameTo": [
+          "INSTRUCTORS",
+          "RECEIVER"
+        ]
       },
-      "giver": "student3@teammates.tmt",
-      "recipient": "student2@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000603",
+        "type": "student",
+        "email": "student3@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000602",
+        "type": "student",
+        "email": "student2@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1171,8 +1254,16 @@
           "questionText": "My comments on the class"
         }
       },
-      "giver": "student1@teammates.tmt",
-      "recipient": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1192,7 +1283,10 @@
           "hasAssignedWeights": false,
           "mcqWeights": [],
           "mcqOtherWeight": 0.0,
-          "mcqChoices": ["Great", "Perfect"],
+          "mcqChoices": [
+            "Great",
+            "Perfect"
+          ],
           "otherEnabled": false,
           "questionDropdownEnabled": false,
           "generateOptionsFor": "NONE",
@@ -1200,8 +1294,16 @@
           "questionText": "How do you think you did?"
         }
       },
-      "giver": "student1@teammates.tmt",
-      "recipient": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
+      "recipient": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
       },
@@ -1224,7 +1326,11 @@
           "answer": "Student 1 self feedback."
         }
       },
-      "giver": "instr1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      },
       "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1237,7 +1343,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "instr1@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      }
     },
     "comment2ToResponse1ForQ1": {
       "feedbackResponse": {
@@ -1247,7 +1357,11 @@
           "answer": "Student 1 self feedback."
         }
       },
-      "giver": "student1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      },
       "giverType": "STUDENTS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1260,7 +1374,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "student1@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000601",
+        "type": "student",
+        "email": "student1@teammates.tmt"
+      }
     },
     "comment2ToResponse2ForQ1": {
       "feedbackResponse": {
@@ -1270,7 +1388,11 @@
           "answer": "Student 2 self feedback."
         }
       },
-      "giver": "instr2@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000502",
+        "type": "instructor",
+        "email": "instr2@teammates.tmt"
+      },
       "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1283,7 +1405,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "instr2@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000502",
+        "type": "instructor",
+        "email": "instr2@teammates.tmt"
+      }
     },
     "comment1ToResponse1ForQ2s": {
       "feedbackResponse": {
@@ -1293,7 +1419,11 @@
           "answer": "Student 2 self feedback."
         }
       },
-      "giver": "instr2@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000502",
+        "type": "instructor",
+        "email": "instr2@teammates.tmt"
+      },
       "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1306,7 +1436,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "instr2@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000502",
+        "type": "instructor",
+        "email": "instr2@teammates.tmt"
+      }
     },
     "comment1ToResponse1ForQ3": {
       "feedbackResponse": {
@@ -1316,7 +1450,11 @@
           "answer": "The class is great."
         }
       },
-      "giver": "instr1@teammates.tmt",
+      "giver": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      },
       "giverType": "INSTRUCTORS",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1329,7 +1467,11 @@
       "isCommentFromFeedbackParticipant": false,
       "showCommentTo": [],
       "showGiverNameTo": [],
-      "lastEditorEmail": "instr1@teammates.tmt"
+      "lastEditor": {
+        "id": "00000000-0000-4000-8000-000000000501",
+        "type": "instructor",
+        "email": "instr1@teammates.tmt"
+      }
     }
   },
   "notifications": {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackQuestionRecipient;
 import teammates.common.datatransfer.FeedbackResultFetchType;
 import teammates.common.datatransfer.NotificationStyle;
@@ -21,6 +22,7 @@ import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.exception.StudentUpdateException;
+import teammates.logic.core.StudentsLogic;
 import teammates.sqllogic.core.AccountRequestsLogic;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
@@ -1608,4 +1610,12 @@ public class Logic {
     public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
         return feedbackSessionsLogic.getFeedbackSessionsOpeningWithinTimeLimit();
     }
+
+    public User getUserByEmail(String courseId, String email) {
+        assert courseId != null;
+        assert email != null;
+
+        return usersLogic.getUserByEmail(courseId, email);
+    }
+
 }

--- a/src/main/java/teammates/sqllogic/core/CoursesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/CoursesLogic.java
@@ -257,4 +257,17 @@ public final class CoursesLogic {
     public static void sortById(List<Course> courses) {
         courses.sort(Comparator.comparing(Course::getId));
     }
+
+    /**
+     * Gets the course associated with a feedback response comment.
+     * 
+     * @param id The identifier of a feedback response comment.
+     * @return A course.
+     */
+    public Course getCourseForFeedbackResponseCommentId(Long id) {
+        assert id != null;
+
+        return coursesDb.getCourseForFeedbackResponseCommentId(id);
+    }
+
 }

--- a/src/main/java/teammates/sqllogic/core/CoursesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/CoursesLogic.java
@@ -260,7 +260,7 @@ public final class CoursesLogic {
 
     /**
      * Gets the course associated with a feedback response comment.
-     * 
+     *
      * @param id The identifier of a feedback response comment.
      * @return A course.
      */

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -3,8 +3,10 @@ package teammates.sqllogic.core;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -220,6 +222,40 @@ public final class DataBundleLogic {
             FeedbackResponse fr = responseMap.get(responseComment.getFeedbackResponse().getId());
             Section giverSection = sectionsMap.get(responseComment.getGiverSection().getId());
             Section recipientSection = sectionsMap.get(responseComment.getRecipientSection().getId());
+            String giverEmail = responseComment.getGiver().getEmail();
+            if (responseComment.getGiver() instanceof Instructor) {
+                Instructor giver = instructors
+                        .stream()
+                        .filter(instructor -> giverEmail.equals(instructor.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setGiver(giver);
+            } else if (responseComment.getGiver() instanceof Student) {
+                Student giver = students
+                        .stream()
+                        .filter(student -> giverEmail.equals(student.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setGiver(giver);
+            }
+
+            String lastEditorEmail = responseComment.getLastEditor().getEmail();
+            if (responseComment.getLastEditor() instanceof Instructor) {
+                Instructor lastEditor = instructors
+                        .stream()
+                        .filter(instructor -> lastEditorEmail.equals(instructor.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setLastEditor(lastEditor);
+            } else if (responseComment.getGiver() instanceof Student) {
+                Student lastEditor = students
+                        .stream()
+                        .filter(student -> lastEditorEmail.equals(student.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setLastEditor(lastEditor);
+            }
+
             responseComment.setFeedbackResponse(fr);
             responseComment.setGiverSection(giverSection);
             responseComment.setRecipientSection(recipientSection);
@@ -333,6 +369,41 @@ public final class DataBundleLogic {
 
         for (FeedbackResponseComment responseComment : responseComments) {
             responseComment.setId(null);
+
+            String giverEmail = responseComment.getGiver().getEmail();
+            if (responseComment.getGiver() instanceof Instructor) {
+                Instructor giver = instructors
+                        .stream()
+                        .filter(instructor -> giverEmail.equals(instructor.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setGiver(giver);
+            } else if (responseComment.getGiver() instanceof Student) {
+                Student giver = students
+                        .stream()
+                        .filter(student -> giverEmail.equals(student.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setGiver(giver);
+            }
+
+            String lastEditorEmail = responseComment.getLastEditor().getEmail();
+            if (responseComment.getLastEditor() instanceof Instructor) {
+                Instructor lastEditor = instructors
+                        .stream()
+                        .filter(instructor -> lastEditorEmail.equals(instructor.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setLastEditor(lastEditor);
+            } else if (responseComment.getGiver() instanceof Student) {
+                Student lastEditor = students
+                        .stream()
+                        .filter(student -> lastEditorEmail.equals(student.getEmail()))
+                        .findFirst()
+                        .orElseThrow(NoSuchElementException::new);
+                responseComment.setLastEditor(lastEditor);
+            }
+
             frcLogic.createFeedbackResponseComment(responseComment);
         }
 

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -16,6 +16,8 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
 import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.User;
 import teammates.ui.request.FeedbackResponseCommentUpdateRequest;
 
 /**
@@ -28,6 +30,8 @@ public final class FeedbackResponseCommentsLogic {
 
     private static final FeedbackResponseCommentsLogic instance = new FeedbackResponseCommentsLogic();
     private FeedbackResponseCommentsDb frcDb;
+    private UsersLogic usersLogic;
+    private CoursesLogic coursesLogic;
 
     private FeedbackResponseCommentsLogic() {
         // prevent initialization
@@ -40,8 +44,11 @@ public final class FeedbackResponseCommentsLogic {
     /**
      * Initialize dependencies for {@code FeedbackResponseCommentsLogic}.
      */
-    void initLogicDependencies(FeedbackResponseCommentsDb frcDb) {
+    void initLogicDependencies(FeedbackResponseCommentsDb frcDb,
+            UsersLogic usersLogic, CoursesLogic coursesLogic) {
         this.frcDb = frcDb;
+        this.usersLogic = usersLogic;
+        this.coursesLogic = coursesLogic;
     }
 
     /**
@@ -118,11 +125,13 @@ public final class FeedbackResponseCommentsLogic {
         if (comment == null) {
             throw new EntityDoesNotExistException("Trying to update a feedback response comment that does not exist.");
         }
-
+        
+        Course course = coursesLogic.getCourseForFeedbackResponseCommentId(frcId);
+        User lastEditor = usersLogic.getUserByEmail(course.getId(), updaterEmail);
         comment.setCommentText(updateRequest.getCommentText());
         comment.setShowCommentTo(updateRequest.getShowCommentTo());
         comment.setShowGiverNameTo(updateRequest.getShowGiverNameTo());
-        comment.setLastEditorEmail(updaterEmail);
+        comment.setLastEditor(lastEditor);
 
         return comment;
     }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -981,7 +981,7 @@ public final class FeedbackResponsesLogic {
                     || relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS_IN_SAME_SECTION
                     || relatedQuestion.getRecipientType() == FeedbackParticipantType.TEAMS_EXCLUDING_SELF)
                     && relatedQuestion.isResponseVisibleTo(FeedbackParticipantType.RECEIVER)
-                    && response.getRecipient().getEmail().equals(student.getTeamName())) {
+                    && response.getRecipient().getTeam().getName().equals(student.getTeamName())) {
                 isVisibleResponse = true;
             } else if (relatedQuestion.getGiverType() == FeedbackParticipantType.TEAMS
                     && response.getGiver().getEmail().equals(student.getTeamName())) {

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -121,7 +121,7 @@ public final class FeedbackResponsesLogic {
             boolean hasResponse = question
                     .getFeedbackResponses()
                     .stream()
-                    .anyMatch(response -> response.getGiver().equals(giverIdentifier));
+                    .anyMatch(response -> response.getGiver().getEmail().equals(giverIdentifier));
             if (hasResponse) {
                 return true;
             }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -33,6 +33,7 @@ import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.Team;
 import teammates.storage.sqlentity.responses.FeedbackMissingResponse;
+import teammates.storage.sqlentity.User;
 import teammates.storage.sqlentity.responses.FeedbackRankRecipientsResponse;
 
 /**
@@ -283,24 +284,34 @@ public final class FeedbackResponsesLogic {
 
     /**
      * Gets all responses given by a user for a course.
+     * 
+     * @param courseId the identifier of a course.
+     * @param giver the email of the giver.
      */
     public List<FeedbackResponse> getFeedbackResponsesFromGiverForCourse(
             String courseId, String giver) {
         assert courseId != null;
         assert giver != null;
 
-        return frDb.getFeedbackResponsesFromGiverForCourse(courseId, giver);
+        User user = usersLogic.getUserByEmail(courseId, giver);
+
+        return frDb.getFeedbackResponsesFromGiverForCourse(courseId, user.getId());
     }
 
     /**
      * Gets all responses received by a user for a course.
+     * 
+     * @param courseId the identifier of a course.
+     * @param recipient the email of the recipient.
      */
     public List<FeedbackResponse> getFeedbackResponsesForRecipientForCourse(
             String courseId, String recipient) {
         assert courseId != null;
         assert recipient != null;
 
-        return frDb.getFeedbackResponsesForRecipientForCourse(courseId, recipient);
+        User user = usersLogic.getUserByEmail(courseId, recipient);
+
+        return frDb.getFeedbackResponsesForRecipientForCourse(courseId, user.getId());
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -174,7 +174,7 @@ public final class FeedbackSessionsLogic {
 
         fqLogic.getFeedbackQuestionsForSession(feedbackSession).forEach(question -> {
             frLogic.getFeedbackResponsesForQuestion(question.getId()).forEach(response -> {
-                giverSet.add(response.getGiver());
+                giverSet.add(response.getGiver().getEmail());
             });
         });
 
@@ -191,7 +191,7 @@ public final class FeedbackSessionsLogic {
 
         fqLogic.getFeedbackQuestionsForSession(fs).forEach(question -> {
             frLogic.getFeedbackResponsesForQuestion(question.getId()).forEach(response -> {
-                giverSet.add(response.getGiver());
+                giverSet.add(response.getGiver().getEmail());
             });
         });
 

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -49,7 +49,7 @@ public class LogicStarter implements ServletContextListener {
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst(), fsLogic);
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), coursesLogic, frLogic, fqLogic, usersLogic);
         frLogic.initLogicDependencies(FeedbackResponsesDb.inst(), usersLogic, fqLogic, frcLogic);
-        frcLogic.initLogicDependencies(FeedbackResponseCommentsDb.inst());
+        frcLogic.initLogicDependencies(FeedbackResponseCommentsDb.inst(), usersLogic, coursesLogic);
         fqLogic.initLogicDependencies(FeedbackQuestionsDb.inst(), coursesLogic, frLogic, usersLogic, fsLogic);
         notificationsLogic.initLogicDependencies(NotificationsDb.inst());
         usageStatisticsLogic.initLogicDependencies(UsageStatisticsDb.inst());

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -182,7 +182,7 @@ public final class UsersLogic {
                 FeedbackQuestion question = responseFromUser.getFeedbackQuestion();
                 if (question.getGiverType() == FeedbackParticipantType.INSTRUCTORS
                         || question.getGiverType() == FeedbackParticipantType.SELF) {
-                    responseFromUser.setGiver(newEmail);
+                    responseFromUser.setGiver(instructor);
                 }
             }
             List<FeedbackResponse> responsesToUser =
@@ -192,7 +192,7 @@ public final class UsersLogic {
                 if (question.getRecipientType() == FeedbackParticipantType.INSTRUCTORS
                         || question.getGiverType() == FeedbackParticipantType.INSTRUCTORS
                         && question.getRecipientType() == FeedbackParticipantType.SELF) {
-                    responseToUser.setRecipient(newEmail);
+                    responseToUser.setRecipient(instructor);
                 }
             }
             // cascade comments
@@ -693,7 +693,7 @@ public final class UsersLogic {
             // the student is the only student in the team, delete responses related to the team
             feedbackResponsesLogic
                     .deleteFeedbackResponsesForCourseCascade(
-                            student.getCourse().getId(), student.getTeamName());
+                            student.getCourse().getId(), student.getEmail());
         }
 
         deadlineExtensionsLogic.deleteDeadlineExtensionsForUser(student);
@@ -988,6 +988,13 @@ public final class UsersLogic {
         users.forEach(u -> emailUserMap.put(u.getEmail(), u));
 
         return emailUserMap;
+    }
+
+    public User getUserByEmail(String courseId, String email) {
+        assert courseId != null;
+        assert email != null;
+
+        return usersDb.getUserByEmail(courseId, email);
     }
 
 }

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -990,6 +990,9 @@ public final class UsersLogic {
         return emailUserMap;
     }
 
+    /**
+     * Gets a User by course id and email.
+     */
     public User getUserByEmail(String courseId, String email) {
         assert courseId != null;
         assert email != null;

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -997,4 +997,16 @@ public final class UsersLogic {
         return usersDb.getUserByEmail(courseId, email);
     }
 
+    /**
+     * Gets user associated with {@code id}.
+     *
+     * @param id Id of User.
+     * @return Returns User if found else null.
+     */
+    public User getUser(UUID id) {
+        assert id != null;
+
+        return usersDb.getUser(id);
+    }
+
 }

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -242,7 +242,7 @@ public final class CoursesDb extends EntitiesDb {
 
     /**
      * Gets the course associated with a feedback response comment.
-     * 
+     *
      * @param id The identifier of a feedback response comment.
      * @return A course.
      */

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -11,6 +11,10 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.FeedbackResponseComment;
+import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Team;
 
@@ -234,6 +238,29 @@ public final class CoursesDb extends EntitiesDb {
                 cb.equal(teamRoot.get("name"), teamName)));
 
         return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
+    }
+
+    /**
+     * Gets the course associated with a feedback response comment.
+     * 
+     * @param id The identifier of a feedback response comment.
+     * @return A course.
+     */
+    public Course getCourseForFeedbackResponseCommentId(Long id) {
+        assert id != null;
+
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<Course> cq = cb.createQuery(Course.class);
+        Root<FeedbackResponseComment> frcRoot = cq.from(FeedbackResponseComment.class);
+        Join<FeedbackResponseComment, FeedbackResponse> frJoin = frcRoot.join("feedbackResponse");
+        Join<FeedbackResponse, FeedbackQuestion> fqJoin = frJoin.join("feedbackQuestion");
+        Join<FeedbackQuestion, FeedbackSession> fsJoin = fqJoin.join("feedbackSession");
+        Join<FeedbackSession, Course> courseJoin = fsJoin.join("course");
+
+        cq.select(courseJoin)
+                .where(cb.equal(frcRoot.get("id"), id));
+
+        return HibernateUtil.createQuery(cq).getSingleResult();
     }
 
 }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -55,7 +55,7 @@ public final class FeedbackResponsesDb extends EntitiesDb {
      * Gets all responses given by a user in a course.
      */
     public List<FeedbackResponse> getFeedbackResponsesFromGiverForCourse(
-            String courseId, String giver) {
+            String courseId, UUID giverId) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackResponse> cr = cb.createQuery(FeedbackResponse.class);
         Root<FeedbackResponse> frRoot = cr.from(FeedbackResponse.class);
@@ -66,7 +66,7 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         cr.select(frRoot)
                 .where(cb.and(
                     cb.equal(cJoin.get("id"), courseId),
-                    cb.equal(frRoot.get("giver"), giver)));
+                    cb.equal(frRoot.get("giver").get("id"), giverId)));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }
@@ -74,7 +74,7 @@ public final class FeedbackResponsesDb extends EntitiesDb {
     /**
      * Gets all responses given to a user in a course.
      */
-    public List<FeedbackResponse> getFeedbackResponsesForRecipientForCourse(String courseId, String recipient) {
+    public List<FeedbackResponse> getFeedbackResponsesForRecipientForCourse(String courseId, UUID recipientId) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackResponse> cr = cb.createQuery(FeedbackResponse.class);
         Root<FeedbackResponse> frRoot = cr.from(FeedbackResponse.class);
@@ -85,7 +85,7 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         cr.select(frRoot)
                 .where(cb.and(
                     cb.equal(cJoin.get("id"), courseId),
-                    cb.equal(frRoot.get("recipient"), recipient)));
+                    cb.equal(frRoot.get("recipient").get("id"), recipientId)));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -185,7 +185,7 @@ public final class FeedbackResponsesDb extends EntitiesDb {
 
     /**
      * Checks whether a user has responses in a session.
-     * 
+     *
      * @param giver the email of the giver.
      * @param feedbackSessionName the name of the feedback session.
      * @param courseId the identifier of the course.

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -16,6 +16,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.User;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
@@ -130,10 +131,11 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         CriteriaQuery<FeedbackResponse> cq = cb.createQuery(FeedbackResponse.class);
         Root<FeedbackResponse> root = cq.from(FeedbackResponse.class);
         Join<FeedbackResponse, FeedbackQuestion> frJoin = root.join("feedbackQuestion");
+        Join<FeedbackResponse, User> uJoin = root.join("giver");
         cq.select(root)
                 .where(cb.and(
                         cb.equal(frJoin.get("id"), feedbackQuestionId),
-                        cb.equal(root.get("giver"), giverEmail)));
+                        cb.equal(uJoin.get("email"), giverEmail)));
         return HibernateUtil.createQuery(cq).getResultList();
     }
 
@@ -183,6 +185,11 @@ public final class FeedbackResponsesDb extends EntitiesDb {
 
     /**
      * Checks whether a user has responses in a session.
+     * 
+     * @param giver the email of the giver.
+     * @param feedbackSessionName the name of the feedback session.
+     * @param courseId the identifier of the course.
+     * @return a boolean if there are responses from the given giver in this feedback session.
      */
     public boolean hasResponsesFromGiverInSession(
             String giver, String feedbackSessionName, String courseId) {
@@ -192,10 +199,11 @@ public final class FeedbackResponsesDb extends EntitiesDb {
         Join<FeedbackResponse, FeedbackQuestion> fqJoin = root.join("feedbackQuestion");
         Join<FeedbackQuestion, FeedbackSession> fsJoin = fqJoin.join("feedbackSession");
         Join<FeedbackSession, Course> courseJoin = fsJoin.join("course");
+        Join<FeedbackResponse, User> uJoin = root.join("giver");
 
         cq.select(root)
                 .where(cb.and(
-                        cb.equal(root.get("giver"), giver),
+                        cb.equal(uJoin.get("email"), giver),
                         cb.equal(fsJoin.get("name"), feedbackSessionName),
                         cb.equal(courseJoin.get("id"), courseId)));
 

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -22,7 +22,7 @@ import teammates.storage.sqlentity.User;
 import teammates.storage.sqlsearch.InstructorSearchManager;
 import teammates.storage.sqlsearch.SearchManagerFactory;
 import teammates.storage.sqlsearch.StudentSearchManager;
-
+import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
@@ -669,6 +669,22 @@ public final class UsersDb extends EntitiesDb {
         if (getStudent(student.getId()) == null) {
             throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
         }
+    }
+
+    public User getUserByEmail(String courseId, String email) {
+        assert courseId != null;
+        assert email != null;
+
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<User> cq = cb.createQuery(User.class);
+        Root<User> root = cq.from(User.class);
+        Join<User, Course> courseJoin = root.join("course");
+        cq.select(root)
+                .where(cb.and(
+                        cb.equal(courseJoin.get("id"), courseId),
+                        cb.equal(root.get("email"), email)));
+        TypedQuery<User> query = HibernateUtil.createQuery(cq);
+        return query.getSingleResult();
     }
 
 }

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -22,6 +22,7 @@ import teammates.storage.sqlentity.User;
 import teammates.storage.sqlsearch.InstructorSearchManager;
 import teammates.storage.sqlsearch.SearchManagerFactory;
 import teammates.storage.sqlsearch.StudentSearchManager;
+
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -671,6 +672,9 @@ public final class UsersDb extends EntitiesDb {
         }
     }
 
+    /**
+     * Gets a User by course id and email.
+     */
     public User getUserByEmail(String courseId, String email) {
         assert courseId != null;
         assert email != null;

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -687,4 +687,13 @@ public final class UsersDb extends EntitiesDb {
         return query.getSingleResult();
     }
 
+    /**
+     * Gets a User by its {@code id}.
+     */
+    public User getUser(UUID id) {
+        assert id != null;
+
+        return HibernateUtil.get(User.class, id);
+    }
+
 }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
@@ -20,7 +22,6 @@ import teammates.storage.sqlentity.responses.FeedbackRubricResponse;
 import teammates.storage.sqlentity.responses.FeedbackTextResponse;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
@@ -47,15 +48,19 @@ public abstract class FeedbackResponse extends BaseEntity {
     @OneToMany(mappedBy = "feedbackResponse", cascade = CascadeType.REMOVE)
     private List<FeedbackResponseComment> feedbackResponseComments = new ArrayList<>();
 
-    @Column(nullable = false)
-    private String giver;
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "giverId", nullable = false)
+    private User giver;
 
     @ManyToOne
     @JoinColumn(name = "giverSectionId")
     private Section giverSection;
 
-    @Column(nullable = false)
-    private String recipient;
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "recipientId", nullable = false)
+    private User recipient;
 
     @ManyToOne
     @JoinColumn(name = "recipientSectionId")
@@ -69,8 +74,8 @@ public abstract class FeedbackResponse extends BaseEntity {
     }
 
     public FeedbackResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection
     ) {
         this.setId(UUID.randomUUID());
         this.setFeedbackQuestion(feedbackQuestion);
@@ -84,8 +89,8 @@ public abstract class FeedbackResponse extends BaseEntity {
      * Creates a feedback response according to its {@code FeedbackQuestionType}.
      */
     public static FeedbackResponse makeResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User receiver, Section receiverSection,
             FeedbackResponseDetails responseDetails
     ) {
         FeedbackResponse feedbackResponse = null;
@@ -192,11 +197,11 @@ public abstract class FeedbackResponse extends BaseEntity {
         this.feedbackResponseComments = feedbackResponseComments;
     }
 
-    public String getGiver() {
+    public User getGiver() {
         return giver;
     }
 
-    public void setGiver(String giver) {
+    public void setGiver(User giver) {
         this.giver = giver;
     }
 
@@ -212,11 +217,11 @@ public abstract class FeedbackResponse extends BaseEntity {
         this.giverSection = giverSection;
     }
 
-    public String getRecipient() {
+    public User getRecipient() {
         return recipient;
     }
 
-    public void setRecipient(String recipient) {
+    public void setRecipient(User recipient) {
         this.recipient = recipient;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -151,8 +151,8 @@ public abstract class FeedbackResponse extends BaseEntity {
      */
     public static FeedbackResponse updateResponse(
             FeedbackResponse originalFeedbackResponse,
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String receiver, Section receiverSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User receiver, Section receiverSection,
             FeedbackResponseDetails responseDetails
     ) {
         FeedbackResponse updatedFeedbackResponse = FeedbackResponse.makeResponse(

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -48,7 +48,7 @@ public abstract class FeedbackResponse extends BaseEntity {
     @OneToMany(mappedBy = "feedbackResponse", cascade = CascadeType.REMOVE)
     private List<FeedbackResponseComment> feedbackResponseComments = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(cascade = {CascadeType.MERGE, CascadeType.REMOVE})
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "giverId", nullable = false)
     private User giver;
@@ -57,7 +57,7 @@ public abstract class FeedbackResponse extends BaseEntity {
     @JoinColumn(name = "giverSectionId")
     private Section giverSection;
 
-    @ManyToOne
+    @ManyToOne(cascade = {CascadeType.MERGE, CascadeType.REMOVE})
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "recipientId", nullable = false)
     private User recipient;

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -37,8 +37,10 @@ public class FeedbackResponseComment extends BaseEntity {
     @JoinColumn(name = "responseId")
     private FeedbackResponse feedbackResponse;
 
-    @Column(nullable = false)
-    private String giver;
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "giverId", nullable = false)
+    private User giver;
 
     @Column(nullable = false)
     @Convert(converter = FeedbackParticipantTypeConverter.class)
@@ -72,19 +74,21 @@ public class FeedbackResponseComment extends BaseEntity {
     @UpdateTimestamp
     private Instant updatedAt;
 
-    @Column(nullable = false)
-    private String lastEditorEmail;
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "lastEditorId", nullable = false)
+    private User lastEditor;
 
     protected FeedbackResponseComment() {
         // required by Hibernate
     }
 
     public FeedbackResponseComment(
-            FeedbackResponse feedbackResponse, String giver, FeedbackParticipantType giverType,
+            FeedbackResponse feedbackResponse, User giver, FeedbackParticipantType giverType,
             Section giverSection, Section recipientSection, String commentText,
             boolean isVisibilityFollowingFeedbackQuestion, boolean isCommentFromFeedbackParticipant,
             List<FeedbackParticipantType> showCommentTo, List<FeedbackParticipantType> showGiverNameTo,
-            String lastEditorEmail
+            User lastEditor
     ) {
         this.setFeedbackResponse(feedbackResponse);
         this.setGiver(giver);
@@ -96,7 +100,7 @@ public class FeedbackResponseComment extends BaseEntity {
         this.setIsCommentFromFeedbackParticipant(isCommentFromFeedbackParticipant);
         this.setShowCommentTo(showCommentTo);
         this.setShowGiverNameTo(showGiverNameTo);
-        this.setLastEditorEmail(lastEditorEmail);
+        this.setLastEditor(lastEditor);
     }
 
     public Long getId() {
@@ -115,11 +119,11 @@ public class FeedbackResponseComment extends BaseEntity {
         this.feedbackResponse = feedbackResponse;
     }
 
-    public String getGiver() {
+    public User getGiver() {
         return giver;
     }
 
-    public void setGiver(String giver) {
+    public void setGiver(User giver) {
         this.giver = giver;
     }
 
@@ -195,12 +199,12 @@ public class FeedbackResponseComment extends BaseEntity {
         this.updatedAt = updatedAt;
     }
 
-    public String getLastEditorEmail() {
-        return lastEditorEmail;
+    public User getLastEditor() {
+        return lastEditor;
     }
 
-    public void setLastEditorEmail(String lastEditorEmail) {
-        this.lastEditorEmail = lastEditorEmail;
+    public void setLastEditor(User lastEditor) {
+        this.lastEditor = lastEditor;
     }
 
     /**
@@ -235,7 +239,7 @@ public class FeedbackResponseComment extends BaseEntity {
         return "FeedbackResponse [id=" + id + ", giver=" + giver + ", commentText=" + commentText
                 + ", isVisibilityFollowingFeedbackQuestion=" + isVisibilityFollowingFeedbackQuestion
                 + ", isCommentFromFeedbackParticipant=" + isCommentFromFeedbackParticipant
-                + ", lastEditorEmail=" + lastEditorEmail + ", createdAt=" + getCreatedAt()
+                + ", lastEditor=" + lastEditor + ", createdAt=" + getCreatedAt()
                 + ", updatedAt=" + updatedAt + "]";
     }
 

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -9,7 +9,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
-
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -39,7 +39,7 @@ public abstract class User extends BaseEntity {
     @Column(nullable = false, insertable = false, updatable = false)
     private String courseId;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "courseId", nullable = false)
     private Course course;
 

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackConstantSumResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackConstantSumResponse extends FeedbackResponse {
     }
 
     public FeedbackConstantSumResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackContributionResponse extends FeedbackResponse {
     }
 
     public FeedbackContributionResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackContributionResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackMcqResponse extends FeedbackResponse {
     }
 
     public FeedbackMcqResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMcqResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMissingResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMissingResponse.java
@@ -3,6 +3,7 @@ package teammates.storage.sqlentity.responses;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.User;
 
 /**
  * Represents a missing response.
@@ -17,8 +18,8 @@ public class FeedbackMissingResponse extends FeedbackTextResponse {
     }
 
     public FeedbackMissingResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            String giverSectionName, String recipient, String recipientSectionName
+            FeedbackQuestion feedbackQuestion, User giver,
+            String giverSectionName, User recipient, String recipientSectionName
     ) {
         super(feedbackQuestion, giver, null, recipient, null, new FeedbackTextResponseDetails(Const.MISSING_RESPONSE_TEXT));
         this.giverSectionName = giverSectionName;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackMsqResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackMsqResponse extends FeedbackResponse {
     }
 
     public FeedbackMsqResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackNumericalScaleResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackNumericalScaleResponse extends FeedbackResponse {
     }
 
     public FeedbackNumericalScaleResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankOptionsResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackRankOptionsResponse extends FeedbackResponse {
     }
 
     public FeedbackRankOptionsResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRankRecipientsResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackRankRecipientsResponse extends FeedbackResponse {
     }
 
     public FeedbackRankRecipientsResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackRubricResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackRubricResponse extends FeedbackResponse {
     }
 
     public FeedbackRubricResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackRubricResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -5,7 +5,7 @@ import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
-
+import teammates.storage.sqlentity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
@@ -26,8 +26,8 @@ public class FeedbackTextResponse extends FeedbackResponse {
     }
 
     public FeedbackTextResponse(
-            FeedbackQuestion feedbackQuestion, String giver,
-            Section giverSection, String recipient, Section recipientSection,
+            FeedbackQuestion feedbackQuestion, User giver,
+            Section giverSection, User recipient, Section recipientSection,
             FeedbackResponseDetails responseDetails
     ) {
         super(feedbackQuestion, giver, giverSection, recipient, recipientSection);

--- a/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/responses/FeedbackTextResponse.java
@@ -6,6 +6,7 @@ import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -39,12 +39,14 @@ public class FeedbackResponseCommentData extends ApiOutput {
     public FeedbackResponseCommentData(FeedbackResponseComment frc) {
         this.feedbackResponseCommentId = frc.getId();
         this.commentText = frc.getCommentText();
-        this.commentGiver = frc.getGiver();
+        // TODO: To remove .getEmail() after v9-migration
+        this.commentGiver = frc.getGiver().getEmail();
         this.showGiverNameTo = convertToFeedbackVisibilityType(frc.getShowGiverNameTo());
         this.showCommentTo = convertToFeedbackVisibilityType(frc.getShowCommentTo());
         this.createdAt = frc.getCreatedAt().toEpochMilli();
         this.lastEditedAt = frc.getUpdatedAt().toEpochMilli();
-        this.lastEditorEmail = frc.getLastEditorEmail();
+        // TODO: To remove .getEmail() after v9-migration
+        this.lastEditorEmail = frc.getLastEditor().getEmail();
         this.isVisibilityFollowingFeedbackQuestion = frc.getIsVisibilityFollowingFeedbackQuestion();
     }
 

--- a/src/main/java/teammates/ui/output/FeedbackResponseData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseData.java
@@ -32,8 +32,10 @@ public class FeedbackResponseData extends ApiOutput {
 
     public FeedbackResponseData(FeedbackResponse feedbackResponse) {
         this.feedbackResponseId = feedbackResponse.getId().toString();
-        this.giverIdentifier = feedbackResponse.getGiver();
-        this.recipientIdentifier = feedbackResponse.getRecipient();
+        // TODO: To remove .getEmail() after v9-migration
+        this.giverIdentifier = feedbackResponse.getGiver().getEmail();
+        // TODO: To remove .getEmail() after v9-migration
+        this.recipientIdentifier = feedbackResponse.getRecipient().getEmail();
         this.responseDetails = feedbackResponse.getFeedbackResponseDetailsCopy();
     }
 

--- a/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
@@ -56,11 +56,11 @@ abstract class BasicCommentSubmissionAction extends BasicFeedbackSubmissionActio
                                            FeedbackQuestion question)
             throws UnauthorizedAccessException {
         if (question.getGiverType() == FeedbackParticipantType.TEAMS
-                && !response.getGiver().equals(student.getTeamName())) {
+                && !response.getGiver().getTeam().getName().equals(student.getTeamName())) {
             throw new UnauthorizedAccessException("Response [" + response.getId() + "] is not accessible to "
                     + student.getTeam());
         } else if (question.getGiverType() == FeedbackParticipantType.STUDENTS
-                && !response.getGiver().equals(student.getEmail())) {
+                && !response.getGiver().getEmail().equals(student.getEmail())) {
             throw new UnauthorizedAccessException("Response [" + response.getId() + "] is not accessible to "
                     + student.getName());
         }

--- a/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
@@ -83,7 +83,7 @@ abstract class BasicCommentSubmissionAction extends BasicFeedbackSubmissionActio
      */
     void verifyResponseOwnerShipForInstructor(Instructor instructor, FeedbackResponse response)
             throws UnauthorizedAccessException {
-        if (!response.getGiver().equals(instructor.getEmail())) {
+        if (!response.getGiver().getEmail().equals(instructor.getEmail())) {
             throw new UnauthorizedAccessException("Response [" + response.getId() + "] is not accessible to "
                     + instructor.getName());
         }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -133,7 +133,7 @@ public class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionA
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
-            if (comment.getGiver().equals(instructor.getEmail())) { // giver, allowed by default
+            if (comment.getGiver().getEmail().equals(instructor.getEmail())) { // giver, allowed by default
                 return;
             }
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -466,10 +466,10 @@ final class GateKeeper {
     void verifyOwnership(FeedbackResponseComment frc, String feedbackParticipant)
             throws UnauthorizedAccessException {
         verifyNotNull(frc, "feedback response comment");
-        verifyNotNull(frc.getGiver(), "feedback response comment giver");
+        verifyNotNull(frc.getGiver().getEmail(), "feedback response comment giver");
         verifyNotNull(feedbackParticipant, "comment giver");
 
-        if (!frc.getGiver().equals(feedbackParticipant)) {
+        if (!frc.getGiver().getEmail().equals(feedbackParticipant)) {
             throw new UnauthorizedAccessException("Comment [" + frc.getId() + "] is not accessible to "
                     + feedbackParticipant);
         }

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -214,7 +214,8 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
         }
 
         Map<String, FeedbackResponse> existingResponsesPerRecipient = new HashMap<>();
-        existingResponses.forEach(response -> existingResponsesPerRecipient.put(response.getRecipient().getEmail(), response));
+        existingResponses.forEach(response ->
+                existingResponsesPerRecipient.put(response.getRecipient().getEmail(), response));
 
         FeedbackResponsesRequest submitRequest = getAndValidateRequestBody(FeedbackResponsesRequest.class);
         log.info(JsonUtils.toCompactJson(submitRequest));

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -158,7 +158,7 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
-            if (feedbackResponseComment.getGiver().equals(instructor.getEmail())) { // giver, allowed by default
+            if (feedbackResponseComment.getGiver().getEmail().equals(instructor.getEmail())) { // giver, allowed by default
                 return;
             }
             gateKeeper.verifyAccessible(instructor, session, response.getGiverSection().getName(),

--- a/src/test/java/teammates/sqllogic/core/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackResponseCommentsLogicTest.java
@@ -32,11 +32,13 @@ public class FeedbackResponseCommentsLogicTest extends BaseTestCase {
     private static final UUID TYPICAL_UUID = UUID.randomUUID();
     private FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
     private FeedbackResponseCommentsDb frcDb;
+    private UsersLogic usersLogic;
+    private CoursesLogic coursesLogic;
 
     @BeforeMethod
     public void setUpMethod() {
         frcDb = mock(FeedbackResponseCommentsDb.class);
-        frcLogic.initLogicDependencies(frcDb);
+        frcLogic.initLogicDependencies(frcDb, usersLogic, coursesLogic);
     }
 
     @Test
@@ -156,7 +158,7 @@ public class FeedbackResponseCommentsLogicTest extends BaseTestCase {
         assertEquals(updatedCommentText, updatedComment.getCommentText());
         assertEquals(expectedShowCommentTo, updatedComment.getShowCommentTo());
         assertEquals(expectedShowGiverNameTo, updatedComment.getShowGiverNameTo());
-        assertEquals(lastEditorEmail, updatedComment.getLastEditorEmail());
+        assertEquals(lastEditorEmail, updatedComment.getLastEditor().getEmail());
     }
 
     @Test

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -190,7 +190,11 @@ public class BaseTestCase {
     }
 
     protected FeedbackResponse getTypicalFeedbackResponseForQuestion(FeedbackQuestion question) {
-        return FeedbackResponse.makeResponse(question, "test-giver", getTypicalSection(), "test-recipient",
+        Student giver = getTypicalStudent();
+        giver.setEmail("test-giver");
+        Student recipient = getTypicalStudent();
+        recipient.setEmail("test-recipient");
+        return FeedbackResponse.makeResponse(question, giver, getTypicalSection(), recipient,
                 getTypicalSection(), getTypicalFeedbackResponseDetails());
     }
 

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -199,7 +199,7 @@ public class BaseTestCase {
     }
 
     protected FeedbackResponseComment getTypicalResponseComment(Long id) {
-        FeedbackResponseComment comment = new FeedbackResponseComment(null, "",
+        FeedbackResponseComment comment = new FeedbackResponseComment(null, null,
                 FeedbackParticipantType.STUDENTS, null, null, "",
                 false, false,
                 null, null, null);

--- a/src/test/java/teammates/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -88,8 +88,8 @@ public abstract class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
                     expectedFeedbackResponse.getFeedbackResponseDetailsCopy();
             FeedbackResponseData actualResponse = (FeedbackResponseData) actual;
             FeedbackResponseDetails actualResponseDetails = actualResponse.getResponseDetails();
-            assertEquals(expectedFeedbackResponse.getGiver(), actualResponse.getGiverIdentifier());
-            assertEquals(expectedFeedbackResponse.getRecipient(), actualResponse.getRecipientIdentifier());
+            assertEquals(expectedFeedbackResponse.getGiver().getEmail(), actualResponse.getGiverIdentifier());
+            assertEquals(expectedFeedbackResponse.getRecipient().getEmail(), actualResponse.getRecipientIdentifier());
             assertEquals(expectedResponseDetails.getAnswerString(),
                     actualResponse.getResponseDetails().getAnswerString());
             assertEquals(expectedResponseDetails.getQuestionType(),
@@ -116,11 +116,11 @@ public abstract class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
         } else if (expected instanceof FeedbackResponseComment) {
             FeedbackResponseComment expectedFeedbackResponseComment = (FeedbackResponseComment) expected;
             FeedbackResponseCommentData actualComment = (FeedbackResponseCommentData) actual;
-            assertEquals(expectedFeedbackResponseComment.getGiver(), actualComment.getCommentGiver());
+            assertEquals(expectedFeedbackResponseComment.getGiver().getEmail(), actualComment.getCommentGiver());
             assertEquals(expectedFeedbackResponseComment.getCommentText(), actualComment.getCommentText());
             assertEquals(expectedFeedbackResponseComment.getIsVisibilityFollowingFeedbackQuestion(),
                     actualComment.isVisibilityFollowingFeedbackQuestion());
-            assertEquals(expectedFeedbackResponseComment.getLastEditorEmail(), actualComment.getLastEditorEmail());
+            assertEquals(expectedFeedbackResponseComment.getLastEditor().getEmail(), actualComment.getLastEditorEmail());
         } else if (expected instanceof FeedbackSession) {
             FeedbackSession expectedFeedbackSession = (FeedbackSession) expected;
             FeedbackSessionData actualFeedbackSession = (FeedbackSessionData) actual;


### PR DESCRIPTION
Part of #12048. Fixes #12724

**Outline of Solution**

FeedbackResponses:
- Update `giver` attribute to use `User` entity instead
- Update `recipient` attribute to use `User` entity instead

FeedbackResponseComments:
- Update `giver` attribute to use `User` entity instead
- Update `recipient` attribute to use `User` entity instead
- Update `lastEditor` attribute to use `User` entity instead