### PR TITLE
[#12552] Session Copy Modal: Instructors able to select the Course that they are copying from

### DIFF
--- a/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
+++ b/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`CopySessionModalComponent should snap with default fields 1`] = `
   copyToCourseSet={[Function Set]}
   courseCandidates={[Function Array]}
   newFeedbackSessionName=""
+  originalSessionName=""
   sessionToCopyCourseId=""
 >
   <div
@@ -97,6 +98,7 @@ exports[`CopySessionModalComponent should snap with some session and courses can
   copyToCourseSet={[Function Set]}
   courseCandidates={[Function Array]}
   newFeedbackSessionName={[Function String]}
+  originalSessionName=""
   sessionToCopyCourseId={[Function String]}
 >
   <div

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -146,4 +146,34 @@ describe('CopySessionModalComponent', () => {
     expect(component.copyToCourseSet.has(courseId)).toBe(false);
   });
 
+  it('should update session name to "Copy of ..." when the same course is selected', () => {
+    component.newFeedbackSessionName = feedbackSessionToCopy.feedbackSessionName;
+    component.originalSessionName = feedbackSessionToCopy.feedbackSessionName;
+    component.sessionToCopyCourseId = courseSessionIn.courseId;
+    component.courseCandidates = [courseSessionIn, courseCopyTo];
+    fixture.detectChanges();
+
+    const options: DebugElement[] = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+    const firstOption: any = options[0];
+    firstOption.triggerEventHandler('click', { target: firstOption.nativeElement });
+    fixture.detectChanges();
+
+    expect(component.newFeedbackSessionName).toBe(`Copy of ${feedbackSessionToCopy.feedbackSessionName}`);
+  });
+
+  it('should restore the original session name when the same course is deselected', () => {
+    component.newFeedbackSessionName = `Copy of ${feedbackSessionToCopy.feedbackSessionName}`;
+    component.originalSessionName = feedbackSessionToCopy.feedbackSessionName;
+    component.sessionToCopyCourseId = courseSessionIn.courseId;
+    component.courseCandidates = [courseSessionIn, courseCopyTo];
+    component.copyToCourseSet.add(courseSessionIn.courseId);
+    fixture.detectChanges();
+
+    const options: DebugElement[] = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+    const firstOption: any = options[0];
+    firstOption.triggerEventHandler('click', { target: firstOption.nativeElement });
+    fixture.detectChanges();
+
+    expect(component.newFeedbackSessionName).toBe(feedbackSessionToCopy.feedbackSessionName);
+  });
 });

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Course } from '../../../types/api-output';
 import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator';
@@ -11,7 +11,7 @@ import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator
   templateUrl: './copy-session-modal.component.html',
   styleUrls: ['./copy-session-modal.component.scss'],
 })
-export class CopySessionModalComponent {
+export class CopySessionModalComponent implements OnInit {
 
   // const
   FEEDBACK_SESSION_NAME_MAX_LENGTH: number = FEEDBACK_SESSION_NAME_MAX_LENGTH;
@@ -24,8 +24,13 @@ export class CopySessionModalComponent {
 
   newFeedbackSessionName: string = '';
   copyToCourseSet: Set<string> = new Set<string>();
+  originalSessionName: string = '';
 
   constructor(public activeModal: NgbActiveModal) {}
+
+  ngOnInit(): void {
+    this.originalSessionName = this.newFeedbackSessionName;
+  }
 
   /**
    * Fires the copy event.
@@ -44,8 +49,14 @@ export class CopySessionModalComponent {
   select(courseId: string): void {
     if (this.copyToCourseSet.has(courseId)) {
       this.copyToCourseSet.delete(courseId);
+      if (courseId === this.sessionToCopyCourseId) {
+        this.newFeedbackSessionName = this.originalSessionName;
+      }
     } else {
       this.copyToCourseSet.add(courseId);
+      if (courseId === this.sessionToCopyCourseId) {
+        this.newFeedbackSessionName = `Copy of ${this.originalSessionName}`;
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12552

**Outline of Solution**
To fix this issue, whenever the instructor selects the same course that the feedback session belongs to, it will automatically prepend "Copy of" to the new feedback session name (inspired by Google Docs). So `XXX` will become `Copy of XXX`.

Of course, this leads to one small side effect in that whenever the same course is selected along with other courses, all the new names will have the `Copy of` in their name too. It's all illustrated in the video below. 

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

1. The same course is selected. Adds `Copy of` to the front of the new feedback session name. 

https://github.com/user-attachments/assets/1c4bef11-278e-4737-9407-3b9510c27bed


2. The same course and another one is selected. Both new feedback session names have `Copy of`.

https://github.com/user-attachments/assets/a010b184-7c84-43cb-accb-e928fbf08d89


3. Copied to new course. No Copy of prepended.

https://github.com/user-attachments/assets/a216780d-6bb0-4d4c-a4be-827df24b71fb


I'm open to suggestions on how else we could improve the UX. Perhaps we just standardise all of them to have 'Copy of' attached to the front just like Google Docs?
