### PR TITLE
[#12048] data migration student chain students

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -75,13 +75,26 @@ public class DataMigrationForCourseEntitySql extends
 
         for (Map.Entry<String, List<CourseStudent>> entry : sectionToStuMap.entrySet()) {
             String sectionName = entry.getKey();
-            // List<CourseStudent> stuList = entry.getValue();
+            List<CourseStudent> stuList = entry.getValue();
             teammates.storage.sqlentity.Section newSection = createSection(newCourse, sectionName);
             sections.put(sectionName, newSection);
-            // migrateTeams(newCourse, newSection, stuList);
+            migrateTeams(newCourse, newSection, stuList);
             saveEntityDeferred(newSection);
         }
         return sections;
+    }
+
+    private void migrateTeams(teammates.storage.sqlentity.Course newCourse,
+            teammates.storage.sqlentity.Section newSection, List<CourseStudent> studentsInSection) {
+        Map<String, List<CourseStudent>> teamNameToStuMap = studentsInSection.stream()
+                .collect(Collectors.groupingBy(CourseStudent::getTeamName));
+        for (Map.Entry<String, List<CourseStudent>> entry : teamNameToStuMap.entrySet()) {
+            String teamName = entry.getKey();
+            // List<CourseStudent> stuList = entry.getValue();
+            teammates.storage.sqlentity.Team newTeam = createTeam(newSection, teamName);
+            // migrateStudent(newCourse, newTeam, stuList);
+            saveEntityDeferred(newTeam);
+        }
     }
 
     private teammates.storage.sqlentity.Course createCourse(Course oldCourse) {
@@ -100,4 +113,9 @@ public class DataMigrationForCourseEntitySql extends
             String sectionName) {
         return new teammates.storage.sqlentity.Section(newCourse, sectionName);
     }
+
+    private teammates.storage.sqlentity.Team createTeam(teammates.storage.sqlentity.Section section, String teamName) {
+        return new teammates.storage.sqlentity.Team(section, teamName);
+    }
+
 }

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -132,6 +132,7 @@ public class DataMigrationForCourseEntitySql extends
         Student newStudent = new Student(newCourse, oldStudent.getName(), oldStudent.getEmail(),
                 oldStudent.getComments(), newTeam);
         newStudent.setUpdatedAt(oldStudent.getUpdatedAt());
+
         return newStudent;
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.googlecode.objectify.cmd.Query;
 
+import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
 import teammates.storage.sqlentity.Student;
@@ -92,12 +93,12 @@ public class DataMigrationForCourseEntitySql extends
             String teamName = entry.getKey();
             List<CourseStudent> stuList = entry.getValue();
             teammates.storage.sqlentity.Team newTeam = createTeam(newSection, teamName);
-            migrateStudent(newCourse, newTeam, stuList);
+            migrateStudents(newCourse, newTeam, stuList);
             saveEntityDeferred(newTeam);
         }
     }
 
-    private void migrateStudent(teammates.storage.sqlentity.Course newCourse, teammates.storage.sqlentity.Team newTeam,
+    private void migrateStudents(teammates.storage.sqlentity.Course newCourse, teammates.storage.sqlentity.Team newTeam,
             List<CourseStudent> studentsInTeam) {
         for (CourseStudent oldStudent : studentsInTeam) {
             teammates.storage.sqlentity.Student newStudent = createStudent(newCourse, newTeam, oldStudent);
@@ -112,13 +113,17 @@ public class DataMigrationForCourseEntitySql extends
                 oldCourse.getTimeZone(),
                 oldCourse.getInstitute());
         newCourse.setDeletedAt(oldCourse.getDeletedAt());
-        // newCourse.setCreatedAt(oldCourse.getCreatedAt());
+        newCourse.setCreatedAt(oldCourse.getCreatedAt());
+
         saveEntityDeferred(newCourse);
         return newCourse;
     }
 
     private teammates.storage.sqlentity.Section createSection(teammates.storage.sqlentity.Course newCourse,
             String sectionName) {
+        if (sectionName.equals(Const.DEFAULT_SECTION)) {
+            return Const.DEFAULT_SQL_SECTION;
+        }
         return new teammates.storage.sqlentity.Section(newCourse, sectionName);
     }
 
@@ -132,6 +137,7 @@ public class DataMigrationForCourseEntitySql extends
         Student newStudent = new Student(newCourse, oldStudent.getName(), oldStudent.getEmail(),
                 oldStudent.getComments(), newTeam);
         newStudent.setUpdatedAt(oldStudent.getUpdatedAt());
+        newStudent.setRegKey(oldStudent.getRegistrationKey());
 
         return newStudent;
     }

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -1,5 +1,6 @@
 package teammates.client.scripts.sql;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -7,10 +8,11 @@ import java.util.stream.Collectors;
 
 import com.googlecode.objectify.cmd.Query;
 
