### PR TITLE
[#12048] Migrate GetFeedbackSessionLogsAction

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
@@ -181,22 +181,17 @@ public class GetFeedbackSessionLogsActionIT extends BaseActionIT<GetFeedbackSess
         Course course = typicalBundle.courses.get("course1");
         String courseId = course.getId();
         Instructor helper = typicalBundle.instructors.get("instructor2OfCourse1");
-
-        ______TS("Only instructors of the same course can access");
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
         };
 
         ______TS("Only instructors with modify student, session and instructor privilege can access");
-        submissionParams = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-        };
-
         verifyCannotAccess(submissionParams);
 
         loginAsInstructor(helper.getGoogleId());
         verifyCannotAccess(submissionParams);
 
+        ______TS("Only instructors of the same course can access");
         loginAsInstructor(instructor.getGoogleId());
         verifyCanAccess(submissionParams);
     }

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
@@ -1,0 +1,204 @@
+package teammates.it.ui.webapi;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.logs.FeedbackSessionLogType;
+import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.FeedbackSessionLogData;
+import teammates.ui.output.FeedbackSessionLogEntryData;
+import teammates.ui.output.FeedbackSessionLogsData;
+import teammates.ui.webapi.GetFeedbackSessionLogsAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link GetFeedbackSessionLogsAction}.
+ */
+public class GetFeedbackSessionLogsActionIT extends BaseActionIT<GetFeedbackSessionLogsAction> {
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SESSION_LOGS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() {
+        JsonResult actionOutput;
+
+        Course course = typicalBundle.courses.get("course1");
+        String courseId = course.getId();
+        FeedbackSession fsa1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        FeedbackSession fsa2 = typicalBundle.feedbackSessions.get("session2InTypicalCourse");
+        String fsa1Name = fsa1.getName();
+        String fsa2Name = fsa2.getName();
+        Student student1 = typicalBundle.students.get("student1InCourse1");
+        Student student2 = typicalBundle.students.get("student2InCourse1");
+        String student1Email = student1.getEmail();
+        String student2Email = student2.getEmail();
+        long endTime = Instant.now().toEpochMilli();
+        long startTime = endTime - (Const.LOGS_RETENTION_PERIOD.toDays() - 1) * 24 * 60 * 60 * 1000;
+        long invalidStartTime = endTime - (Const.LOGS_RETENTION_PERIOD.toDays() + 1) * 24 * 60 * 60 * 1000;
+
+        mockLogsProcessor.insertFeedbackSessionLog(student1Email, fsa1Name,
+                FeedbackSessionLogType.ACCESS.getLabel(), startTime);
+        mockLogsProcessor.insertFeedbackSessionLog(student1Email, fsa2Name,
+                FeedbackSessionLogType.ACCESS.getLabel(), startTime + 1000);
+        mockLogsProcessor.insertFeedbackSessionLog(student1Email, fsa2Name,
+                FeedbackSessionLogType.SUBMISSION.getLabel(), startTime + 2000);
+        mockLogsProcessor.insertFeedbackSessionLog(student2Email, fsa1Name,
+                FeedbackSessionLogType.ACCESS.getLabel(), startTime + 3000);
+        mockLogsProcessor.insertFeedbackSessionLog(student2Email, fsa1Name,
+                FeedbackSessionLogType.SUBMISSION.getLabel(), startTime + 4000);
+
+        ______TS("Failure case: not enough parameters");
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, courseId
+        );
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime)
+        );
+        verifyHttpParameterFailure(
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime)
+        );
+
+        ______TS("Failure case: invalid course id");
+        String[] paramsInvalid1 = {
+                Const.ParamsNames.COURSE_ID, "fake-course-id",
+                Const.ParamsNames.STUDENT_EMAIL, student1Email,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        verifyEntityNotFound(paramsInvalid1);
+
+        ______TS("Failure case: invalid student email");
+        String[] paramsInvalid2 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_EMAIL, "fake-student-email@gmail.com",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        verifyEntityNotFound(paramsInvalid2);
+
+        ______TS("Failure case: invalid start or end times");
+        String[] paramsInvalid3 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, "abc",
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        verifyHttpParameterFailure(paramsInvalid3);
+
+        String[] paramsInvalid4 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, " ",
+        };
+        verifyHttpParameterFailure(paramsInvalid4);
+
+        ______TS("Failure case: start time is before earliest search time");
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(invalidStartTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime)
+        );
+
+        ______TS("Success case: should group by feedback session");
+        String[] paramsSuccessful1 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        actionOutput = getJsonResult(getAction(paramsSuccessful1));
+
+        // The filtering by the logs processor cannot be tested directly, assume that it filters correctly
+        // Here, it simply returns all log entries
+        FeedbackSessionLogsData fslData = (FeedbackSessionLogsData) actionOutput.getOutput();
+        List<FeedbackSessionLogData> fsLogs = fslData.getFeedbackSessionLogs();
+
+        // Course has 6 feedback sessions, last 4 of which have no log entries
+        assertEquals(fsLogs.size(), 6);
+        assertEquals(fsLogs.get(2).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(3).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(4).getFeedbackSessionLogEntries().size(), 0);
+        assertEquals(fsLogs.get(5).getFeedbackSessionLogEntries().size(), 0);
+
+        List<FeedbackSessionLogEntryData> fsLogEntries1 = fsLogs.get(0).getFeedbackSessionLogEntries();
+        List<FeedbackSessionLogEntryData> fsLogEntries2 = fsLogs.get(1).getFeedbackSessionLogEntries();
+
+        assertEquals(fsLogEntries1.size(), 3);
+        assertEquals(fsLogEntries1.get(0).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries1.get(0).getFeedbackSessionLogType(), FeedbackSessionLogType.ACCESS);
+        assertEquals(fsLogEntries1.get(1).getStudentData().getEmail(), student2Email);
+        assertEquals(fsLogEntries1.get(1).getFeedbackSessionLogType(), FeedbackSessionLogType.ACCESS);
+        assertEquals(fsLogEntries1.get(2).getStudentData().getEmail(), student2Email);
+        assertEquals(fsLogEntries1.get(2).getFeedbackSessionLogType(), FeedbackSessionLogType.SUBMISSION);
+
+        assertEquals(fsLogEntries2.size(), 2);
+        assertEquals(fsLogEntries2.get(0).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries2.get(0).getFeedbackSessionLogType(), FeedbackSessionLogType.ACCESS);
+        assertEquals(fsLogEntries2.get(1).getStudentData().getEmail(), student1Email);
+        assertEquals(fsLogEntries2.get(1).getFeedbackSessionLogType(), FeedbackSessionLogType.SUBMISSION);
+
+        ______TS("Success case: should accept optional email");
+        String[] paramsSuccessful2 = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_EMAIL, student1Email,
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_STARTTIME, String.valueOf(startTime),
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_ENDTIME, String.valueOf(endTime),
+        };
+        getJsonResult(getAction(paramsSuccessful2));
+        // No need to check output again here, it will be exactly the same as the previous case
+
+        // TODO: if we restrict the range from start to end time, it should be tested here as well
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        Course course = typicalBundle.courses.get("course1");
+        String courseId = course.getId();
+        Instructor helper = typicalBundle.instructors.get("instructor2OfCourse1");
+
+        ______TS("Only instructors of the same course can access");
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, courseId,
+        };
+
+        ______TS("Only instructors with modify student, session and instructor privilege can access");
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, courseId,
+        };
+
+        verifyCannotAccess(submissionParams);
+
+        loginAsInstructor(helper.getGoogleId());
+        verifyCannotAccess(submissionParams);
+
+        loginAsInstructor(instructor.getGoogleId());
+        verifyCanAccess(submissionParams);
+    }
+
+}

