### PR TITLE
13064 use account request update request as parameter

### DIFF
--- a/src/web/app/components/account-requests-table/account-request-table.component.ts
+++ b/src/web/app/components/account-requests-table/account-request-table.component.ts
@@ -3,6 +3,7 @@ import { NgbModalRef, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AccountRequestTableRowModel } from './account-request-table-model';
 import { EditRequestModalComponentResult } from './admin-edit-request-modal/admin-edit-request-modal-model';
 import { EditRequestModalComponent } from './admin-edit-request-modal/admin-edit-request-modal.component';
+import { AccountRequestUpdateRequest } from '../../../types/api-request';
 import {
   RejectWithReasonModalComponentResult,
 } from './admin-reject-with-reason-modal/admin-reject-with-reason-modal-model';
@@ -76,7 +77,7 @@ export class AccountRequestTableComponent {
             institute: res.accountRequestInstitution,
             status: accountRequest.status,
             comment: res.accountRequestComment
-          })
+          } as AccountRequestUpdateRequest)
       .subscribe({
         next: (resp: AccountRequest) => {
           accountRequest.comments = resp.comments ?? '';

--- a/src/web/app/components/account-requests-table/account-request-table.component.ts
+++ b/src/web/app/components/account-requests-table/account-request-table.component.ts
@@ -70,11 +70,13 @@ export class AccountRequestTableComponent {
     modalRef.result.then((res: EditRequestModalComponentResult) => {
       this.accountService.editAccountRequest(
         accountRequest.id,
-        res.accountRequestName,
-        res.accountRequestEmail,
-        res.accountRequestInstitution,
-        accountRequest.status,
-        res.accountRequestComment)
+          {
+            name: res.accountRequestName,
+            email: res.accountRequestEmail,
+            institute: res.accountRequestInstitution,
+            status: accountRequest.status,
+            comment: res.accountRequestComment
+          })
       .subscribe({
         next: (resp: AccountRequest) => {
           accountRequest.comments = resp.comments ?? '';

--- a/src/web/services/account.service.ts
+++ b/src/web/services/account.service.ts
@@ -118,21 +118,12 @@ export class AccountService {
   /**
    * Edits an account request by calling API.
    */
-  editAccountRequest(id: string, name: string, email: string, institute: string,
-    status: AccountRequestStatus, comments: string)
+  editAccountRequest(id: string, request: AccountRequestUpdateRequest)
   : Observable<AccountRequest> {
     const paramMap: Record<string, string> = {
       id,
     };
-    const accountReqUpdateRequest : AccountRequestUpdateRequest = {
-      name,
-      email,
-      institute,
-      status,
-      comments,
-    };
-
-    return this.httpRequestService.put(ResourceEndpoints.ACCOUNT_REQUEST, paramMap, accountReqUpdateRequest);
+    return this.httpRequestService.put(ResourceEndpoints.ACCOUNT_REQUEST, paramMap, request);
   }
 
   /**


### PR DESCRIPTION
[#13064] Use AccountRequestUpdateRequest as parameter

Fixes #13064 

**Outline of Solution**
Changed input parameter of the editAccountRequest method to AccountRequestUpdateRequest as required.
Updated any usages of the editAccountRequest method to pass in the AccountRequestUpdateRequest object.
