### PR TITLE
[#12048] Data migration for team entities

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
@@ -11,18 +11,19 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
+
 import teammates.common.util.HibernateUtil;
+import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Team;
-import teammates.storage.entity.Course;
 
 /**
  * Data migration class for team entity.
  */
 @SuppressWarnings("PMD")
 public class DataMigrationForTeamSql extends
-        DataMigrationEntitiesBaseScriptSql<teammates.storage.entity.Course, teammates.storage.sqlentity.Team> {
+        DataMigrationEntitiesBaseScriptSql<Course, teammates.storage.sqlentity.Team> {
 
     public static void main(String[] args) {
         new DataMigrationForTeamSql().doOperationRemotely();
@@ -30,7 +31,7 @@ public class DataMigrationForTeamSql extends
 
     @Override
     protected Query<Course> getFilterQuery() {
-        return ofy().load().type(teammates.storage.entity.Course.class);
+        return ofy().load().type(Course.class);
     }
 
     @Override
@@ -66,7 +67,7 @@ public class DataMigrationForTeamSql extends
         CriteriaQuery<teammates.storage.sqlentity.Course> cr = cb.createQuery(teammates.storage.sqlentity.Course.class);
         Root<teammates.storage.sqlentity.Course> courseRoot = cr.from(teammates.storage.sqlentity.Course.class);
         courseRoot.fetch("sections", JoinType.LEFT); // Fetch sections to avoid lazy-loading
-        
+
         cr.select(courseRoot).where(cb.equal(courseRoot.get("id"), courseId));
 
         return HibernateUtil.createQuery(cr).getSingleResult();

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
@@ -56,10 +56,11 @@ public class DataMigrationForTeamSql extends
         teammates.storage.sqlentity.Course newCourse = getNewCourse(oldCourse.getUniqueId());
         Map<String, Section> sectionNameToSectionMap =
                 newCourse.getSections().stream().collect(Collectors.toMap(Section::getName, s -> s));
-        HibernateUtil.commitTransaction();
 
         getTeamNameToSectionNameMap(oldCourse).forEach((teamName, sectionName) ->
-                        saveEntityDeferred(new Team(sectionNameToSectionMap.get(sectionName), teamName)));
+                        HibernateUtil.persist(new Team(sectionNameToSectionMap.get(sectionName), teamName)));
+
+        HibernateUtil.commitTransaction();
     }
 
     private teammates.storage.sqlentity.Course getNewCourse(String courseId) {

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForTeamSql.java
@@ -1,0 +1,93 @@
+package teammates.client.scripts.sql;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import com.googlecode.objectify.cmd.Query;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.Team;
+import teammates.storage.entity.Course;
+
+/**
+ * Data migration class for team entity.
+ */
+@SuppressWarnings("PMD")
+public class DataMigrationForTeamSql extends
+        DataMigrationEntitiesBaseScriptSql<teammates.storage.entity.Course, teammates.storage.sqlentity.Team> {
+
+    public static void main(String[] args) {
+        new DataMigrationForTeamSql().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<Course> getFilterQuery() {
+        return ofy().load().type(teammates.storage.entity.Course.class);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return false;
+    }
+
+    /*
+     * Sets the migration criteria used in isMigrationNeeded.
+     */
+    @Override
+    protected void setMigrationCriteria() {
+        // No migration criteria currently needed.
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(Course entity) {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(Course oldCourse) throws Exception {
+        HibernateUtil.beginTransaction();
+        teammates.storage.sqlentity.Course newCourse = getNewCourse(oldCourse.getUniqueId());
+        HibernateUtil.commitTransaction();
+
+        getTeamNameToSectionNameMap(oldCourse)
+                .forEach((teamName, sectionName) -> createTeam(teamName, sectionName, newCourse.getSections()));
+    }
+
+    private teammates.storage.sqlentity.Course getNewCourse(String courseId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<teammates.storage.sqlentity.Course> cr = cb.createQuery(teammates.storage.sqlentity.Course.class);
+        Root<teammates.storage.sqlentity.Course> courseRoot = cr.from(teammates.storage.sqlentity.Course.class);
+        courseRoot.fetch("sections", JoinType.LEFT); // Fetch sections to avoid lazy-loading
+        
+        cr.select(courseRoot).where(cb.equal(courseRoot.get("id"), courseId));
+
+        return HibernateUtil.createQuery(cr).getSingleResult();
+    }
+
+    private Map<String, String> getTeamNameToSectionNameMap(Course course) {
+        return ofy()
+                .load()
+                .type(CourseStudent.class)
+                .filter("courseId", course.getUniqueId())
+                .list()
+                .stream()
+                .collect(Collectors.toMap(CourseStudent::getTeamName, CourseStudent::getSectionName));
+    }
+
+    private void createTeam(String teamName, String sectionName, List<Section> sections) throws NoSuchElementException {
+        Section section = sections.stream()
+                .filter(s -> s.getName().equals(sectionName))
+                .findFirst()
+                .get();
+
+        saveEntityDeferred(new Team(section, teamName));
+    }
+}

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -43,6 +43,7 @@ public class SeedDb extends DatastoreClient {
 
     private static final int MAX_ENTITY_SIZE = 10000;
     private static final int MAX_STUDENT_PER_COURSE = 100;
+    private static final int MAX_TEAM_PER_SECTION = 10;
     private static final int MAX_SECTION_PER_COURSE = 10;
     private static final int MAX_FEEDBACKSESSION_FOR_EACH_COURSE_SIZE = 3;
     private final LogicExtension logic = new LogicExtension();
@@ -154,10 +155,16 @@ public class SeedDb extends DatastoreClient {
 
         log("Seeding students for course " + courseNumber);
         int currSection = -1;
+        int currTeam = -1;
         for (int i = 0; i < MAX_STUDENT_PER_COURSE; i++) {
 
             if (i % (MAX_STUDENT_PER_COURSE / MAX_SECTION_PER_COURSE) == 0) {
                 currSection++;
+                currTeam = -1; // Reset team number for each section
+            }
+
+            if (i % (MAX_STUDENT_PER_COURSE / (MAX_SECTION_PER_COURSE * MAX_TEAM_PER_SECTION)) == 0) {
+                currTeam++;
             }
 
             int googleIdNumber = courseNumber * MAX_STUDENT_PER_COURSE + i;
@@ -166,7 +173,7 @@ public class SeedDb extends DatastoreClient {
                 String studentName = String.format("Student %s in Course %s", i, courseNumber);
                 String studentGoogleId = String.format("Account Google ID %s", googleIdNumber);
                 String studentComments = String.format("Comments for student %s in course %s", i, courseNumber);
-                String studentTeamName = String.format("Course %s Team %s", courseNumber, i);
+                String studentTeamName = String.format("Course %s Section %s Team %s", courseNumber, currSection, currTeam);
                 String studentSectionName = String.format("Course %s Section %s", courseNumber, currSection);
                 String studentRegistrationKey = String.format("Student %s in Course %s Registration Key", i,
                         courseNumber);

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
@@ -15,8 +15,8 @@ import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.BaseEntity;
 import teammates.storage.entity.CourseStudent;
 import teammates.storage.sqlentity.Section;
-// CHECKSTYLE.ON:ImportOrder
 import teammates.storage.sqlentity.Team;
+// CHECKSTYLE.ON:ImportOrder
 
 /**
  * Verify the counts of non-course entities are correct.
@@ -67,7 +67,7 @@ public class VerifyCourseEntityCounts extends DatastoreClient {
                 new HashMap<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>>();
 
         entities.put(teammates.storage.entity.Course.class, teammates.storage.sqlentity.Course.class);
-        // entities.put(teammates.storage.entity.FeedbackSession.class, teammates.storage.sqlentity.FeedbackSession.class);
+        entities.put(teammates.storage.entity.FeedbackSession.class, teammates.storage.sqlentity.FeedbackSession.class);
 
         // Compare datastore "table" to postgres table for each entity
         for (Map.Entry<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entry : entities

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityCounts.java
@@ -16,6 +16,7 @@ import teammates.storage.entity.BaseEntity;
 import teammates.storage.entity.CourseStudent;
 import teammates.storage.sqlentity.Section;
 // CHECKSTYLE.ON:ImportOrder
+import teammates.storage.sqlentity.Team;
 
 /**
  * Verify the counts of non-course entities are correct.
@@ -66,7 +67,7 @@ public class VerifyCourseEntityCounts extends DatastoreClient {
                 new HashMap<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>>();
 
         entities.put(teammates.storage.entity.Course.class, teammates.storage.sqlentity.Course.class);
-        entities.put(teammates.storage.entity.FeedbackSession.class, teammates.storage.sqlentity.FeedbackSession.class);
+        // entities.put(teammates.storage.entity.FeedbackSession.class, teammates.storage.sqlentity.FeedbackSession.class);
 
         // Compare datastore "table" to postgres table for each entity
         for (Map.Entry<Class<? extends BaseEntity>, Class<? extends teammates.storage.sqlentity.BaseEntity>> entry : entities
@@ -84,6 +85,7 @@ public class VerifyCourseEntityCounts extends DatastoreClient {
     private void verifyNewEntities() {
         List<CourseStudent> students = ofy().load().type(CourseStudent.class).order("courseId").list();
         verifySectionEntities(students);
+        verifyTeamEntities(students);
     }
 
     private void verifySectionEntities(List<CourseStudent> students) {
@@ -92,5 +94,13 @@ public class VerifyCourseEntityCounts extends DatastoreClient {
         Long postgresEntityCount = countPostgresEntities(Section.class);
 
         printEntityVerification("Section", objectifyEntityCount, postgresEntityCount);
+    }
+
+    private void verifyTeamEntities(List<CourseStudent> students) {
+        int objectifyEntityCount = (int) students.stream().map(stu -> stu.getTeamName() + stu.getCourseId())
+                .distinct().count();
+        Long postgresEntityCount = countPostgresEntities(Team.class);
+
+        printEntityVerification("Team", objectifyEntityCount, postgresEntityCount);
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyTeamAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyTeamAttributes.java
@@ -1,0 +1,63 @@
+package teammates.client.scripts.sql;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import teammates.storage.entity.Course;
+import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.Team;
+
+/**
+ * Class for verifying section attributes.
+ */
+@SuppressWarnings("PMD")
+public class VerifyTeamAttributes
+        extends VerifyNonCourseEntityAttributesBaseScript<Course, teammates.storage.sqlentity.Course> {
+
+    public VerifyTeamAttributes() {
+        super(Course.class,
+                teammates.storage.sqlentity.Course.class);
+    }
+
+    @Override
+    protected String generateID(teammates.storage.sqlentity.Course sqlEntity) {
+        return sqlEntity.getId();
+    }
+
+    public static void main(String[] args) {
+        VerifyTeamAttributes script = new VerifyTeamAttributes();
+        script.doOperationRemotely();
+    }
+
+    private Set<String> getAllTeamNames(Course course) {
+        return ofy()
+                .load()
+                .type(CourseStudent.class)
+                .filter("courseId", course.getUniqueId())
+                .list()
+                .stream()
+                .map(stu -> stu.getTeamName())
+                .distinct()
+                .collect(Collectors.toCollection(HashSet::new));
+
+    }
+
+    // Used for sql data migration
+    @Override
+    public boolean equals(teammates.storage.sqlentity.Course sqlEntity, Course datastoreEntity) {
+        List<Team> teams = sqlEntity.getSections().stream()
+                .flatMap(section -> section.getTeams().stream())
+                .collect(Collectors.toList());
+        Set<String> newTeamNames = new HashSet<>(
+                teams.stream().map(Team::getName).collect(Collectors.toList()));
+        Set<String> oldTeamNames = getAllTeamNames(datastoreEntity);
+
+        return sqlEntity.getId().equals(datastoreEntity.getUniqueId())
+                && teams.size() == newTeamNames.size()
+                && newTeamNames.equals(oldTeamNames);
+    }
+
+}

--- a/src/client/java/teammates/client/scripts/sql/VerifyTeamAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyTeamAttributes.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
-import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Team;
 
 /**


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
- Adjusted `SeedDb.java` for `teamName` seeding
- Added migration and verification scripts
  - Used `root.fetch("sections")` to optimise fetching of `sections` field

| Entity  | Test counts | Migration Time | Verification Time |
|---------|-------------|----------------|-------------------|
| Team | 100 courses * 10 sections * 10 teams | 47s | 1m 4s |












