### PR TITLE
[#12048] Add migration script for Account Request

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
@@ -53,10 +53,8 @@ public class DataMigrationForAccountRequestSql extends DataMigrationEntitiesBase
             newEntity.setRegisteredAt(oldEntity.getRegisteredAt());
         }
 
-        // set createdAt to the old value if exists
-        if (oldEntity.getCreatedAt() != null) {
-            newEntity.setCreatedAt(oldEntity.getCreatedAt());
-        }
+        // for the createdAt, the Hibernate annotation will auto generate the value always
+        // even if we set it.
 
         // for the updatedAt, we will let the db auto generate since this is the latest update time
         // is during the migration

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
@@ -1,0 +1,69 @@
+package teammates.client.scripts.sql;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.storage.sqlentity.AccountRequest;
+
+public class DataMigrationForAccountRequestSql extends DataMigrationEntitiesBaseScriptSql<
+    teammates.storage.entity.AccountRequest,
+    AccountRequest
+> {
+
+    public static void main(String[] args) {
+        new DataMigrationForAccountRequestSql().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<teammates.storage.entity.AccountRequest> getFilterQuery() {
+        // returns all AccountRequest entities
+        return ofy().load().type(teammates.storage.entity.AccountRequest.class);
+    }
+
+    /**
+     * Set to true to preview the migration without actually performing it.
+     */
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    /**
+     * Always returns true, as the migration is needed for all entities from Datastore to CloudSQL.
+     */
+    @Override
+    protected boolean isMigrationNeeded(teammates.storage.entity.AccountRequest accountRequest) {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(teammates.storage.entity.AccountRequest oldEntity) throws Exception {
+        AccountRequest newEntity = new AccountRequest(
+            oldEntity.getEmail(),
+            oldEntity.getName(),
+            oldEntity.getInstitute()
+        );
+
+        // set registration key to the old value if exists
+        if (oldEntity.getRegistrationKey() != null) {
+            newEntity.setRegistrationKey(oldEntity.getRegistrationKey());
+        }
+
+        // set registeredAt to the old value if exists
+        if (oldEntity.getRegisteredAt() != null) {
+            newEntity.setRegisteredAt(oldEntity.getRegisteredAt());
+        }
+
+        // set createdAt to the old value if exists
+        if (oldEntity.getCreatedAt() != null) {
+            newEntity.setCreatedAt(oldEntity.getCreatedAt());
+        }
+
+        // for the updatedAt, we will let the db auto generate since this is the latest update time
+        // is during the migration
+
+        // for the id, we need to use the new UUID, since the old id is email + institute
+        // with % as delimiter
+
+        saveEntityDeferred(newEntity);
+    }
+}


### PR DESCRIPTION
Add migration script for Account Request 

Verification: 
1. Seed the db with TypicalJsonBundle 

2. Migrate on preview mode
`./gradlew -PuserScript=sql/DataMigrationForAccountRequestSql execScript`
![image](https://github.com/TEAMMATES/teammates/assets/55353265/48de960d-784d-4d26-adfd-8cc1e1c0792b)
16 matches with the # of seed account requests 

4. Migrate on non-preview on test CloudSQL, verify fields match with seed data in datastore. 
`./gradlew -PuserScript=sql/DataMigrationForAccountRequestSql execScript`
![image](https://github.com/TEAMMATES/teammates/assets/55353265/2ae8be8b-5209-4872-be22-b2e2de43f05a)
fields seem to map correctly apart from createdAt which is always overwritten by the hibernate @CreatedTimestamp annotation 