### PR TITLE
[#11878] Create instructor request acknowledgement email

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -125,9 +125,11 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         assertEquals("My road leads into the desert. I can see it.", accountRequest.getComments());
         assertNull(accountRequest.getRegisteredAt());
         verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsSent(2);
         EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
+        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
+        assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -155,9 +155,11 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         assertNull(accountRequest.getComments());
         assertNull(accountRequest.getRegisteredAt());
         verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsSent(2);
         EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
+        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
+        assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }
 
     @Test
@@ -188,9 +190,11 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         assertEquals("My road leads into the desert. I can see it.", accountRequest.getComments());
         assertNull(accountRequest.getRegisteredAt());
         verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsSent(2);
         EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
+        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
+        assertEquals(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }
 
     @Override

--- a/src/main/java/teammates/common/util/EmailType.java
+++ b/src/main/java/teammates/common/util/EmailType.java
@@ -24,6 +24,7 @@ public enum EmailType {
     STUDENT_COURSE_JOIN("TEAMMATES: Invitation to join course [%s][Course ID: %s]"),
     STUDENT_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
     NEW_ACCOUNT_REQUEST_ADMIN_ALERT("TEAMMATES (Action Needed): New Account Request Received"),
+    NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT("TEAMMATES: Acknowledgement of Instructor Account Request"),
     INSTRUCTOR_COURSE_JOIN("TEAMMATES: Invitation to join course as an instructor [%s][Course ID: %s]"),
     INSTRUCTOR_COURSE_REJOIN_AFTER_GOOGLE_ID_RESET("TEAMMATES: Your account has been reset for course [%s][Course ID: %s]"),
     USER_COURSE_REGISTER("TEAMMATES: Registered for Course [%s][Course ID: %s]"),

--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -34,6 +34,8 @@ public final class Templates {
     public static class EmailTemplates {
         public static final String ADMIN_NEW_ACCOUNT_REQUEST_ALERT =
                 FileHelper.readResourceFile("adminEmailTemplate-newAccountRequestAlert.html");
+        public static final String INSTRUCTOR_NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT =
+                FileHelper.readResourceFile("instructorEmailTemplate-newAccountRequestAcknowledgement.html");
         public static final String USER_COURSE_JOIN =
                 FileHelper.readResourceFile("userEmailTemplate-courseJoin.html");
         public static final String USER_COURSE_REGISTER =

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -1017,6 +1017,7 @@ public final class SqlEmailGenerator {
                 "${institute}", institute,
                 "${emailAddress}", emailAddress,
                 "${comments}", comments,
+                "${supportEmail}", Config.SUPPORT_EMAIL,
         };
         String content = Templates.populateTemplate(
                 EmailTemplates.INSTRUCTOR_NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, templateKeyValuePairs);

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -1021,7 +1021,7 @@ public final class SqlEmailGenerator {
         };
         String content = Templates.populateTemplate(
                 EmailTemplates.INSTRUCTOR_NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, templateKeyValuePairs);
-        EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
+        EmailWrapper email = getEmptyEmailAddressedToEmail(emailAddress);
         email.setType(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT);
         email.setSubjectFromType();
         email.setContent(content);

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -1005,10 +1005,10 @@ public final class SqlEmailGenerator {
      * Generates the acknowledgement email to be sent to the person who submitted {@code accountRequest}.
      */
     public EmailWrapper generateNewAccountRequestAcknowledgementEmail(AccountRequest accountRequest) {
-        String name = accountRequest.getName();
-        String institute = accountRequest.getInstitute();
-        String emailAddress = accountRequest.getEmail();
-        String comments = accountRequest.getComments();
+        String name = SanitizationHelper.sanitizeForHtml(accountRequest.getName());
+        String institute = SanitizationHelper.sanitizeForHtml(accountRequest.getInstitute());
+        String emailAddress = SanitizationHelper.sanitizeForHtml(accountRequest.getEmail());
+        String comments = SanitizationHelper.sanitizeForHtml(accountRequest.getComments());
         if (comments == null) {
             comments = "";
         }

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -1023,6 +1023,7 @@ public final class SqlEmailGenerator {
                 EmailTemplates.INSTRUCTOR_NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, templateKeyValuePairs);
         EmailWrapper email = getEmptyEmailAddressedToEmail(emailAddress);
         email.setType(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT);
+        email.setBcc(Config.SUPPORT_EMAIL);
         email.setSubjectFromType();
         email.setContent(content);
         return email;

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -1002,6 +1002,32 @@ public final class SqlEmailGenerator {
     }
 
     /**
+     * Generates the acknowledgement email to be sent to the person who submitted {@code accountRequest}.
+     */
+    public EmailWrapper generateNewAccountRequestAcknowledgementEmail(AccountRequest accountRequest) {
+        String name = accountRequest.getName();
+        String institute = accountRequest.getInstitute();
+        String emailAddress = accountRequest.getEmail();
+        String comments = accountRequest.getComments();
+        if (comments == null) {
+            comments = "";
+        }
+        String[] templateKeyValuePairs = new String[] {
+                "${name}", name,
+                "${institute}", institute,
+                "${emailAddress}", emailAddress,
+                "${comments}", comments,
+        };
+        String content = Templates.populateTemplate(
+                EmailTemplates.INSTRUCTOR_NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT, templateKeyValuePairs);
+        EmailWrapper email = getEmptyEmailAddressedToEmail(Config.SUPPORT_EMAIL);
+        email.setType(EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT);
+        email.setSubjectFromType();
+        email.setContent(content);
+        return email;
+    }
+
+    /**
      * Generates the course registered email for the user with the given details in {@code course}.
      */
     public EmailWrapper generateUserCourseRegisteredEmail(

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -47,7 +47,10 @@ public class CreateAccountRequestAction extends Action {
 
         assert accountRequest != null;
         EmailWrapper adminAlertEmail = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        EmailWrapper userAcknowledgementEmail = sqlEmailGenerator
+                .generateNewAccountRequestAcknowledgementEmail(accountRequest);
         emailSender.sendEmail(adminAlertEmail);
+        emailSender.sendEmail(userAcknowledgementEmail);
         AccountRequestData output = new AccountRequestData(accountRequest);
         return new JsonResult(output);
     }

--- a/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
+++ b/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
@@ -56,7 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at ${supportEmail}. 
+  If you have any additional queries, please feel free to contact us at ${supportEmail}.
 </p>
 
 <p>

--- a/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
+++ b/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
@@ -1,0 +1,66 @@
+<p>Hello, ${name}</p>
+
+<p>
+  Thank you for submitting an account request. This is what you have submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${name}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Country & Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${institute}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${emailAddress}
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Home Page URL<br>& Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${comments}
+      </td>
+    </tr>
+  </table>
+</div>
+
+<p>
+  Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
+</p>
+<p>
+  If you have any additional queries, please feel free to contact us at
+  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+</p>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>

--- a/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
+++ b/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
@@ -56,8 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at
-  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+  If you have any additional queries, please feel free to contact us at ${supportEmail}. 
 </p>
 
 <p>

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -47,6 +47,7 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
         verifyEmail(email, "darth-vader@sith.org", EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
+                Config.SUPPORT_EMAIL,
                 "/instructorNewAccountRequestAcknowledgementEmailWithComments.html");
     }
 
@@ -57,6 +58,7 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
         verifyEmail(email, "maul@sith.org", EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
+                Config.SUPPORT_EMAIL,
                 "/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html");
     }
 
@@ -68,6 +70,20 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
         assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
         assertEquals(expectedEmailType, email.getType());
         assertEquals(expectedSubject, email.getSubject());
+        String emailContent = email.getContent();
+        EmailChecker.verifyEmailContent(emailContent, expectedEmailContentFilePathname);
+        verifyEmailContentHasNoPlaceholders(emailContent);
+    }
+
+    private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType,
+            String expectedSubject, String expectedBcc, String expectedEmailContentFilePathname) throws IOException {
+        assertEquals(expectedRecipientEmailAddress, email.getRecipient());
+        assertEquals(Config.EMAIL_SENDEREMAIL, email.getSenderEmail());
+        assertEquals(Config.EMAIL_SENDERNAME, email.getSenderName());
+        assertEquals(Config.EMAIL_REPLYTO, email.getReplyTo());
+        assertEquals(expectedEmailType, email.getType());
+        assertEquals(expectedSubject, email.getSubject());
+        assertEquals(expectedBcc, email.getBcc());
         String emailContent = email.getContent();
         EmailChecker.verifyEmailContent(emailContent, expectedEmailContentFilePathname);
         verifyEmailContentHasNoPlaceholders(emailContent);

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -44,8 +44,8 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
         AccountRequest accountRequest = new AccountRequest("darth-vader@sith.org", "Darth Vader", "Sith Order",
                 AccountRequestStatus.PENDING,
                 "I Am Your Father");
-        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
                 "/instructorNewAccountRequestAcknowledgementEmailWithComments.html");
     }
@@ -54,8 +54,8 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
     void testGenerateNewAccountRequestAcknowledgementEmail_withNoComments_generatesSuccessfully() throws IOException {
         AccountRequest accountRequest = new AccountRequest("maul@sith.org", "Maul", "Sith Order",
                 AccountRequestStatus.PENDING, null);
-        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
                 "/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html");
     }

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -45,7 +45,7 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 AccountRequestStatus.PENDING,
                 "I Am Your Father");
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
+        verifyEmail(email, "darth-vader@sith.org", EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
                 "/instructorNewAccountRequestAcknowledgementEmailWithComments.html");
     }
