### PR TITLE
[#13147] Didn't Account for the Timezone in Session Edit Form component tests

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -123,8 +123,10 @@ describe('SessionEditFormComponent', () => {
   it('should not adjust the session visibility date and time if submission opening date and time are later', () => {
     const date: DateFormat = component.minDateForSubmissionStart;
     const time: TimeFormat = component.minTimeForSubmissionStart;
-    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().tz(component.model.timeZone).subtract(1, 'days'));
-    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().tz(component.model.timeZone).subtract(1, 'hours'));
+    component.model.customSessionVisibleDate = dateTimeService
+      .getDateInstance(moment().tz(component.model.timeZone).subtract(1, 'days'));
+    component.model.customSessionVisibleTime = dateTimeService
+      .getTimeInstance(moment().tz(component.model.timeZone).subtract(1, 'hours'));
     component.configureSessionVisibleDateTime(date, time);
     expect(component.model.customSessionVisibleDate).not.toEqual(date);
     expect(component.model.customSessionVisibleTime).not.toEqual(time);

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -123,8 +123,8 @@ describe('SessionEditFormComponent', () => {
   it('should not adjust the session visibility date and time if submission opening date and time are later', () => {
     const date: DateFormat = component.minDateForSubmissionStart;
     const time: TimeFormat = component.minTimeForSubmissionStart;
-    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().subtract(1, 'days'));
-    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().subtract(1, 'hours'));
+    component.model.customSessionVisibleDate = dateTimeService.getDateInstance(moment().tz(component.model.timeZone).subtract(1, 'days'));
+    component.model.customSessionVisibleTime = dateTimeService.getTimeInstance(moment().tz(component.model.timeZone).subtract(1, 'hours'));
     component.configureSessionVisibleDateTime(date, time);
     expect(component.model.customSessionVisibleDate).not.toEqual(date);
     expect(component.model.customSessionVisibleTime).not.toEqual(time);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #13147

**Outline of Solution**
Added `.tz()` to account for the timezones when comparing the datetimes.

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
