### PR TITLE
[#12048] Add v9.0.0 tag to liquibase changelog

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-v9.0.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-v9.0.0.xml
@@ -533,4 +533,7 @@
             initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
             referencedColumnNames="id" referencedTableName="feedback_questions" validate="true" />
     </changeSet>
+    <changeSet  author="NicolasCwy"  id="1711160431792-42">
+        <tagDatabase  tag="v9.0.0"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
Add a tag to the V9 liquibase changelog

Note: This changelog was not run on production since Hibernate had created the tables. Instead we have marked this changelog as "run" and deployed using the command `./gradlew liquibaseChangelogSync`. [Changelog Sync command](https://docs.liquibase.com/commands/utility/changelog-sync.html) 
