### PR TITLE
[#12048] Add locale for java datetime formatter

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -16,6 +16,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.openqa.selenium.By;
@@ -739,7 +740,7 @@ public abstract class AppPage {
     String getDisplayedDateTime(Instant instant, String timeZone, String pattern) {
         ZonedDateTime zonedDateTime = TimeHelper.getMidnightAdjustedInstantBasedOnZone(instant, timeZone, false)
                 .atZone(ZoneId.of(timeZone));
-        return DateTimeFormatter.ofPattern(pattern).format(zonedDateTime);
+        return DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH).format(zonedDateTime);
     }
 
     private String getFullDateString(Instant instant, String timeZone) {


### PR DESCRIPTION
Part of https://github.com/TEAMMATES/teammates/issues/12048

**Outline of Solution:**
In `InstructorHomePage` page object, the datatime formatter for feedback session start and end time in the feedback session table does not include a Locale. This may cause the am/pm to be formatted in lowercase instead of uppercase, causing the test to fail in some cases.