### PR TITLE
[#11878] Reference account requests by ID in tests

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/AccountRequestsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountRequestsLogicIT.java
@@ -54,8 +54,8 @@ public class AccountRequestsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         AccountRequestsDb accountRequestsDb = AccountRequestsDb.inst();
 
         toReset.setRegisteredAt(Instant.now());
-        toReset = accountRequestsDb.getAccountRequest(email, institute);
         UUID id = toReset.getId();
+        toReset = accountRequestsDb.getAccountRequest(id);
 
         assertNotNull(toReset);
         assertNotNull(toReset.getRegisteredAt());

--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
@@ -27,10 +27,9 @@ public class AccountRequestsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
                 new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
         accountRequestDb.createAccountRequest(accountRequest);
 
-        ______TS("Read account request using the given email and institute");
+        ______TS("Read account request using the given ID");
 
-        AccountRequest actualAccReqEmalAndInstitute =
-                accountRequestDb.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+        AccountRequest actualAccReqEmalAndInstitute = accountRequestDb.getAccountRequest(accountRequest.getId());
         verifyEquals(accountRequest, actualAccReqEmalAndInstitute);
 
         ______TS("Read account request using the given registration key");

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -257,7 +257,7 @@ public class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
             return logic.getNotification(((Notification) entity).getId());
         } else if (entity instanceof AccountRequest) {
             AccountRequest accountRequest = (AccountRequest) entity;
-            return logic.getAccountRequest(accountRequest.getEmail(), accountRequest.getInstitute());
+            return logic.getAccountRequest(accountRequest.getId());
         } else if (entity instanceof Instructor) {
             return logic.getInstructor(((Instructor) entity).getId());
         } else if (entity instanceof Student) {

--- a/src/it/java/teammates/it/ui/webapi/CreateAccountActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountActionIT.java
@@ -75,7 +75,7 @@ public class CreateAccountActionIT extends BaseActionIT<CreateAccountAction> {
 
         ______TS("Normal case with valid timezone");
         String timezone = "Asia/Singapore";
-        AccountRequest accountRequest = logic.getAccountRequest(email, institute);
+        AccountRequest accountRequest = logic.getAccountRequest(accReq.getId());
 
         String[] params = new String[] {
                 Const.ParamsNames.REGKEY, accountRequest.getRegistrationKey(),
@@ -118,10 +118,9 @@ public class CreateAccountActionIT extends BaseActionIT<CreateAccountAction> {
 
         accReq = typicalBundle.accountRequests.get("unregisteredInstructor2");
         email = accReq.getEmail();
-        institute = accReq.getInstitute();
         timezone = "InvalidTimezone";
 
-        accountRequest = logic.getAccountRequest(email, institute);
+        accountRequest = logic.getAccountRequest(accReq.getId());
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, accountRequest.getRegistrationKey(),

--- a/src/it/java/teammates/it/ui/webapi/GetCourseJoinStatusActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetCourseJoinStatusActionIT.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.AccountRequest;
 import teammates.ui.output.JoinStatus;
 import teammates.ui.webapi.GetCourseJoinStatusAction;
 import teammates.ui.webapi.JsonResult;
@@ -131,8 +132,8 @@ public class GetCourseJoinStatusActionIT extends BaseActionIT<GetCourseJoinStatu
 
         ______TS("Normal case: account request not used, instructor has not joined course");
 
-        String accountRequestNotUsedKey = logic.getAccountRequest("unregisteredinstructor1@gmail.tmt",
-                "TEAMMATES Test Institute 1").getRegistrationKey();
+        AccountRequest unregisteredInstructor1AccountRequest = typicalBundle.accountRequests.get("unregisteredInstructor1");
+        String accountRequestNotUsedKey = unregisteredInstructor1AccountRequest.getRegistrationKey();
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, accountRequestNotUsedKey,
@@ -148,8 +149,8 @@ public class GetCourseJoinStatusActionIT extends BaseActionIT<GetCourseJoinStatu
 
         ______TS("Normal case: account request already used, instructor has joined course");
 
-        String accountRequestUsedKey =
-                logic.getAccountRequest("instr1@teammates.tmt", "TEAMMATES Test Institute 1").getRegistrationKey();
+        AccountRequest instructor1AccountRequest = typicalBundle.accountRequests.get("instructor1");
+        String accountRequestUsedKey = instructor1AccountRequest.getRegistrationKey();
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, accountRequestUsedKey,

--- a/src/test/java/teammates/storage/sqlapi/AccountRequestsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountRequestsDbTest.java
@@ -1,6 +1,5 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -50,24 +49,11 @@ public class AccountRequestsDbTest extends BaseTestCase {
     }
 
     @Test
-    public void testCreateAccountRequest_accountRequestDoesNotExist_success() throws InvalidParametersException {
+    public void testCreateAccountRequest_typicalCase_success() throws InvalidParametersException {
         AccountRequest accountRequest =
                 new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-        doReturn(null).when(accountRequestDb).getAccountRequest(anyString(), anyString());
-
         accountRequestDb.createAccountRequest(accountRequest);
 
-        mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest));
-    }
-
-    @Test
-    public void testCreateAccountRequest_accountRequestAlreadyExists_createsSuccessfully()
-            throws InvalidParametersException {
-        AccountRequest accountRequest =
-                new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-        doReturn(new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments"))
-                .when(accountRequestDb).getAccountRequest(anyString(), anyString());
-        accountRequestDb.createAccountRequest(accountRequest);
         mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest));
     }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #11878 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Tests were changed to reference account requests by ID. There were no longer any checks for account requests with the same email address and institute in `AccountRequestsDb::createAccountRequest`, so `AccountRequestsDbTest::testCreateAccountRequest_accountRequestAlreadyExists_createsSuccessfully` was removed. I do not think there is a way to check the behaviour through a unit test without that method. There is still an existing integration test that checks that exact behaviour when there are multiple account requests with the same email address and institute, so I think it's fine.