--- a/src/main/java/teammates/ui/output/FeedbackSessionLogData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogData.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import teammates.common.datatransfer.FeedbackSessionLogEntry;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Student;
 
 /**
  * The response log of a single feedback session.
@@ -15,14 +17,42 @@ public class FeedbackSessionLogData {
     private final FeedbackSessionData feedbackSessionData;
     private final List<FeedbackSessionLogEntryData> feedbackSessionLogEntries;
 
-    public FeedbackSessionLogData(FeedbackSessionAttributes feedbackSession, List<FeedbackSessionLogEntry> logEntries,
-            Map<String, StudentAttributes> studentsMap) {
-        FeedbackSessionData fsData = new FeedbackSessionData(feedbackSession);
-        List<FeedbackSessionLogEntryData> fsLogEntryDatas = logEntries.stream()
-                .map(log -> new FeedbackSessionLogEntryData(log, studentsMap.get(log.getStudentEmail())))
-                .collect(Collectors.toList());
-        this.feedbackSessionData = fsData;
-        this.feedbackSessionLogEntries = fsLogEntryDatas;
+    // Remove generic types after migration is done (i.e. can just use FeedbackSession and Student)
+    public <S, T> FeedbackSessionLogData(S feedbackSession, List<FeedbackSessionLogEntry> logEntries,
+            Map<String, T> studentsMap) {
+        if (feedbackSession instanceof FeedbackSessionAttributes) {
+            FeedbackSessionAttributes fs = (FeedbackSessionAttributes) feedbackSession;
+            FeedbackSessionData fsData = new FeedbackSessionData(fs);
+            List<FeedbackSessionLogEntryData> fsLogEntryDatas = logEntries.stream()
+                    .map(log -> {
+                        T student = studentsMap.get(log.getStudentEmail());
+                        if (student instanceof StudentAttributes) {
+                            return new FeedbackSessionLogEntryData(log, (StudentAttributes) student);
+                        } else {
+                            throw new IllegalArgumentException("Invalid student type");
+                        }
+                    })
+                    .collect(Collectors.toList());
+            this.feedbackSessionData = fsData;
+            this.feedbackSessionLogEntries = fsLogEntryDatas;
+        } else if (feedbackSession instanceof FeedbackSession) {
+            FeedbackSession fs = (FeedbackSession) feedbackSession;
+            FeedbackSessionData fsData = new FeedbackSessionData(fs);
+            List<FeedbackSessionLogEntryData> fsLogEntryDatas = logEntries.stream()
+                    .map(log -> {
+                        T student = studentsMap.get(log.getStudentEmail());
+                        if (student instanceof Student) {
+                            return new FeedbackSessionLogEntryData(log, (Student) student);
+                        } else {
+                            throw new IllegalArgumentException("Invalid student type");
+                        }
+                    })
+                    .collect(Collectors.toList());
+            this.feedbackSessionData = fsData;
+            this.feedbackSessionLogEntries = fsLogEntryDatas;
+        } else {
+            throw new IllegalArgumentException("Invalid feedback session type");
+        }
     }
 
     public FeedbackSessionData getFeedbackSessionData() {

--- a/src/main/java/teammates/ui/output/FeedbackSessionLogEntryData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogEntryData.java
@@ -3,6 +3,7 @@ package teammates.ui.output;
 import teammates.common.datatransfer.FeedbackSessionLogEntry;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
+import teammates.storage.sqlentity.Student;
 
 /**
  * The session log of a student for a single feedback session.
@@ -13,6 +14,15 @@ public class FeedbackSessionLogEntryData {
     private final long timestamp;
 
     public FeedbackSessionLogEntryData(FeedbackSessionLogEntry logEntry, StudentAttributes student) {
+        StudentData studentData = new StudentData(student);
+        FeedbackSessionLogType logType = FeedbackSessionLogType.valueOfLabel(logEntry.getFeedbackSessionLogType());
+        long timestamp = logEntry.getTimestamp();
+        this.studentData = studentData;
+        this.feedbackSessionLogType = logType;
+        this.timestamp = timestamp;
+    }
+
+    public FeedbackSessionLogEntryData(FeedbackSessionLogEntry logEntry, Student student) {
         StudentData studentData = new StudentData(student);
         FeedbackSessionLogType logType = FeedbackSessionLogType.valueOfLabel(logEntry.getFeedbackSessionLogType());
         long timestamp = logEntry.getTimestamp();

--- a/src/main/java/teammates/ui/output/FeedbackSessionLogsData.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionLogsData.java
@@ -5,8 +5,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.FeedbackSessionLogEntry;
-import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
 
 /**
  * The API output format for logs on all feedback sessions in a course.
@@ -15,11 +13,12 @@ public class FeedbackSessionLogsData extends ApiOutput {
 
     private final List<FeedbackSessionLogData> feedbackSessionLogs;
 
-    public FeedbackSessionLogsData(Map<String, List<FeedbackSessionLogEntry>> groupedEntries,
-            Map<String, StudentAttributes> studentsMap, Map<String, FeedbackSessionAttributes> sessionsMap) {
+    // Remove generic types after migration is done (i.e. can just use FeedbackSession and Student)
+    public <S, T> FeedbackSessionLogsData(Map<String, List<FeedbackSessionLogEntry>> groupedEntries,
+            Map<String, S> studentsMap, Map<String, T> sessionsMap) {
         this.feedbackSessionLogs = groupedEntries.entrySet().stream()
                 .map(entry -> {
-                    FeedbackSessionAttributes feedbackSession = sessionsMap.get(entry.getKey());
+                    T feedbackSession = sessionsMap.get(entry.getKey());
                     List<FeedbackSessionLogEntry> logEntries = entry.getValue();
                     return new FeedbackSessionLogData(feedbackSession, logEntries, studentsMap);
                 })

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -15,6 +15,10 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
 import teammates.ui.output.FeedbackSessionLogsData;
 
 /**
@@ -33,33 +37,64 @@ public class GetFeedbackSessionLogsAction extends Action {
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        CourseAttributes courseAttributes = logic.getCourse(courseId);
 
-        if (courseAttributes == null) {
-            throw new EntityNotFoundException("Course is not found");
+        if (!isCourseMigrated(courseId)) {
+            CourseAttributes courseAttributes = logic.getCourse(courseId);
+
+            if (courseAttributes == null) {
+                throw new EntityNotFoundException("Course is not found");
+            }
+
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+            gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        } else {
+            Course course = sqlLogic.getCourse(courseId);
+
+            if (course == null) {
+                throw new EntityNotFoundException("Course is not found");
+            }
+
+            Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
-
-        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
-        gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
-        gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_SESSION);
-        gateKeeper.verifyAccessible(instructor, courseAttributes, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override
     public JsonResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        if (logic.getCourse(courseId) == null) {
-            throw new EntityNotFoundException("Course not found");
-        }
         String email = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        if (email != null && logic.getStudentForEmail(courseId, email) == null) {
-            throw new EntityNotFoundException("Student not found");
-        }
         String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 
-        if (feedbackSessionName != null && logic.getFeedbackSession(feedbackSessionName, courseId) == null) {
-            throw new EntityNotFoundException("Feedback session not found");
+        if (!isCourseMigrated(courseId)) {
+            if (logic.getCourse(courseId) == null) {
+                throw new EntityNotFoundException("Course not found");
+            }
+
+            if (email != null && logic.getStudentForEmail(courseId, email) == null) {
+                throw new EntityNotFoundException("Student not found");
+            }
+
+            if (feedbackSessionName != null && logic.getFeedbackSession(feedbackSessionName, courseId) == null) {
+                throw new EntityNotFoundException("Feedback session not found");
+            }
+        } else {
+            if (sqlLogic.getCourse(courseId) == null) {
+                throw new EntityNotFoundException("Course not found");
+            }
+
+            if (email != null && sqlLogic.getStudentForEmail(courseId, email) == null) {
+                throw new EntityNotFoundException("Student not found");
+            }
+
+            if (feedbackSessionName != null && sqlLogic.getFeedbackSession(feedbackSessionName, courseId) == null) {
+                throw new EntityNotFoundException("Feedback session not found");
+            }
         }
+
         String fslTypes = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE);
         List<FeedbackSessionLogType> convertedFslTypes = new ArrayList<>();
         if (fslTypes != null) {
@@ -101,38 +136,74 @@ public class GetFeedbackSessionLogsAction extends Action {
 
         List<FeedbackSessionLogEntry> fsLogEntries =
                 logsProcessor.getFeedbackSessionLogs(courseId, email, startTime, endTime, feedbackSessionName);
-        Map<String, StudentAttributes> studentsMap = new HashMap<>();
-        Map<String, FeedbackSessionAttributes> sessionsMap = new HashMap<>();
-        List<FeedbackSessionAttributes> feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
-        feedbackSessions.forEach(fs -> sessionsMap.put(fs.getFeedbackSessionName(), fs));
 
-        fsLogEntries = fsLogEntries.stream().filter(logEntry -> {
-            String logType = logEntry.getFeedbackSessionLogType();
-            FeedbackSessionLogType convertedLogType = FeedbackSessionLogType.valueOfLabel(logType);
-            if (convertedLogType == null || fslTypes != null && !convertedFslTypes.contains(convertedLogType)) {
-                // If the feedback session log type retrieved from the log is invalid
-                // or not the type being queried, ignore the log
-                return false;
-            }
+        if (!isCourseMigrated(courseId)) {
+            Map<String, StudentAttributes> studentsMap = new HashMap<>();
+            Map<String, FeedbackSessionAttributes> sessionsMap = new HashMap<>();
+            List<FeedbackSessionAttributes> feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
+            feedbackSessions.forEach(fs -> sessionsMap.put(fs.getFeedbackSessionName(), fs));
 
-            if (!studentsMap.containsKey(logEntry.getStudentEmail())) {
-                StudentAttributes student = logic.getStudentForEmail(courseId, logEntry.getStudentEmail());
-                if (student == null) {
-                    // If the student email retrieved from the log is invalid, ignore the log
+            fsLogEntries = fsLogEntries.stream().filter(logEntry -> {
+                String logType = logEntry.getFeedbackSessionLogType();
+                FeedbackSessionLogType convertedLogType = FeedbackSessionLogType.valueOfLabel(logType);
+                if (convertedLogType == null || fslTypes != null && !convertedFslTypes.contains(convertedLogType)) {
+                    // If the feedback session log type retrieved from the log is invalid
+                    // or not the type being queried, ignore the log
                     return false;
                 }
-                studentsMap.put(logEntry.getStudentEmail(), student);
-            }
-            // If the feedback session retrieved from the log is invalid, ignore the log
-            return sessionsMap.containsKey(logEntry.getFeedbackSessionName());
-        }).collect(Collectors.toList());
 
-        Map<String, List<FeedbackSessionLogEntry>> groupedEntries =
-                groupFeedbackSessionLogEntries(fsLogEntries);
-        feedbackSessions.forEach(fs -> groupedEntries.putIfAbsent(fs.getFeedbackSessionName(), new ArrayList<>()));
+                if (!studentsMap.containsKey(logEntry.getStudentEmail())) {
+                    StudentAttributes student = logic.getStudentForEmail(courseId, logEntry.getStudentEmail());
+                    if (student == null) {
+                        // If the student email retrieved from the log is invalid, ignore the log
+                        return false;
+                    }
+                    studentsMap.put(logEntry.getStudentEmail(), student);
+                }
+                // If the feedback session retrieved from the log is invalid, ignore the log
+                return sessionsMap.containsKey(logEntry.getFeedbackSessionName());
+            }).collect(Collectors.toList());
 
-        FeedbackSessionLogsData fslData = new FeedbackSessionLogsData(groupedEntries, studentsMap, sessionsMap);
-        return new JsonResult(fslData);
+            Map<String, List<FeedbackSessionLogEntry>> groupedEntries =
+                    groupFeedbackSessionLogEntries(fsLogEntries);
+            feedbackSessions.forEach(fs -> groupedEntries.putIfAbsent(fs.getFeedbackSessionName(), new ArrayList<>()));
+
+            FeedbackSessionLogsData fslData = new FeedbackSessionLogsData(groupedEntries, studentsMap, sessionsMap);
+            return new JsonResult(fslData);
+        } else {
+            Map<String, Student> studentsMap = new HashMap<>();
+            Map<String, FeedbackSession> sessionsMap = new HashMap<>();
+            List<FeedbackSession> feedbackSessions = sqlLogic.getFeedbackSessionsForCourse(courseId);
+            feedbackSessions.forEach(fs -> sessionsMap.put(fs.getName(), fs));
+
+            fsLogEntries = fsLogEntries.stream().filter(logEntry -> {
+                String logType = logEntry.getFeedbackSessionLogType();
+                FeedbackSessionLogType convertedLogType = FeedbackSessionLogType.valueOfLabel(logType);
+                if (convertedLogType == null || fslTypes != null && !convertedFslTypes.contains(convertedLogType)) {
+                    // If the feedback session log type retrieved from the log is invalid
+                    // or not the type being queried, ignore the log
+                    return false;
+                }
+
+                if (!studentsMap.containsKey(logEntry.getStudentEmail())) {
+                    Student student = sqlLogic.getStudentForEmail(courseId, logEntry.getStudentEmail());
+                    if (student == null) {
+                        // If the student email retrieved from the log is invalid, ignore the log
+                        return false;
+                    }
+                    studentsMap.put(logEntry.getStudentEmail(), student);
+                }
+                // If the feedback session retrieved from the log is invalid, ignore the log
+                return sessionsMap.containsKey(logEntry.getFeedbackSessionName());
+            }).collect(Collectors.toList());
+
+            Map<String, List<FeedbackSessionLogEntry>> groupedEntries =
+                    groupFeedbackSessionLogEntries(fsLogEntries);
+            feedbackSessions.forEach(fs -> groupedEntries.putIfAbsent(fs.getName(), new ArrayList<>()));
+
+            FeedbackSessionLogsData fslData = new FeedbackSessionLogsData(groupedEntries, studentsMap, sessionsMap);
+            return new JsonResult(fslData);
+        }
     }
 
     private Map<String, List<FeedbackSessionLogEntry>> groupFeedbackSessionLogEntries(


### PR DESCRIPTION
Part of #12048 

Couldn't create an alternate constructor because the generic types used in `Map<String, *>` are erased, so constructors will conflict. I instead used generic types for the 2 affected constructors, and placed all the type checks in `FeedbackSessionLogData` to reduce messiness. Also left a comment so that after migration is done, the generic types can be replaced with the actual types used (i.e. `FeedbackSession` and `Student`)