### PR TITLE
[#12664] Instructor's Student Records Page: Accessibility issue for comment buttons

### DIFF
--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
@@ -47,10 +47,10 @@
                        placeholderText="Enter your comment here" [isDisabled]="isDisabled"></tm-rich-text-editor>
 </div>
 
-<button type="button" class="btn btn-success btn-sm float-end btn-margin-left"
-        (click)="triggerSaveCommentEvent()" *ngIf="!shouldHideSavingButton" [disabled]="isDisabled"><i class="fas fa-save"></i>
-  {{ mode === CommentRowMode.EDIT ? 'Save' : 'Add' }}</button>
-
 <button type="button" class="btn btn-light btn-sm float-end"
         (click)="triggerCloseCommentBoxEvent()" *ngIf="!shouldHideClosingButton" [disabled]="isDisabled"><i class="fas fa-times"></i>
   Cancel</button>
+
+<button type="button" class="btn btn-success btn-sm float-end btn-margin-left"
+        (click)="triggerSaveCommentEvent()" *ngIf="!shouldHideSavingButton" [disabled]="isDisabled"><i class="fas fa-save"></i>
+  {{ mode === CommentRowMode.EDIT ? 'Save' : 'Add' }}</button>

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -34,9 +34,9 @@
 
         <div class="float-end">
           <button type="button" class="btn-edit-comment btn btn-outline-primary btn-sm" *ngIf="!shouldHideEditButton" ngbTooltip='Edit this comment'
-                  (click)="triggerModelChange('isEditing', true)" [disabled]="isDisabled"><i class="fas fa-pencil-alt"></i></button>
+                  (click)="triggerModelChange('isEditing', true)" [disabled]="isDisabled" aria-label="Edit Comment Button"><i class="fas fa-pencil-alt"></i></button>
           <button type="button" class="btn-delete-comment btn btn-outline-primary btn-sm btn-margin-left" *ngIf="!shouldHideDeleteButton" ngbTooltip='Delete this comment'
-                  (click)="triggerDeleteCommentEvent()" [disabled]="isDisabled"><i class="fas fa-trash"></i></button>
+                  (click)="triggerDeleteCommentEvent()" [disabled]="isDisabled" aria-label="Delete Comment Button"><i class="fas fa-trash"></i></button>
         </div>
       </div>
       <div class="comment-text col-12" [innerHTML]="model.originalComment.commentText | safeHtml"></div>


### PR DESCRIPTION
Fixes #12664

Outline of Solution

1. Added aria-labels to the edit comment button and the delete comment button on the "Instructor's Student Records Page"  to serve as more meaningful descriptions for a screen reader.
2. I switched the placement of the discard and save buttons so that the screen reader goes to Discard and then Save.
