### PR TITLE
[#11878] Foundation for getting by ID in account request endpoints

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -122,6 +122,8 @@ public final class Const {
         public static final String INSTRUCTOR_INSTITUTION = "instructorinstitution";
         public static final String IS_CREATING_ACCOUNT = "iscreatingaccount";
         public static final String IS_INSTRUCTOR = "isinstructor";
+
+        public static final String ACCOUNT_REQUEST_ID = "id";
         public static final String ACCOUNT_REQUEST_STATUS = "status";
 
         public static final String FEEDBACK_SESSION_NAME = "fsname";

--- a/src/web/app/components/account-requests-table/account-request-table-model.ts
+++ b/src/web/app/components/account-requests-table/account-request-table-model.ts
@@ -2,6 +2,7 @@
  * Model for the row entries in the account requests table.
  */
 export interface AccountRequestTableRowModel {
+    id: string;
     name: string;
     email: string;
     status: string;

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -253,6 +253,7 @@ export class AdminHomePageComponent implements OnInit {
     const timezone: string = this.timezoneService.guessTimezone() || 'UTC';
     return requests.accountRequests.map((request) => {
       return {
+        id: request.id,
         name: request.name,
         email: request.email,
         status: request.status,

--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
@@ -70,6 +70,7 @@ const DEFAULT_INSTRUCTOR_SEARCH_RESULT: InstructorAccountSearchResult = {
 };
 
 const DEFAULT_ACCOUNT_REQUEST_SEARCH_RESULT: AccountRequestTableRowModel = {
+  id: '132efa02-b208-4195-a262-a8eae25ceb95',
   name: 'name',
   email: 'email',
   instituteAndCountry: 'institute',
@@ -239,6 +240,7 @@ describe('AdminSearchPageComponent', () => {
   it('should snap with an expanded account requests table', () => {
     component.accountRequests = [
       {
+        id: '132efa02-b208-4195-a262-a8eae25ceb95',
         name: 'name',
         email: 'email',
         instituteAndCountry: 'institute',
@@ -411,6 +413,7 @@ describe('AdminSearchPageComponent', () => {
   it('should display account request results', () => {
     const accountRequestResults: AccountRequestTableRowModel[] = [
       {
+        id: '132efa02-b208-4195-a262-a8eae25ceb95',
         name: 'name1',
         email: 'email1',
         instituteAndCountry: 'institute1',
@@ -421,6 +424,7 @@ describe('AdminSearchPageComponent', () => {
         showLinks: false,
         comments: '',
       }, {
+        id: '132efa02-b208-4195-a262-a8eae25ceb95',
         name: 'name2',
         email: 'email2',
         instituteAndCountry: 'institute2',

--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.ts
@@ -114,6 +114,7 @@ export class AdminSearchPageComponent {
   private formatAccountRequests(accountRequests: AccountRequestSearchResult[]): AccountRequestTableRowModel[] {
     return accountRequests.map((accountRequest: AccountRequestSearchResult): AccountRequestTableRowModel => {
       return {
+        id: accountRequest.id,
         name: accountRequest.name,
         email: accountRequest.email,
         status: accountRequest.status,

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -185,7 +185,7 @@ describe('SearchService', () => {
   };
 
   const mockAccountRequest: AccountRequest = {
-    id: 'test@example.com%Test Institute',
+    id: '132efa02-b208-4195-a262-a8eae25ceb95',
     registrationKey: 'regkey',
     createdAt: 1585487897502,
     name: 'Test Instructor',
@@ -305,6 +305,7 @@ describe('SearchService', () => {
     };
     const result: AccountRequestSearchResult = service.joinAdminAccountRequest(accountRequest);
 
+    expect(result.id).toBe('132efa02-b208-4195-a262-a8eae25ceb95');
     expect(result.email).toBe('test@example.com');
     expect(result.institute).toBe('Test Institute');
     expect(result.name).toBe('Test Instructor');

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -299,6 +299,7 @@ export class SearchService {
 
   joinAdminAccountRequest(accountRequest: AccountRequest): AccountRequestSearchResult {
     let accountRequestResult: AccountRequestSearchResult = {
+      id: '',
       name: '',
       email: '',
       institute: '',
@@ -311,7 +312,7 @@ export class SearchService {
     };
 
     const {
-      registrationKey, createdAt, registeredAt,
+      id, registrationKey, createdAt, registeredAt,
       name, institute, email, status, comments,
     }: AccountRequest = accountRequest;
 
@@ -321,7 +322,7 @@ export class SearchService {
     accountRequestResult.comments = comments || '';
 
     const registrationLink: string = this.linkService.generateAccountRegistrationLink(registrationKey);
-    accountRequestResult = { ...accountRequestResult, name, email, institute, registrationLink, status };
+    accountRequestResult = { ...accountRequestResult, id, name, email, institute, registrationLink, status };
 
     return accountRequestResult;
   }
@@ -470,6 +471,7 @@ export interface AdminSearchResult {
  * Search results for account requests from the admin endpoint.
  */
 export interface AccountRequestSearchResult {
+  id: string;
   name: string;
   email: string;
   status: string;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

This is needed for a number of account request API endpoints.

- Added account request ID query parameter
- Added ID in
  - `AccountRequestTableRowModel`
    - This is necessary so that we can pass the ID as the query parameter for API endpoints.
  - `AccountRequestSearchResult`
    - This is necessary so that we can pass the ID into `AccountRequestTableRowModel`.