### PR TITLE
[#11878] Create Update Account Request Action

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -1,5 +1,8 @@
 package teammates.it.ui.webapi;
 
+import java.util.List;
+
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -221,4 +224,16 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         verifyAccessibleWithoutLogin();
     }
 
+    @Override
+    @AfterMethod
+    protected void tearDown() {
+        HibernateUtil.beginTransaction();
+        List<AccountRequest> accountRequests = logic.getPendingAccountRequests();
+        for (AccountRequest ar : accountRequests) {
+            logic.deleteAccountRequest(ar.getEmail(), ar.getInstitute());
+        }
+        accountRequests = logic.getPendingAccountRequests();
+        HibernateUtil.commitTransaction();
+        assert accountRequests.isEmpty();
+    }
 }

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -49,14 +49,13 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
     @Test
     public void testExecute() throws Exception {
         ______TS("edit fields of an account request");
-        AccountRequest accountRequest = typicalBundle.accountRequests.get("instructor1");
+        AccountRequest accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor1");
         UUID id = accountRequest.getId();
         String name = "newName";
         String email = "newEmail@email.com";
         String institute = "newInstitute";
         String comments = "newComments";
-        AccountRequestStatus status = accountRequest.getStatus() == null
-                ? AccountRequestStatus.PENDING : accountRequest.getStatus();
+        AccountRequestStatus status = accountRequest.getStatus();
 
         AccountRequestUpdateRequest requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
         String[] params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -76,6 +76,7 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
 
         ______TS("approve a pending account request");
         accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor2");
+        assertEquals(AccountRequestStatus.PENDING, accountRequest.getStatus());
         requestBody = new AccountRequestUpdateRequest(accountRequest.getName(), accountRequest.getEmail(),
                 accountRequest.getInstitute(), AccountRequestStatus.APPROVED, accountRequest.getComments());
         params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.getId().toString()};

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -50,6 +50,7 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
     public void testExecute() throws Exception {
         ______TS("edit fields of an account request");
         AccountRequest accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor1");
+        accountRequest.setStatus(AccountRequestStatus.PENDING);
         UUID id = accountRequest.getId();
         String name = "newName";
         String email = "newEmail@email.com";
@@ -75,7 +76,7 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
 
         ______TS("approve a pending account request");
         accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor2");
-        assertEquals(AccountRequestStatus.PENDING, accountRequest.getStatus());
+        accountRequest.setStatus(AccountRequestStatus.PENDING);
         requestBody = new AccountRequestUpdateRequest(accountRequest.getName(), accountRequest.getEmail(),
                 accountRequest.getInstitute(), AccountRequestStatus.APPROVED, accountRequest.getComments());
         params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.getId().toString()};
@@ -176,6 +177,19 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
         ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
 
         assertEquals("email cannot be null", ihrbe.getMessage());
+
+        ______TS("allow null comments in request");
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, status, null);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        action = getAction(requestBody, params);
+        result = getJsonResult(action, 200);
+        data = (AccountRequestData) result.getOutput();
+
+        assertEquals(name, data.getName());
+        assertEquals(email, data.getEmail());
+        assertEquals(institute, data.getInstitute());
+        assertEquals(null, data.getComments());
     }
 
     @Override

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -130,7 +130,7 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
         accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor1");
         id = accountRequest.getId();
         email = "newEmail";
-        status = accountRequest.getStatus() == null ? AccountRequestStatus.PENDING : accountRequest.getStatus();
+        status = accountRequest.getStatus();
 
         requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
         params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -15,9 +15,9 @@ import teammates.common.util.StringHelperExtension;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.ui.output.AccountRequestData;
-import teammates.ui.output.MessageOutput;
 import teammates.ui.request.AccountRequestUpdateRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.webapi.EntityNotFoundException;
 import teammates.ui.webapi.InvalidHttpParameterException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UpdateAccountRequestAction;
@@ -113,11 +113,9 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
         String validUuid = UUID.randomUUID().toString();
         params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, validUuid};
 
-        action = getAction(requestBody, params);
-        result = getJsonResult(action, 404);
+        EntityNotFoundException enfe = verifyEntityNotFound(requestBody, params);
 
