### PR TITLE
[#11878] Change institute length limit

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -46,7 +46,7 @@ public final class FieldValidator {
     public static final int SECTION_NAME_MAX_LENGTH = 60;
 
     public static final String INSTITUTE_NAME_FIELD_NAME = "institute name";
-    public static final int INSTITUTE_NAME_MAX_LENGTH = 64;
+    public static final int INSTITUTE_NAME_MAX_LENGTH = 128;
 
     // email-related
     public static final String EMAIL_FIELD_NAME = "email";

--- a/src/test/java/teammates/common/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/common/util/FieldValidatorTest.java
@@ -210,11 +210,12 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidInstituteName = StringHelperExtension.generateStringOfLength(
                                                                 FieldValidator.INSTITUTE_NAME_MAX_LENGTH + 1);
         String actual = FieldValidator.getInvalidityInfoForInstituteName(invalidInstituteName);
+        String expectedTemplate = "\"%s\" is not "
+                + "acceptable to TEAMMATES as a/an institute name because it is too long. The value "
+                + "of a/an institute name should be no longer than 128 characters. It should not be empty.";
+        String expected = String.format(expectedTemplate, invalidInstituteName);
         assertEquals("Invalid institute name (too long) should return error message that is specific to institute name",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not "
-                         + "acceptable to TEAMMATES as a/an institute name because it is too long. The value "
-                         + "of a/an institute name should be no longer than 64 characters. It should not be empty.",
-                     actual);
+                expected, actual);
     }
 
     @Test


### PR DESCRIPTION
Part of #11878

**Outline of Solution**
* Change `INSTITUTE_NAME_MAX_LENGTH` to 128 to accommodate longer institution names. (No need to modify DB as the relevant columns are `varchar(255)`)