-import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.Team;
 
 /**
  * Data migration class for course entity.
@@ -121,14 +123,18 @@ public class DataMigrationForCourseEntitySql extends
 
     private teammates.storage.sqlentity.Section createSection(teammates.storage.sqlentity.Course newCourse,
             String sectionName) {
-        if (sectionName.equals(Const.DEFAULT_SECTION)) {
-            return Const.DEFAULT_SQL_SECTION;
-        }
-        return new teammates.storage.sqlentity.Section(newCourse, sectionName);
+        // if (sectionName.equals(Const.DEFAULT_SECTION)) {
+        // return Const.DEFAULT_SQL_SECTION;
+        // }
+        Section newSection = new Section(newCourse, sectionName);
+        newSection.setCreatedAt(Instant.now());
+        return newSection;
     }
 
     private teammates.storage.sqlentity.Team createTeam(teammates.storage.sqlentity.Section section, String teamName) {
-        return new teammates.storage.sqlentity.Team(section, teamName);
+        Team newTeam = new teammates.storage.sqlentity.Team(section, teamName);
+        newTeam.setCreatedAt(Instant.now());
+        return newTeam;
     }
 
     private Student createStudent(teammates.storage.sqlentity.Course newCourse,
@@ -138,6 +144,7 @@ public class DataMigrationForCourseEntitySql extends
                 oldStudent.getComments(), newTeam);
         newStudent.setUpdatedAt(oldStudent.getUpdatedAt());
         newStudent.setRegKey(oldStudent.getRegistrationKey());
+        newStudent.setCreatedAt(oldStudent.getCreatedAt());
 
         return newStudent;
     }

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -1,0 +1,81 @@
+package teammates.client.scripts.sql;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.storage.entity.Course;
+import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Student;
+
+/**
+ * Data migration class for course entity.
+ */
+@SuppressWarnings("PMD")
+public class DataMigrationForCourseEntitySql extends
+        DataMigrationEntitiesBaseScriptSql<teammates.storage.entity.Course, teammates.storage.sqlentity.BaseEntity> {
+
+    public static void main(String[] args) {
+        new DataMigrationForCourseEntitySql().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<Course> getFilterQuery() {
+        return ofy().load().type(teammates.storage.entity.Course.class);
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return false;
+    }
+
+    /*
+     * Sets the migration criteria used in isMigrationNeeded.
+     */
+    @Override
+    protected void setMigrationCriteria() {
+        // No migration criteria currently needed.
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(Course entity) {
+        return true;
+    }
+
+    @Override
+    protected void migrateEntity(Course oldCourse) throws Exception {
+        teammates.storage.sqlentity.Course newCourse = createCourse(oldCourse);
+        // TODO: add shutdown hook to save the entity
+        // Runnable shutdownScript = () -> { cascadeDelete(newCourse)};
+        // Runtime.getRuntime().addShutdownHook(new Thread(shutdownScript));
+
+        migrateCourseEntity(newCourse);
+        // verifyCourseEntity(newCourse);
+        // markOldCourseAsMigrated(courseId)
+        // Runtime.getRuntime().removeShutDownHook(new Thread(shutdownScript));
+    }
+
+    private void migrateCourseEntity(teammates.storage.sqlentity.Course newCourse) {
+        // Map<String, teammates.storage.sqlentity.Section> sectionNameToSectionMap =
+        // migrateSectionChain(newCourse);
+        // System.out.println(sectionNameToSectionMap); // To stop lint from complaining
+        // TODO: Add mirgrateFeedbackChain
+        // migrateFeedbackChain(sectionNameToSectionMap);
+    }
+
+
+    private teammates.storage.sqlentity.Course createCourse(Course oldCourse) {
+        teammates.storage.sqlentity.Course newCourse = new teammates.storage.sqlentity.Course(
+                oldCourse.getUniqueId(),
+                oldCourse.getName(),
+                oldCourse.getTimeZone(),
+                oldCourse.getInstitute());
+        newCourse.setDeletedAt(oldCourse.getDeletedAt());
+        // newCourse.setCreatedAt(oldCourse.getCreatedAt());
+        saveEntityDeferred(newCourse);
+        return newCourse;
+    }
+}

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -90,10 +90,18 @@ public class DataMigrationForCourseEntitySql extends
                 .collect(Collectors.groupingBy(CourseStudent::getTeamName));
         for (Map.Entry<String, List<CourseStudent>> entry : teamNameToStuMap.entrySet()) {
             String teamName = entry.getKey();
-            // List<CourseStudent> stuList = entry.getValue();
+            List<CourseStudent> stuList = entry.getValue();
             teammates.storage.sqlentity.Team newTeam = createTeam(newSection, teamName);
-            // migrateStudent(newCourse, newTeam, stuList);
+            migrateStudent(newCourse, newTeam, stuList);
             saveEntityDeferred(newTeam);
+        }
+    }
+
+    private void migrateStudent(teammates.storage.sqlentity.Course newCourse, teammates.storage.sqlentity.Team newTeam,
+            List<CourseStudent> studentsInTeam) {
+        for (CourseStudent oldStudent : studentsInTeam) {
+            teammates.storage.sqlentity.Student newStudent = createStudent(newCourse, newTeam, oldStudent);
+            saveEntityDeferred(newStudent);
         }
     }
 
@@ -118,4 +126,12 @@ public class DataMigrationForCourseEntitySql extends
         return new teammates.storage.sqlentity.Team(section, teamName);
     }
 
