### PR TITLE
[#12048] Update changelog docs and changelog name

### DIFF
--- a/docs/schema-migration.md
+++ b/docs/schema-migration.md
@@ -31,5 +31,5 @@ Here is a brief description of the activities defined for Liquibase
 5. Generate snapshot of database by running `./gradlew liquibaseSnapshot -PrunList=snapshot`, the snapshot will be output to `liquibase-snapshot.json`
 6. Checkout your branch and repeat steps 2 and 4 to generate the tables found on your branch
 7. Run `./gradlew liquibaseDiffChangeLog -PrunList=diffMain` to generate changeLog to resolve database schema differences
-8. Manually add a changeSet to tag the database using `release_number` (See the last changeset in v9.0.0 for reference).
-9. Include the new changelog file in `changelog-root.xml`.
+8. Manually add a changeSet to tag the database using `release_number`. The tag should be named `<release_number` e.g `v9.0.0-beta.1` (See the last changeset in v9.0.0 for reference).
+9. Include the new changelog file as the last entry in `changelog-root.xml` as this is the order which changelogs are executed! (See [liquibase include tag](https://docs.liquibase.com/change-types/include.html))

--- a/src/main/resources/db/changelog/db.changelog-root.xml
+++ b/src/main/resources/db/changelog/db.changelog-root.xml
@@ -5,5 +5,5 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <include file="src/main/resources/db/changelog/db.changelog-v9.0.0.xml" />
-    <include file="src/main/resources/db/changelog/db.changelog-v9.0.0.beta.5.xml" />
+    <include file="src/main/resources/db/changelog/db.changelog-v9.0.0-beta.5.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-root.xml
+++ b/src/main/resources/db/changelog/db.changelog-root.xml
@@ -5,5 +5,5 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <include file="src/main/resources/db/changelog/db.changelog-v9.0.0.xml" />
-    <include file="src/main/resources/db/changelog/db.changelog-v9.0.0beta.5.xml" />
+    <include file="src/main/resources/db/changelog/db.changelog-v9.0.0.beta.5.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-v9.0.0-beta.5.xml
+++ b/src/main/resources/db/changelog/db.changelog-v9.0.0-beta.5.xml
@@ -32,6 +32,6 @@
         <dropUniqueConstraint constraintName="Unique name and institute" tableName="account_requests"/>
     </changeSet>
     <changeSet author="ziqing" id="1713527659740-5">
-        <tagDatabase tag="v9.0.0.beta.5"/>
+        <tagDatabase tag="v9.0.0-beta.5"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-v9.0.0.beta.5.xml
+++ b/src/main/resources/db/changelog/db.changelog-v9.0.0.beta.5.xml
@@ -32,6 +32,6 @@
         <dropUniqueConstraint constraintName="Unique name and institute" tableName="account_requests"/>
     </changeSet>
     <changeSet author="ziqing" id="1713527659740-5">
-        <tagDatabase tag="v9.0.0beta.5"/>
+        <tagDatabase tag="v9.0.0.beta.5"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Part of #12048

**Context**
Previously I mentioned that liquibase runs changelogs in alphanumeric order, but this is incorrect. Changelogs are run in numeric order if the [includeAll tag](https://docs.liquibase.com/change-types/includeall.html) is used to run changelogs. In Teammates, we use the [include tag](https://docs.liquibase.com/change-types/include.htm) which runs in the order they are placed in the `changelog-root.xml` file

**Outline of Solution**
- Amend documentation to remind devs to add newest changelog to bottom of file.
- Rename changelog name and tag name

Note: I'll update the Teammates Ops process which is more critical
