### PR TITLE
[#12048] Fix account request indexing

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -1,10 +1,12 @@
 package teammates.it.ui.webapi;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
+import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.ui.output.JoinLinkData;
 import teammates.ui.request.AccountCreateRequest;
@@ -26,6 +28,13 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         return POST;
     }
 
+    @BeforeMethod
+    @Override
+    protected void setUp() {
+        // CreateAccountRequestAction handles its own transactions;
+        // There is thus no need to setup a transaction.
+    }
+
     @Override
     @Test
     protected void testExecute() throws Exception {
@@ -37,7 +46,9 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         CreateAccountRequestAction action = getAction(request);
         JsonResult result = getJsonResult(action);
         JoinLinkData output = (JoinLinkData) result.getOutput();
+        HibernateUtil.beginTransaction();
         AccountRequest accountRequest = logic.getAccountRequest("ring-bearer@fellowship.net", "The Fellowship of the Ring");
+        HibernateUtil.commitTransaction();
         assertEquals("ring-bearer@fellowship.net", accountRequest.getEmail());
         assertEquals("Frodo Baggins", accountRequest.getName());
         assertEquals("The Fellowship of the Ring", accountRequest.getInstitute());

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -228,10 +228,8 @@ public class TaskQueuer {
         paramMap.put(ParamsNames.INSTRUCTOR_EMAIL, email);
         paramMap.put(ParamsNames.INSTRUCTOR_INSTITUTION, institute);
 
-        // TODO: change the action CreateAccountRequestAction to call scheduleAccountRequestForSearchIndexing
-        // after AccountRequest is inserted in the DB
-        addDeferredTask(TaskQueue.SEARCH_INDEXING_QUEUE_NAME, TaskQueue.ACCOUNT_REQUEST_SEARCH_INDEXING_WORKER_URL,
-                paramMap, null, 60);
+        addTask(TaskQueue.SEARCH_INDEXING_QUEUE_NAME, TaskQueue.ACCOUNT_REQUEST_SEARCH_INDEXING_WORKER_URL,
+                paramMap, null);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -3,6 +3,7 @@ package teammates.logic.api;
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.util.Config;
+import teammates.common.util.HibernateUtil;
 import teammates.logic.core.InstructorsLogic;
 import teammates.logic.core.StudentsLogic;
 import teammates.sqllogic.core.UsersLogic;
@@ -46,6 +47,16 @@ public class UserProvision {
                 || studentsLogic.isStudentInAnyCourse(userId);
         user.isMaintainer = Config.APP_MAINTAINERS.contains(user.getId());
         return user;
+    }
+
+    /**
+     * Gets the information of the current logged in user, with an SQL transaction.
+     */
+    public UserInfo getCurrentUserWithTransaction(UserInfoCookie uic) {
+        HibernateUtil.beginTransaction();
+        UserInfo userInfo = getCurrentUser(uic);
+        HibernateUtil.commitTransaction();
+        return userInfo;
     }
 
     // TODO: method visibility to package-private after migration

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -95,6 +95,19 @@ public class Logic {
     }
 
     /**
+     * Creates a or gets an account request.
+     *
+     * @return newly created account request.
+     * @throws InvalidParametersException if the account request details are invalid.
+     * @throws EntityAlreadyExistsException if the account request already exists.
+     */
+    public AccountRequest createAccountRequestWithTransaction(String name, String email, String institute)
+            throws InvalidParametersException {
+
+        return accountRequestLogic.createOrGetAccountRequestWithTransaction(name, email, institute);
+    }
+
+    /**
      * Gets the account request with the given email and institute.
      *
      * @return account request with the given email and institute.

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -136,15 +136,10 @@ public class WebApiServlet extends HttpServlet {
 
     private ActionResult executeWithoutTransaction(Action action, HttpServletRequest req)
             throws InvalidOperationException, InvalidHttpRequestBodyException, UnauthorizedAccessException {
-        try {
-            action.init(req);
-            action.checkAccessControl();
+        action.init(req);
+        action.checkAccessControl();
 
-            ActionResult result = action.execute();
-            return result;
-        } catch (Exception e) {
-            throw e;
-        }
+        return action.execute();
     }
 
     private void throwErrorBasedOnRequester(HttpServletRequest req, HttpServletResponse resp, Exception e, int statusCode)

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -216,7 +216,11 @@ public abstract class Action {
         } else {
             String cookie = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.AUTH_COOKIE_NAME);
             UserInfoCookie uic = UserInfoCookie.fromCookie(cookie);
-            userInfo = userProvision.getCurrentUser(uic);
+            if (isTransactionNeeded()) {
+                userInfo = userProvision.getCurrentUser(uic);
+            } else {
+                userInfo = userProvision.getCurrentUserWithTransaction(uic);
+            }
         }
 
         authType = userInfo == null ? AuthType.PUBLIC : AuthType.LOGGED_IN;
@@ -478,6 +482,14 @@ public abstract class Action {
                             Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS));
         }
         return privilege;
+    }
+
+    /**
+     * Checks if the action requires a SQL transaction when executed.
+     * If false, the action will have to handle its own SQL transactions.
+     */
+    public boolean isTransactionNeeded() {
+        return true;
     }
 
     /**


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048

**Outline of Solution**
Account request was not indexing due to a race condition: the account request was not in the database before indexing, as the transaction was not committed.
This PR allows CreateAccountRequestAction to handle its own transactions and queues the indexing action after the AccountRequestCreation is commited.

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