+    private Student createStudent(teammates.storage.sqlentity.Course newCourse,
+            teammates.storage.sqlentity.Team newTeam,
+            CourseStudent oldStudent) {
+        Student newStudent = new Student(newCourse, oldStudent.getName(), oldStudent.getEmail(),
+                oldStudent.getComments(), newTeam);
+        newStudent.setUpdatedAt(oldStudent.getUpdatedAt());
+        return newStudent;
+    }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -52,7 +52,7 @@ public class VerifyCourseEntityAttributes
                 && sqlEntity.getName().equals(datastoreEntity.getName())
                 && sqlEntity.getTimeZone().equals(datastoreEntity.getTimeZone())
                 && sqlEntity.getInstitute().equals(datastoreEntity.getInstitute())
-                // && sqlEntity.getCreatedAt().equals(datastoreEntity.getCreatedAt())
+                && sqlEntity.getCreatedAt().equals(datastoreEntity.getCreatedAt())
                 && datastoreEntity.getDeletedAt() == null ? sqlEntity.getDeletedAt() == null
                         : sqlEntity.getDeletedAt().equals(datastoreEntity.getDeletedAt());
     }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -143,7 +143,9 @@ public class VerifyCourseEntityAttributes
         return newStudent.getName().equals(oldStudent.getName())
                 && newStudent.getEmail().equals(oldStudent.getEmail())
                 && newStudent.getComments().equals(oldStudent.getComments())
