### PR TITLE
[#11878] Remove unused modal in AdminHomePage

### DIFF
--- a/src/web/app/pages-admin/admin-home-page/__snapshots__/admin-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-home-page/__snapshots__/admin-home-page.component.spec.ts.snap
@@ -5,7 +5,6 @@ exports[`AdminHomePageComponent should snap with default view 1`] = `
   accountReqs={[Function Array]}
   accountService={[Function AccountService]}
   activeRequests="0"
-  courseService={[Function CourseService]}
   currentPage={[Function Number]}
   formatDateDetailPipe={[Function FormatDateDetailPipe]}
   instructorDetails=""
@@ -14,15 +13,9 @@ exports[`AdminHomePageComponent should snap with default view 1`] = `
   instructorName=""
   instructorsConsolidated={[Function Array]}
   isAddingInstructors="false"
-  isRegisteredInstructorModalLoading="false"
   items$={[Function Observable]}
   linkService={[Function LinkService]}
-  ngbModal={[Function _NgbModal]}
   pageSize={[Function Number]}
-  registeredInstructorAccountData={[Function Array]}
-  registeredInstructorIndex="0"
-  registeredInstructorModal={[Function TemplateRef2]}
-  simpleModalService={[Function SimpleModalService]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -140,7 +133,6 @@ exports[`AdminHomePageComponent should snap with disabled adding instructor butt
   accountReqs={[Function Array]}
   accountService={[Function AccountService]}
   activeRequests={[Function Number]}
-  courseService={[Function CourseService]}
   currentPage={[Function Number]}
   formatDateDetailPipe={[Function FormatDateDetailPipe]}
   instructorDetails=""
@@ -149,15 +141,9 @@ exports[`AdminHomePageComponent should snap with disabled adding instructor butt
   instructorName=""
   instructorsConsolidated={[Function Array]}
   isAddingInstructors={[Function Boolean]}
-  isRegisteredInstructorModalLoading="false"
   items$={[Function Observable]}
   linkService={[Function LinkService]}
-  ngbModal={[Function _NgbModal]}
   pageSize={[Function Number]}
-  registeredInstructorAccountData={[Function Array]}
-  registeredInstructorIndex="0"
-  registeredInstructorModal={[Function TemplateRef2]}
-  simpleModalService={[Function SimpleModalService]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -439,7 +425,6 @@ exports[`AdminHomePageComponent should snap with some instructors details 1`] = 
   accountReqs={[Function Array]}
   accountService={[Function AccountService]}
   activeRequests="0"
-  courseService={[Function CourseService]}
   currentPage={[Function Number]}
   formatDateDetailPipe={[Function FormatDateDetailPipe]}
   instructorDetails=""
@@ -448,15 +433,9 @@ exports[`AdminHomePageComponent should snap with some instructors details 1`] = 
   instructorName=""
   instructorsConsolidated={[Function Array]}
   isAddingInstructors="false"
-  isRegisteredInstructorModalLoading="false"
   items$={[Function Observable]}
   linkService={[Function LinkService]}
-  ngbModal={[Function _NgbModal]}
   pageSize={[Function Number]}
-  registeredInstructorAccountData={[Function Array]}
-  registeredInstructorIndex="0"
-  registeredInstructorModal={[Function TemplateRef2]}
-  simpleModalService={[Function SimpleModalService]}
   statusMessageService={[Function StatusMessageService]}
   timezoneService={[Function TimezoneService]}
 >
@@ -783,85 +762,6 @@ exports[`AdminHomePageComponent should snap with some instructors details 1`] = 
                   id="message-instructor-2"
                 >
                   The instructor cannot be added for some reason
-                </span>
-              </td>
-            </tr>
-            <tr
-              tm-new-instructor-data-row=""
-            >
-              <td>
-                <span
-                  id="instructor-3-name"
-                >
-                  Instructor D
-                </span>
-              </td>
-              <td>
-                <span
-                  id="instructor-3-email"
-                >
-                  instructord@example.com
-                </span>
-              </td>
-              <td>
-                <span
-                  id="instructor-3-institution"
-                >
-                  Sample Institution C
-                </span>
-              </td>
-              <td
-                style="width: 17%;"
-              >
-                <div
-                  class="button-group"
-                >
-                  <button
-                    class="action-btn btn btn-sm btn-primary text-nowrap"
-                    id="add-instructor-3"
-                    style="margin-right: 10px;"
-                  >
-                    Add
-                  </button>
-                  <button
-                    class="action-btn btn btn-sm btn-info text-nowrap"
-                    id="edit-instructor-3"
-                    style="margin-right: 10px;"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    class="action-btn btn btn-sm btn-danger"
-                    id="remove-instructor-3"
-                  >
-                    Remove
-                  </button>
-                </div>
-              </td>
-              <td
-                style="width: 8%;"
-              >
-                FAIL
-              </td>
-              <td
-                style="width: 40%;"
-              >
-                <span
-                  class="message"
-                  id="message-instructor-3"
-                >
-                  Cannot create account request as instructor has already registered.
-                </span>
-                <span>
-                  <a
-                    class="btn btn-link"
-                    id="instructor-3-registered-info-button"
-                    type="button"
-                  >
-                    <i
-                      class="fas fa-info-circle"
-                    />
-                  </a>
                 </span>
               </td>
             </tr>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -73,7 +73,6 @@
               (addInstructorEvent)="addInstructor(i)"
               (removeInstructorEvent)="removeInstructor(i)"
               (toggleEditModeEvent)="setInstructorRowEditModeEnabled(i, $event)"
-              (showRegisteredInstructorModalEvent)="showRegisteredInstructorModal(i)"
           ></tr>
         </tbody>
       </table>
@@ -84,65 +83,3 @@
     </div>
   </div>
 </div>
-<ng-template #registeredInstructorModal>
-  <div *tmIsLoading="isRegisteredInstructorModalLoading">
-    <p>
-      You may <a id="reset-account-request-link" href="javascript:;" (click)="resetAccountRequest(registeredInstructorIndex)">reset</a>
-      this account request. Alternatively, reset the Google account or use the Google ID migration script.
-    </p>
-    <p *ngIf="!registeredInstructorAccountData.length">
-      No accounts found for instructor associated with email
-      <b>{{ instructorsConsolidated[registeredInstructorIndex].email }}</b>.
-    </p>
-    <p *ngIf="registeredInstructorAccountData.length">
-      The following {{ registeredInstructorAccountData.length }} account(s) are associated with the email
-      <b>{{ instructorsConsolidated[registeredInstructorIndex].email }}</b>:
-    </p>
-    <div class="card" *ngFor="let account of registeredInstructorAccountData">
-      <a href="{{ account.manageAccountLink }}" target="_blank"><h5 class="card-header">{{ account.googleId }}</h5></a>
-      <div class="card-body">
-        <h6 *ngIf="!account.instructorCourses.length">No instructor courses found for this account.</h6>
-        <div *ngIf="account.instructorCourses.length">
-          <h6 class="card-title">Instructor for the following <b>{{ account.instructorCourses.length }}</b> courses:</h6>
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>Course ID</th>
-                <th>Course Name</th>
-                <th>Institute</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr *ngFor="let course of account.instructorCourses">
-                <td class="text-break">{{ course.courseId }}</td>
-                <td class="text-break">{{ course.courseName }}</td>
-                <td class="text-break">{{ course.institute }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <h6 class="mt-3" *ngIf="!account.studentCourses.length">No student courses found for this account.</h6>
-        <div *ngIf="account.studentCourses.length">
-          <h6 class="card-title mt-3">Student for the following <b>{{ account.studentCourses.length }}</b> courses:</h6>
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>Course ID</th>
-                <th>Course Name</th>
-                <th>Institute</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr *ngFor="let course of account.studentCourses">
-                <td class="text-break">{{ course.courseId }}</td>
-                <td class="text-break">{{ course.courseName }}</td>
-                <td class="text-break">{{ course.institute }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </div>
-</ng-template>
-<tm-account-request-table *ngIf="accountReqs.length" [accountRequests]="accountReqs" [searchString]=""></tm-account-request-table>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.spec.ts
@@ -7,11 +7,8 @@ import { AdminHomePageComponent } from './admin-home-page.component';
 import { InstructorData } from './instructor-data';
 import { NewInstructorDataRowComponent } from './new-instructor-data-row/new-instructor-data-row.component';
 import { AccountService } from '../../../services/account.service';
-import { CourseService } from '../../../services/course.service';
 import { LinkService } from '../../../services/link.service';
-import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StatusMessageService } from '../../../services/status-message.service';
-import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
 import { AccountRequestStatus } from '../../../types/api-output';
 import { AccountRequestTableModule } from '../../components/account-requests-table/account-request-table.module';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
@@ -22,9 +19,7 @@ describe('AdminHomePageComponent', () => {
   let component: AdminHomePageComponent;
   let fixture: ComponentFixture<AdminHomePageComponent>;
   let accountService: AccountService;
-  let courseService: CourseService;
   let linkService: LinkService;
-  let simpleModalService: SimpleModalService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -42,9 +37,7 @@ describe('AdminHomePageComponent', () => {
       ],
       providers: [
         AccountService,
-        CourseService,
         FormatDateDetailPipe,
-        SimpleModalService,
         StatusMessageService,
         LinkService,
       ],
@@ -55,8 +48,6 @@ describe('AdminHomePageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AdminHomePageComponent);
     accountService = TestBed.inject(AccountService);
-    courseService = TestBed.inject(CourseService);
-    simpleModalService = TestBed.inject(SimpleModalService);
     linkService = TestBed.inject(LinkService);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -446,16 +437,6 @@ describe('AdminHomePageComponent', () => {
         joinLink: 'This should not be displayed',
         message: 'The instructor cannot be added for some reason',
       },
-      {
-        name: 'Instructor D',
-        email: 'instructord@example.com',
-        institution: 'Sample Institution C',
-        status: 'FAIL',
-        statusCode: 409,
-        isCurrentlyBeingEdited: false,
-        joinLink: 'This should not be displayed',
-        message: 'Cannot create account request as instructor has already registered.',
-      },
     ];
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
@@ -547,153 +528,5 @@ describe('AdminHomePageComponent', () => {
         isCurrentlyBeingEdited: false,
       },
     );
-  });
-
-  it('should call showRegisteredInstructorModal when info button for registered instructors clicked', () => {
-    component.instructorsConsolidated = [
-      {
-        name: 'Instructor A',
-        email: 'instructora@example.com',
-        institution: 'Sample Institution A',
-        status: 'FAIL',
-        statusCode: 409,
-        isCurrentlyBeingEdited: false,
-        joinLink: 'This should not be displayed',
-        message: 'message',
-      },
-    ];
-
-    fixture.detectChanges();
-
-    const spy = jest.spyOn(component, 'showRegisteredInstructorModal').mockImplementation(() => {});
-
-    const infoButton = fixture.debugElement.nativeElement.querySelector('#instructor-0-registered-info-button');
-    infoButton.click();
-
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fetch account and course information when showRegisteredInstructorModal is called', () => {
-    component.instructorsConsolidated = [
-      {
-        name: 'Instructor A',
-        email: 'instructora@example.com',
-        institution: 'Sample Institution A',
-        status: 'FAIL',
-        statusCode: 409,
-        isCurrentlyBeingEdited: false,
-        joinLink: 'This should not be displayed',
-        message: 'message',
-      },
-    ];
-
-    const modalSpy = jest
-      .spyOn(simpleModalService, 'openInformationModal')
-      .mockReturnValue(createMockNgbModalRef());
-    const getAccountsSpy = jest
-      .spyOn(accountService, 'getAccounts')
-      .mockReturnValue(of({
-        accounts: [
-          {
-            googleId: 'googleId',
-            name: 'name',
-            email: 'email',
-            readNotifications: {},
-          },
-        ],
-      }));
-    const getStudentCoursesSpy = jest
-      .spyOn(courseService, 'getStudentCoursesInMasqueradeMode')
-      .mockReturnValue(of({
-        courses: [
-          {
-            courseId: 'courseId',
-            courseName: 'courseName',
-            isCourseDeleted: false,
-            timeZone: 'not used',
-            institute: 'institute',
-            creationTimestamp: 0,
-            deletionTimestamp: 0,
-          },
-        ],
-      }));
-    const getInstructorCoursesSpy = jest
-      .spyOn(courseService, 'getInstructorCoursesInMasqueradeMode')
-      .mockReturnValue(of({
-        courses: [
-          {
-            courseId: 'courseId',
-            courseName: 'courseName',
-            isCourseDeleted: false,
-            timeZone: 'not used',
-            institute: 'institute',
-            creationTimestamp: 0,
-            deletionTimestamp: 0,
-          },
-        ],
-      }));
-    const generateAccountLinkSpy = jest
-      .spyOn(linkService, 'generateManageAccountLink')
-      .mockReturnValue('manageAccountLink');
-
-    fixture.detectChanges();
-
-    component.showRegisteredInstructorModal(0);
-
-    expect(modalSpy).toHaveBeenCalledTimes(1);
-    expect(getAccountsSpy).toHaveBeenCalledTimes(1);
-    expect(getAccountsSpy).toHaveBeenCalledWith('instructora@example.com');
-    expect(getStudentCoursesSpy).toHaveBeenCalledTimes(1);
-    expect(getStudentCoursesSpy).toHaveBeenCalledWith('googleId');
-    expect(getInstructorCoursesSpy).toHaveBeenCalledTimes(1);
-    expect(getInstructorCoursesSpy).toHaveBeenCalledWith('googleId');
-    expect(generateAccountLinkSpy).toHaveBeenCalledTimes(1);
-    expect(generateAccountLinkSpy).toHaveBeenCalledWith('googleId', '/admin/accounts');
-    expect(component.isRegisteredInstructorModalLoading).toBeFalsy();
-  });
-
-  it('should call reset account endpoint when resetAccountRequest called', async () => {
-    component.instructorsConsolidated = [
-      {
-        name: 'Instructor A',
-        email: 'instructora@example.com',
-        institution: 'Sample Institution A',
-        status: 'FAIL',
-        statusCode: 409,
-        isCurrentlyBeingEdited: false,
-        joinLink: 'This should not be displayed',
-        message: 'message',
-      },
-    ];
-
-    fixture.detectChanges();
-
-    const resetAccountSpy = jest.spyOn(accountService, 'resetAccountRequest').mockReturnValue(of({
-      joinLink: 'link',
-    }));
-
-    const modalSpy = jest
-      .spyOn(simpleModalService, 'openConfirmationModal')
-      .mockImplementation(() => {
-        return createMockNgbModalRef();
-      });
-
-    component.resetAccountRequest(0);
-
-    await fixture.whenStable().then(() => {
-      expect(modalSpy).toHaveBeenCalledTimes(1);
-      expect(resetAccountSpy).toHaveBeenCalledTimes(1);
-      expect(resetAccountSpy).toHaveBeenCalledWith('instructora@example.com', 'Sample Institution A');
-      expect(component.instructorsConsolidated[0]).toEqual({
-        name: 'Instructor A',
-        email: 'instructora@example.com',
-        institution: 'Sample Institution A',
-        status: 'SUCCESS',
-        statusCode: 200,
-        isCurrentlyBeingEdited: false,
-        joinLink: 'link',
-        message: 'message',
-      });
-    });
   });
 });

--- a/src/web/app/pages-admin/admin-home-page/instructor-data.ts
+++ b/src/web/app/pages-admin/admin-home-page/instructor-data.ts
@@ -1,5 +1,3 @@
-import { Course } from '../../../types/api-output';
-
 /**
  * Represents the data of a new instructor.
  */
@@ -12,15 +10,4 @@ export interface InstructorData {
   statusCode?: number;
   joinLink?: string;
   message?: string;
-}
-
-/**
- * Represents the account data associated with a registered instructor.
- * See registered instructor modal of {@link AdminHomePageComponent}.
- */
-export interface RegisteredInstructorAccountData {
-  googleId: string;
-  studentCourses: Course[];
-  instructorCourses: Course[];
-  manageAccountLink: string;
 }

--- a/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/__snapshots__/new-instructor-data-row.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/__snapshots__/new-instructor-data-row.component.spec.ts.snap
@@ -11,7 +11,6 @@ exports[`NewInstructorDataRowComponent should snap with default view 1`] = `
   isAddDisabled="false"
   isBeingEdited="false"
   removeInstructorEvent={[Function EventEmitter_]}
-  showRegisteredInstructorModalEvent={[Function EventEmitter_]}
   toggleEditModeEvent={[Function EventEmitter_]}
 >
   <td>
@@ -81,7 +80,6 @@ exports[`NewInstructorDataRowComponent should snap with edit cancelled 1`] = `
   isAddDisabled="false"
   isBeingEdited="false"
   removeInstructorEvent={[Function EventEmitter_]}
-  showRegisteredInstructorModalEvent={[Function EventEmitter_]}
   toggleEditModeEvent={[Function EventEmitter_]}
 >
   <td>
@@ -151,7 +149,6 @@ exports[`NewInstructorDataRowComponent should snap with edit confirmed 1`] = `
   isAddDisabled="false"
   isBeingEdited="false"
   removeInstructorEvent={[Function EventEmitter_]}
-  showRegisteredInstructorModalEvent={[Function EventEmitter_]}
   toggleEditModeEvent={[Function EventEmitter_]}
 >
   <td>
@@ -221,7 +218,6 @@ exports[`NewInstructorDataRowComponent should snap with instructor details edite
   isAddDisabled="false"
   isBeingEdited={[Function Boolean]}
   removeInstructorEvent={[Function EventEmitter_]}
-  showRegisteredInstructorModalEvent={[Function EventEmitter_]}
   toggleEditModeEvent={[Function EventEmitter_]}
 >
   <td>
@@ -285,7 +281,6 @@ exports[`NewInstructorDataRowComponent should snap with start of edit 1`] = `
   isAddDisabled="false"
   isBeingEdited={[Function Boolean]}
   removeInstructorEvent={[Function EventEmitter_]}
-  showRegisteredInstructorModalEvent={[Function EventEmitter_]}
   toggleEditModeEvent={[Function EventEmitter_]}
 >
   <td>

--- a/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.html
+++ b/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.html
@@ -27,9 +27,4 @@
     Instructor "{{ instructor.name }}" has been successfully created. [<a href="{{ instructor.joinLink }}">join link</a>]
   </span>
   <span class="message" *ngIf="instructor.status === 'FAIL'" id="message-instructor-{{ index }}">{{ instructor.message }}</span>
-  <span *ngIf="instructor.statusCode === 409">
-    <a id="instructor-{{ index }}-registered-info-button" type="button" (click)="showRegisteredInstructorModal();" class="btn btn-link">
-      <i class="fas fa-info-circle"></i>
-    </a>
-  </span>
 </td>

--- a/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.spec.ts
+++ b/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.spec.ts
@@ -142,57 +142,6 @@ describe('NewInstructorDataRowComponent', () => {
     expect(isInEditMode).toBeFalsy();
   });
 
-  it('should emit showRegisteredInstructorModalEvent when info button clicked', () => {
-    component.instructor = {
-      name: 'Instructor',
-      email: 'instructor@instruct.or',
-      institution: 'Institutional Institution of Institute',
-      status: 'FAIL',
-      statusCode: 409,
-      isCurrentlyBeingEdited: false,
-    };
-    fixture.detectChanges();
-
-    let hasEmitted = false;
-    testEventEmission(component.showRegisteredInstructorModalEvent, () => { hasEmitted = true; });
-    fixture.debugElement
-      .query(By.css(`#instructor-${expectedIndex}-registered-info-button`))
-      .triggerEventHandler('click', null);
-    expect(hasEmitted).toBeTruthy();
-  });
-
-  it('should not display more info button if statusCode is not 409', () => {
-    component.instructor = {
-      name: 'Instructor',
-      email: 'instructor@instruct.or',
-      institution: 'Institutional Institution of Institute',
-      status: 'FAIL',
-      statusCode: 500,
-      isCurrentlyBeingEdited: false,
-    };
-    fixture.detectChanges();
-
-    const debugElement = fixture.debugElement
-      .query(By.css(`#instructor-${expectedIndex}-registered-info-button`));
-    expect(debugElement).toBeNull();
-  });
-
-  it('should display more info button if statusCode is 409', () => {
-    component.instructor = {
-      name: 'Instructor',
-      email: 'instructor@instruct.or',
-      institution: 'Institutional Institution of Institute',
-      status: 'FAIL',
-      statusCode: 409,
-      isCurrentlyBeingEdited: false,
-    };
-    fixture.detectChanges();
-
-    const debugElement = fixture.debugElement
-      .query(By.css(`#instructor-${expectedIndex}-registered-info-button`));
-    expect(debugElement).toBeTruthy();
-  });
-
   it('should set isBeingEdited to true when editing starts', () => {
     editButtonEl.click();
 

--- a/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -20,7 +20,6 @@ export class NewInstructorDataRowComponent implements OnInit {
   @Output() addInstructorEvent: EventEmitter<void> = new EventEmitter();
   @Output() removeInstructorEvent: EventEmitter<void> = new EventEmitter();
   @Output() toggleEditModeEvent: EventEmitter<boolean> = new EventEmitter();
-  @Output() showRegisteredInstructorModalEvent: EventEmitter<void> = new EventEmitter();
 
   isBeingEdited: boolean = false;
   editedInstructorName!: string;
@@ -37,10 +36,6 @@ export class NewInstructorDataRowComponent implements OnInit {
 
   removeInstructor(): void {
     this.removeInstructorEvent.emit();
-  }
-
-  showRegisteredInstructorModal(): void {
-    this.showRegisteredInstructorModalEvent.emit();
   }
 
   /**


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878 

**Outline of Solution**
Previously admin home page included a `registeredInstructorModal`.

This modal is only accessible if `createAccountRequest` returns a response with the http status code 409. 
The reponse would only have a 409 status code if `CreateAccountRequestAction` throws a `InvalidOperationException`. 

`CreateAccountRequestAction` used to throw a `InvalidOperationException` when a user tries to add an instructor that is already registered.
Since `CreateAccountRequestAction` no longer throws `InvalidOperationException`, this modal is no longer accessible.

All functions that are only used by the modal is removed in this pr.

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
