### PR TITLE
[13144] - Copy students from existing students table to new students table

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:css:syntax": "stylelint \"src/web/**/*.css\" \"src/web/**/*.scss\" \"src/web/**/*.html\" --ignore-pattern \"src/web/dist/*.css\" --cache --config static-analysis/teammates-stylelint.yml",
     "lint:css:styles": "prettier --print-width=120 --single-quote=true \"src/web/**/*.css\" \"src/web/**/*.scss\"",
     "lint:windows:spaces": "lintspaces -n -t -d spaces -l 1 -. \"src/main/**/*.html\" \"src/web/**/*.html\" \"src/**/*.xml\" \"src/**/*.json\" \"src/**/*.properties\" \"*.yml\" \"*.json\" \"*.gradle\" \"static-analysis/*.*ml\" \".gitattributes\"",
-    "lint:nix:spaces": "lintspaces -n -t -d spaces -l 1 --matchdotfiles $(git diff --name-only --diff-filter=ACMRTUXB origin/master HEAD | grep -E \"src/(main|web)/.*.html|src/.*.(xml|json|properties)|*.(yml|json|gradle)|static-analysis/*.*ml|.gitattributes\") || :",
+    "lint:nix:spaces": "lintspaces -n -t -d spaces -l 1 --matchdotfiles $(git diff --name-only --diff-filter=ACMRTUXB origin/master HEAD | grep -E \"src/(main|web)/.*\\.html|src/.*\\.(xml|json|properties)|.*\\.(yml|json|gradle)|static-analysis/.*\\.(xml|yml)\") || :",
     "lint": "run-script-os",
     "lint:windows": "npm-run-all lint:ts lint:css:syntax lint:css:styles lint:windows:spaces -c",
     "lint:nix": "npm-run-all lint:ts lint:css:syntax lint:css:styles lint:nix:spaces -c"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -101,7 +101,20 @@
                     title="Enroll"
                     id="btn-enroll"
                     name="button-enroll"
-                    class="btn btn-success float-end"
+                    class="btn btn-info"
+                    [disabled]="isEnrolling"
+                    (click)="submitEnrollData()">
+                  <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>
+                  <tm-ajax-loading *ngIf="isEnrolling"></tm-ajax-loading>
+                  Copy students
+                </button>
+                <button
+                    [ngClass]="{'w-50': isEnrolling}"
+                    type="submit"
+                    title="Enroll"
+                    id="btn-enroll"
+                    name="button-enroll"
+                    class="btn btn-success"
                     [disabled]="isEnrolling"
                     (click)="submitEnrollData()">
                   <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -96,16 +96,16 @@
               </div>
               <div class="enroll-button-group">
                 <button
-                    [ngClass]="{'w-50': isEnrolling}"
-                    type="submit"
-                    title="Enroll"
-                    id="btn-enroll"
-                    name="button-enroll"
+                    [ngClass]="{'w-50': isCopying}"
+                    type="button"
+                    title="Copy"
+                    id="btn-copy"
+                    name="button-copy"
                     class="btn btn-info"
