### PR TITLE
Create script to verify row count for non-course entities

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/VerifyNonCourseEntityCounts.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyNonCourseEntityCounts.java
@@ -82,19 +82,18 @@ public class VerifyNonCourseEntityCounts extends DatastoreClient {
         entities.put(teammates.storage.entity.UsageStatistics.class, teammates.storage.sqlentity.UsageStatistics.class);
         entities.put(teammates.storage.entity.Notification.class, teammates.storage.sqlentity.Notification.class);
 
+        // Compare datastore "table" to postgres table for each entity
         for (Map.Entry<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entry : entities.entrySet()) {
-             // fetch number of entities in datastore
             Class<? extends BaseEntity> objectifyClass = entry.getKey();
             Class<? extends teammates.storage.sqlentity.BaseEntity> sqlClass = entry.getValue();
 
             int objectifyEntityCount = ofy().load().type(objectifyClass).count();
-            // fetch number of entities in postgres
-           
             Long postgresEntityCount = countPostgresEntities(sqlClass);
 
             printEntityVerification(objectifyClass.getSimpleName(), objectifyEntityCount, postgresEntityCount);
         }
 
+        // Read notification did not have its own entity in datastore, therefore has to be counted differently
         verifyReadNotification();
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyNonCourseEntityCounts.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyNonCourseEntityCounts.java
@@ -1,0 +1,76 @@
+package teammates.client.scripts.sql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import teammates.client.connector.DatastoreClient;
+import teammates.client.util.ClientProperties;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.entity.BaseEntity;
+
+public class VerifyNonCourseEntityCounts extends DatastoreClient {
+    private VerifyNonCourseEntityCounts() {
+        String connectionUrl = ClientProperties.SCRIPT_API_URL;
+        String username = ClientProperties.SCRIPT_API_NAME;
+        String password = ClientProperties.SCRIPT_API_PASSWORD;
+
+        HibernateUtil.buildSessionFactory(connectionUrl, username, password);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new VerifyNonCourseEntityCounts().doOperationRemotely();
+    }
+
+
+    private Long countPostgresEntities(Class<? extends teammates.storage.sqlentity.BaseEntity> entity) {
+        HibernateUtil.beginTransaction();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<Long> cr = cb.createQuery(Long.class);
+        Root<? extends teammates.storage.sqlentity.BaseEntity> root = cr.from(entity);
+
+        cr.select(cb.count(root));
+        
+        
+        Long count = HibernateUtil.createQuery(cr).getSingleResult();
+        HibernateUtil.commitTransaction();
+        return count;
+    }
+
+
+    @Override
+    protected void doOperation() {
+        HashMap<
+            Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entities = 
+                new HashMap<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>>();
+
+        entities.put(teammates.storage.entity.Account.class, teammates.storage.sqlentity.Account.class);
+        entities.put(teammates.storage.entity.AccountRequest.class, teammates.storage.sqlentity.AccountRequest.class);
+        entities.put(teammates.storage.entity.UsageStatistics.class, teammates.storage.sqlentity.UsageStatistics.class);
+        entities.put(teammates.storage.entity.Notification.class, teammates.storage.sqlentity.Notification.class);
+        
+        
+
+        for (Map.Entry<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entry : entities.entrySet()) {
+             // fetch number of entities in datastore
+            Class<? extends BaseEntity> objectifyClass = entry.getKey();
+            Class<? extends teammates.storage.sqlentity.BaseEntity> sqlClass = entry.getValue();
+
+            int objectifyEntityCount = ofy().load().type(objectifyClass).count();
+            // fetch number of entities in postgres
+           
+            Long postgresEntityCount = countPostgresEntities(sqlClass);
+
+
+            System.out.println("========================================");
+            System.out.println(objectifyClass.getName());
+            System.out.println("Objectify count: " + objectifyEntityCount);
+            System.out.println("Postgres count: " + postgresEntityCount);
+            
+        }
+        ofy().load().type(teammates.storage.entity.UsageStatistics.class);
+    }
+}


### PR DESCRIPTION
**Outline of Solution**
Script compares datastore entity count with the postgres entities count to ensure that all entities have been migrated.

**Other alternatives**
Datastore Statistics: Apparently these [aren't updated in realtime](https://github.com/googleapis/google-cloud-node/issues/413#issuecomment-299784784).

Todo
- [ ] ~Add limited batch size and cursor for datastore query? Similar to other SQL data migration scripts~ (since count aggregate is used for the most part)
- [x] Add verification for account requests  
- [x] Add verification for account  
- [x] Add verification for notification  
- [x] Add verification for read notification  
- [x] Add verification for usage statistics

