### PR TITLE
[#11878] Add new account request alert email for admins

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -43,8 +43,8 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         assertEquals("The Fellowship of the Ring", accountRequest.getInstitute());
         assertNull(accountRequest.getRegisteredAt());
         assertEquals(accountRequest.getRegistrationUrl(), output.getJoinLink());
-        verifyNumberOfEmailsSent(1);
         verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
+        verifyNumberOfEmailsSent(2);
         EmailWrapper emailSent = mockEmailSender.getEmailsSent().get(0);
         assertEquals(String.format(EmailType.NEW_INSTRUCTOR_ACCOUNT.getSubject(), "Frodo Baggins"),
                 emailSent.getSubject());

--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -50,6 +50,9 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
                 emailSent.getSubject());
         assertEquals("ring-bearer@fellowship.net", emailSent.getRecipient());
         assertTrue(emailSent.getContent().contains(output.getJoinLink()));
+        EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(1);
+        // Check only the email type. The content of the email is not tested here, but in the email generator test(s).
+        assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
     }
 
     @Override

--- a/src/main/java/teammates/common/util/EmailType.java
+++ b/src/main/java/teammates/common/util/EmailType.java
@@ -23,6 +23,7 @@ public enum EmailType {
     NEW_INSTRUCTOR_ACCOUNT("TEAMMATES: Welcome to TEAMMATES! %s"),
     STUDENT_COURSE_JOIN("TEAMMATES: Invitation to join course [%s][Course ID: %s]"),
     STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
+    NEW_ACCOUNT_REQUEST_ADMIN_ALERT("TEAMMATES: New Account Request Received"),
     INSTRUCTOR_COURSE_JOIN("TEAMMATES: Invitation to join course as an instructor [%s][Course ID: %s]"),
     INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
     USER_COURSE_REGISTER("TEAMMATES: Registered for Course [%s][Course ID: %s]"),

--- a/src/main/java/teammates/common/util/EmailType.java
+++ b/src/main/java/teammates/common/util/EmailType.java
@@ -23,7 +23,7 @@ public enum EmailType {
     NEW_INSTRUCTOR_ACCOUNT("TEAMMATES: Welcome to TEAMMATES! %s"),
     STUDENT_COURSE_JOIN("TEAMMATES: Invitation to join course [%s][Course ID: %s]"),
     STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
-    NEW_ACCOUNT_REQUEST_ADMIN_ALERT("TEAMMATES: New Account Request Received"),
+    NEW_ACCOUNT_REQUEST_ADMIN_ALERT("TEAMMATES (Action Needed): New Account Request Received"),
     INSTRUCTOR_COURSE_JOIN("TEAMMATES: Invitation to join course as an instructor [%s][Course ID: %s]"),
     INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
     USER_COURSE_REGISTER("TEAMMATES: Registered for Course [%s][Course ID: %s]"),

--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -32,6 +32,8 @@ public final class Templates {
      * Collection of templates of emails to be sent by the system.
      */
     public static class EmailTemplates {
+        public static final String ADMIN_NEW_ACCOUNT_REQUEST_ALERT =
+                FileHelper.readResourceFile("adminEmailTemplate-newAccountRequestAlert.html");
         public static final String USER_COURSE_JOIN =
                 FileHelper.readResourceFile("userEmailTemplate-courseJoin.html");
         public static final String USER_COURSE_REGISTER =

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -26,6 +26,7 @@ import teammates.sqllogic.core.DeadlineExtensionsLogic;
 import teammates.sqllogic.core.FeedbackSessionsLogic;
 import teammates.sqllogic.core.UsersLogic;
 import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -970,6 +971,14 @@ public final class SqlEmailGenerator {
         email.setType(EmailType.INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET);
         email.setSubjectFromType(course.getName(), course.getId());
         email.setContent(emailBody);
+        return email;
+    }
+
+    /**
+     * Generates the email to alert the admin of the new {@code accountRequest}.
+     */
+    public EmailWrapper generateNewAccountRequestAdminAlertEmail(AccountRequest accountRequest) {
+        EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
         return email;
     }
 

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -979,6 +979,7 @@ public final class SqlEmailGenerator {
      */
     public EmailWrapper generateNewAccountRequestAdminAlertEmail(AccountRequest accountRequest) {
         EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
+        email.setType(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT);
         return email;
     }
 

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -980,6 +980,7 @@ public final class SqlEmailGenerator {
     public EmailWrapper generateNewAccountRequestAdminAlertEmail(AccountRequest accountRequest) {
         EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
         email.setType(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT);
+        email.setSubjectFromType();
         return email;
     }
 

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -978,9 +978,26 @@ public final class SqlEmailGenerator {
      * Generates the email to alert the admin of the new {@code accountRequest}.
      */
     public EmailWrapper generateNewAccountRequestAdminAlertEmail(AccountRequest accountRequest) {
+        String name = accountRequest.getName();
+        String institute = accountRequest.getInstitute();
+        String emailAddress = accountRequest.getEmail();
+        String comments = accountRequest.getComments();
+        if (comments == null) {
+            comments = "";
+        }
+        String adminAccountRequestsPageUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.ADMIN_HOME_PAGE).toAbsoluteString();
+        String[] templateKeyValuePairs = new String[] {
+                "${name}", name,
+                "${institute}", institute,
+                "${emailAddress}", emailAddress,
+                "${comments}", comments,
+                "${adminAccountRequestsPageUrl}", adminAccountRequestsPageUrl,
+        };
+        String content = Templates.populateTemplate(EmailTemplates.ADMIN_NEW_ACCOUNT_REQUEST_ALERT, templateKeyValuePairs);
         EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
         email.setType(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT);
         email.setSubjectFromType();
+        email.setContent(content);
         return email;
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -45,7 +45,8 @@ public class CreateAccountRequestAction extends AdminOnlyAction {
         EmailWrapper email = emailGenerator.generateNewInstructorAccountJoinEmail(
                 instructorEmail, instructorName, joinLink);
         emailSender.sendEmail(email);
-
+        EmailWrapper adminAlertEmail = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        emailSender.sendEmail(adminAlertEmail);
         JoinLinkData output = new JoinLinkData(joinLink);
         return new JsonResult(output);
     }

--- a/src/main/resources/adminEmailTemplate-newAccountRequestAlert.html
+++ b/src/main/resources/adminEmailTemplate-newAccountRequestAlert.html
@@ -1,0 +1,60 @@
+<p>Hello, Admin</p>
+
+<p>
+  A new instructor account request has been submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${name}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${institute}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${emailAddress}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${comments}
+      </td>
+    </tr>
+  </table>
+</div>
+
+Accept/reject this request on the admin panel: <a href="${adminAccountRequestsPageUrl}">${adminAccountRequestsPageUrl}</a>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -21,14 +21,17 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 AccountRequestStatus.PENDING,
                 "I don't like sand. It's coarse and rough and irritating... and it gets everywhere.");
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+                "TEAMMATES: New Account Request Received");
     }
 
-    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType) {
+    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType,
+            String expectedSubject) {
         assertEquals(expectedRecipientEmailAddress, email.getRecipient());
         assertEquals(Config.EMAIL_SENDEREMAIL, email.getSenderEmail());
         assertEquals(Config.EMAIL_SENDERNAME, email.getSenderName());
         assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
         assertEquals(expectedEmailType, email.getType());
+        assertEquals(expectedSubject, email.getSubject());
     }
 }

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -1,0 +1,32 @@
+package teammates.sqllogic.api;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.AccountRequestStatus;
+import teammates.common.util.Config;
+import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.test.BaseTestCase;
+
+/**
+ * SUT: {@link SqlEmailGenerator}.
+ */
+public class SqlEmailGeneratorTest extends BaseTestCase {
+    private final SqlEmailGenerator sqlEmailGenerator = SqlEmailGenerator.inst();
+
+    @Test
+    void testGenerateNewAccountRequestAdminAlertEmail_typicalCase_generatesSuccessfully() {
+        AccountRequest accountRequest = new AccountRequest("chosen-one@jedi.org", "Anakin Skywalker", "Jedi Order",
+                AccountRequestStatus.PENDING,
+                "I don't like sand. It's coarse and rough and irritating... and it gets everywhere.");
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL);
+    }
+
+    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress) {
+        assertEquals(expectedRecipientEmailAddress, email.getRecipient());
+        assertEquals(Config.EMAIL_SENDEREMAIL, email.getSenderEmail());
+        assertEquals(Config.EMAIL_SENDERNAME, email.getSenderName());
+        assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
+    }
+}

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -25,7 +25,8 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 "I don't like sand. It's coarse and rough and irritating... and it gets everywhere.");
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
         verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
