### PR TITLE
[#12048] Add seed and verification scripts for feedback chain

### DIFF
--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -36,7 +36,6 @@ import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.JsonUtils;
-import teammates.common.util.SanitizationHelper;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Section;
@@ -335,7 +334,7 @@ public class DataMigrationForCourseEntitySql extends DatastoreClient {
                 oldSession.getFeedbackSessionName(),
                 newCourse,
                 oldSession.getCreatorEmail(),
-                SanitizationHelper.sanitizeForRichText(oldSession.getInstructions()),
+                oldSession.getInstructions(),
                 oldSession.getStartTime(),
                 oldSession.getEndTime(),
                 oldSession.getSessionVisibleFromTime(),

--- a/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
+++ b/src/client/java/teammates/client/scripts/sql/DataMigrationForCourseEntitySql.java
@@ -30,6 +30,7 @@ import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.SanitizationHelper;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.BaseEntity;
@@ -329,7 +330,7 @@ public class DataMigrationForCourseEntitySql extends DatastoreClient {
                 oldSession.getFeedbackSessionName(),
                 newCourse,
                 oldSession.getCreatorEmail(),
-                oldSession.getInstructions(),
+                SanitizationHelper.sanitizeForRichText(oldSession.getInstructions()),
                 oldSession.getStartTime(),
                 oldSession.getEndTime(),
                 oldSession.getSessionVisibleFromTime(),

--- a/src/client/java/teammates/client/scripts/sql/SeedDb.java
+++ b/src/client/java/teammates/client/scripts/sql/SeedDb.java
@@ -19,9 +19,13 @@ import com.googlecode.objectify.util.Closeable;
 import teammates.client.connector.DatastoreClient;
 import teammates.client.scripts.GenerateUsageStatisticsObjects;
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.attributes.AccountRequestAttributes;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
 import teammates.logic.api.LogicExtension;
@@ -31,6 +35,9 @@ import teammates.storage.entity.Account;
 import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
+import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackResponse;
+import teammates.storage.entity.FeedbackResponseComment;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Notification;
 import teammates.test.FileHelper;
@@ -46,6 +53,9 @@ public class SeedDb extends DatastoreClient {
     private static final int MAX_TEAM_PER_SECTION = 10;
     private static final int MAX_SECTION_PER_COURSE = 10;
     private static final int MAX_FEEDBACKSESSION_FOR_EACH_COURSE_SIZE = 3;
+    private static final int MAX_QUESTION_PER_COURSE = 6;
+    private static final int MAX_RESPONSES_PER_QUESTION = 10;
+    private static final int MAX_COMMENTS_PER_RESPONSE = 2;
     private final LogicExtension logic = new LogicExtension();
     private Closeable closeable;
 
@@ -125,11 +135,12 @@ public class SeedDb extends DatastoreClient {
                         (int) (100 * ((float) i / (float) MAX_ENTITY_SIZE))));
             }
 
-            String courseId = UUID.randomUUID().toString();
+            String courseId = String.format("Course ID %s", i);
             try {
                 seedCourseWithCourseId(i, courseId);
                 seedStudents(i, courseId);
-                seedFeedbackSession(courseId);
+                seedFeedbackSession(i, courseId);
+                seedFeedbackQuestions(i, courseId);
             } catch (Exception e) {
                 log(e.toString());
             }
@@ -192,11 +203,13 @@ public class SeedDb extends DatastoreClient {
         }
     }
 
-    private void seedFeedbackSession(String courseId) {
+    private void seedFeedbackSession(int courseNumber, String courseId) {
         Random rand = new Random();
+
+        log("Seeding feedback chain for course " + courseNumber);
         for (int i = 0; i < MAX_FEEDBACKSESSION_FOR_EACH_COURSE_SIZE; i++) {
             try {
-                String feedbackSessionName = String.format("Feedback Session %s", i);
+                String feedbackSessionName = String.format("Course %s Feedback Session %s", courseNumber, i);
                 String feedbackSessionCreatorEmail = String.format("Creator Email %s", i);
                 String feedbackSessionInstructions = String.format("Instructions %s", i);
                 String timezone = String.format("Time Zone %s", i);
@@ -220,6 +233,103 @@ public class SeedDb extends DatastoreClient {
             } catch (Exception e) {
                 log(e.toString());
             }
+        }
+    }
+
+    private void seedFeedbackQuestions(int courseNumber, String courseId) {
+        assert MAX_FEEDBACKSESSION_FOR_EACH_COURSE_SIZE <= MAX_QUESTION_PER_COURSE;
+
+        int currSession = -1;
+        for (int i = 0; i < MAX_QUESTION_PER_COURSE; i++) {
+
+            if (i % (MAX_QUESTION_PER_COURSE / MAX_FEEDBACKSESSION_FOR_EACH_COURSE_SIZE) == 0) {
+                currSession++;
+            }
+
+            String feedbackSessionName = String.format("Course %s Feedback Session %s", courseNumber, currSession);
+            String questionDescription = String.format("Course %s Session %s Question %s Description",
+                    courseNumber, currSession, i);
+            String questionText = new FeedbackTextQuestionDetails(
+                    String.format("Session %s Question %s Text", currSession, i)).getJsonString();
+            int questionNumber = i;
+            FeedbackQuestionType feedbackQuestionType = FeedbackQuestionType.TEXT;
+            FeedbackParticipantType giverType = FeedbackParticipantType.STUDENTS;
+            FeedbackParticipantType recipientType = FeedbackParticipantType.INSTRUCTORS;
+            int numberOfEntitiesToGiveFeedbackTo = 1;
+
+            FeedbackQuestion feedbackQuestion = new FeedbackQuestion(feedbackSessionName, courseId,
+                    questionText, questionDescription, questionNumber, feedbackQuestionType, giverType, recipientType,
+                    numberOfEntitiesToGiveFeedbackTo, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+            feedbackQuestion.setCreatedAt(getRandomInstant());
+            feedbackQuestion.setLastUpdate(getRandomInstant());
+
+            ofy().save().entities(feedbackQuestion).now();
+
+            String feedbackQuestionId = feedbackQuestion.getId();
+            assert feedbackQuestionId != null;
+            seedFeedbackResponses(courseNumber, courseId, feedbackQuestionId, feedbackQuestionType);
+        }
+    }
+
+    private void seedFeedbackResponses(int courseNumber, String courseId, String feedbackQuestionId,
+            FeedbackQuestionType feedbackQuestionType){
+        int currGiverSection = -1;
+        int currRecipientSection = 0;
+
+        for (int i = 0; i < MAX_RESPONSES_PER_QUESTION; i++) {
+
+            currGiverSection = (currGiverSection + 1) % MAX_SECTION_PER_COURSE;
+            currRecipientSection = (currRecipientSection + 1) % MAX_SECTION_PER_COURSE;
+
+            String feedbackSessionName = String.format("Course %s Feedback Session %s", courseNumber, i);
+            String giverEmail = String.format("Giver Email %s", i);
+            String giverSection = String.format("Course %s Section %s", courseNumber, currGiverSection);
+            String recipient = String.format("Recipient %s", i);
+            String recipientSection = String.format("Course %s Section %s", courseNumber, currRecipientSection);
+            String answer = new FeedbackTextResponseDetails(
+                    String.format("Response %s for Question Id: %s", i, feedbackQuestionId)).getJsonString();
+
+            FeedbackResponse feedbackResponse = new FeedbackResponse(feedbackSessionName, courseId, feedbackQuestionId,
+                    feedbackQuestionType, giverEmail, giverSection, recipient, recipientSection, answer);
+            feedbackResponse.setCreatedAt(getRandomInstant());
+            feedbackResponse.setLastUpdate(getRandomInstant());
+
+            ofy().save().entities(feedbackResponse).now();
+
+            String feedbackResponseId = feedbackResponse.getId();
+            assert feedbackResponseId != null;
+            seedFeedbackResponseComments(courseNumber, courseId, feedbackQuestionId, feedbackResponseId, giverSection,
+                    recipientSection);
+        }
+    }
+
+    private void seedFeedbackResponseComments(int courseNumber, String courseId, String feedbackQuestionId, String feedbackResponseId,
+            String giverSection, String receiverSection) {
+        Random rand = new Random();
+
+        int currGiverSection = -1;
+        int currRecipientSection = 0;
+
+        for (int i = 0; i < MAX_COMMENTS_PER_RESPONSE; i++) {
+
+            currGiverSection = (currGiverSection + 1) % MAX_SECTION_PER_COURSE;
+            currRecipientSection = (currRecipientSection + 1) % MAX_SECTION_PER_COURSE;
+
+            String feedbackSessionName = String.format("Course %s Feedback Session %s", courseNumber, i);
+            String giverEmail = String.format("Giver Email %s", i);
+            FeedbackParticipantType commentGiverType = FeedbackParticipantType.STUDENTS;
+            Instant createdAt = getRandomInstant();
+            String commentText = String.format("Comment %s for Response Id: %s", i, feedbackResponseId);
+            String lastEditorEmail = String.format("Last Editor Email %s", i);
+            Instant lastEditedAt = getRandomInstant();
+
+            FeedbackResponseComment feedbackResponseComment = new FeedbackResponseComment(courseId,
+                    feedbackSessionName, feedbackQuestionId, giverEmail, commentGiverType, feedbackResponseId,
+                    createdAt, commentText, giverSection, receiverSection, new ArrayList<>(), new ArrayList<>(),
+                    lastEditorEmail, lastEditedAt, rand.nextBoolean(), rand.nextBoolean());
+            feedbackResponseComment.setCreatedAt(createdAt);
+
+            ofy().save().entities(feedbackResponseComment).now();
         }
     }
 

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -55,8 +55,8 @@ public class VerifyCourseEntityAttributes
             return verifyCourse(sqlEntity, datastoreEntity)
                     && verifySectionChain(sqlEntity)
                     && verifyFeedbackChain(sqlEntity)
-                    && verifyInstructors(sqlEntity);
-                    // && verifyDeadlineExtensions(sqlEntity);
+                    && verifyInstructors(sqlEntity)
+                    && verifyDeadlineExtensions(sqlEntity);
         } catch (IllegalArgumentException iae) {
             return false;
         }
@@ -417,40 +417,34 @@ public class VerifyCourseEntityAttributes
 
     // Verify Get methods ----------------------------
     private List<Student> getNewStudents(String courseId) {
-        // HibernateUtil.beginTransaction();
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<teammates.storage.sqlentity.Student> cr = cb
                 .createQuery(teammates.storage.sqlentity.Student.class);
         Root<teammates.storage.sqlentity.Student> studentRoot = cr.from(teammates.storage.sqlentity.Student.class);
         cr.select(studentRoot).where(cb.equal(studentRoot.get("courseId"), courseId));
         List<Student> newStudents = HibernateUtil.createQuery(cr).getResultList();
-        // HibernateUtil.commitTransaction();
         return newStudents;
     }
 
     private List<teammates.storage.sqlentity.Instructor> getNewInstructors(String courseId) {
-        // HibernateUtil.beginTransaction();
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<teammates.storage.sqlentity.Instructor> cr = cb
                 .createQuery(teammates.storage.sqlentity.Instructor.class);
         Root<teammates.storage.sqlentity.Instructor> instructorRoot = cr.from(teammates.storage.sqlentity.Instructor.class);
         cr.select(instructorRoot).where(cb.equal(instructorRoot.get("courseId"), courseId));
         List<teammates.storage.sqlentity.Instructor> newInstructors = HibernateUtil.createQuery(cr).getResultList();
-        // HibernateUtil.commitTransaction();
         return newInstructors;
     }
 
     private List<teammates.storage.sqlentity.DeadlineExtension> getNewDeadlineExtensions(String courseId) {
-        // HibernateUtil.beginTransaction();
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<teammates.storage.sqlentity.DeadlineExtension> cr = cb
                 .createQuery(teammates.storage.sqlentity.DeadlineExtension.class);
         Root<teammates.storage.sqlentity.DeadlineExtension> deadlineExtensionsRoot = cr
                 .from(teammates.storage.sqlentity.DeadlineExtension.class);
-        cr.select(deadlineExtensionsRoot).where(cb.equal(deadlineExtensionsRoot.get("courseId"), courseId));
+        cr.select(deadlineExtensionsRoot).where(cb.equal(deadlineExtensionsRoot.get("user").get("courseId"), courseId));
         List<teammates.storage.sqlentity.DeadlineExtension> newDeadlineExt = HibernateUtil.createQuery(cr)
                 .getResultList();
-        // HibernateUtil.commitTransaction();
         return newDeadlineExt;
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -1,12 +1,18 @@
 package teammates.client.scripts.sql;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import teammates.common.util.HibernateUtil;
+import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
+import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackResponse;
+import teammates.storage.entity.FeedbackResponseComment;
+import teammates.storage.entity.FeedbackSession;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.Team;
@@ -41,7 +47,8 @@ public class VerifyCourseEntityAttributes
     @Override
     public boolean equals(teammates.storage.sqlentity.Course sqlEntity, Course datastoreEntity) {
         try {
-            return verifyCourse(sqlEntity, datastoreEntity) && verifySectionChain(sqlEntity);
+            return verifyCourse(sqlEntity, datastoreEntity) && verifySectionChain(sqlEntity)
+                    && verifyFeedbackChain(sqlEntity);
         } catch (IllegalArgumentException iae) {
             return false;
         }
@@ -56,6 +63,8 @@ public class VerifyCourseEntityAttributes
                 && datastoreEntity.getDeletedAt() == null ? sqlEntity.getDeletedAt() == null
                         : sqlEntity.getDeletedAt().equals(datastoreEntity.getDeletedAt());
     }
+
+    // methods for verify section chain  -----------------------------------------------------------------------------------
 
     private boolean verifySectionChain(teammates.storage.sqlentity.Course newCourse) {
         // Get old and new students
@@ -154,14 +163,180 @@ public class VerifyCourseEntityAttributes
     }
 
     private List<Student> getNewStudents(String courseId) {
-        HibernateUtil.beginTransaction();
+        // HibernateUtil.beginTransaction();
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<teammates.storage.sqlentity.Student> cr = cb
                 .createQuery(teammates.storage.sqlentity.Student.class);
         Root<teammates.storage.sqlentity.Student> courseRoot = cr.from(teammates.storage.sqlentity.Student.class);
         cr.select(courseRoot).where(cb.equal(courseRoot.get("courseId"), courseId));
         List<Student> newStudents = HibernateUtil.createQuery(cr).getResultList();
-        HibernateUtil.commitTransaction();
+        // HibernateUtil.commitTransaction();
         return newStudents;
+    }
+
+    // methods for verify feedback chain -----------------------------------------------------------------------------------
+
+    private boolean verifyFeedbackChain(teammates.storage.sqlentity.Course newCourse) {
+        List<teammates.storage.sqlentity.FeedbackSession> newSessions = newCourse.getFeedbackSessions();
+        List<FeedbackSession> oldSessions = ofy().load().type(FeedbackSession.class)
+                .filter("courseId", newCourse.getId()).list();
+
+        if (newSessions.size() != oldSessions.size()) {
+            log(String.format("Mismatched session counts for course id: %s", newCourse.getId()));
+            return false;
+        }
+
+        Map<String, FeedbackSession> sessionNameToOldSessionMap = oldSessions.stream()
+                .collect(Collectors.toMap(FeedbackSession::getFeedbackSessionName, session -> session));
+
+        return newSessions.stream().allMatch(newSession -> {
+            FeedbackSession oldSession = sessionNameToOldSessionMap.get(newSession.getName());
+            return verifyFeedbackSession(oldSession, newSession);
+        });
+    }
+
+    private boolean verifyFeedbackSession(FeedbackSession oldSession, teammates.storage.sqlentity.FeedbackSession newSession) {
+        boolean doFieldsMatch = newSession.getCourse().getId().equals(oldSession.getCourseId())
+                && newSession.getName().equals(oldSession.getFeedbackSessionName())
+                && newSession.getCreatorEmail().equals(oldSession.getCreatorEmail())
+                && newSession.getInstructions().equals(SanitizationHelper.sanitizeForRichText(oldSession.getInstructions()))
+                && newSession.getStartTime().equals(oldSession.getStartTime())
+                && newSession.getEndTime().equals(oldSession.getEndTime())
+                && newSession.getSessionVisibleFromTime().equals(oldSession.getSessionVisibleFromTime())
+                && newSession.getResultsVisibleFromTime().equals(oldSession.getResultsVisibleFromTime())
+                && newSession.getGracePeriod().equals(Duration.ofMinutes(oldSession.getGracePeriod()))
+                && newSession.isOpeningEmailEnabled() == oldSession.isOpeningEmailEnabled()
+                && newSession.isClosingEmailEnabled() == oldSession.isClosingEmailEnabled()
+                && newSession.isOpenEmailSent() == oldSession.isSentOpenEmail()
+                && newSession.isOpeningSoonEmailSent() == oldSession.isSentOpeningSoonEmail()
+                && newSession.isClosedEmailSent() == oldSession.isSentClosedEmail()
+                && newSession.isClosingSoonEmailSent() == oldSession.isSentClosingEmail()
+                && newSession.isPublishedEmailSent() == oldSession.isSentPublishedEmail()
+                && newSession.getCreatedAt().equals(oldSession.getCreatedTime())
+                && (newSession.getDeletedAt() == oldSession.getDeletedTime()
+                        || newSession.getDeletedAt().equals(oldSession.getDeletedTime()));
+        if (!doFieldsMatch) {
+            log(String.format("Mismatched fields for session: %s, course id: %s",
+                    oldSession.getFeedbackSessionName(), oldSession.getCourseId()));
+            return false;
+        }
+
+        List<teammates.storage.sqlentity.FeedbackQuestion> newQuestions = newSession.getFeedbackQuestions();
+        List<FeedbackQuestion> oldQuestions = ofy().load().type(FeedbackQuestion.class)
+                .filter("courseId", newSession.getCourse().getId())
+                .filter("feedbackSessionName", newSession.getName()).list();
+
+        if (newQuestions.size() != oldQuestions.size()) {
+            log(String.format("Mismatched question counts for session: %s, course id: %s",
+                    oldSession.getFeedbackSessionName(), oldSession.getCourseId()));
+            return false;
+        }
+
+        Map<Integer, FeedbackQuestion> questionNumberToOldQuestionMap = oldQuestions.stream()
+                .collect(Collectors.toMap(FeedbackQuestion::getQuestionNumber, question -> question));
+
+        return newQuestions.stream().allMatch(newQuestion -> {
+            FeedbackQuestion oldQuestion = questionNumberToOldQuestionMap.get(newQuestion.getQuestionNumber());
+            return verifyFeedbackQuestion(oldQuestion, newQuestion);
+        });
+    }
+
+    private boolean verifyFeedbackQuestion(FeedbackQuestion oldQuestion, teammates.storage.sqlentity.FeedbackQuestion newQuestion) {
+        boolean doFieldsMatch = newQuestion.getQuestionNumber() == oldQuestion.getQuestionNumber()
+                && newQuestion.getDescription().equals(oldQuestion.getQuestionDescription())
+                && newQuestion.getGiverType().equals(oldQuestion.getGiverType())
+                && newQuestion.getRecipientType().equals(oldQuestion.getRecipientType())
+                && newQuestion.getNumOfEntitiesToGiveFeedbackTo().equals(oldQuestion.getNumberOfEntitiesToGiveFeedbackTo())
+                && newQuestion.getShowResponsesTo().equals(oldQuestion.getShowResponsesTo())
+                && newQuestion.getShowGiverNameTo().equals(oldQuestion.getShowGiverNameTo())
+                && newQuestion.getShowRecipientNameTo().equals(oldQuestion.getShowRecipientNameTo())
+                && newQuestion.getQuestionDetailsCopy()
+                        .equals(DataMigrationForCourseEntitySql.getFeedbackQuestionDetails(oldQuestion))
+                && newQuestion.getCreatedAt().equals(oldQuestion.getCreatedAt())
+                && newQuestion.getUpdatedAt().equals(oldQuestion.getUpdatedAt());
+        if (!doFieldsMatch) {
+            log(String.format("Mismatched fields for question %s, session: %s, course id: %s",
+                    oldQuestion.getQuestionNumber(), oldQuestion.getFeedbackSessionName(), oldQuestion.getCourseId()));
+            return false;
+        }
+
+        List<teammates.storage.sqlentity.FeedbackResponse> newResponses = newQuestion.getFeedbackResponses();
+        List<FeedbackResponse> oldResponses = ofy().load().type(FeedbackResponse.class)
+                .filter("feedbackQuestionId", oldQuestion.getId()).list();
+
+        if (newResponses.size() != oldResponses.size()) {
+            log(String.format("Mismatched response counts for question %s, session: %s, course id: %s",
+                    oldQuestion.getQuestionNumber(), oldQuestion.getFeedbackSessionName(), oldQuestion.getCourseId()));
+            return false;
+        }
+
+        Map<String, FeedbackResponse> responseIdToOldResponseMap = oldResponses.stream()
+                .collect(Collectors.toMap(FeedbackResponse::getId, response -> response));
+
+        return newResponses.stream().allMatch(newResponse -> {
+            String oldResponseId = FeedbackResponse.generateId(oldQuestion.getId(), newResponse.getGiver(),
+                    newResponse.getRecipient());
+            FeedbackResponse oldResponse = responseIdToOldResponseMap.get(oldResponseId);
+            return verifyFeedbackResponse(oldResponse, newResponse);
+        });
+    }
+
+    private boolean verifyFeedbackResponse(FeedbackResponse oldResponse, teammates.storage.sqlentity.FeedbackResponse newResponse) {
+        boolean allFieldsMatch = newResponse.getGiver().equals(oldResponse.getGiverEmail())
+                && newResponse.getGiverSection().getCourse().getId().equals(oldResponse.getCourseId())
+                && newResponse.getGiverSectionName().equals(oldResponse.getGiverSection())
+                && newResponse.getRecipient().equals(oldResponse.getRecipientEmail())
+                && newResponse.getRecipientSectionName().equals(oldResponse.getRecipientSection())
+                && newResponse.getCreatedAt().equals(oldResponse.getCreatedAt())
+                && newResponse.getUpdatedAt().equals(oldResponse.getUpdatedAt())
+                && newResponse.getFeedbackResponseDetailsCopy().getJsonString().equals(oldResponse.getAnswer());
+        if (!allFieldsMatch) {
+            log(String.format("Mismatched fields for response %s, question %s, session: %s, course id: %s",
+                    oldResponse.getId(), oldResponse.getFeedbackQuestionId(), oldResponse.getFeedbackSessionName(),
+                    oldResponse.getCourseId()));
+            return false;
+        }
+
+        List<teammates.storage.sqlentity.FeedbackResponseComment> newComments = newResponse.getFeedbackResponseComments();
+        List<FeedbackResponseComment> oldComments = ofy().load()
+                .type(teammates.storage.entity.FeedbackResponseComment.class)
+                .filter("feedbackResponseId", oldResponse.getId()).list();
+        
+        if (newComments.size() != oldComments.size()) {
+            log(String.format("Mismatched comment counts for response %s, question %s, session: %s, course id: %s",
+                    oldResponse.getId(), oldResponse.getFeedbackQuestionId(), oldResponse.getFeedbackSessionName(),
+                    oldResponse.getCourseId()));
+            return false;
+        }
+
+        return oldComments.stream().allMatch(oldComment -> newComments.stream()
+                .anyMatch(newComment -> verifyFeedbackResponseComment(oldComment, newComment)));
+    }
+
+    private boolean verifyFeedbackResponseComment(FeedbackResponseComment oldComment, teammates.storage.sqlentity.FeedbackResponseComment newComment) {
+        boolean allFieldsMatch = 
+                newComment.getGiver().equals(oldComment.getGiverEmail())
+                && newComment.getCommentText().equals(oldComment.getCommentText())
+                && newComment.getGiverType().equals(oldComment.getCommentGiverType())
+                && newComment.getGiverSection().getCourse().getId().equals(oldComment.getCourseId())
+                && newComment.getGiverSection().getName().equals(oldComment.getGiverSection())
+                && newComment.getRecipientSection().getName().equals(oldComment.getReceiverSection())
+                && newComment.getIsVisibilityFollowingFeedbackQuestion()
+                        == oldComment.getIsVisibilityFollowingFeedbackQuestion()
+                && newComment.getIsCommentFromFeedbackParticipant() == oldComment.getIsCommentFromFeedbackParticipant()
+                && newComment.getShowCommentTo().equals(oldComment.getShowCommentTo())
+                && newComment.getShowGiverNameTo().equals(oldComment.getShowGiverNameTo())
+                && newComment.getCreatedAt().equals(oldComment.getCreatedAt())
+                && newComment.getUpdatedAt().equals(oldComment.getLastEditedAt())
+                && newComment.getLastEditorEmail().equals(oldComment.getLastEditorEmail());
+
+        if (allFieldsMatch) {
+            return true;
+        } else {
+            log(String.format("Mismatched fields for comment %s, response %s, question %s, session: %s, course id: %s",
+                    oldComment.getFeedbackResponseCommentId(), oldComment.getFeedbackResponseId(), oldComment.getFeedbackQuestionId(),
+                    oldComment.getFeedbackSessionName(), oldComment.getCourseId()));
+            return false;
+        }
     }
 }

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -65,6 +65,7 @@ public class VerifyCourseEntityAttributes
     }
 
     // methods for verify section chain  -----------------------------------------------------------------------------------
+    // entities: Section, Team, Student
 
     private boolean verifySectionChain(teammates.storage.sqlentity.Course newCourse) {
         // Get old and new students
@@ -175,6 +176,7 @@ public class VerifyCourseEntityAttributes
     }
 
     // methods for verify feedback chain -----------------------------------------------------------------------------------
+    // entities: FeedbackSession, FeedbackQuestion, FeedbackResponse, FeedbackResponseComment
 
     private boolean verifyFeedbackChain(teammates.storage.sqlentity.Course newCourse) {
         List<teammates.storage.sqlentity.FeedbackSession> newSessions = newCourse.getFeedbackSessions();
@@ -241,7 +243,8 @@ public class VerifyCourseEntityAttributes
         });
     }
 
