### PR TITLE
[#12048] Revert getFilterQuery for Account Data Migration Script

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountAndReadNotificationSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountAndReadNotificationSql.java
@@ -96,14 +96,14 @@ public class DataMigrationForAccountAndReadNotificationSql extends DatastoreClie
      * Returns whether the account has been migrated.
      */
     protected boolean isMigrationNeeded(teammates.storage.entity.Account entity) {
-        return true;
+        return !entity.isMigrated();
     }
 
     /**
      * Returns the filter query.
      */
     protected Query<teammates.storage.entity.Account> getFilterQuery() {
-        return ofy().load().type(teammates.storage.entity.Account.class).filter("isMigrated =", false);
+        return ofy().load().type(teammates.storage.entity.Account.class);
     }
 
     private void doMigration(teammates.storage.entity.Account entity) {

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -173,7 +173,7 @@ public class SeedDb extends DatastoreClient {
                 }
 
                 Account account = new Account(accountGoogleId, accountName,
-                        accountEmail, readNotificationsToCreate, true);
+                        accountEmail, readNotificationsToCreate, false);
 
                 ofy().save().entities(account).now();
                 ofy().save().entities(accountRequest).now();


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

* Revert the getFilterQuery to not filter by `isMigrated`, instead check this flag in `isMigrationNeeded` method.
* Seed account with the `isMigrated` check to be false.