### PR TITLE
[#12901] Added Check for Active Search Service

### DIFF
--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
@@ -11,6 +11,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.AccountRequestsDb;
 import teammates.storage.sqlentity.AccountRequest;
+import teammates.test.TestProperties;
 
 /**
  * SUT: {@link AccountRequestsDb}.
@@ -239,6 +240,10 @@ public class AccountRequestsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testSqlInjectionSearchAccountRequestsInWholeSystem() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
+
         ______TS("SQL Injection test in searchAccountRequestsInWholeSystem");
 
         AccountRequest accountRequest =

--- a/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.HibernateUtil;

--- a/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
+++ b/src/it/java/teammates/it/storage/sqlsearch/AccountRequestSearchIT.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.datatransfer.SqlDataBundle;
 import teammates.common.exception.SearchServiceException;
 import teammates.common.util.HibernateUtil;


### PR DESCRIPTION
Fixes #12901

**Outline of Solution**

As discussed in the issue, I added a check for an active search service before the rest of `AccountRequestsDbIT::testSqlInjectionSearchAccountsRequestsInWholeSystem` ran, but I did not shift the test to `AccountRequestSearchIT` as the test utilised methods from the `accountRequestDb` class, which I feel should not be put into `AccountRequestsDbIT` as it has tests which make use of database related functionality.