-    private boolean verifyFeedbackQuestion(FeedbackQuestion oldQuestion, teammates.storage.sqlentity.FeedbackQuestion newQuestion) {
+    private boolean verifyFeedbackQuestion(FeedbackQuestion oldQuestion,
+            teammates.storage.sqlentity.FeedbackQuestion newQuestion) {
         boolean doFieldsMatch = newQuestion.getQuestionNumber() == oldQuestion.getQuestionNumber()
                 && newQuestion.getDescription().equals(oldQuestion.getQuestionDescription())
                 && newQuestion.getGiverType().equals(oldQuestion.getGiverType())
@@ -250,8 +253,7 @@ public class VerifyCourseEntityAttributes
                 && newQuestion.getShowResponsesTo().equals(oldQuestion.getShowResponsesTo())
                 && newQuestion.getShowGiverNameTo().equals(oldQuestion.getShowGiverNameTo())
                 && newQuestion.getShowRecipientNameTo().equals(oldQuestion.getShowRecipientNameTo())
-                && newQuestion.getQuestionDetailsCopy()
-                        .equals(DataMigrationForCourseEntitySql.getFeedbackQuestionDetails(oldQuestion))
+                && newQuestion.getQuestionDetailsCopy().getJsonString().equals(oldQuestion.getQuestionText())
                 && newQuestion.getCreatedAt().equals(oldQuestion.getCreatedAt())
                 && newQuestion.getUpdatedAt().equals(oldQuestion.getUpdatedAt());
         if (!doFieldsMatch) {
@@ -281,7 +283,8 @@ public class VerifyCourseEntityAttributes
         });
     }
 
