### PR TITLE
[#11878] Check if account request is not created by admin before sending email

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -229,22 +229,7 @@ public class CreateAccountRequestActionIT extends BaseActionIT<CreateAccountRequ
         CreateAccountRequestAction action = getAction(request);
         JsonResult result = getJsonResult(action);
         AccountRequestData output = (AccountRequestData) result.getOutput();
-        assertEquals("kwisatz.haderach@atreides.org", output.getEmail());
-        assertEquals("Paul Atreides", output.getName());
-        assertEquals("House Atreides", output.getInstitute());
-        assertEquals(AccountRequestStatus.PENDING, output.getStatus());
-        assertEquals("My road leads into the desert. I can see it.", output.getComments());
         assertNull(output.getRegisteredAt());
-        HibernateUtil.beginTransaction();
-        AccountRequest accountRequest = logic.getAccountRequestByRegistrationKey(output.getRegistrationKey());
-        HibernateUtil.commitTransaction();
-        assertEquals("kwisatz.haderach@atreides.org", accountRequest.getEmail());
-        assertEquals("Paul Atreides", accountRequest.getName());
-        assertEquals("House Atreides", accountRequest.getInstitute());
-        assertEquals(AccountRequestStatus.PENDING, accountRequest.getStatus());
-        assertEquals("My road leads into the desert. I can see it.", accountRequest.getComments());
-        assertNull(accountRequest.getRegisteredAt());
-        verifySpecifiedTasksAdded(Const.TaskQueue.SEARCH_INDEXING_QUEUE_NAME, 1);
         verifyNoEmailsSent();
         logoutUser();
     }

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -52,11 +52,15 @@ public class CreateAccountRequestAction extends Action {
         taskQueuer.scheduleAccountRequestForSearchIndexing(accountRequest.getId().toString());
 
         assert accountRequest != null;
-        EmailWrapper adminAlertEmail = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-        EmailWrapper userAcknowledgementEmail = sqlEmailGenerator
-                .generateNewAccountRequestAcknowledgementEmail(accountRequest);
-        emailSender.sendEmail(adminAlertEmail);
-        emailSender.sendEmail(userAcknowledgementEmail);
+
+        if (userInfo == null || !userInfo.isAdmin) {
+            EmailWrapper adminAlertEmail = sqlEmailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+            EmailWrapper userAcknowledgementEmail = sqlEmailGenerator
+                    .generateNewAccountRequestAcknowledgementEmail(accountRequest);
+            emailSender.sendEmail(adminAlertEmail);
+            emailSender.sendEmail(userAcknowledgementEmail);
+        }
+
         AccountRequestData output = new AccountRequestData(accountRequest);
         return new JsonResult(output);
     }


### PR DESCRIPTION
Part of #11878

**Outline of Solution**

* Check that user is not logged in as admin in create account request action. Send acknowledgement email to instructor and notification email to admin only if the user is not admin.
* Add test case to check that no emails are sent for admin