-                "TEAMMATES: New Account Request Received", "/adminNewAccountRequestAlertEmailWithComments.html");
+                "TEAMMATES (Action Needed): New Account Request Received",
+                "/adminNewAccountRequestAlertEmailWithComments.html");
     }
 
     @Test
@@ -34,7 +35,8 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 AccountRequestStatus.PENDING, null);
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
         verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
-                "TEAMMATES: New Account Request Received", "/adminNewAccountRequestAlertEmailWithNoComments.html");
+                "TEAMMATES (Action Needed): New Account Request Received",
+                "/adminNewAccountRequestAlertEmailWithNoComments.html");
     }
 
     private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType,

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -4,6 +4,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.util.Config;
+import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.test.BaseTestCase;
@@ -20,13 +21,14 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 AccountRequestStatus.PENDING,
                 "I don't like sand. It's coarse and rough and irritating... and it gets everywhere.");
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT);
     }
 
-    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress) {
+    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType) {
         assertEquals(expectedRecipientEmailAddress, email.getRecipient());
         assertEquals(Config.EMAIL_SENDEREMAIL, email.getSenderEmail());
         assertEquals(Config.EMAIL_SENDERNAME, email.getSenderName());
         assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
+        assertEquals(expectedEmailType, email.getType());
     }
 }

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -1,5 +1,7 @@
 package teammates.sqllogic.api;
 
