### PR TITLE
[#12048] Data migration for student entities

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForStudentSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForStudentSql.java
@@ -1,0 +1,112 @@
+package teammates.client.scripts.sql;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.util.HibernateUtil;
+import teammates.storage.entity.Course;
+import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.Team;
+
+/**
+ * Data migration class for course entity.
+ */
+@SuppressWarnings("PMD")
+public class DataMigrationForStudentSql extends
+        DataMigrationEntitiesBaseScriptSql<Course, teammates.storage.sqlentity.Student> {
+
+    public static void main(String[] args) {
+        new DataMigrationForStudentSql().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<Course> getFilterQuery() {
+        return ofy().load().type(Course.class);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return false;
+    }
+
+    /*
+     * Sets the migration criteria used in isMigrationNeeded.
+     */
+    @Override
+    protected void setMigrationCriteria() {
+        // No migration criteria currently needed.
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(Course entity) {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(Course oldCourse) throws Exception {
+        HibernateUtil.beginTransaction();
+        teammates.storage.sqlentity.Course newCourse =
+                HibernateUtil.getReference(teammates.storage.sqlentity.Course.class, oldCourse.getUniqueId());
+        Map<String, Account> accountMap = getAccountMap(oldCourse.getUniqueId());
+        List<Team> teams = getTeams(newCourse);
+        HibernateUtil.commitTransaction();
+
+        getCourseStudents(oldCourse.getUniqueId())
+                .forEach(oldStudent -> migrateStudent(oldStudent, newCourse, accountMap, teams));
+    }
+
+    private Map<String, Account> getAccountMap(String courseId) {
+        return ofy()
+                .load()
+                .type(CourseStudent.class)
+                .filter("courseId", courseId)
+                .list()
+                .stream()
+                .map(CourseStudent::getGoogleId)
+                .collect(Collectors.toMap(googleId -> googleId,
+                        googleId -> HibernateUtil.getReferenceBySimpleNaturalId(Account.class, googleId)));
+    }
+
+    private List<Team> getTeams(teammates.storage.sqlentity.Course newCourse) {
+        return newCourse.getSections().stream()
+                .flatMap(section -> section.getTeams().stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<CourseStudent> getCourseStudents(String courseId) {
+        return ofy()
+                .load()
+                .type(CourseStudent.class)
+                .filter("courseId", courseId)
+                .list();
+    }
+
+    private void migrateStudent(CourseStudent oldStudent, teammates.storage.sqlentity.Course course,
+            Map<String, Account> accountMap, List<Team> teams) {
+
+        Account account = accountMap.get(oldStudent.getGoogleId());
+
+        Team team = teams.stream()
+                .filter(t -> t.getName().equals(oldStudent.getTeamName()))
+                .findFirst()
+                .get();
+
+        teammates.storage.sqlentity.Student newStudent = new teammates.storage.sqlentity.Student(
+                course,
+                oldStudent.getName(),
+                oldStudent.getEmail(),
+                oldStudent.getComments());
+
+        newStudent.setAccount(account);
+        newStudent.setTeam(team);
+        newStudent.setCreatedAt(oldStudent.getCreatedAt());
+        newStudent.setUpdatedAt(oldStudent.getUpdatedAt());
+        newStudent.setRegKey(oldStudent.getRegistrationKey());
+
+        saveEntityDeferred(newStudent);
+    }
+}

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseAttributes.java
@@ -3,7 +3,7 @@ package teammates.client.scripts.sql;
 import teammates.storage.entity.Course;
 
 /**
- * Class for verifying account attributes.
+ * Class for verifying course attributes.
  */
 @SuppressWarnings("PMD")
 public class VerifyCourseAttributes

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
@@ -67,6 +67,7 @@ public class VerifyCourseEntityCounts extends DatastoreClient {
 
         entities.put(teammates.storage.entity.Course.class, teammates.storage.sqlentity.Course.class);
         entities.put(teammates.storage.entity.FeedbackSession.class, teammates.storage.sqlentity.FeedbackSession.class);
+        entities.put(teammates.storage.entity.CourseStudent.class, teammates.storage.sqlentity.Student.class);
 
         // Compare datastore "table" to postgres table for each entity
         for (Map.Entry<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entry : entities

--- a/src/client/java/teammates/client/scripts/sql/VerifyStudentAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyStudentAttributes.java
@@ -1,0 +1,51 @@
+package teammates.client.scripts.sql;
+
+import teammates.storage.entity.CourseStudent;
+
+/**
+ * Class for verifying student attributes.
+ */
+@SuppressWarnings("PMD")
+public class VerifyStudentAttributes
+        extends VerifyNonCourseEntityAttributesBaseScript<CourseStudent, teammates.storage.sqlentity.Student> {
+
+    public VerifyStudentAttributes() {
+        super(CourseStudent.class, teammates.storage.sqlentity.Student.class);
+    }
+
+    @Override
+    protected String generateID(teammates.storage.sqlentity.Student sqlEntity) {
+        return CourseStudent.generateId(sqlEntity.getEmail(), sqlEntity.getCourse().getId());
+    }
+
+    public static void main(String[] args) {
+        VerifyStudentAttributes script = new VerifyStudentAttributes();
+        script.doOperationRemotely();
+    }
+
+    // Used for sql data migration
+    @Override
+    public boolean equals(teammates.storage.sqlentity.Student sqlEntity, CourseStudent datastoreEntity) {
+        // skips over students without accounts
+        boolean doesgoogleIdMatch;
+        if (sqlEntity.getGoogleId() == null) {
+            doesgoogleIdMatch = true;
+        } else {
+            doesgoogleIdMatch = sqlEntity.getGoogleId().equals(datastoreEntity.getGoogleId());
+        }
+
+        try {
+            return sqlEntity.getCourse().getId().equals(datastoreEntity.getCourseId())
+                    && sqlEntity.getName().equals(datastoreEntity.getName())
+                    && sqlEntity.getEmail().equals(datastoreEntity.getEmail())
+                    && sqlEntity.getComments().equals(datastoreEntity.getComments())
+                    && doesgoogleIdMatch
+                    && sqlEntity.getTeamName().equals(datastoreEntity.getTeamName())
+                    // && sqlEntity.getCreatedAt().equals(datastoreEntity.getCreatedAt())
+                    // && sqlEntity.getUpdatedAt().equals(datastoreEntity.getUpdatedAt())
+                    && sqlEntity.getRegKey().equals(datastoreEntity.getRegistrationKey());
+        } catch (IllegalArgumentException iae) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -259,6 +259,17 @@ public final class HibernateUtil {
     }
 
     /**
+     * Return an instance with the given natural id, whose state may be lazily fetched.
+     * Id is the only field that is fetched eagerly.
+     * If there is no such persistent instance, EntityNotFoundException is thrown when the instance state
+     * is first accessed. This method can be used to increase performance, if it is known that the instance exists
+     * and fetching of other attributes of the entity is not necessary.
+     */
+    public static <T extends BaseEntity> T getReferenceBySimpleNaturalId(Class<T> entityType, Object id) {
+        return HibernateUtil.getCurrentSession().bySimpleNaturalId(entityType).getReference(id);
+    }
+
+    /**
      * Copy the state of the given object onto the persistent object with the same identifier.
      * @see Session#merge(E)
      */


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

- Added method to seed students in `SeedDb.java`
- Added migration and verification scripts
    - `User` entities are automatically created by Hibernate along with `Student` creation
- Added `getReferenceBySimpleNaturalId` in `HibernateUtil` to fetch `Accounts`
    - speeds up (previous iteration of) migration script from 30mins to 21mins for 10k student entities
- Added student count verification to `VerifyCourseEntityCounts`

| Entity | Test counts | Migration Time | Verification Time |
|--------|-------------|-------------------|-------------------|
| Student | 100 students * 100 courses| 25m 32s | 6m 1s |