-    private boolean verifyFeedbackResponse(FeedbackResponse oldResponse, teammates.storage.sqlentity.FeedbackResponse newResponse) {
+    private boolean verifyFeedbackResponse(FeedbackResponse oldResponse,
+            teammates.storage.sqlentity.FeedbackResponse newResponse) {
         boolean allFieldsMatch = newResponse.getGiver().equals(oldResponse.getGiverEmail())
                 && newResponse.getGiverSection().getCourse().getId().equals(oldResponse.getCourseId())
                 && newResponse.getGiverSectionName().equals(oldResponse.getGiverSection())
@@ -301,7 +304,7 @@ public class VerifyCourseEntityAttributes
         List<FeedbackResponseComment> oldComments = ofy().load()
                 .type(teammates.storage.entity.FeedbackResponseComment.class)
                 .filter("feedbackResponseId", oldResponse.getId()).list();
-        
+
         if (newComments.size() != oldComments.size()) {
             log(String.format("Mismatched comment counts for response %s, question %s, session: %s, course id: %s",
                     oldResponse.getId(), oldResponse.getFeedbackQuestionId(), oldResponse.getFeedbackSessionName(),
@@ -316,12 +319,13 @@ public class VerifyCourseEntityAttributes
                     oldResponse.getId(), oldResponse.getFeedbackQuestionId(), oldResponse.getFeedbackSessionName(),
                     oldResponse.getCourseId()));
             return false;
-        } 
+        }
 
         return true;
     }
 
