### PR TITLE
[#12048] fix resetAccountAction

### DIFF
--- a/src/main/java/teammates/ui/webapi/ResetAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/ResetAccountAction.java
@@ -35,12 +35,7 @@ public class ResetAccountAction extends AdminOnlyAction {
                 wrongGoogleId = existingStudent.getGoogleId();
 
                 try {
-                    if (isAccountMigrated(wrongGoogleId)) {
-                        sqlLogic.resetStudentGoogleId(studentEmail, courseId, wrongGoogleId);
-                    } else {
-                        logic.resetStudentGoogleId(studentEmail, courseId);
-                    }
-
+                    sqlLogic.resetStudentGoogleId(studentEmail, courseId, wrongGoogleId);
                     taskQueuer.scheduleCourseRegistrationInviteToStudent(courseId, studentEmail, true);
                 } catch (EntityDoesNotExistException e) {
                     throw new EntityNotFoundException(e);
@@ -55,12 +50,7 @@ public class ResetAccountAction extends AdminOnlyAction {
                 wrongGoogleId = existingInstructor.getGoogleId();
 
                 try {
-                    if (isAccountMigrated(wrongGoogleId)) {
-                        sqlLogic.resetInstructorGoogleId(instructorEmail, courseId, wrongGoogleId);
-                    } else {
-                        logic.resetInstructorGoogleId(instructorEmail, courseId);
-                    }
-
+                    sqlLogic.resetInstructorGoogleId(instructorEmail, courseId, wrongGoogleId);
                     taskQueuer.scheduleCourseRegistrationInviteToInstructor(null, instructorEmail, courseId, true);
                 } catch (EntityDoesNotExistException e) {
                     throw new EntityNotFoundException(e);
@@ -76,12 +66,7 @@ public class ResetAccountAction extends AdminOnlyAction {
                 wrongGoogleId = existingStudent.getGoogleId();
 
                 try {
-                    if (isAccountMigrated(wrongGoogleId)) {
-                        sqlLogic.resetStudentGoogleId(studentEmail, courseId, wrongGoogleId);
-                    } else {
-                        logic.resetStudentGoogleId(studentEmail, courseId);
-                    }
-
+                    logic.resetStudentGoogleId(studentEmail, courseId);
                     taskQueuer.scheduleCourseRegistrationInviteToStudent(courseId, studentEmail, true);
                 } catch (EntityDoesNotExistException e) {
                     throw new EntityNotFoundException(e);
@@ -95,12 +80,7 @@ public class ResetAccountAction extends AdminOnlyAction {
                 wrongGoogleId = existingInstructor.getGoogleId();
 
                 try {
-                    if (isAccountMigrated(wrongGoogleId)) {
-                        sqlLogic.resetInstructorGoogleId(instructorEmail, courseId, wrongGoogleId);
-                    } else {
-                        logic.resetInstructorGoogleId(instructorEmail, courseId);
-                    }
-
+                    logic.resetInstructorGoogleId(instructorEmail, courseId);
                     taskQueuer.scheduleCourseRegistrationInviteToInstructor(null, instructorEmail, courseId, true);
                 } catch (EntityDoesNotExistException e) {
                     throw new EntityNotFoundException(e);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048

**Outline of Solution**
Fix ResetAccountAction

Remove `isAccountMigrated` as all accounts will be migrated
Fix the logic to change it to query SQL if course is migrated and query datastore if not

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