-        assertEquals(String.format("Account request with id = %s not found", validUuid),
-                ((MessageOutput) result.getOutput()).getMessage());
+        assertEquals(String.format("Account request with id = %s not found", validUuid), enfe.getMessage());
 
         ______TS("invalid uuid");
         requestBody = new AccountRequestUpdateRequest("name", "email",

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -1,0 +1,169 @@
+package teammates.it.ui.webapi;
+
+import java.util.UUID;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.AccountRequestStatus;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.common.util.FieldValidator;
+import teammates.common.util.HibernateUtil;
+import teammates.common.util.StringHelperExtension;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.storage.sqlentity.Course;
+import teammates.ui.output.AccountRequestData;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.request.AccountRequestUpdateRequest;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.webapi.InvalidHttpParameterException;
+import teammates.ui.webapi.JsonResult;
+import teammates.ui.webapi.UpdateAccountRequestAction;
+
+/**
+ * SUT: {@link UpdateAccountRequestAction}.
+ */
+public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequestAction> {
+
+    @Override
+    @BeforeMethod
+    protected void setUp() throws Exception {
+        super.setUp();
+        persistDataBundle(typicalBundle);
+        HibernateUtil.flushSession();
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.ACCOUNT_REQUEST;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return PUT;
+    }
+
+    @Override
+    @Test
+    public void testExecute() throws Exception {
+        ______TS("edit fields of an account request");
+        AccountRequest accountRequest = typicalBundle.accountRequests.get("instructor1");
+        UUID id = accountRequest.getId();
+        String name = "newName";
+        String email = "newEmail@email.com";
+        String institute = "newInstitute";
+        String comments = "newComments";
+        AccountRequestStatus status = accountRequest.getStatus() == null
+                ? AccountRequestStatus.PENDING : accountRequest.getStatus();
+
+        AccountRequestUpdateRequest requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
+        String[] params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        UpdateAccountRequestAction action = getAction(requestBody, params);
+        JsonResult result = action.execute();
+
+        assertEquals(result.getStatusCode(), 200);
+        AccountRequestData data = (AccountRequestData) result.getOutput();
+
+        assertEquals(data.getName(), name);
+        assertEquals(data.getEmail(), email);
+        assertEquals(data.getInstitute(), institute);
+        assertEquals(data.getStatus(), status);
+        assertEquals(data.getComments(), comments);
+        verifyNoEmailsSent();
+
+        ______TS("approve account request");
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, AccountRequestStatus.APPROVED, comments);
+        action = getAction(requestBody, params);
+        result = getJsonResult(action, 200);
+        data = (AccountRequestData) result.getOutput();
+
+        assertEquals(data.getName(), name);
+        assertEquals(data.getEmail(), email);
+        assertEquals(data.getInstitute(), institute);
+        assertEquals(data.getStatus(), AccountRequestStatus.APPROVED);
+        assertEquals(data.getComments(), comments);
+        verifyNumberOfEmailsSent(1);
+
+        ______TS("non-existent but valid uuid");
+        requestBody = new AccountRequestUpdateRequest("name", "email",
+                "institute", AccountRequestStatus.PENDING, "comments");
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, "63338e93-db1e-474d-9207-ea7cd3ddd491"};
+
+        action = getAction(requestBody, params);
+        result = getJsonResult(action, 404);
+
+        assertEquals("Account request not found", ((MessageOutput) result.getOutput()).getMessage());
+
+        ______TS("invalid uuid");
+        requestBody = new AccountRequestUpdateRequest("name", "email",
+                "institute", AccountRequestStatus.PENDING, "comments");
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, "invalid"};
+
+        InvalidHttpParameterException ihpe = verifyHttpParameterFailure(requestBody, params);
+
+        assertEquals("Invalid UUID string: invalid", ihpe.getMessage());
+
+        ______TS("invalid email");
+        accountRequest = typicalBundle.accountRequests.get("unregisteredInstructor1");
+        id = accountRequest.getId();
+        name = "newName";
+        email = "newEmail";
+        institute = "newInstitute";
+        comments = "newComments";
+        status = accountRequest.getStatus() == null ? AccountRequestStatus.PENDING : accountRequest.getStatus();
+
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        InvalidHttpRequestBodyException ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals(getPopulatedErrorMessage(FieldValidator.EMAIL_ERROR_MESSAGE, email,
+                FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT, FieldValidator.EMAIL_MAX_LENGTH),
+                ihrbe.getMessage());
+
+        ______TS("invalid name alphanumeric");
+        name = "@$@#$#@#@$#@$";
+        email = "newEmail@email.com";
+
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals(getPopulatedErrorMessage(FieldValidator.INVALID_NAME_ERROR_MESSAGE, name,
+                FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_START_WITH_NON_ALPHANUMERIC_CHAR),
+                ihrbe.getMessage());
+
+        ______TS("invalid name too long");
+        name = StringHelperExtension.generateStringOfLength(FieldValidator.PERSON_NAME_MAX_LENGTH + 1);
+
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, name,
+                FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
+                FieldValidator.PERSON_NAME_MAX_LENGTH), ihrbe.getMessage());
+
+        ______TS("null param");
+        name = "newName";
+
+        requestBody = new AccountRequestUpdateRequest(name, null, institute, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals("email cannot be null", ihrbe.getMessage());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws InvalidParametersException, EntityAlreadyExistsException {
+        Course course = typicalBundle.courses.get("course1");
+        verifyOnlyAdminCanAccess(course);
+    }
+}

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -168,7 +168,7 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
                 FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                 FieldValidator.PERSON_NAME_MAX_LENGTH), ihrbe.getMessage());
 