+import java.io.IOException;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AccountRequestStatus;
@@ -8,6 +10,7 @@ import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.test.BaseTestCase;
+import teammates.test.EmailChecker;
 
 /**
  * SUT: {@link SqlEmailGenerator}.
@@ -16,22 +19,38 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
     private final SqlEmailGenerator sqlEmailGenerator = SqlEmailGenerator.inst();
 
     @Test
-    void testGenerateNewAccountRequestAdminAlertEmail_typicalCase_generatesSuccessfully() {
+    void testGenerateNewAccountRequestAdminAlertEmail_withComments_generatesSuccessfully() throws IOException {
         AccountRequest accountRequest = new AccountRequest("chosen-one@jedi.org", "Anakin Skywalker", "Jedi Order",
                 AccountRequestStatus.PENDING,
                 "I don't like sand. It's coarse and rough and irritating... and it gets everywhere.");
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
         verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
-                "TEAMMATES: New Account Request Received");
+                "TEAMMATES: New Account Request Received", "/adminNewAccountRequestAlertEmailWithComments.html");
+    }
+
+    @Test
+    void testGenerateNewAccountRequestAdminAlertEmail_withNoComments_generatesSuccessfully() throws IOException {
+        AccountRequest accountRequest = new AccountRequest("maul@sith.org", "Maul", "Sith Order",
+                AccountRequestStatus.PENDING, null);
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+                "TEAMMATES: New Account Request Received", "/adminNewAccountRequestAlertEmailWithNoComments.html");
     }
 
     private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType,
-            String expectedSubject) {
+            String expectedSubject, String expectedEmailContentFilePathname) throws IOException {
         assertEquals(expectedRecipientEmailAddress, email.getRecipient());
         assertEquals(Config.EMAIL_SENDEREMAIL, email.getSenderEmail());
         assertEquals(Config.EMAIL_SENDERNAME, email.getSenderName());
         assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
         assertEquals(expectedEmailType, email.getType());
         assertEquals(expectedSubject, email.getSubject());
+        String emailContent = email.getContent();
+        EmailChecker.verifyEmailContent(emailContent, expectedEmailContentFilePathname);
+        verifyEmailContentHasNoPlaceholders(emailContent);
+    }
+
+    private void verifyEmailContentHasNoPlaceholders(String emailContent) {
+        assertFalse(emailContent.contains("${"));
     }
 }

--- a/src/test/resources/emails/adminNewAccountRequestAlertEmailWithComments.html
+++ b/src/test/resources/emails/adminNewAccountRequestAlertEmailWithComments.html
@@ -1,0 +1,60 @@
+<p>Hello, Admin</p>
+
+<p>
+  A new instructor account request has been submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Anakin Skywalker
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Jedi Order
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        chosen-one@jedi.org
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        I don't like sand. It's coarse and rough and irritating... and it gets everywhere.
+      </td>
+    </tr>
+  </table>
+</div>
+
+Accept/reject this request on the admin panel: <a href="${app.url}/web/admin/home">${app.url}/web/admin/home</a>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>

--- a/src/test/resources/emails/adminNewAccountRequestAlertEmailWithNoComments.html
+++ b/src/test/resources/emails/adminNewAccountRequestAlertEmailWithNoComments.html
@@ -1,0 +1,60 @@
+<p>Hello, Admin</p>
+
+<p>
+  A new instructor account request has been submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Maul
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Sith Order
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        maul@sith.org
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        
+      </td>
+    </tr>
+  </table>
+</div>
+
+Accept/reject this request on the admin panel: <a href="${app.url}/web/admin/home">${app.url}/web/admin/home</a>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Added the new account request alert email for admins. If `comments` is null, we leave the table entry blank.

The following is a preview of the email template.

![image](https://github.com/TEAMMATES/teammates/assets/65202977/864206f4-dde8-4a85-8947-73c328c1daef)

<!-- The following is a preview of a sample email. -->

<!-- ![image](https://github.com/TEAMMATES/teammates/assets/65202977/a83f3161-07c8-4006-9271-0528e78a2c11) -->
