### PR TITLE
[#12048] Relax read notif verification for migration verification script

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -157,7 +157,7 @@ public class SeedDb extends DatastoreClient {
                 String accountRequestEmail = String.format("Account Email %s", i);
                 String accountRequestInstitute = String.format("Account Institute %s", i);
                 AccountRequest accountRequest = AccountRequestAttributes
-                        .builder(accountRequestName, accountRequestEmail, accountRequestInstitute)
+                        .builder(accountRequestEmail, accountRequestName, accountRequestInstitute)
                         .withRegisteredAt(Instant.now()).build().toEntity();
 
                 String accountGoogleId = String.format("Account Google ID %s", i);

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -157,7 +157,7 @@ public class SeedDb extends DatastoreClient {
                 String accountRequestEmail = String.format("Account Email %s", i);
                 String accountRequestInstitute = String.format("Account Institute %s", i);
                 AccountRequest accountRequest = AccountRequestAttributes
-                        .builder(accountRequestEmail, accountRequestName, accountRequestInstitute)
+                        .builder(accountRequestEmail, accountRequestInstitute, accountRequestName)
                         .withRegisteredAt(Instant.now()).build().toEntity();
 
                 String accountGoogleId = String.format("Account Google ID %s", i);

--- a/src/client/java/teammates/client/scripts/sql/VerifyAccountAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyAccountAttributes.java
@@ -87,18 +87,23 @@ public class VerifyAccountAttributes
             return false;
         }
 
-        Map<String, Instant> datastoreReadNotifications = datastoreEntity.getReadNotifications();
-        List<ReadNotification> sqlReadNotifications = sqlEntity.getReadNotifications();
+        return true;
 
-        List<Instant> datastoreEndTimes = new ArrayList<Instant>(datastoreReadNotifications.values());
-        Collections.sort(datastoreEndTimes);
+        // Not verifying read notification as current datastore implementation does not remove notifications that have been deleted
+        // from account entities. During migration, the notification will not be migrated since it is deleted and read notification will fail
+        // during migration (foreign key error) causing the verification to fail
+        // Map<String, Instant> datastoreReadNotifications = datastoreEntity.getReadNotifications();
+        // List<ReadNotification> sqlReadNotifications = sqlEntity.getReadNotifications();
 
-        List<Instant> sqlEndTimes = new ArrayList<>();
-        for (ReadNotification sqlReadNotification : sqlReadNotifications) {
-            sqlEndTimes.add(sqlReadNotification.getNotification().getEndTime());
-        }
-        Collections.sort(sqlEndTimes);
+        // List<Instant> datastoreEndTimes = new ArrayList<Instant>(datastoreReadNotifications.values());
+        // Collections.sort(datastoreEndTimes);
 
-        return datastoreEndTimes.equals(sqlEndTimes);
+        // List<Instant> sqlEndTimes = new ArrayList<>();
+        // for (ReadNotification sqlReadNotification : sqlReadNotifications) {
+        //     sqlEndTimes.add(sqlReadNotification.getNotification().getEndTime());
+        // }
+        // Collections.sort(sqlEndTimes);
+
+        // return datastoreEndTimes.equals(sqlEndTimes);
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyAccountAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyAccountAttributes.java
@@ -1,12 +1,8 @@
 package teammates.client.scripts.sql;
 
 // CHECKSTYLE.OFF:ImportOrder
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -17,7 +13,6 @@ import jakarta.persistence.criteria.Root;
 
 import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.Account;
-import teammates.storage.sqlentity.ReadNotification;
 
 /**
  * Class for verifying account attributes.
@@ -89,9 +84,11 @@ public class VerifyAccountAttributes
 
         return true;
 
-        // Not verifying read notification as current datastore implementation does not remove notifications that have been deleted
-        // from account entities. During migration, the notification will not be migrated since it is deleted and read notification will fail
-        // during migration (foreign key error) causing the verification to fail
+        // Not verifying read notification as current datastore implementation does not remove notifications
+        // that have been deleted from account entities. During migration, the notification will not be
+        // migrated since it is deleted and read notification will fail during migration (foreign key error)
+        // causing the verification to fail
+
         // Map<String, Instant> datastoreReadNotifications = datastoreEntity.getReadNotifications();
         // List<ReadNotification> sqlReadNotifications = sqlEntity.getReadNotifications();
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048

**Context**
Due to a flaw in the datastore implementation of read notifications, a deleted notification will not be removed from each accounts read notification list. This would cause the verification script to fail as the postgres entity would not have migrated that an account has seen this deleted notification. e.g datastore account has seen deleted notification Y, postgres would not migrate notification Y and therefore not be able to create a foreign key in the read notification table for notification Y.

**Outline of Solution**
- Relax read notification verification by not verifying them but we still migrate any that are seen.
- Fixed incorrect field order for account request in SeedDb (unrelated to problem)

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
