### PR TITLE
Fix seeding of data for data migration

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -165,7 +165,7 @@ public class SeedDb extends DatastoreClient {
         // Persisting basic data bundle
         DataBundle dataBundle = getTypicalDataBundle();
         try {
-            // logic.persistDataBundle(dataBundle);
+            logic.persistDataBundle(dataBundle);
             persistAdditionalData();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -144,7 +144,6 @@ public class SeedDb extends DatastoreClient {
                     int randIndex = rand.nextInt(NOTIFICATION_SIZE);
                     String notificationUUID = notificationUUIDs.get(randIndex);
                     assert(notificationEndTimes.get(notificationUUID) != null);
-                    // System.out.println(notificationEndTimes.get(notificationUUID));
                     readNotificationsToCreate.put(notificationUUID, notificationEndTimes.get(notificationUUID));
 
                 }

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -2,6 +2,7 @@ package teammates.client.scripts.sql;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -97,17 +98,20 @@ public class SeedDb extends DatastoreClient {
             }
             notificationUUIDs.add(notificationUUID.toString());
             notificationsUUIDSeen.add(notificationUUID.toString());
+            // Since we are not using logic class, referencing MarkNotificationAsReadAction.class and CreateNotificationAction.class
+            // endTime is to nearest milli not nanosecond
+            Instant endTime = getRandomInstant().truncatedTo(ChronoUnit.MILLIS);
             Notification notification = new Notification(
                     notificationUUID.toString(),
                     getRandomInstant(),
-                    getRandomInstant(),
+                    endTime,
                     NotificationStyle.PRIMARY,
                     NotificationTargetUser.INSTRUCTOR,
                     notificationUUID.toString(),
                     notificationUUID.toString(),
                     false,
                     getRandomInstant(),
-                    getRandomInstant());            
+                    getRandomInstant());
             try {
                 ofy().save().entities(notification).now();
                 notificationEndTimes.put(notificationUUID.toString(), notification.getEndTime());
@@ -140,6 +144,7 @@ public class SeedDb extends DatastoreClient {
                     int randIndex = rand.nextInt(NOTIFICATION_SIZE);
                     String notificationUUID = notificationUUIDs.get(randIndex);
                     assert(notificationEndTimes.get(notificationUUID) != null);
+                    // System.out.println(notificationEndTimes.get(notificationUUID));
                     readNotificationsToCreate.put(notificationUUID, notificationEndTimes.get(notificationUUID));
 
                 }
@@ -161,7 +166,7 @@ public class SeedDb extends DatastoreClient {
         // Persisting basic data bundle
         DataBundle dataBundle = getTypicalDataBundle();
         try {
-            logic.persistDataBundle(dataBundle);
+            // logic.persistDataBundle(dataBundle);
             persistAdditionalData();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -84,17 +84,36 @@ public class SeedDb extends DatastoreClient {
 
         String[] args = {};
 
-        Set<String> readNotificationsUUIDSeen = new HashSet<String>();
+        Set<String> notificationsUUIDSeen = new HashSet<String>();
         ArrayList<String> notificationUUIDs = new ArrayList<>();
+        HashMap<String, Instant> notificationEndTimes = new HashMap<>();
+
         Random rand = new Random();
 
         for (int j = 0; j < NOTIFICATION_SIZE; j++) {
             UUID notificationUUID = UUID.randomUUID();
-            while (readNotificationsUUIDSeen.contains(notificationUUID)) {
+            while (notificationsUUIDSeen.contains(notificationUUID)) {
                 notificationUUID = UUID.randomUUID();
             }
             notificationUUIDs.add(notificationUUID.toString());
-            readNotificationsUUIDSeen.add(notificationUUID.toString());
+            notificationsUUIDSeen.add(notificationUUID.toString());
+            Notification notification = new Notification(
+                    notificationUUID.toString(),
+                    getRandomInstant(),
+                    getRandomInstant(),
+                    NotificationStyle.PRIMARY,
+                    NotificationTargetUser.INSTRUCTOR,
+                    notificationUUID.toString(),
+                    notificationUUID.toString(),
+                    false,
+                    getRandomInstant(),
+                    getRandomInstant());            
+            try {
+                ofy().save().entities(notification).now();
+                notificationEndTimes.put(notificationUUID.toString(), notification.getEndTime());
+            } catch (Exception e) {
+                System.out.println(e);
+            }
         }
 
         for (int i = 0; i < ENTITY_SIZE; i++) {
@@ -119,8 +138,9 @@ public class SeedDb extends DatastoreClient {
 
                 for (int j = 0; j < READ_NOTIFICATION_SIZE; j++) {
                     int randIndex = rand.nextInt(NOTIFICATION_SIZE);
-                    UUID notificationUUID = UUID.fromString(notificationUUIDs.get(randIndex));
-                    readNotificationsToCreate.put(notificationUUID.toString(), getRandomInstant());
+                    String notificationUUID = notificationUUIDs.get(randIndex);
+                    assert(notificationEndTimes.get(notificationUUID) != null);
+                    readNotificationsToCreate.put(notificationUUID, notificationEndTimes.get(notificationUUID));
 
                 }
                 Account account = new Account(accountGoogleId, accountName,
@@ -133,26 +153,6 @@ public class SeedDb extends DatastoreClient {
             }
         }
 
-        int readNotifIndex = 0;
-        for (String readNotification : readNotificationsUUIDSeen) {
-            Notification notification = new Notification(
-                    readNotification,
-                    getRandomInstant(),
-                    getRandomInstant(),
-                    NotificationStyle.PRIMARY,
-                    NotificationTargetUser.INSTRUCTOR,
-                    String.valueOf(readNotifIndex),
-                    String.valueOf(readNotifIndex),
-                    false,
-                    getRandomInstant(),
-                    getRandomInstant());
-            try {
-                ofy().save().entities(notification).now();
-            } catch (Exception e) {
-                System.out.println(e);
-            }
-            readNotifIndex += 1;
-        }
         GenerateUsageStatisticsObjects.main(args);
 
     }


### PR DESCRIPTION
**Context**
VerificationAccountAttributes state there was errors in the data migration of accounts. After investigation, discovered script was ok, the seeding of mock data to the datastore was incorrect and caused the script to fail.

**Outline of Solution**
- Notification and readNotification now use the same instant
- endTime is rounded to nearest millisecond to correspond with the 2 actions that create and update notifications, MarkNotificationAsReadAction.class and CreateNotificationAction.class
