### PR TITLE
[#12655] Instructor Edit Session Page: If make session visible is later than submission opening time, automatically default to opening time

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -144,7 +144,7 @@
                                [date]="model.submissionStartDate"></tm-datepicker>
               </div>
               <div class="col-md-5">
-                <tm-timepicker id="submission-start-time" [isDisabled]="!model.isEditable" (timeChange)="triggerModelChange('submissionStartTime', $event)"
+                <tm-timepicker id="submission-start-time" [isDisabled]="!model.isEditable" (timeChange)="triggerSubmissionOpeningTimeModelChange('submissionStartTime', $event)"
                                [minDate]="minDateForSubmissionStart" [maxDate]="maxDateForSubmissionStart"
                                [date]="model.submissionStartDate"
                                [minTime]="minTimeForSubmissionStart" [maxTime]="maxTimeForSubmissionStart"

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -21,6 +21,7 @@ describe('SessionEditFormComponent', () => {
   let dateTimeService: DateTimeService;
 
   const submissionStartDateField = 'submissionStartDate';
+  const submissionStartTimeField = 'submissionStartTime';
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -92,6 +93,40 @@ describe('SessionEditFormComponent', () => {
     component.triggerSubmissionOpeningDateModelChange(submissionStartDateField, date);
     expect(triggerModelChangeSpy).toHaveBeenCalledWith(submissionStartDateField, date);
     expect(configureSubmissionOpeningTimeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should trigger the change of the model when the submission opening time changes to before the visibility time', () => {
+    const date: DateFormat = { day: 12, month: 7, year: 2024 };
+    const time: TimeFormat = { hour: 4, minute: 0 };
+    const visibilityTime: TimeFormat = { hour: 14, minute: 0 };
+    const triggerModelChangeSpy = jest.spyOn(component, 'triggerModelChange');
+    const configureSessionVisibleDateTimeSpy = jest.spyOn(component, 'configureSessionVisibleDateTime');
+    component.model.customSessionVisibleDate = date;
+    component.model.submissionStartDate = date;
+    component.model.customSessionVisibleTime = visibilityTime;
+    component.triggerSubmissionOpeningTimeModelChange(submissionStartTimeField, time);
+    expect(triggerModelChangeSpy).toHaveBeenCalledWith(submissionStartTimeField, time);
+    expect(configureSessionVisibleDateTimeSpy).toHaveBeenCalledWith(date, time);
+  });
+
+  it('should adjust the session visibility date if submission opening date is earlier', () => {
+    const date: DateFormat = { day: 12, month: 7, year: 2024 };
+    const time: TimeFormat = { hour: 14, minute: 0 };
+    component.model.customSessionVisibleDate = { day: 13, month: 7, year: 2024 };
+    component.model.customSessionVisibleTime = time;
+    component.configureSessionVisibleDateTime(date, time);
+    expect(component.model.customSessionVisibleDate).toEqual(date);
+    expect(component.model.customSessionVisibleTime).toEqual(time);
+  });
+
+  it('should not adjust the session visibility date and time if submission opening date and time are later', () => {
+    const date: DateFormat = component.minDateForSubmissionStart;
+    const time: TimeFormat = component.minTimeForSubmissionStart;
+    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().subtract(1, 'days'));
+    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().subtract(1, 'hours'));
+    component.configureSessionVisibleDateTime(date, time);
+    expect(component.model.customSessionVisibleDate).not.toEqual(date);
+    expect(component.model.customSessionVisibleTime).not.toEqual(time);
   });
 
   it('should emit a modelChange event with the updated field when triggerModelChange is called', () => {

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -95,7 +95,8 @@ describe('SessionEditFormComponent', () => {
     expect(configureSubmissionOpeningTimeSpy).not.toHaveBeenCalled();
   });
 
-  it('should trigger the change of the model when the submission opening time changes to before the visibility time', () => {
+  it('should trigger the change of the model when the submission opening time '
+    + 'changes to before the visibility time', () => {
     const date: DateFormat = { day: 12, month: 7, year: 2024 };
     const time: TimeFormat = { hour: 4, minute: 0 };
     const visibilityTime: TimeFormat = { hour: 14, minute: 0 };

--- a/src/web/app/components/session-edit-form/session-edit-form.component.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.ts
@@ -143,12 +143,12 @@ export class SessionEditFormComponent {
   adjustSessionVisibilityTime(value: any, field: string): void {
     const submissionDateTime = this.combineDateAndTime(
       field === 'submissionStartDate' ? value : this.model.submissionStartDate,
-      field === 'submissionStartTime' ? value : this.model.submissionStartTime
+      field === 'submissionStartTime' ? value : this.model.submissionStartTime,
     );
-    
+
     const visibilityDateTime = this.combineDateAndTime(
       this.model.customSessionVisibleDate,
-      this.model.customSessionVisibleTime
+      this.model.customSessionVisibleTime,
     );
 
     if (submissionDateTime.isBefore(visibilityDateTime)) {
@@ -169,7 +169,7 @@ export class SessionEditFormComponent {
       month: date.month - 1,
       day: date.day,
       hour: time.hour,
-      minute: time.minute
+      minute: time.minute,
     }, this.model.timeZone);
   }
 
@@ -226,7 +226,7 @@ export class SessionEditFormComponent {
   configureSessionVisibleDateTime(date: DateFormat, time: TimeFormat): void {
     const sessionDate: DateFormat = this.model.customSessionVisibleDate;
     const sessionTime: TimeFormat = this.model.customSessionVisibleTime;
-    
+
     if (DateTimeService.compareDateFormat(date, sessionDate) === -1) {
       this.model.customSessionVisibleDate = date;
     } else if (DateTimeService.compareDateFormat(date, sessionDate) === 0

--- a/src/web/app/components/session-edit-form/session-edit-form.component.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.ts
@@ -128,10 +128,49 @@ export class SessionEditFormComponent {
    * Triggers the change of the model for the form.
    */
   triggerModelChange(field: string, data: any): void {
+    if (field === 'submissionStartDate' || field === 'submissionStartTime') {
+      this.adjustSessionVisibilityTime(data, field);
+    }
     this.modelChange.emit({
       ...this.model,
       [field]: data,
     });
+  }
+
+  /**
+   * Adjusts session visibility time to ensure it does not occur after submission opening time.
+   */
+  adjustSessionVisibilityTime(value: any, field: string): void {
+    const submissionDateTime = this.combineDateAndTime(
+      field === 'submissionStartDate' ? value : this.model.submissionStartDate,
+      field === 'submissionStartTime' ? value : this.model.submissionStartTime
+    );
+    
+    const visibilityDateTime = this.combineDateAndTime(
+      this.model.customSessionVisibleDate,
+      this.model.customSessionVisibleTime
+    );
+
+    if (submissionDateTime.isBefore(visibilityDateTime)) {
+      if (field === 'submissionStartDate') {
+        this.model.customSessionVisibleDate = value;
+      } else {
+        this.model.customSessionVisibleTime = value;
+      }
+    }
+  }
+
+  /**
+   * Combines date and time into a single moment instance.
+   */
+  combineDateAndTime(date: DateFormat, time: TimeFormat): moment.Moment {
+    return moment.tz({
+      year: date.year,
+      month: date.month - 1,
+      day: date.day,
+      hour: time.hour,
+      minute: time.minute
+    }, this.model.timeZone);
   }
 
   /**
@@ -148,6 +187,7 @@ export class SessionEditFormComponent {
       this.model.submissionStartTime = minTime;
     }
 
+    this.adjustSessionVisibilityTime(date, field);
     this.triggerModelChange(field, date);
   }
 
@@ -161,6 +201,37 @@ export class SessionEditFormComponent {
       // Case where minutes is not 0 since the earliest time with 0 minutes is the hour before
       time.hour += 1;
       time.minute = 0;
+    }
+  }
+
+  /**
+   * Triggers the change of the model when the submission opening time changes.
+   */
+  triggerSubmissionOpeningTimeModelChange(field: string, time: TimeFormat): void {
+    const date: DateFormat = this.model.submissionStartDate;
+    const sessionDate: DateFormat = this.model.customSessionVisibleDate;
+    const sessionTime: TimeFormat = this.model.customSessionVisibleTime;
+
+    if (DateTimeService.compareDateFormat(date, sessionDate) === 0
+        && DateTimeService.compareTimeFormat(time, sessionTime) === -1) {
+      this.configureSessionVisibleDateTime(date, time);
+    }
+
+    this.triggerModelChange(field, time);
+  }
+
+  /**
+   * Configures the session visible date and time to ensure it is not after submission opening time.
+   */
+  configureSessionVisibleDateTime(date: DateFormat, time: TimeFormat): void {
+    const sessionDate: DateFormat = this.model.customSessionVisibleDate;
+    const sessionTime: TimeFormat = this.model.customSessionVisibleTime;
+    
+    if (DateTimeService.compareDateFormat(date, sessionDate) === -1) {
+      this.model.customSessionVisibleDate = date;
+    } else if (DateTimeService.compareDateFormat(date, sessionDate) === 0
+               && DateTimeService.compareTimeFormat(time, sessionTime) === -1) {
+      this.model.customSessionVisibleTime = time;
     }
   }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12655

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
Added logic to ensure that when the submission opening date and time are changed, the session visibility date and time are also adjusted if necessary.

Introduced `configureSessionVisibleDateTime` to adjust the session visibility date and time if they are earlier than the submission opening date and time.

<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

https://github.com/user-attachments/assets/5ad14748-5aa9-4be6-8af7-187f0921debd

