### PR TITLE
[#12048] Fix incorrect usage of `recipient` as param for E2E test

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
@@ -247,7 +247,7 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
     }
 
     FeedbackResponseData getFeedbackResponse(String questionId, String giver, String recipient) {
-        return BACKDOOR.getFeedbackResponseData(questionId, recipient, recipient);
+        return BACKDOOR.getFeedbackResponseData(questionId, giver, recipient);
     }
 
     @Override


### PR DESCRIPTION
Part of #12048 and #12775.

**Outline of Solution**
As per title.