-                && newStudent.getUpdatedAt().equals(oldStudent.getUpdatedAt());
+                && newStudent.getUpdatedAt().equals(oldStudent.getUpdatedAt())
+                && newStudent.getCreatedAt().equals(oldStudent.getCreatedAt())
+                && newStudent.getRegKey().equals(oldStudent.getRegistrationKey());
 
     }
 

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -1,0 +1,60 @@
+package teammates.client.scripts.sql;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import teammates.common.util.HibernateUtil;
+import teammates.storage.entity.Course;
+import teammates.storage.entity.CourseStudent;
+import teammates.storage.sqlentity.Section;
+import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.Team;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+/**
+ * Class for verifying account attributes.
+ */
+@SuppressWarnings("PMD")
+public class VerifyCourseEntityAttributes
+        extends VerifyNonCourseEntityAttributesBaseScript<Course, teammates.storage.sqlentity.Course> {
+
+    public VerifyCourseEntityAttributes() {
+        super(Course.class,
+                teammates.storage.sqlentity.Course.class);
+    }
+
+    @Override
+    protected String generateID(teammates.storage.sqlentity.Course sqlEntity) {
+        return sqlEntity.getId();
+    }
+
+    public static void main(String[] args) {
+        VerifyCourseEntityAttributes script = new VerifyCourseEntityAttributes();
+        script.doOperationRemotely();
+    }
+
+    // Used for sql data migration
+    @Override
+    public boolean equals(teammates.storage.sqlentity.Course sqlEntity, Course datastoreEntity) {
+        try {
+            return verifyCourse(sqlEntity, datastoreEntity); // && verifySectionChain(sqlEntity);
+        } catch (IllegalArgumentException iae) {
+            return false;
+        }
+    }
+
+    private boolean verifyCourse(teammates.storage.sqlentity.Course sqlEntity, Course datastoreEntity) {
+        return sqlEntity.getId().equals(datastoreEntity.getUniqueId())
+                && sqlEntity.getName().equals(datastoreEntity.getName())
+                && sqlEntity.getTimeZone().equals(datastoreEntity.getTimeZone())
+                && sqlEntity.getInstitute().equals(datastoreEntity.getInstitute())
+                // && sqlEntity.getCreatedAt().equals(datastoreEntity.getCreatedAt())
+                && datastoreEntity.getDeletedAt() == null ? sqlEntity.getDeletedAt() == null
+                        : sqlEntity.getDeletedAt().equals(datastoreEntity.getDeletedAt());
+    }
+
+}

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -88,13 +88,36 @@ public class VerifyCourseEntityAttributes
             }
 
             // Group students by team
-            // Map<String, List<CourseStudent>> teamNameToOldStuMap = oldSectionStudents.stream()
-            //         .collect(Collectors.groupingBy(CourseStudent::getTeamName));
-            // Map<String, List<Student>> teamNameToNewStuMap = newSectionStudents.stream()
-            //         .collect(Collectors.groupingBy(Student::getTeamName));
-            return true; // verifyTeams(section, teamNameToOldStuMap, teamNameToNewStuMap);
+            Map<String, List<CourseStudent>> teamNameToOldStuMap = oldSectionStudents.stream()
+                    .collect(Collectors.groupingBy(CourseStudent::getTeamName));
+            Map<String, List<Student>> teamNameToNewStuMap = newSectionStudents.stream()
+                    .collect(Collectors.groupingBy(Student::getTeamName));
+            return verifyTeams(section, teamNameToOldStuMap, teamNameToNewStuMap);
         });
 
     }
 
+    private boolean verifyTeams(Section newSection,
+            Map<String, List<CourseStudent>> teamNameToOldStuMap, Map<String, List<Student>> teamNameToNewStuMap) {
+
+        List<Team> newTeam = newSection.getTeams();
+
+        boolean isTeamCountEqual = newTeam.size() != teamNameToNewStuMap.size()
+                || newTeam.size() != teamNameToOldStuMap.size();
+        if (!isTeamCountEqual) {
+            return false;
+        }
+
+        return newTeam.stream().allMatch(team -> {
+            List<CourseStudent> oldTeamStudents = teamNameToOldStuMap.get(team.getName());
+            List<Student> newTeamStudents = teamNameToNewStuMap.get(team.getName());
+
+            // If teamStudents is null, then team is not present in sql
+            boolean isTeamNamePresent = oldTeamStudents != null && newTeamStudents != null;
+            if (!isTeamNamePresent) {
+                return false;
+            }
+            return true; // verifyStudents(oldTeamStudents, newTeamStudents);
+        });
+    }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -117,7 +117,43 @@ public class VerifyCourseEntityAttributes
             if (!isTeamNamePresent) {
                 return false;
             }
-            return true; // verifyStudents(oldTeamStudents, newTeamStudents);
+            return verifyStudents(oldTeamStudents, newTeamStudents);
         });
