### PR TITLE
[#12048] Data migration for feedback entities chain

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -1,5 +1,6 @@
 package teammates.client.scripts.sql;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -8,11 +9,34 @@ import java.util.stream.Collectors;
 
 import com.googlecode.objectify.cmd.Query;
 
+import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
+import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackResponse;
+import teammates.storage.entity.FeedbackResponseComment;
+import teammates.storage.entity.FeedbackSession;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.Team;
+import teammates.storage.sqlentity.questions.FeedbackConstantSumQuestion.FeedbackConstantSumQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackContributionQuestion.FeedbackContributionQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackMcqQuestion.FeedbackMcqQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackMsqQuestion.FeedbackMsqQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackNumericalScaleQuestion.FeedbackNumericalScaleQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackRankOptionsQuestion.FeedbackRankOptionsQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackRankRecipientsQuestion.FeedbackRankRecipientsQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackRubricQuestion.FeedbackRubricQuestionDetailsConverter;
+import teammates.storage.sqlentity.questions.FeedbackTextQuestion.FeedbackTextQuestionDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackConstantSumResponse.FeedbackConstantSumResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackContributionResponse.FeedbackContributionResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackMsqResponse.FeedbackMsqResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackNumericalScaleResponse.FeedbackNumericalScaleResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackRankOptionsResponse.FeedbackRankOptionsResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackRankRecipientsResponse.FeedbackRankRecipientsResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackRubricResponse.FeedbackRubricResponseDetailsConverter;
+import teammates.storage.sqlentity.responses.FeedbackTextResponse.FeedbackTextResponseDetailsConverter;
 
 /**
  * Data migration class for course entity.
@@ -62,11 +86,11 @@ public class DataMigrationForCourseEntitySql extends
     }
 
     private void migrateCourseEntity(teammates.storage.sqlentity.Course newCourse) {
-        Map<String, teammates.storage.sqlentity.Section> sectionNameToSectionMap = migrateSectionChain(newCourse);
-        System.out.println(sectionNameToSectionMap); // To stop lint from complaining
-        // TODO: Add mirgrateFeedbackChain
-        // migrateFeedbackChain(sectionNameToSectionMap);
+        Map<String, Section> sectionNameToSectionMap = migrateSectionChain(newCourse);
+        migrateFeedbackChain(newCourse, sectionNameToSectionMap);
     }
+
+    // methods for migrate section chain ----------------------------------------------------------------------------------
 
     private Map<String, teammates.storage.sqlentity.Section> migrateSectionChain(
             teammates.storage.sqlentity.Course newCourse) {
@@ -148,4 +172,246 @@ public class DataMigrationForCourseEntitySql extends
 
         return newStudent;
     }
+
+    // methods for migrate feedback chain ---------------------------------------------------------------------------------
+
+    private void migrateFeedbackChain(teammates.storage.sqlentity.Course newCourse,
+            Map<String, Section> sectionNameToSectionMap) {
+
+        List<FeedbackSession> oldSessions = ofy().load().type(FeedbackSession.class)
+                .filter("courseId", newCourse.getId()).list();
+        
+        Map<String, List<FeedbackQuestion>> sessionNameToQuestionsMap = ofy().load().type(FeedbackQuestion.class)
+                .filter("courseId", newCourse.getId()).list().stream()
+                .collect(Collectors.groupingBy(FeedbackQuestion::getFeedbackSessionName));
+
+        for (FeedbackSession oldSession : oldSessions) {
+            migrateFeedbackSession(newCourse, oldSession, sessionNameToQuestionsMap, sectionNameToSectionMap);
+        }
+    }
+
+    private void migrateFeedbackSession(teammates.storage.sqlentity.Course newCourse, FeedbackSession oldSession,
+            Map<String, List<FeedbackQuestion>> sessionNameToQuestionsMap, Map<String, Section> sectionNameToSectionMap) {
+        teammates.storage.sqlentity.FeedbackSession newSession = createFeedbackSession(newCourse, oldSession);
+        saveEntityDeferred(newSession);
+
+        Map<String, List<FeedbackResponse>> questionIdToResponsesMap = ofy().load().type(FeedbackResponse.class)
+                .filter("courseId", newCourse.getId())
+                .filter("feedbackSessionName", oldSession.getFeedbackSessionName()).list().stream()
+                .collect(Collectors.groupingBy(FeedbackResponse::getFeedbackQuestionId));
+
+        // cascade migrate questions
+        List<FeedbackQuestion> oldQuestions = sessionNameToQuestionsMap.get(oldSession.getFeedbackSessionName());
+        for (FeedbackQuestion oldQuestion : oldQuestions) {
+            migrateFeedbackQuestion(newSession, oldQuestion, questionIdToResponsesMap, sectionNameToSectionMap);
+        }
+    }
+
+    private void migrateFeedbackQuestion(teammates.storage.sqlentity.FeedbackSession newSession,
+            FeedbackQuestion oldQuestion, Map<String, List<FeedbackResponse>> questionIdToResponsesMap,
+            Map<String, Section> sectionNameToSectionMap) {
+        teammates.storage.sqlentity.FeedbackQuestion newFeedbackQuestion = createFeedbackQuestion(newSession, oldQuestion);
+        saveEntityDeferred(newFeedbackQuestion);
+
+        Map<String, List<FeedbackResponseComment>> responseIdToCommentsMap = ofy().load()
+                .type(FeedbackResponseComment.class)
+                .filter("courseId", newSession.getCourse().getId())
+                .filter("feedbackSessionName", newSession.getName())
+                .filter("feedbackQuestionId", oldQuestion.getId()).list().stream()
+                .collect(Collectors.groupingBy(FeedbackResponseComment::getFeedbackResponseId));
+
+        // cascade migrate responses
+        List<FeedbackResponse> oldResponses = questionIdToResponsesMap.get(oldQuestion.getId());
+        for (FeedbackResponse oldResponse : oldResponses) {
+            Section newGiverSection = sectionNameToSectionMap.get(oldResponse.getGiverSection());
+            Section newRecipientSection = sectionNameToSectionMap.get(oldResponse.getRecipientSection());
+            migrateFeedbackResponse(newFeedbackQuestion, oldResponse, newGiverSection,
+                    newRecipientSection, responseIdToCommentsMap);
+        }
+    }
+
+    private void migrateFeedbackResponse(teammates.storage.sqlentity.FeedbackQuestion newQuestion,
+            FeedbackResponse oldResponse, Section newGiverSection, Section newRecipientSection,
+            Map<String, List<FeedbackResponseComment>> responseIdToCommentsMap) {
+        teammates.storage.sqlentity.FeedbackResponse newResponse = createFeedbackResponse(newQuestion, oldResponse,
+                newGiverSection, newRecipientSection);
+        saveEntityDeferred(newResponse);
+        
+        // cascade migrate response comments
+        List<FeedbackResponseComment> oldComments = responseIdToCommentsMap.get(oldResponse.getId());
+        for (FeedbackResponseComment oldComment : oldComments) {
+            migrateFeedbackResponseComment(newResponse, oldComment, newGiverSection, newRecipientSection);
+        }
+    }
+
+    private void migrateFeedbackResponseComment(teammates.storage.sqlentity.FeedbackResponse newResponse,
+            FeedbackResponseComment oldComment, Section newGiverSection, Section newRecipientSection) {
+        teammates.storage.sqlentity.FeedbackResponseComment newComment = createFeedbackResponseComment(newResponse,
+                oldComment, newGiverSection, newRecipientSection);
+        saveEntityDeferred(newComment);
+    }
+
+    private teammates.storage.sqlentity.FeedbackSession createFeedbackSession(teammates.storage.sqlentity.Course newCourse,
+            FeedbackSession oldSession) {
+        teammates.storage.sqlentity.FeedbackSession newSession = new teammates.storage.sqlentity.FeedbackSession(
+                oldSession.getFeedbackSessionName(),
+                newCourse,
+                oldSession.getCreatorEmail(),
+                oldSession.getInstructions(),
+                oldSession.getStartTime(),
+                oldSession.getEndTime(),
+                oldSession.getSessionVisibleFromTime(),
+                oldSession.getResultsVisibleFromTime(),
+                Duration.ofMinutes(oldSession.getGracePeriod()),
+                oldSession.isOpeningEmailEnabled(),
+                oldSession.isClosingEmailEnabled(),
+                oldSession.isPublishedEmailEnabled());
+
+        newSession.setClosedEmailSent(oldSession.isSentClosedEmail());
+        newSession.setClosingSoonEmailSent(oldSession.isSentClosingEmail());
+        newSession.setOpenEmailSent(oldSession.isSentOpenEmail());
+        newSession.setOpeningSoonEmailSent(oldSession.isSentOpeningSoonEmail());
+        newSession.setPublishedEmailSent(oldSession.isSentPublishedEmail());
+        newSession.setCreatedAt(oldSession.getCreatedTime());
+        // newSession.setUpdatedAt(oldSession.getUpdatedAt()); // present in sql but not in datstore section
+        newSession.setDeletedAt(oldSession.getDeletedTime());
+
+        return newSession;
+    }
+
+    private teammates.storage.sqlentity.FeedbackQuestion createFeedbackQuestion(
+            teammates.storage.sqlentity.FeedbackSession newSession, FeedbackQuestion oldQuestion) {
+
+        teammates.storage.sqlentity.FeedbackQuestion newFeedbackQuestion =
+                teammates.storage.sqlentity.FeedbackQuestion.makeQuestion(
+                        newSession,
+                        oldQuestion.getQuestionNumber(),
+                        oldQuestion.getQuestionDescription(),
+                        oldQuestion.getGiverType(),
+                        oldQuestion.getRecipientType(),
+                        oldQuestion.getNumberOfEntitiesToGiveFeedbackTo(),
+                        oldQuestion.getShowResponsesTo(),
+                        oldQuestion.getShowGiverNameTo(),
+                        oldQuestion.getShowRecipientNameTo(),
+                        getFeedbackQuestionDetails(oldQuestion));
+            
+        newFeedbackQuestion.setCreatedAt(oldQuestion.getCreatedAt());
+        newFeedbackQuestion.setUpdatedAt(oldQuestion.getUpdatedAt());
+
+        return newFeedbackQuestion;
+    }
+
+    private FeedbackQuestionDetails getFeedbackQuestionDetails(FeedbackQuestion oldQuestion) {
+        switch (oldQuestion.getQuestionType()) {
+            case MCQ:
+                return new FeedbackMcqQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText());
+            case MSQ:
+                return new FeedbackMsqQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText());
+            case TEXT:
+                return new FeedbackTextQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText());
+            case RUBRIC:
+                return new FeedbackRubricQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText()); 
+            case CONTRIB:
+                return new FeedbackContributionQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText()); 
+            case CONSTSUM:
+            case CONSTSUM_RECIPIENTS:
+            case CONSTSUM_OPTIONS:
+                return new FeedbackConstantSumQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText()); 
+            case NUMSCALE:
+                return new FeedbackNumericalScaleQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText());
+            case RANK_OPTIONS:
+                return new FeedbackRankOptionsQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText()); 
+            case RANK_RECIPIENTS:
+                return new FeedbackRankRecipientsQuestionDetailsConverter()
+                        .convertToEntityAttribute(oldQuestion.getQuestionText()); 
+            default:
+                throw new IllegalArgumentException("Invalid question type");
+        }
+    }
+
+    private teammates.storage.sqlentity.FeedbackResponse createFeedbackResponse(
+            teammates.storage.sqlentity.FeedbackQuestion newQuestion, FeedbackResponse oldResponse,
+            Section giverSection, Section recipientSection) {
+        teammates.storage.sqlentity.FeedbackResponse newResponse =
+                teammates.storage.sqlentity.FeedbackResponse.makeResponse(
+                        newQuestion,
+                        oldResponse.getGiverEmail(),
+                        giverSection,
+                        oldResponse.getRecipientEmail(),
+                        recipientSection,
+                        getFeedbackResponseDetails(oldResponse));
+
+        newResponse.setCreatedAt(oldResponse.getCreatedAt());
+        newResponse.setUpdatedAt(oldResponse.getUpdatedAt());
+
+        return newResponse;
+    }
+
+    private FeedbackResponseDetails getFeedbackResponseDetails(FeedbackResponse oldResponse) {
+        switch(oldResponse.getFeedbackQuestionType()) {
+            case MCQ:
+                return new FeedbackTextResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case MSQ:
+                return new FeedbackMsqResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case TEXT:
+                return new FeedbackTextResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case RUBRIC:
+                return new FeedbackRubricResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case CONTRIB:
+                return new FeedbackContributionResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case CONSTSUM:
+            case CONSTSUM_RECIPIENTS:
+            case CONSTSUM_OPTIONS:
+                return new FeedbackConstantSumResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case NUMSCALE:
+                return new FeedbackNumericalScaleResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case RANK_OPTIONS:
+                return new FeedbackRankOptionsResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            case RANK_RECIPIENTS:
+                return new FeedbackRankRecipientsResponseDetailsConverter()
+                        .convertToEntityAttribute(oldResponse.getAnswer());
+            default:
+                throw new IllegalArgumentException("Invalid response type");
+        }
+    }
+
+    private teammates.storage.sqlentity.FeedbackResponseComment createFeedbackResponseComment(
+            teammates.storage.sqlentity.FeedbackResponse newResponse, FeedbackResponseComment oldComment,
+            Section giverSection, Section recipientSection) {
+        teammates.storage.sqlentity.FeedbackResponseComment newComment =
+                new teammates.storage.sqlentity.FeedbackResponseComment(
+                        newResponse,
+                        oldComment.getGiverEmail(),
+                        oldComment.getCommentGiverType(),
+                        giverSection,
+                        recipientSection,
+                        oldComment.getCommentText(),
+                        oldComment.getIsVisibilityFollowingFeedbackQuestion(),
+                        oldComment.getIsCommentFromFeedbackParticipant(),
+                        oldComment.getShowCommentTo(),
+                        oldComment.getShowGiverNameTo(),
+                        oldComment.getLastEditorEmail());
+
+        newComment.setCreatedAt(oldComment.getCreatedAt());
+        newComment.setUpdatedAt(oldComment.getLastEditedAt());
+
+        return newComment;
+    }
+
 }

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -270,7 +270,7 @@ public class DataMigrationForCourseEntitySql extends
         newSession.setOpeningSoonEmailSent(oldSession.isSentOpeningSoonEmail());
         newSession.setPublishedEmailSent(oldSession.isSentPublishedEmail());
         newSession.setCreatedAt(oldSession.getCreatedTime());
-        newSession.setUpdatedAt(Instant.now()); // not present in datastore section
+        newSession.setUpdatedAt(Instant.now()); // not present in datastore session
         newSession.setDeletedAt(oldSession.getDeletedTime());
 
         return newSession;

--- a/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
@@ -81,7 +81,7 @@ public abstract class FeedbackQuestion extends BaseEntity implements Comparable<
     @Convert(converter = FeedbackParticipantTypeListConverter.class)
     private List<FeedbackParticipantType> showRecipientNameTo;
 
-    @UpdateTimestamp
+    // @UpdateTimestamp
     @Column
     private Instant updatedAt;
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -61,7 +61,7 @@ public abstract class FeedbackResponse extends BaseEntity {
     @JoinColumn(name = "recipientSectionId")
     private Section recipientSection;
 
-    @UpdateTimestamp
+    // @UpdateTimestamp
     private Instant updatedAt;
 
     protected FeedbackResponse() {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponseComment.java
@@ -69,7 +69,7 @@ public class FeedbackResponseComment extends BaseEntity {
     @Convert(converter = FeedbackParticipantTypeListConverter.class)
     private List<FeedbackParticipantType> showGiverNameTo;
 
-    @UpdateTimestamp
+    // @UpdateTimestamp
     private Instant updatedAt;
 
     @Column(nullable = false)

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -101,7 +101,7 @@ public class FeedbackSession extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<FeedbackQuestion> feedbackQuestions = new ArrayList<>();
 
-    @UpdateTimestamp
+    // @UpdateTimestamp
     private Instant updatedAt;
 
     private Instant deletedAt;


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
- Added methods for cascading migration of `FeedbackSession`, `FeedbackQuestion`, `FeedbackResponse` and `FeedbackResponseComment`
- Remove `@UpdateTimestamp` annotation for affected entities


Todo in other PRs:
- [ ] Verification script for feedback entity chain
- [ ] `DeadlineExtension` and `Instructor` migration methods