### PR TITLE
[#8557] Standardize locale

### DIFF
--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -1,6 +1,7 @@
 package teammates.common.util;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -179,7 +180,9 @@ public final class StringHelper {
      * Converts a double value between 0 and 1 to 3dp-string.
      */
     public static String toDecimalFormatString(double doubleVal) {
-        DecimalFormat df = new DecimalFormat("0.###");
+        DecimalFormatSymbols syms = new DecimalFormatSymbols();
+        syms.setDecimalSeparator('.');
+        DecimalFormat df = new DecimalFormat("0.###", syms);
         return df.format(doubleVal);
     }
 

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 
 /**
  * A helper class to hold time-related functions (e.g., converting dates to strings etc.).
@@ -105,7 +106,9 @@ public final class TimeHelper {
         if (zonedDateTime.getHour() == 12 && zonedDateTime.getMinute() == 0) {
             processedPattern = pattern.replace("a", "'NOON'");
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(processedPattern);
+        DateTimeFormatter formatter = DateTimeFormatter
+                .ofPattern(processedPattern)
+                .withLocale(Locale.US);
         return zonedDateTime.format(formatter);
     }
 


### PR DESCRIPTION
Fixes #8557 

```shell
OS: macOS Sonoma 14.2.1 arm64
Host: MacBook Pro (14-inch, 2021)
Locale: en_GB.UTF-8, de_DE.UTF-8
```

When running tests locally, some tests fail because of differences in locale, like `teammates.common.util.TimeHelperTest.testGetMidnightAdjustedInstantBasedOnZone`. Even though this might not be a problem when running tests as part of a workflow, it might cause confusion to some users who are running tests locally and encountering errors.

Testing on `en_GB.UTF-8`:
```shell
org.gradle.internal.serialize.PlaceholderAssertionError: expected: <Sun, 29 Nov 2015, 11:59 PM UTC> but was: <Sun, 29 Nov 2015, 11:59 pm UTC>
```
Testing on `de_DE.UTF-8`:
```shell
org.gradle.internal.serialize.PlaceholderAssertionError: expected: <Sun, 29 Nov 2015, 11:59 PM UTC> but was: <So., 29 Nov. 2015, 11:59 PM UTC>
```
For me, 5 tests were failing locally, so I ran this command to run the 5 tests which were failing.
```shell
./gradlew unitTests \ 
    --tests "teammates.common.util.TimeHelperTest.testFormatDateTimeForDisplay" \
    --tests "teammates.common.util.TimeHelperTest.testGetMidnightAdjustedInstantBasedOnZone" \
    --tests "teammates.logic.api.EmailGeneratorTest.testGenerateFeedbackSessionEmails" \
    --tests "teammates.logic.api.EmailGeneratorTest.testGenerateFeedbackSessionEmails_testSanitization" \
    --tests "teammates.logic.api.EmailGeneratorTest.testGenerateFeedbackSessionEmails_testUsersWithDeadlineExtensions"
```

**Outline of Solution**
I updated `teammates/common/util/TimeHelper::formatInstant` to use the US locale when generating dates, as seen below:
```java
        DateTimeFormatter formatter = DateTimeFormatter
                .ofPattern(processedPattern)
                .withLocale(Locale.US);
```
This standardises the locale used in the app to use a US locale, so that the tests which are related to datetime formatting can pass locally.

After making this change, local tests pass on both `de_DE.UTF-8` and `en_GB.UTF-8`.

I have yet to test this on Linux, which was what was reported in the referenced issue, but I believe that the issues that we are facing are somewhat related.