-        ______TS("null update value");
+        ______TS("null email value");
         name = "newName";
 
         requestBody = new AccountRequestUpdateRequest(name, null, institute, status, comments);
@@ -177,6 +177,30 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
         ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
 
         assertEquals("email cannot be null", ihrbe.getMessage());
+
+        ______TS("null name value");
+        requestBody = new AccountRequestUpdateRequest(null, email, institute, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals("name cannot be null", ihrbe.getMessage());
+
+        ______TS("null status value");
+        requestBody = new AccountRequestUpdateRequest(name, email, institute, null, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals("status cannot be null", ihrbe.getMessage());
+
+        ______TS("null institute value");
+        requestBody = new AccountRequestUpdateRequest(name, email, null, status, comments);
+        params = new String[] {Const.ParamsNames.ACCOUNT_REQUEST_ID, id.toString()};
+
+        ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
+
+        assertEquals("institute cannot be null", ihrbe.getMessage());
 
         ______TS("allow null comments in request");
         requestBody = new AccountRequestUpdateRequest(name, email, institute, status, null);

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -73,8 +73,7 @@
       "name": "Instructor 1",
       "email": "instr1@teammates.tmt",
       "institute": "TEAMMATES Test Institute 1",
-      "registeredAt": "2010-02-14T00:00:00Z",
-      "status": "REGISTERED"
+      "registeredAt": "2010-02-14T00:00:00Z"
     },
     "instructor2": {
       "id": "00000000-0000-4000-8000-000000000102",
@@ -138,7 +137,9 @@
       "name": "Unregistered Instructor 1",
       "email": "unregisteredinstructor1@gmail.tmt",
       "institute": "TEAMMATES Test Institute 1",
-      "createdAt": "2011-01-01T00:00:00Z"
+      "createdAt": "2011-01-01T00:00:00Z",
+      "status": "PENDING",
+      "comments": "Test"
     },
     "unregisteredInstructor2": {
       "name": "Unregistered Instructor 2",
@@ -146,7 +147,7 @@
       "institute": "TEAMMATES Test Institute 2",
       "createdAt": "2011-01-01T00:00:00Z",
       "status": "PENDING",
-      "comments": "Comments"
+      "comments": "Test"
     }
   },
   "courses": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -137,17 +137,13 @@
       "name": "Unregistered Instructor 1",
       "email": "unregisteredinstructor1@gmail.tmt",
       "institute": "TEAMMATES Test Institute 1",