-    private boolean verifyFeedbackResponseComment(FeedbackResponseComment oldComment, teammates.storage.sqlentity.FeedbackResponseComment newComment) {
+    private boolean verifyFeedbackResponseComment(FeedbackResponseComment oldComment,
+            teammates.storage.sqlentity.FeedbackResponseComment newComment) {
         return newComment.getGiver().equals(oldComment.getGiverEmail())
                 && newComment.getCommentText().equals(oldComment.getCommentText())
                 && newComment.getGiverType().equals(oldComment.getCommentGiverType())

--- a/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
+++ b/src/client/java/teammates/client/scripts/sql/VerifyCourseEntityAttributes.java
@@ -309,13 +309,20 @@ public class VerifyCourseEntityAttributes
             return false;
         }
 
-        return oldComments.stream().allMatch(oldComment -> newComments.stream()
+        boolean allCommentFieldsMatch = oldComments.stream().allMatch(oldComment -> newComments.stream()
                 .anyMatch(newComment -> verifyFeedbackResponseComment(oldComment, newComment)));
+        if (!allCommentFieldsMatch) {
+            log(String.format("Mismatched fields for comments in response %s, question %s, session: %s, course id: %s",
+                    oldResponse.getId(), oldResponse.getFeedbackQuestionId(), oldResponse.getFeedbackSessionName(),
+                    oldResponse.getCourseId()));
+            return false;
+        } 
+
+        return true;
     }
 
     private boolean verifyFeedbackResponseComment(FeedbackResponseComment oldComment, teammates.storage.sqlentity.FeedbackResponseComment newComment) {
-        boolean allFieldsMatch = 
-                newComment.getGiver().equals(oldComment.getGiverEmail())
+        return newComment.getGiver().equals(oldComment.getGiverEmail())
                 && newComment.getCommentText().equals(oldComment.getCommentText())
                 && newComment.getGiverType().equals(oldComment.getCommentGiverType())
                 && newComment.getGiverSection().getCourse().getId().equals(oldComment.getCourseId())
@@ -329,14 +336,5 @@ public class VerifyCourseEntityAttributes
                 && newComment.getCreatedAt().equals(oldComment.getCreatedAt())
                 && newComment.getUpdatedAt().equals(oldComment.getLastEditedAt())
                 && newComment.getLastEditorEmail().equals(oldComment.getLastEditorEmail());
-
-        if (allFieldsMatch) {
-            return true;
-        } else {
-            log(String.format("Mismatched fields for comment %s, response %s, question %s, session: %s, course id: %s",
-                    oldComment.getFeedbackResponseCommentId(), oldComment.getFeedbackResponseId(), oldComment.getFeedbackQuestionId(),
-                    oldComment.getFeedbackSessionName(), oldComment.getCourseId()));
-            return false;
-        }
     }
 }


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**
- Added methods to seed and verify feedback chain entities
- Constraints - only seeds: 
  - `FeedbackTextQuestions`, with
  - `giverType = STUDENTS`, and
  - `recipientType = INSTRUCTORS`
- Tested for `MAX_RESPONSE_COUNT` values of -1 and 1000

