### PR TITLE
[#12048] Add migration script for Usage Statistics

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
@@ -26,7 +26,7 @@ public class DataMigrationForUsageStatisticsSql extends
      */
     @Override
     protected boolean isPreview() {
-        return false;
+        return true;
     }
 
     /**

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
@@ -1,0 +1,59 @@
+package teammates.client.scripts.sql;
+
+import java.util.UUID;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.storage.sqlentity.UsageStatistics;
+
+public class DataMigrationForUsageStatisticsSql extends
+    DataMigrationEntitiesBaseScriptSql<
+        teammates.storage.entity.UsageStatistics,
+        UsageStatistics> {
+
+    @Override
+    protected Query<teammates.storage.entity.UsageStatistics> getFilterQuery() {
+        // returns all UsageStatistics entities
+        return ofy().load().type(teammates.storage.entity.UsageStatistics.class);
+    }
+
+    /**
+     * Set to true to preview the migration without actually performing it.
+     */
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    /**
+     * Always returns true, as the migration is needed for all entities from Datastore to CloudSQL .
+     */
+    @Override
+    protected boolean isMigrationNeeded(teammates.storage.entity.UsageStatistics entity) {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(teammates.storage.entity.UsageStatistics oldEntity) throws Exception {
+        UsageStatistics newEntity = new UsageStatistics(
+            oldEntity.getStartTime(),
+            oldEntity.getTimePeriod(),
+            oldEntity.getNumResponses(),
+            oldEntity.getNumCourses(),
+            oldEntity.getNumStudents(),
+            oldEntity.getNumInstructors(),
+            oldEntity.getNumAccountRequests(),
+            oldEntity.getNumEmails(),
+            oldEntity.getNumSubmissions()
+        );
+
+        try {
+            UUID oldUuid = UUID.fromString(oldEntity.getId());
+            newEntity.setId(oldUuid);
+        } catch (IllegalArgumentException iae) {
+            // Auto-generated UUID from entity is created in newEntity constructor.
+            // Do nothing.
+        }
+        saveEntityDeferred(newEntity);
+    }
+}

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
@@ -11,6 +11,10 @@ public class DataMigrationForUsageStatisticsSql extends
         teammates.storage.entity.UsageStatistics,
         UsageStatistics> {
 
+    public static void main(String[] args) {
+        new DataMigrationForUsageStatisticsSql().doOperationRemotely();
+    }
+
     @Override
     protected Query<teammates.storage.entity.UsageStatistics> getFilterQuery() {
         // returns all UsageStatistics entities
@@ -22,7 +26,7 @@ public class DataMigrationForUsageStatisticsSql extends
      */
     @Override
     protected boolean isPreview() {
-        return true;
+        return false;
     }
 
     /**

--- a/src/client/java/teammates/client/scripts/sql/SeedUsageStatistics.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedUsageStatistics.java
@@ -1,0 +1,44 @@
+package teammates.client.scripts.sql;
+
+import java.time.Instant;
+
+import com.google.cloud.datastore.DatastoreOptions;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+
+import teammates.client.connector.DatastoreClient;
+import teammates.common.util.Config;
+import teammates.storage.api.OfyHelper;
+import teammates.storage.entity.UsageStatistics;
+
+public class SeedUsageStatistics extends DatastoreClient {
+
+    public static void main(String[] args) {
+        setupObjectify();
+        new SeedUsageStatistics().doOperationRemotely();
+    }
+
+    static private void setupObjectify() {
+        DatastoreOptions.Builder builder = DatastoreOptions.newBuilder().setProjectId(Config.APP_ID);
+        ObjectifyService.init(new ObjectifyFactory(builder.build().getService()));
+        OfyHelper.registerEntityClasses();
+        ObjectifyService.begin();
+    }
+
+    @Override
+    protected void doOperation() {
+        persistDummyUsageStatistics();
+    }
+
+    private void persistDummyUsageStatistics() {
+        Instant startTimeOne = Instant.parse("2012-01-01T00:00:00Z");
+        UsageStatistics usageStatisticsOne = new UsageStatistics(
+                startTimeOne, 1, 1, 2, 3, 4, 5, 6, 7);
+
+        Instant startTimeTwo = Instant.parse("2012-01-02T00:00:00Z");
+        UsageStatistics usageStatisticsTwo = new UsageStatistics(
+                startTimeTwo, 1, 2, 2, 2, 2, 2, 2, 2);
+
+        ofy().save().entities(usageStatisticsOne, usageStatisticsTwo).now(); // save synchronously
+    }
+}


### PR DESCRIPTION
Write script to migrate all usage statistics from datastore to cloudSQL 

Verification: 
1. Seed DB with UsageStatistics. 
`./gradlew -PuserScript=sql/SeedUsageStatistics execScript`

2. Run the migration script in preview (im using non preview to check on live CloudSQL in the screenshot) 
`./gradlew -PuserScript=sql/DataMigrationForUsageStatisticsSql execScript` 
![image](https://github.com/TEAMMATES/teammates/assets/55353265/aad32413-0da9-42ff-9be1-3b2655f034d3)
We can see the 2 seeded UsageStatistics are reported to be migrated. 

3. Verify on CloudSQL 
![image](https://github.com/TEAMMATES/teammates/assets/55353265/babd14c5-f0ce-4bd3-99a7-bb57742771d6)
the fields seem to match seeded datastore records. 