### PR TITLE
[#12375] Update phrasing of contact page

### DIFF
--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -12,7 +12,7 @@
   <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
 </p>
 <p>
-  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Developer Website</a>.
+  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Project Website</a>.
 </p>
 <p>
   <b>Becoming a sponsor</b>:

--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -3,16 +3,21 @@
 </h1>
 <img src="assets/images/contact.png">
 <p>
-  <b>Email:</b> You can contact us at the following email address: <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a>.
+  <b>Email:</b> You can contact us at the following email address:
+  <a href="mailto:{{ supportEmail }}"><span aria-hidden="true" class="fas fa-envelope"></span>{{ supportEmail }}</a>.
 </p>
 <p>
-  <b>Blog:</b> Visit the <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer">TEAMMATES Blog</a> to see our latest updates and information.
+  <b>Blog:</b> Visit the
+  <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fab fa-blogger"></span>TEAMMATES Blog</a>
+  to see our latest updates and information.
 </p>
 <p>
   <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
 </p>
 <p>
-  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fab fa-github"></span> TEAMMATES Github</a>.
+  <b>Interested in joining us?</b> Visit our
+  <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">
+    <span aria-hidden="true" class="fab fa-github"></span>TEAMMATES Github</a>.
 </p>
 <p>
   <b>Becoming a sponsor</b>:

--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -12,7 +12,7 @@
   <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
 </p>
 <p>
-  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Project Website</a>.
+  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fab fa-github"></span> TEAMMATES Github</a>.
 </p>
 <p>
   <b>Becoming a sponsor</b>:


### PR DESCRIPTION
Fixes #12375

**Outline of Solution**

Changed the text hyperlinked to the TEAMMATES GitHub on the contact page to be Project Website to be consistent with the phrasing used on the [NUS-OSS](https://nus-oss.github.io/index.html#projects) projects page.