+    }
+
+    private boolean verifyStudents(
+            List<CourseStudent> oldTeamStudents, List<Student> newTeamStudents) {
+        if (oldTeamStudents.size() != newTeamStudents.size()) {
+            return false;
+        }
+        oldTeamStudents.sort((a, b) -> a.getEmail().compareTo(b.getEmail()));
+        newTeamStudents.sort((a, b) -> a.getEmail().compareTo(b.getEmail()));
+        for (int i = 0; i < oldTeamStudents.size(); i++) {
+            CourseStudent oldStudent = oldTeamStudents.get(i);
+            Student newStudent = newTeamStudents.get(i);
+            if (!verifyStudent(oldStudent, newStudent)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean verifyStudent(CourseStudent oldStudent,
+            Student newStudent) {
+        return newStudent.getName().equals(oldStudent.getName())
+                && newStudent.getEmail().equals(oldStudent.getEmail())
+                && newStudent.getComments().equals(oldStudent.getComments());
+    }
+
+    private List<Student> getCurrStudents(String courseId) {
+        HibernateUtil.beginTransaction();
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<teammates.storage.sqlentity.Student> cr = cb
+                .createQuery(teammates.storage.sqlentity.Student.class);
+        Root<teammates.storage.sqlentity.Student> courseRoot = cr.from(teammates.storage.sqlentity.Student.class);
+        cr.select(courseRoot).where(cb.equal(courseRoot.get("courseId"), courseId));
+        List<Student> newStudents = HibernateUtil.createQuery(cr).getResultList();
+        HibernateUtil.commitTransaction();
+        return newStudents;
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -61,7 +61,7 @@ public class VerifyCourseEntityAttributes
         // Get old and new students
         List<CourseStudent> oldStudents = ofy().load().type(CourseStudent.class).filter("courseId", sqlEntity.getId())
                 .list();
-        List<Student> newStudents = getCurrStudents(sqlEntity.getId());
+        List<Student> newStudents = getNewStudents(sqlEntity.getId());
 
         // Group students by section
         Map<String, List<CourseStudent>> sectionToOldStuMap = oldStudents.stream()
@@ -142,10 +142,12 @@ public class VerifyCourseEntityAttributes
             Student newStudent) {
         return newStudent.getName().equals(oldStudent.getName())
                 && newStudent.getEmail().equals(oldStudent.getEmail())
-                && newStudent.getComments().equals(oldStudent.getComments());
+                && newStudent.getComments().equals(oldStudent.getComments())
+                && newStudent.getUpdatedAt().equals(oldStudent.getUpdatedAt());
+
     }
 
-    private List<Student> getCurrStudents(String courseId) {
+    private List<Student> getNewStudents(String courseId) {
         HibernateUtil.beginTransaction();
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<teammates.storage.sqlentity.Student> cr = cb

--- a/src/main/java/teammates/storage/sqlentity/BaseEntity.java
+++ b/src/main/java/teammates/storage/sqlentity/BaseEntity.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import com.google.common.reflect.TypeToken;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -26,8 +24,9 @@ import jakarta.persistence.MappedSuperclass;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-    @CreationTimestamp
-    @Column(updatable = false)
+    // @CreationTimestamp
+    // @Column(updatable = false)
+    @Column(updatable = true)
     private Instant createdAt;
 
     BaseEntity() {

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -5,8 +5,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
-import org.hibernate.annotations.UpdateTimestamp;
-
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 
@@ -56,7 +54,7 @@ public abstract class User extends BaseEntity {
     @Column(nullable = false)
     private String regKey;
 
-    @UpdateTimestamp
+    // @UpdateTimestamp
     private Instant updatedAt;
 
     protected User() {


### PR DESCRIPTION
Part of  #12048

**Outline of Solution**
Cascade migrate student
Verify migrated students
Change createdAt to be updatable
Remove creationTimeStamp annotation from createdAt
Reemove updateTimeStamp annotation from updatedAt

**Things left to do in other PR**
- [ ] Follow up from fergus on usage of `DEFAULT_SECTION` or `DEFAULT_SQL_SECTION`
- [ ] Shutdown hook or its equivalent
- [ ] migrateFeedbackChain method
- [ ] verifyCourseEnitity Method or its equivalent
