### PR TITLE
[#12921] Reintroduce AccountRequest search indexing

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -1,0 +1,60 @@
+package teammates.it.ui.webapi;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.ui.output.JoinLinkData;
+import teammates.ui.request.AccountCreateRequest;
+import teammates.ui.webapi.CreateAccountRequestAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link CreateAccountRequestAction}.
+ */
+public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequestAction> {
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.ACCOUNT_REQUEST;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return POST;
+    }
+
+    @Override
+    @Test
+    protected void testExecute() throws Exception {
+        // This is a minimal test; other cases are not tested due to upcoming changes in behaviour.
+        AccountCreateRequest request = new AccountCreateRequest();
+        request.setInstructorEmail("ring-bearer@fellowship.net");
+        request.setInstructorName("Frodo Baggins");
+        request.setInstructorInstitution("The Fellowship of the Ring");
+        CreateAccountRequestAction action = getAction(request);
+        JsonResult result = getJsonResult(action);
+        JoinLinkData output = (JoinLinkData) result.getOutput();
+        AccountRequest accountRequest = logic.getAccountRequest("ring-bearer@fellowship.net", "The Fellowship of the Ring");
+        assertEquals("ring-bearer@fellowship.net", accountRequest.getEmail());
+        assertEquals("Frodo Baggins", accountRequest.getName());
+        assertEquals("The Fellowship of the Ring", accountRequest.getInstitute());
+        assertNull(accountRequest.getRegisteredAt());
+        assertEquals(accountRequest.getRegistrationUrl(), output.getJoinLink());
+        verifyNumberOfEmailsSent(1);
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
+        EmailWrapper emailSent = mockEmailSender.getEmailsSent().get(0);
+        assertEquals(String.format(EmailType.NEW_INSTRUCTOR_ACCOUNT.getSubject(), "Frodo Baggins"),
+                emailSent.getSubject());
+        assertEquals("ring-bearer@fellowship.net", emailSent.getRecipient());
+        assertTrue(emailSent.getContent().contains(output.getJoinLink()));
+    }
+
+    @Override
+    protected void testAccessControl() throws Exception {
+        // This is not tested due to upcoming changes in behaviour.
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -11,7 +11,7 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 /**
  * Creates a new account request.
  */
-class CreateAccountRequestAction extends AdminOnlyAction {
+public class CreateAccountRequestAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute()
@@ -26,6 +26,7 @@ class CreateAccountRequestAction extends AdminOnlyAction {
 
         try {
             accountRequest = sqlLogic.createAccountRequest(instructorName, instructorEmail, instructorInstitution);
+            taskQueuer.scheduleAccountRequestForSearchIndexing(instructorEmail, instructorInstitution);
         } catch (InvalidParametersException ipe) {
             throw new InvalidHttpRequestBodyException(ipe);
         } catch (EntityAlreadyExistsException eaee) {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12921 
Part of #12048 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Search indexing for `AccountRequest` was reintroduced. There were effectively no integration tests for `CreateAccountRequestAction`; `teammates.ui.webapi.CreateAccountRequestActionTest` is not enabled, and even if it were, it tests using Datastore, not SQL. Thus, I also added `CreateAccountRequestActionIT`. However, I only give a minimal test because the behaviour of `CreateAccountRequestAction` will change with the upcoming account request form upgrade (see #12913). I felt it would not be very productive to test every single case. The minimal test only serves to give confidence that the core functionality of `CreateAccountRequestAction` works, especially the newly reintroduced search indexing.