### PR TITLE
[#11878] Fix AccountRequest migration script

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForAccountRequestSql.java
@@ -40,11 +40,17 @@ public class DataMigrationForAccountRequestSql
 
     @Override
     protected void migrateEntity(teammates.storage.entity.AccountRequest oldEntity) throws Exception {
+        AccountRequestStatus status;
+        if (oldEntity.getRegisteredAt() == null) {
+            status = AccountRequestStatus.APPROVED;
+        } else {
+            status = AccountRequestStatus.REGISTERED;
+        }
         AccountRequest newEntity = new AccountRequest(
                 oldEntity.getEmail(),
                 oldEntity.getName(),
                 oldEntity.getInstitute(),
-                AccountRequestStatus.APPROVED,
+                status,
                 null);
 
         // set registration key to the old value if exists


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
Checks if `registeredAt` is null. If it is, the status is set to `APPROVED`, otherwise it is set to `REGISTERED`.

Under the old logic, the admin adds an account request from the Google form responses into TEAMMATES only when the admin approves it. At this point, an account is not created yet, and `registeredAt` is null, but an email is sent to the instructor with a registration link; this corresponds to the `APPROVED` status in the new logic. When the instructor clicks on the registration link and registers then the account is created and `registeredAt` is non-null; this corresponds to the `REGISTERED` status in the new logic.

For more info, see:
- https://github.com/TEAMMATES/teammates/pull/12898#discussion_r1528941492
- https://github.com/TEAMMATES/teammates/issues/11878#issuecomment-1173783073
- https://github.com/TEAMMATES/teammates/issues/11878#issuecomment-1173803204
- https://github.com/TEAMMATES/teammates/issues/11878#issuecomment-1173816614