### PR TITLE
[#11878] Remove mention of home page URL in email

### DIFF
--- a/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
+++ b/src/main/resources/instructorEmailTemplate-newAccountRequestAcknowledgement.html
@@ -42,7 +42,7 @@
     <tr>
       <td style="padding:5px;">
         <strong>
-          Home Page URL<br>& Comments
+          Comments
         </strong>
       </td>
       <td style="padding:5px;">

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithComments.html
@@ -42,7 +42,7 @@
     <tr>
       <td style="padding:5px;">
         <strong>
-          Home Page URL<br>& Comments
+          Comments
         </strong>
       </td>
       <td style="padding:5px;">

--- a/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
+++ b/src/test/resources/emails/instructorNewAccountRequestAcknowledgementEmailWithNoComments.html
@@ -42,7 +42,7 @@
     <tr>
       <td style="padding:5px;">
         <strong>
-          Home Page URL<br>& Comments
+          Comments
         </strong>
       </td>
       <td style="padding:5px;">


### PR DESCRIPTION
Part of #11878

**Outline of Solution**

Remove mention of home page URL in account request acknowledgement email as the form no longer takes in home page URL.
