### PR TITLE
[#12875] Some feedback sessions duplicated in student home page

### DIFF
--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -115,10 +115,6 @@ export class StudentHomePageComponent implements OnInit {
           });
 
           this.sortCoursesBy(SortBy.COURSE_CREATION_DATE);
-          this.courses.slice(0, 3).forEach((course: StudentCourse) => {
-            course.isTabExpanded = true;
-            this.loadFeedbackSessionsForCourse(course.course.courseId);
-          });
         },
         error: (e: ErrorMessageOutput) => {
           this.hasCoursesLoadingFailed = true;
@@ -306,11 +302,9 @@ export class StudentHomePageComponent implements OnInit {
     this.courses = copy;
 
     // open the first three panels
-    this.courses.forEach((course: StudentCourse, idx: number) => {
-      course.isTabExpanded = idx < 3;
-      if (idx < 3) {
-        this.loadFeedbackSessionsForCourse(course.course.courseId);
-      }
+    this.courses.slice(0, 3).forEach((course: StudentCourse) => {
+      course.isTabExpanded = true;
+      this.loadFeedbackSessionsForCourse(course.course.courseId);
     });
   }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12875

**Outline of Solution**
Removed the duplicate invocation of `loadFeedbackSessionsForCourse()` in both `sortCoursesBy()` and `loadStudentCourses()`.

Kept the call to `loadFeedbackSessionsForCourse()` inside `sortCourseBy()` method to handle the sorting and loading in one place. 

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
