### PR TITLE
[#12048] Prepare Patch Data Migration Script for Account

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountAndReadNotificationSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountAndReadNotificationSql.java
@@ -20,7 +20,7 @@ import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.QueryResults;
 import com.googlecode.objectify.cmd.Query;
 
-import jakarta.persistence.criteria.CriteriaDelete;
+// import jakarta.persistence.criteria.CriteriaDelete;
 
 import teammates.client.connector.DatastoreClient;
 import teammates.client.util.ClientProperties;
@@ -93,10 +93,10 @@ public class DataMigrationForAccountAndReadNotificationSql extends DatastoreClie
     }
 
     /**
-     * Returns whether migration is needed for the entity.
+     * Returns whether the account has been migrated.
      */
     protected boolean isMigrationNeeded(teammates.storage.entity.Account entity) {
-        return true;
+        return !entity.isMigrated();
     }
 
     /**
@@ -131,9 +131,8 @@ public class DataMigrationForAccountAndReadNotificationSql extends DatastoreClie
                 oldAccount.getName(),
                 oldAccount.getEmail());
 
-        oldAccount.setMigrated(true);
-
         entitiesAccountSavingBuffer.add(newAccount);
+
         oldAccount.setMigrated(true);
         entitiesOldAccountSavingBuffer.add(oldAccount);
         migrateReadNotification(oldAccount, newAccount);
@@ -170,8 +169,7 @@ public class DataMigrationForAccountAndReadNotificationSql extends DatastoreClie
         } else {
             log("Start from cursor position: " + cursor.toUrlSafe());
         }
-        // Drop the account and read notification
-        cleanAccountAndReadNotificationInSql();
+        // cleanAccountAndReadNotificationInSql();
         boolean shouldContinue = true;
         while (shouldContinue) {
             shouldContinue = false;
@@ -209,22 +207,25 @@ public class DataMigrationForAccountAndReadNotificationSql extends DatastoreClie
         log("Number of updated entities: " + numberOfUpdatedEntities.get());
     }
 
-    private void cleanAccountAndReadNotificationInSql() {
-        HibernateUtil.beginTransaction();
+    // This method was used to clean the account and read notification in the SQL
+    // private void cleanAccountAndReadNotificationInSql() {
+    // HibernateUtil.beginTransaction();
 
-        CriteriaDelete<ReadNotification> cdReadNotification = HibernateUtil.getCriteriaBuilder()
-                .createCriteriaDelete(ReadNotification.class);
-        cdReadNotification.from(ReadNotification.class);
-        HibernateUtil.executeDelete(cdReadNotification);
+    // CriteriaDelete<ReadNotification> cdReadNotification =
+    // HibernateUtil.getCriteriaBuilder()
+    // .createCriteriaDelete(ReadNotification.class);
+    // cdReadNotification.from(ReadNotification.class);
+    // HibernateUtil.executeDelete(cdReadNotification);
 
-        CriteriaDelete<teammates.storage.sqlentity.Account> cdAccount = HibernateUtil.getCriteriaBuilder()
-                .createCriteriaDelete(
-                        teammates.storage.sqlentity.Account.class);
-        cdAccount.from(teammates.storage.sqlentity.Account.class);
-        HibernateUtil.executeDelete(cdAccount);
+    // CriteriaDelete<teammates.storage.sqlentity.Account> cdAccount =
+    // HibernateUtil.getCriteriaBuilder()
+    // .createCriteriaDelete(
+    // teammates.storage.sqlentity.Account.class);
+    // cdAccount.from(teammates.storage.sqlentity.Account.class);
+    // HibernateUtil.executeDelete(cdAccount);
 
-        HibernateUtil.commitTransaction();
-    }
+    // HibernateUtil.commitTransaction();
+    // }
 
     /**
      * Flushes the saving buffer by issuing Cloud SQL save request.

--- a/src/client/java/teammates/client/scripts/sql/MigrateAndVerifyNonCourseEntities.java
+++ b/src/client/java/teammates/client/scripts/sql/MigrateAndVerifyNonCourseEntities.java
@@ -11,8 +11,8 @@ public class MigrateAndVerifyNonCourseEntities {
             // SeedDb.main(args);
 
             DataMigrationForNotificationSql.main(args);
-            DataMigrationForUsageStatisticsSql.main(args);
-            DataMigrationForAccountRequestSql.main(args);
+            // DataMigrationForUsageStatisticsSql.main(args);
+            // DataMigrationForAccountRequestSql.main(args);
             DataMigrationForAccountAndReadNotificationSql.main(args);
 
             VerifyNonCourseEntityCounts.main(args);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

* To enable patch update of accounts for data migration, we decide to use the `isMigrated` flag in Account.
* If the account is migrated in the online update, the isMigrated flag will be set to true.
* Then when we do patch update in the offline migration for Account and ReadNotification, we check this flag to determine if this account has been migrated or not.