-                    [disabled]="isEnrolling"
-                    (click)="submitEnrollData()">
-                  <tm-progress-bar *ngIf="isEnrolling"></tm-progress-bar>
-                  <tm-ajax-loading *ngIf="isEnrolling"></tm-ajax-loading>
+                    [disabled]="isCopying"
+                    (click)="copyStudents()">
+                  <tm-progress-bar *ngIf="isCopying"></tm-progress-bar>
+                  <tm-ajax-loading *ngIf="isCopying"></tm-ajax-loading>
                   Copy students
                 </button>
                 <button

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -69,8 +69,9 @@
 }
 
 .enroll-button-group {
+  display: flex;
+  justify-content: space-between;
   width: 50%;
-  display: inline-block;
 }
 
 .enroll-button-group * {

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -248,6 +248,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
 
   /**
    * Copies data from existing students HOT to new students HOT
+   * The data is copied only if the existing students tab is expanded
    */
   copyStudents(): void {
     this.isCopying = true;
@@ -255,122 +256,30 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     this.allStudentChunks = [];
 
     const lastColIndex: number = 4;
+    const existingStudentsHOTInstance: Handsontable =
+        this.hotRegisterer.getInstance(this.existingStudentsHOT);
     const newStudentsHOTInstance: Handsontable =
         this.hotRegisterer.getInstance(this.newStudentsHOT);
+    const existingStudentsData: Handsontable.CellValue[] = existingStudentsHOTInstance.getData();
     const hotInstanceColHeaders: string[] = (newStudentsHOTInstance.getColHeader() as string[]);
 
-    // Reset error highlighting on a new submission
+
+    if (existingStudentsData.length == 0) {
+      this.copyErrorMessage = 'No data to copy from existing students.';
+      this.isCopying = false;
+      return;
+    }
+
+    newStudentsHOTInstance.loadData(existingStudentsData);
+
+    // Reset styles on new students HOT
     this.resetTableStyle(newStudentsHOTInstance, 0,
         newStudentsHOTInstance.getData().length - 1,
         0,
         hotInstanceColHeaders.indexOf(this.colHeaders[lastColIndex]));
 
-    // Remove error highlight on click
-    newStudentsHOTInstance.addHook('afterSelectionEnd', (row: number, column: number,
-                                                          row2: number, column2: number) => {
-      this.resetTableStyle(newStudentsHOTInstance, row, row2, column, column2);
-    });
-
-    // Record the row with its index on the table
-    const studentEnrollRequests: Map<number, StudentEnrollRequest> = new Map();
-
-    // Parse the user input to be requests.
-    // Handsontable contains null value initially,
-    // see https://github.com/handsontable/handsontable/issues/3927
-    newStudentsHOTInstance.getData()
-        .forEach((row: string[], index: number) => {
-          if (!row.every((cell: string) => cell === null || cell === '')) {
-            studentEnrollRequests.set(index, {
-              section: row[hotInstanceColHeaders.indexOf(this.colHeaders[0])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[0])].trim(),
-              team: row[hotInstanceColHeaders.indexOf(this.colHeaders[1])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[1])].trim(),
-              name: row[hotInstanceColHeaders.indexOf(this.colHeaders[2])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[2])].trim(),
-              email: row[hotInstanceColHeaders.indexOf(this.colHeaders[3])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[3])].trim(),
-              comments: row[hotInstanceColHeaders.indexOf(this.colHeaders[4])] === null
-                  ? '' : row[hotInstanceColHeaders.indexOf(this.colHeaders[4])].trim(),
-            });
-          }
-        });
-
-    if (studentEnrollRequests.size === 0) {
-      this.enrollErrorMessage = 'Empty table';
-      this.isEnrolling = false;
-      return;
-    }
-
-    this.checkCompulsoryFields(studentEnrollRequests);
-    this.checkEmailNotRepeated(studentEnrollRequests);
-    this.checkTeamsValid(studentEnrollRequests);
-
-    if (this.invalidRowsIndex.size > 0) {
-      this.setTableStyleBasedOnFieldChecks(newStudentsHOTInstance, hotInstanceColHeaders);
-      this.isEnrolling = false;
-      return;
-    }
-
-    this.partitionStudentEnrollRequests(Array.from(studentEnrollRequests.values()));
-    const enrolledStudents: Student[] = [];
-
-    // Use concat because we cannot afford to parallelize with forkJoin when there's data dependency
-    const enrollRequests: Observable<EnrollStudents> = concat(
-        ...this.allStudentChunks.map((studentChunk: StudentEnrollRequest[]) => {
-          const request: StudentsEnrollRequest = {
-            studentEnrollRequests: studentChunk,
-          };
-          return this.studentService.enrollStudents(
-              this.courseId, request,
-          );
-        }),
-    );
-
-    this.progressBarService.updateProgress(0);
-    enrollRequests.pipe(finalize(() => {
-      this.isEnrolling = false;
-    })).subscribe({
-      next: (resp: EnrollStudents) => {
-        enrolledStudents.push(...resp.studentsData.students);
-
-        if (resp.unsuccessfulEnrolls != null) {
-          for (const unsuccessfulEnroll of resp.unsuccessfulEnrolls) {
-            this.unsuccessfulEnrolls[unsuccessfulEnroll.studentEmail] = unsuccessfulEnroll.errorMessage;
-
-            for (const index of studentEnrollRequests.keys()) {
-              if (studentEnrollRequests.get(index)?.email === unsuccessfulEnroll.studentEmail) {
-                this.invalidRowsIndex.add(index);
-                break;
-              }
-            }
-          }
-        }
-        const percentage: number = Math.round(100 * enrolledStudents.length / studentEnrollRequests.size);
-        this.progressBarService.updateProgress(percentage);
-      },
-      complete: () => {
-        this.showEnrollResults = true;
-        this.statusMessage.pop(); // removes any existing error status message
-        this.statusMessageService.showSuccessToast('Enrollment successful. Summary given below.');
-        this.prepareEnrollmentResults(enrolledStudents, studentEnrollRequests);
-
-        if (this.invalidRowsIndex.size > 0
-          || this.newStudentRowsIndex.size > 0
-          || this.modifiedStudentRowsIndex.size > 0
-          || this.unchangedStudentRowsIndex.size > 0) {
-          this.setTableStyleBasedOnFieldChecks(newStudentsHOTInstance, hotInstanceColHeaders);
-        }
-      },
-      error: (resp: ErrorMessageOutput) => {
-        if (enrolledStudents.length > 0) {
-          this.showEnrollResults = true;
-          this.prepareEnrollmentResults(enrolledStudents, studentEnrollRequests);
-        }
-
-        // Set error message after populating result panels to avoid it being overridden
-        this.enrollErrorMessage = resp.error.message;
-      },
-    });
+    this.isCopying = false;
+    this.statusMessageService.showSuccessToast('Students copied successfully.');
   }
 
   private prepareEnrollmentResults(enrolledStudents: Student[],

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -262,30 +262,29 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
         this.hotRegisterer.getInstance(this.newStudentsHOT);
     const hotInstanceColHeaders: string[] = (newStudentsHOTInstance.getColHeader() as string[]);
 
-    const copyData = () => {
+    const copyData = (): void => {
       const existingStudentsData: Handsontable.CellValue[] = existingStudentsHOTInstance.getData();
-  
+
       if (existingStudentsData.length === 0) {
         this.copyErrorMessage = 'No data to copy from existing students.';
         this.isCopying = false;
         return;
       }
-  
+
       newStudentsHOTInstance.loadData(existingStudentsData);
-  
+
       this.resetTableStyle(newStudentsHOTInstance, 0,
           newStudentsHOTInstance.getData().length - 1,
           0,
           hotInstanceColHeaders.indexOf(this.colHeaders[lastColIndex]));
-  
+
       this.isCopying = false;
       this.statusMessageService.showSuccessToast('Students copied successfully.');
     };
 
     if (this.isExistingStudentsPanelCollapsed) {
       this.toggleExistingStudentsPanel(copyData);
-    }
-    else {
+    } else {
       copyData();
     }
   }


### PR DESCRIPTION
Fixes #13144

# Outline of Solution

## Motivation and Context

For instructors who want to batch edit many students, they would have to copy and paste the whole sheet from existing students manually. The slightly clunky cell selection in the sheet would make it sometimes hard to select all students, especially if there are many students.
Therefore, I would suggest the addition of a button to auto-import existing students into the new students sheet below. This would be a QOL change and also helps when instructors want to mass-edit students.

## Changes

Frontend:
1. Added a `copy students` button on the enrol page and formatted it.

Backend:
1. Created functionality to copy existing students' spreadsheets into new students' spreadsheet
  * Ran into the issue that Existing students' spreadsheet has to be expanded for logic to work
  * Another issue was the asynchronous nature of fetching data with API calls in `toggleExistingStudentsPanel`
2. Modify `toggleExistingStudentsPanel` to take in an optional callback
  * This ensures that the data is only copied after it has been successfully loaded

## Video Demo

Before: 


https://github.com/user-attachments/assets/a5cbb0d2-bd77-4b21-b254-388f52fad915






After:


https://github.com/user-attachments/assets/e3b2a84c-10e3-4992-94c8-7a99269f92dc


