### PR TITLE
[#12048] Remove feedbackSession attributes @fetch annotation

### DIFF
--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -92,12 +92,10 @@ public class FeedbackSession extends BaseEntity {
     private boolean isPublishedEmailSent;
 
     @OneToMany(mappedBy = "feedbackSession", cascade = CascadeType.REMOVE)
-    @Fetch(FetchMode.JOIN)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<DeadlineExtension> deadlineExtensions = new ArrayList<>();
 
     @OneToMany(mappedBy = "feedbackSession", cascade = CascadeType.REMOVE)
-    @Fetch(FetchMode.JOIN)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<FeedbackQuestion> feedbackQuestions = new ArrayList<>();
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -8,8 +8,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;


### PR DESCRIPTION
Part of #12048

**Context**
Using the @fetch annotation to eagerly fetching attributes can slow down operations by performing joins on 2 extra tables (deadlineExtension and feedbackResponseQuestion) even if these attributes are not required. This performance hit was seen during migration of feedbackSession entities #12986.

**Outline of Solution**
Remove @fetch annotation from deadlineExtensions and feedbackQuestions attributes to lazily load attributes.