### PR TITLE
[#12048] Patch Usage Statistics Migration

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForUsageStatisticsSql.java
@@ -1,5 +1,7 @@
 package teammates.client.scripts.sql;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import com.googlecode.objectify.cmd.Query;
@@ -10,12 +12,24 @@ import teammates.storage.sqlentity.UsageStatistics;
  * Data migration class for usage statistics.
  */
 public class DataMigrationForUsageStatisticsSql extends
-        DataMigrationEntitiesBaseScriptSql<
-            teammates.storage.entity.UsageStatistics,
-            UsageStatistics> {
+        DataMigrationEntitiesBaseScriptSql<teammates.storage.entity.UsageStatistics, UsageStatistics> {
+
+    // Set the default start time to resume the migration from.
+    // Set it to null if want to migrate all entities.
+    private static final String START_TIME_STRING = "2024-03-12 06:00:00.000 +0800";
+
+    private static final Instant START_TIME = parseStartTime(START_TIME_STRING);
 
     public static void main(String[] args) {
         new DataMigrationForUsageStatisticsSql().doOperationRemotely();
+    }
+
+    private static Instant parseStartTime(String startTimeString) {
+        if (startTimeString == null) {
+            return null;
+        }
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS Z");
+        return Instant.from(formatter.parse(startTimeString));
     }
 
     @Override
@@ -33,11 +47,16 @@ public class DataMigrationForUsageStatisticsSql extends
     }
 
     /**
-     * Always returns true, as the migration is needed for all entities from Datastore to CloudSQL .
+     * Always returns true, as the migration is needed for all entities from
+     * Datastore to CloudSQL .
      */
+    @SuppressWarnings("unused")
     @Override
     protected boolean isMigrationNeeded(teammates.storage.entity.UsageStatistics entity) {
-        return true;
+        if (START_TIME == null) {
+            return true;
+        }
+        return entity.getStartTime().isAfter(START_TIME);
     }
 
     @Override
@@ -51,8 +70,7 @@ public class DataMigrationForUsageStatisticsSql extends
                 oldEntity.getNumInstructors(),
                 oldEntity.getNumAccountRequests(),
                 oldEntity.getNumEmails(),
-                oldEntity.getNumSubmissions()
-        );
+                oldEntity.getNumSubmissions());
 
         try {
             UUID oldUuid = UUID.fromString(oldEntity.getId());


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

* To migrate newly generated usage statistics after the last run of the script, use a START_TIME benchmark to migrate those entities generated _after_ this benchmark time.
* Requires user to run a query `SELECT MAX(start_time) FROM usage_statistics;` and then copy paste the string to the START_TIME_STRING. (Is it possible to do the query in the script?)