### PR TITLE
[#12508] Give respondents a way to reset a rubric question submission 

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
@@ -53,6 +53,6 @@
     id="btn-reset"
     name="button-reset"
     class="btn btn-secondary"
-    (click)="resetRubricAnswer()">
+    (click)="confirmReset()">
   Reset choices
 </button>

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
@@ -1,58 +1,63 @@
-<table class="table table-bordered desktop-view" [attr.aria-label]="getAriaLabel()">
-  <thead>
-    <tr>
-      <td></td>
-      <th *ngFor="let choice of questionDetails.rubricChoices" scope="col">{{ choice }}</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let rubricDescriptionRow of questionDetails.rubricDescriptions; let i = index;"
-        [ngClass]="{ 'row-answered': i < responseDetails.answer.length && responseDetails.answer[i] !== RUBRIC_ANSWER_NOT_CHOSEN }">
-      <th class="fw-normal" scope="row">{{ questionDetails.rubricSubQuestions[i] }}</th>
-      <td *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;" class="text-secondary answer-cell" (click)="selectAnswer(i, j)">
-        <input
-          type="radio"
-          [disabled]="isDisabled"
-          [name]="getInputId(id, i, j, 'desktop')"
-          [id]="getInputId(id, i, j, 'desktop')"
-          [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j"
-        />
-        <label [for]="getInputId(id, i, j, 'desktop')" (click)="$event.stopPropagation()">
-          {{ rubricDescriptionCell }}
-        </label>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<div class="mobile-view" [attr.aria-label]="getAriaLabel()">
-  <div class="card" *ngFor="let rubricDescriptionRow of questionDetails.rubricDescriptions; let i = index;">
-    <div class="card-header bg-light">
-      {{ questionDetails.rubricSubQuestions[i] }}
-    </div>
-    <div class="card-body"
-         [ngClass]="{ 'row-answered': i < responseDetails.answer.length && responseDetails.answer[i] !== RUBRIC_ANSWER_NOT_CHOSEN }">
-      <div *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;">
-        <label>
+<div class="table-container">
+  <table class="table table-bordered desktop-view" [attr.aria-label]="getAriaLabel()">
+    <thead>
+      <tr>
+        <td></td>
+        <th *ngFor="let choice of questionDetails.rubricChoices" scope="col">{{ choice }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let rubricDescriptionRow of questionDetails.rubricDescriptions; let i = index;"
+          [ngClass]="{ 'row-answered': i < responseDetails.answer.length && responseDetails.answer[i] !== RUBRIC_ANSWER_NOT_CHOSEN }">
+        <th class="fw-normal" scope="row">{{ questionDetails.rubricSubQuestions[i] }}</th>
+        <td *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;" class="text-secondary answer-cell" (click)="selectAnswer(i, j)">
           <input
             type="radio"
             [disabled]="isDisabled"
-            (click)="selectAnswer(i, j)"
-            [name]="getInputId(id, i, j, 'mobile')"
+            [name]="getInputId(id, i, j, 'desktop')"
+            [id]="getInputId(id, i, j, 'desktop')"
             [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j"
-            [attr.aria-label]="getAriaLabelForChoice(questionDetails.rubricChoices[j], rubricDescriptionCell, questionDetails.rubricSubQuestions[i])"
-          >
-          {{ getChoiceWithDescription(questionDetails.rubricChoices[j], rubricDescriptionCell) }}
-        </label>
+          />
+          <label [for]="getInputId(id, i, j, 'desktop')" (click)="$event.stopPropagation()">
+            {{ rubricDescriptionCell }}
+          </label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="mobile-view" [attr.aria-label]="getAriaLabel()">
+    <div class="card" *ngFor="let rubricDescriptionRow of questionDetails.rubricDescriptions; let i = index;">
+      <div class="card-header bg-light">
+        {{ questionDetails.rubricSubQuestions[i] }}
+      </div>
+      <div class="card-body"
+           [ngClass]="{ 'row-answered': i < responseDetails.answer.length && responseDetails.answer[i] !== RUBRIC_ANSWER_NOT_CHOSEN }">
+        <div *ngFor="let rubricDescriptionCell of rubricDescriptionRow; let j = index;">
+          <label>
+            <input
+              type="radio"
+              [disabled]="isDisabled"
+              (click)="selectAnswer(i, j)"
+              [name]="getInputId(id, i, j, 'mobile')"
+              [checked]="i < responseDetails.answer.length && responseDetails.answer[i] === j"
+              [attr.aria-label]="getAriaLabelForChoice(questionDetails.rubricChoices[j], rubricDescriptionCell, questionDetails.rubricSubQuestions[i])"
+            >
+            {{ getChoiceWithDescription(questionDetails.rubricChoices[j], rubricDescriptionCell) }}
+          </label>
+        </div>
       </div>
     </div>
   </div>
 </div>
-<button
+
+<div class="button-container">
+  <button
     type="button"
     title="Reset choices"
     id="btn-reset"
     name="button-reset"
     class="btn btn-secondary"
     (click)="confirmReset()">
-  Reset choices
-</button>
+    Reset choices
+  </button>
+</div>

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.html
@@ -47,3 +47,12 @@
     </div>
   </div>
 </div>
+<button
+    type="button"
+    title="Reset choices"
+    id="btn-reset"
+    name="button-reset"
+    class="btn btn-secondary"
+    (click)="resetRubricAnswer()">
+  Reset choices
+</button>

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.scss
@@ -17,3 +17,12 @@
     display: none;
   }
 }
+
+.table-container {
+  margin-bottom: 1.25em;
+}
+
+.button-container {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
@@ -72,6 +72,12 @@ export class RubricQuestionEditAnswerFormComponent extends QuestionEditAnswerFor
     return `${id}-row${row}-col${col}-${platform}`;
   }
 
+  confirmReset(): void {
+    if (confirm('Are you sure you want to reset all choices?')) {
+      this.resetRubricAnswer();
+    }
+  }
+
   resetRubricAnswer(): void {
     const resettedAnswer: number[] = 
         Array(this.questionDetails.rubricSubQuestions.length).fill(RUBRIC_ANSWER_NOT_CHOSEN);

--- a/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/rubric-question-edit-answer-form.component.ts
@@ -71,4 +71,10 @@ export class RubricQuestionEditAnswerFormComponent extends QuestionEditAnswerFor
   getInputId(id: string, row: number, col: number, platform: string): string {
     return `${id}-row${row}-col${col}-${platform}`;
   }
+
+  resetRubricAnswer(): void {
+    const resettedAnswer: number[] = 
+        Array(this.questionDetails.rubricSubQuestions.length).fill(RUBRIC_ANSWER_NOT_CHOSEN);
+    this.triggerResponseDetailsChange('answer', resettedAnswer);
+  }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12569 

**Outline of Solution**
Created functionality to give respondents a way to reset all rows to an empty state by adding a `reset choices` button.
There will be a confirmation dialogue using `confirm` to ensure respondents want to reset their choices.
Added the `reset rubrics` function to be called after confirmation of action.


**UI changes**:
![Screenshot 2024-07-15 at 3 13 33 AM](https://github.com/user-attachments/assets/ad3b0d99-30b0-4ae5-92d0-f04f9ba24ea9)
