### PR TITLE
[#13122] Create cancel button for instructor request form

### DIFF
--- a/src/web/app/pages-static/request-page/instructor-request-form/__snapshots__/instructor-request-form.component.spec.ts.snap
+++ b/src/web/app/pages-static/request-page/instructor-request-form/__snapshots__/instructor-request-form.component.spec.ts.snap
@@ -189,7 +189,16 @@ exports[`InstructorRequestFormComponent should render correctly 1`] = `
       />
     </div>
     <br />
+    <a
+      aria-label="Cancel button"
+      class="btn btn-danger me-3"
+      tmrouterlink="/web/front/home"
+      type="button"
+    >
+       Cancel 
+    </a>
     <button
+      aria-label="Submit form"
       class="btn btn-primary"
       id="submit-button"
       type="submit"

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.html
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.html
@@ -127,7 +127,10 @@
   <ngb-alert type="danger" [dismissible]="false" *ngIf="serverErrorMessage" class="error-box">
     <strong>Error submitting request:</strong> {{serverErrorMessage}}
   </ngb-alert>
-  <button type="submit" class="btn btn-primary" id="submit-button" [disabled]="!canSubmit">
+  <a type="button" class="btn btn-danger me-3" tmRouterLink="/web/front/home" aria-label="Cancel button">
+    Cancel
+  </a>
+  <button type="submit" class="btn btn-primary" id="submit-button" aria-label="Submit form" [disabled]="!canSubmit">
     {{isLoading ? "Submitting..." : "Submit"}}
   </button>
 </form>


### PR DESCRIPTION
Fixes #13122 

**Outline of Solution**

* Add a Cancel button next to the Submit button so users can undo their form request and return to the homepage.
* Added accessibility features to both cancel and submit button

**UI changes**

![Screenshot 2024-07-29 at 11 18 46 PM](https://github.com/user-attachments/assets/191e482e-1466-49de-a4ee-5b04d28c1dac)