-      "createdAt": "2011-01-01T00:00:00Z",
-      "status": "PENDING",
-      "comments": "Test"
+      "createdAt": "2011-01-01T00:00:00Z"
     },
     "unregisteredInstructor2": {
       "name": "Unregistered Instructor 2",
       "email": "unregisteredinstructor2@gmail.tmt",
       "institute": "TEAMMATES Test Institute 2",
-      "createdAt": "2011-01-01T00:00:00Z",
-      "status": "PENDING",
-      "comments": "Test"
+      "createdAt": "2011-01-01T00:00:00Z"
     }
   },
   "courses": {

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -73,7 +73,8 @@
       "name": "Instructor 1",
       "email": "instr1@teammates.tmt",
       "institute": "TEAMMATES Test Institute 1",
-      "registeredAt": "2010-02-14T00:00:00Z"
+      "registeredAt": "2010-02-14T00:00:00Z",
+      "status": "REGISTERED"
     },
     "instructor2": {
       "id": "00000000-0000-4000-8000-000000000102",
@@ -143,7 +144,9 @@
       "name": "Unregistered Instructor 2",
       "email": "unregisteredinstructor2@gmail.tmt",
       "institute": "TEAMMATES Test Institute 2",
-      "createdAt": "2011-01-01T00:00:00Z"
+      "createdAt": "2011-01-01T00:00:00Z",
+      "status": "PENDING",
+      "comments": "Comments"
     }
   },
   "courses": {

--- a/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import javax.annotation.Nullable;
+
 import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.util.SanitizationHelper;
 
@@ -11,6 +13,8 @@ public class AccountRequestUpdateRequest extends BasicRequest {
     private String email;
     private String institute;
     private AccountRequestStatus status;
+
+    @Nullable
     private String comments;
 
     public AccountRequestUpdateRequest(String name, String email, String institute, AccountRequestStatus status,
@@ -19,7 +23,9 @@ public class AccountRequestUpdateRequest extends BasicRequest {
         this.email = SanitizationHelper.sanitizeEmail(email);
         this.institute = SanitizationHelper.sanitizeName(institute);
         this.status = status;
-        this.comments = SanitizationHelper.sanitizeTextField(comments);
+        if (comments != null) {
+            this.comments = SanitizationHelper.sanitizeTextField(comments);
+        }
     }
 
     @Override
@@ -33,7 +39,6 @@ public class AccountRequestUpdateRequest extends BasicRequest {
                 || status == AccountRequestStatus.PENDING
                 || status == AccountRequestStatus.REGISTERED,
                 "status must be one of the following: APPROVED, REJECTED, PENDING, REGISTERED");
-        assertTrue(comments != null, "comments cannot be null");
     }
 
     public String getName() {

--- a/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
@@ -1,0 +1,53 @@
+package teammates.ui.request;
+
+import teammates.common.datatransfer.AccountRequestStatus;
+import teammates.common.util.SanitizationHelper;
+
+/**
+ * The create request for an account request update request.
+ */
+public class AccountRequestUpdateRequest extends BasicRequest {
+    private String name;
+    private String email;
+    private String institute;
+    private AccountRequestStatus status;
+    private String comments;
+
+    public AccountRequestUpdateRequest(String name, String email, String institute, AccountRequestStatus status,
+                                       String comments) {
+        this.name = SanitizationHelper.sanitizeName(name);
+        this.email = SanitizationHelper.sanitizeEmail(email);
+        this.institute = SanitizationHelper.sanitizeName(institute);
+        this.status = status;
+        this.comments = SanitizationHelper.sanitizeTextField(comments);
+    }
+
+    @Override
+    public void validate() throws InvalidHttpRequestBodyException {
+        assertTrue(name != null, "name cannot be null");
+        assertTrue(email != null, "email cannot be null");
+        assertTrue(institute != null, "institute cannot be null");
+        assertTrue(status != null, "status cannot be null");
+        assertTrue(comments != null, "comments cannot be null");
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public String getInstitute() {
+        return this.institute;
+    }
+
+    public AccountRequestStatus getStatus() {
+        return this.status;
+    }
+
+    public String getComments() {
+        return this.comments;
+    }
+}

--- a/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
@@ -28,6 +28,11 @@ public class AccountRequestUpdateRequest extends BasicRequest {
         assertTrue(email != null, "email cannot be null");
         assertTrue(institute != null, "institute cannot be null");
         assertTrue(status != null, "status cannot be null");
+        assertTrue(status == AccountRequestStatus.APPROVED
+                || status == AccountRequestStatus.REJECTED
+                || status == AccountRequestStatus.PENDING
+                || status == AccountRequestStatus.REGISTERED,
+                "status must be one of the following: APPROVED, REJECTED, PENDING, REGISTERED");
         assertTrue(comments != null, "comments cannot be null");
     }
 

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -50,6 +50,7 @@ public final class ActionFactory {
         map(ResourceURIs.ACCOUNT_REQUEST, GET, GetAccountRequestAction.class);
         map(ResourceURIs.ACCOUNT_REQUEST, POST, CreateAccountRequestAction.class);
         map(ResourceURIs.ACCOUNT_REQUEST, DELETE, DeleteAccountRequestAction.class);
+        map(ResourceURIs.ACCOUNT_REQUEST, PUT, UpdateAccountRequestAction.class);
         map(ResourceURIs.ACCOUNT_REQUESTS, GET, GetAccountRequestsAction.class);
         map(ResourceURIs.ACCOUNT_REQUEST_RESET, PUT, ResetAccountRequestAction.class);
         map(ResourceURIs.ACCOUNTS, GET, GetAccountsAction.class);

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -1,0 +1,89 @@
+package teammates.ui.webapi;
+
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+
+import teammates.common.datatransfer.AccountRequestStatus;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.common.util.EmailSendingStatus;
+import teammates.common.util.EmailWrapper;
+import teammates.storage.sqlentity.AccountRequest;
+import teammates.ui.output.AccountRequestData;
+import teammates.ui.request.AccountRequestUpdateRequest;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+
+/**
+ * Updates an account request.
+ */
+public class UpdateAccountRequestAction extends AdminOnlyAction {
+
+    static final String ACCOUNT_REQUEST_NOT_FOUND = "Account request not found";
+    static final String ACCOUNT_REQUEST_UPDATED = "Account request successfully updated";
+    static final String ACCOUNT_REQUEST_APPROVED_EMAIL_FAILED =
+            "Account request successfully approved but email failed to send";
+
+    @Override
+    public JsonResult execute() throws InvalidOperationException, InvalidHttpRequestBodyException {
+        String id = getNonNullRequestParamValue(Const.ParamsNames.ACCOUNT_REQUEST_ID);
+        UUID accountRequestId;
+
+        try {
+            accountRequestId = UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidHttpParameterException(e.getMessage(), e);
+        }
+
+        AccountRequest accountRequest = sqlLogic.getAccountRequest(accountRequestId);
+
+        if (accountRequest == null) {
+            return new JsonResult(ACCOUNT_REQUEST_NOT_FOUND, HttpStatus.SC_NOT_FOUND);
+        }
+
+        boolean toSendEmail = false;
+        AccountRequestUpdateRequest accountRequestUpdateRequest =
+                getAndValidateRequestBody(AccountRequestUpdateRequest.class);
+        if (accountRequestUpdateRequest.getStatus() == AccountRequestStatus.APPROVED
+                && accountRequest.getStatus() == AccountRequestStatus.PENDING) {
+            toSendEmail = true;
+        }
+
+        try {
+            accountRequest.setName(accountRequestUpdateRequest.getName());
+            accountRequest.setEmail(accountRequestUpdateRequest.getEmail());
+            accountRequest.setInstitute(accountRequestUpdateRequest.getInstitute());
+            accountRequest.setStatus(accountRequestUpdateRequest.getStatus());
+            accountRequest.setComments(accountRequestUpdateRequest.getComments());
+            sqlLogic.updateAccountRequest(accountRequest);
+        } catch (InvalidParametersException e) {
+            throw new InvalidHttpRequestBodyException(e);
+        } catch (EntityDoesNotExistException e) {
+            throw new EntityNotFoundException(e);
+        }
+
+        if (toSendEmail) {
+            boolean emailSent = sendEmail(accountRequest.getRegistrationUrl(),
+                    accountRequest.getEmail(), accountRequest.getName());
+
+            if (!emailSent) {
+                return new JsonResult(ACCOUNT_REQUEST_APPROVED_EMAIL_FAILED);
+            }
+        }
+
+        return new JsonResult(new AccountRequestData(accountRequest));
+    }
+
+    /**
+     * Sends the feedback session summary as an email.
+     *
+     * @return The true if email was sent successfully or false otherwise.
+     */
+    private boolean sendEmail(String registrationUrl, String instructorEmail, String instructorName) {
+        EmailWrapper email = sqlEmailGenerator.generateNewInstructorAccountJoinEmail(
+                registrationUrl, instructorEmail, instructorName);
+        EmailSendingStatus status = emailSender.sendEmail(email);
+        return status.isSuccess();
+    }
+}

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -20,8 +20,6 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 public class UpdateAccountRequestAction extends AdminOnlyAction {
 
     static final String ACCOUNT_REQUEST_NOT_FOUND = "Account request with id = %s not found";
-    static final String ACCOUNT_REQUEST_APPROVED_EMAIL_FAILED =
-            "Failed to send approval email to instructor, status reverted to PENDING, please try again";
 
     @Override
     public JsonResult execute() throws InvalidOperationException, InvalidHttpRequestBodyException {

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -2,8 +2,6 @@ package teammates.ui.webapi;
 
 import java.util.UUID;
 
-import org.apache.http.HttpStatus;
-
 import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -36,7 +34,7 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
 
         if (accountRequest == null) {
             String errorMessage = String.format(ACCOUNT_REQUEST_NOT_FOUND, accountRequestId.toString());
-            return new JsonResult(errorMessage, HttpStatus.SC_NOT_FOUND);
+            throw new EntityNotFoundException(errorMessage);
         }
 
         AccountRequestUpdateRequest accountRequestUpdateRequest =

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -76,7 +76,7 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
     }
 
     /**
-     * Sends the feedback session summary as an email.
+     * Sends the approval email to the instructor.
      *
      * @return The true if email was sent successfully or false otherwise.
      */

--- a/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetActionClassesActionTest.java
@@ -87,6 +87,7 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 GetAccountRequestAction.class,
                 DeleteAccountRequestAction.class,
                 GetAccountRequestsAction.class,
+                UpdateAccountRequestAction.class,
                 GetAccountAction.class,
                 GetAccountsAction.class,
                 FeedbackSessionPublishedRemindersAction.class,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878 

**Outline of Solution**
Created `AccountRequestUpdateRequests` to handle and validate update request fields.
 
Add `PUT` endpoint for editing Account Request fields (name, email, institute, comments), and for approving account requests. Only `REJECTED` and `PENDING` account requests can be approved, other statuses will just go through the normal updating branch, as it should not be possible to trigger account requests with other statuses (`REGISTERED`, `APPROVED`) to be approved either.

Upon approval, an email containing the registration url is sent to the specified email address.

Reason for adding an `AfterMethod` to the `CreateAccountRequestActionIT`:

During testing, I realised that the `GetAccountRequestsActionIT` kept failing locally with a initial 4 pending account requests, when the data bundle has 0 pending requests to begin with, even though the [component test](https://github.com/TEAMMATES/teammates/actions/runs/8550675653/job/23428118762) on the `account-request-form` branch  passed.

Upon re-running a couple of times, I realised that these 4 pending requests were actually entries created during the `CreateAccountRequestActionIT`, and since there was no clean-up method for this test as everything is created in its own transaction, the default `tearDown()`, which just does a `HibernateUtil.rollbackTransaction()`, doesn't actually remove these already-committed entries.

A possible reason why the test on the branch currently passes could be due to the order in which they are run, but I'm not entirely sure whether this is actually the case.

From the component test job on the `account-request-form` branch:

On this test run, the output of `GetAccountRequestsActionIT` comes before the `CreateAccountRequestActionIT`, and there was no conflict here.

[Click here to see the job](https://github.com/TEAMMATES/teammates/actions/runs/8550675653/job/23428118762)
<img width="951" alt="Pasted Graphic 2" src="https://github.com/TEAMMATES/teammates/assets/74132255/8045418d-946f-4115-a211-241c0fea7107">
<img width="1308" alt="Pasted Graphic 3" src="https://github.com/TEAMMATES/teammates/assets/74132255/f1da4761-86d0-4a21-87c3-2877694058f2">


From a failing job on this PR:

On this branch, the output of `GetAccountRequestsActionIT` comes after the `CreateAccountRequestActionIT`, and the test fails.

[Click here to see the job](https://github.com/TEAMMATES/teammates/actions/runs/8557457355/job/23449723395)
<img width="919" alt="Pasted Graphic" src="https://github.com/TEAMMATES/teammates/assets/74132255/19ed8671-8616-4354-8184-d0e7717b073e">
<img width="1328" alt="Pasted Graphic 1" src="https://github.com/TEAMMATES/teammates/assets/74132255/66213148-519e-4aaf-b58f-edee6ff540ac">