@@ -55,7 +55,7 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
         AccountRequest accountRequest = new AccountRequest("maul@sith.org", "Maul", "Sith Order",
                 AccountRequestStatus.PENDING, null);
         EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAcknowledgementEmail(accountRequest);
-        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
+        verifyEmail(email, "maul@sith.org", EmailType.NEW_ACCOUNT_REQUEST_ACKNOWLEDGEMENT,
                 "TEAMMATES: Acknowledgement of Instructor Account Request",
                 "/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html");
     }

--- a/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
+++ b/src/test/java/teammates/sqllogic/api/SqlEmailGeneratorTest.java
@@ -39,6 +39,27 @@ public class SqlEmailGeneratorTest extends BaseTestCase {
                 "/adminNewAccountRequestAlertEmailWithNoComments.html");
     }
 
+    @Test
+    void testGenerateNewAccountRequestAcknowledgementEmail_withComments_generatesSuccessfully() throws IOException {
+        AccountRequest accountRequest = new AccountRequest("darth-vader@sith.org", "Darth Vader", "Sith Order",
+                AccountRequestStatus.PENDING,
+                "I Am Your Father");
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+                "TEAMMATES: Acknowledgement of Instructor Account Request",
+                "/instructorNewAccountRequestAcknowledgementEmailWithComments.html");
+    }
+
+    @Test
+    void testGenerateNewAccountRequestAcknowledgementEmail_withNoComments_generatesSuccessfully() throws IOException {
+        AccountRequest accountRequest = new AccountRequest("maul@sith.org", "Maul", "Sith Order",
+                AccountRequestStatus.PENDING, null);
+        EmailWrapper email = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+        verifyEmail(email, Config.SUPPORT_EMAIL, EmailType.NEW_ACCOUNT_REQUEST_ADMIN_ALERT,
+                "TEAMMATES: Acknowledgement of Instructor Account Request",
+                "/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html");
+    }
+
     private void verifyEmail(EmailWrapper email, String expectedRecipientEmailAddress, EmailType expectedEmailType,
             String expectedSubject, String expectedEmailContentFilePathname) throws IOException {
         assertEquals(expectedRecipientEmailAddress, email.getRecipient());

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -1,0 +1,66 @@
+<p>Hello, Darth Vader</p>
+
+<p>
+  Thank you for submitting an account request. This is what you have submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Darth Vader
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Country & Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Sith Order
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        darth-vader@sith.org
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Home Page URL<br>& Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        
+      </td>
+    </tr>
+  </table>
+</div>
+
+<p>
+  Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
+</p>
+<p>
+  If you have any additional queries, please feel free to contact us at
+  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+</p>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -56,7 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at app_admin@gmail.com.
+  If you have any additional queries, please feel free to contact us at ${support.email}.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -46,7 +46,7 @@
         </strong>
       </td>
       <td style="padding:5px;">
-        
+        I Am Your Father
       </td>
     </tr>
   </table>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -56,8 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at
-  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+  If you have any additional queries, please feel free to contact us at teammates@comp.nus.edu.sg.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -56,7 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at teammates@comp.nus.edu.sg.
+  If you have any additional queries, please feel free to contact us at app_admin@gmail.com.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -46,7 +46,7 @@
         </strong>
       </td>
       <td style="padding:5px;">
-        ${comments}
+        
       </td>
     </tr>
   </table>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -1,0 +1,66 @@
+<p>Hello, Maul</p>
+
+<p>
+  Thank you for submitting an account request. This is what you have submitted:
+</p>
+
+<div>
+  <table style="max-width:600px;border:1px solid black;">
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Full Name
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Maul
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Country & Institute
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        Sith Order
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Email Address
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        maul@sith.org
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:5px;">
+        <strong>
+          Home Page URL<br>& Comments
+        </strong>
+      </td>
+      <td style="padding:5px;">
+        ${comments}
+      </td>
+    </tr>
+  </table>
+</div>
+
+<p>
+  Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
+</p>
+<p>
+  If you have any additional queries, please feel free to contact us at
+  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+</p>
+
+<p>
+  Regards,<br>
+  TEAMMATES Team.
+</p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -56,7 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at app_admin@gmail.com.
+  If you have any additional queries, please feel free to contact us at ${support.email}.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -56,8 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at
-  <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a>.
+  If you have any additional queries, please feel free to contact us at teammates@comp.nus.edu.sg.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -56,7 +56,7 @@
   Your request will be reviewed within 24 hours. We will send another email once your request has been accepted.
 </p>
 <p>
-  If you have any additional queries, please feel free to contact us at teammates@comp.nus.edu.sg.
+  If you have any additional queries, please feel free to contact us at app_admin@gmail.com.
 </p>
 
 <p>


### PR DESCRIPTION
Part of #11878

**Outline of Solution**
* Add acknowledgement email to be sent to users who fill in the instructor request form (similar to admin alert email)
* Add test cases
Preview of email format:
<img width="501" alt="image" src="https://github.com/TEAMMATES/teammates/assets/40383042/bc83f46a-afc1-4663-937b-ad891c531802">
