### PR TITLE
[#13104] Add mappings

### DIFF
--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -118,62 +118,62 @@ export class InstructorRequestFormComponent {
     // Country Mapping
     const countryMapping: { [key: string]: string } = {
       'united states': 'USA',
-      'u.s.a': 'USA',
-      'us': 'USA',
-      'america': 'USA',
+      usa: 'USA',
+      us: 'USA',
+      america: 'USA',
       'united states of america': 'USA',
 
       'united kingdom': 'UK',
-      'uk': 'UK',
-      'britain': 'UK',
+      uk: 'UK',
+      britain: 'UK',
       'great britain': 'UK',
-      'england': 'UK',
+      england: 'UK',
 
       'united arab emirates': 'UAE',
-      'uae': 'UAE',
-      'emirates': 'UAE',
+      uae: 'UAE',
+      emirates: 'UAE',
 
-      'deutschland': 'Germany',
-      'germany': 'Germany',
+      deutschland: 'Germany',
+      germany: 'Germany',
 
-      'netherlands': 'Netherlands',
-      'holland': 'Netherlands',
+      netherlands: 'Netherlands',
+      holland: 'Netherlands',
 
-      'belgium': 'Belgium',
+      belgium: 'Belgium',
       'belgië': 'Belgium',
       'belgique': 'Belgium',
 
-      'brazil': 'Brazil',
-      'brasil': 'Brazil',
+      brazil: 'Brazil',
+      brasil: 'Brazil',
 
-      'spain': 'Spain',
+      spain: 'Spain',
       'españa': 'Spain',
 
-      'mexico': 'Mexico',
+      mexico: 'Mexico',
       'méxico': 'Mexico',
 
-      'italy': 'Italy',
-      'italia': 'Italy',
+      italy: 'Italy',
+      italia: 'Italy',
 
-      'china': 'China',
+      china: 'China',
       'peoples republic of china': 'China',
-      'prc': 'China',
+      prc: 'China',
 
-      'france': 'France',
+      france: 'France',
       'republic of france': 'France',
 
-      'india': 'India',
-      'bharat': 'India',
+      india: 'India',
+      bharat: 'India',
 
-      'japan': 'Japan',
-      'nippon': 'Japan',
+      japan: 'Japan',
+      nippon: 'Japan',
 
-      'russia': 'Russia',
+      russia: 'Russia',
       'russian federation': 'Russia',
 
       'south korea': 'South Korea',
       'republic of korea': 'South Korea',
-      'korea': 'South Korea',
+      korea: 'South Korea',
 
       'north korea': 'North Korea',
       'democratic peoples republic of korea': 'North Korea',
@@ -181,19 +181,19 @@ export class InstructorRequestFormComponent {
       'south africa': 'South Africa',
       'republic of south africa': 'South Africa',
 
-      'switzerland': 'Switzerland',
-      'schweiz': 'Switzerland',
-      'suisse': 'Switzerland',
-      'svizzera': 'Switzerland',
-      'svizra': 'Switzerland',
+      switzerland: 'Switzerland',
+      schweiz: 'Switzerland',
+      suisse: 'Switzerland',
+      svizzera: 'Switzerland',
+      svizra: 'Switzerland',
 
-      'taiwan': 'Taiwan',
+      taiwan: 'Taiwan',
       'republic of china': 'Taiwan',
 
-      'turkey': 'Turkey',
+      turkey: 'Turkey',
       'republic of turkey': 'Turkey',
 
-      'vietnam': 'Vietnam',
+      vietnam: 'Vietnam',
       'viet nam': 'Vietnam',
     };
     // Combine country and institution

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -183,8 +183,6 @@ export class InstructorRequestFormComponent {
 
       switzerland: 'Switzerland',
 
-      taiwan: 'Taiwan',
-
       turkey: 'Turkey',
       'republic of turkey': 'Turkey',
       'republic of türkiye': 'Turkey',

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -118,7 +118,7 @@ export class InstructorRequestFormComponent {
     // Country Mapping
     const countryMapping: { [key: string]: string } = {
       'united states': 'USA',
-      usa: 'USA',
+      'u.s.a.': 'USA',
       us: 'USA',
       america: 'USA',
       'united states of america': 'USA',

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -118,15 +118,83 @@ export class InstructorRequestFormComponent {
     // Country Mapping
     const countryMapping: { [key: string]: string } = {
       'united states': 'USA',
-      us: 'USA',
-      america: 'USA',
-      uk: 'United Kingdom',
-      deutschland: 'Germany',
+      'u.s.a': 'USA',
+      'us': 'USA',
+      'america': 'USA',
+      'united states of america': 'USA',
+
+      'united kingdom': 'UK',
+      'uk': 'UK',
+      'britain': 'UK',
+      'great britain': 'UK',
+      'england': 'UK',
+
       'united arab emirates': 'UAE',
-      españa: 'Spain',
-      méxico: 'Mexico',
-      belgië: 'Belgium',
-      holland: 'Netherlands',
+      'uae': 'UAE',
+      'emirates': 'UAE',
+
+      'deutschland': 'Germany',
+      'germany': 'Germany',
+
+      'netherlands': 'Netherlands',
+      'holland': 'Netherlands',
+
+      'belgium': 'Belgium',
+      'belgië': 'Belgium',
+      'belgique': 'Belgium',
+
+      'brazil': 'Brazil',
+      'brasil': 'Brazil',
+
+      'spain': 'Spain',
+      'españa': 'Spain',
+
+      'mexico': 'Mexico',
+      'méxico': 'Mexico',
+
+      'italy': 'Italy',
+      'italia': 'Italy',
+
+      'china': 'China',
+      'peoples republic of china': 'China',
+      'prc': 'China',
+
+      'france': 'France',
+      'republic of france': 'France',
+
+      'india': 'India',
+      'bharat': 'India',
+
+      'japan': 'Japan',
+      'nippon': 'Japan',
+
+      'russia': 'Russia',
+      'russian federation': 'Russia',
+
+      'south korea': 'South Korea',
+      'republic of korea': 'South Korea',
+      'korea': 'South Korea',
+
+      'north korea': 'North Korea',
+      'democratic peoples republic of korea': 'North Korea',
+
+      'south africa': 'South Africa',
+      'republic of south africa': 'South Africa',
+
+      'switzerland': 'Switzerland',
+      'schweiz': 'Switzerland',
+      'suisse': 'Switzerland',
+      'svizzera': 'Switzerland',
+      'svizra': 'Switzerland',
+
+      'taiwan': 'Taiwan',
+      'republic of china': 'Taiwan',
+
+      'turkey': 'Turkey',
+      'republic of turkey': 'Turkey',
+
+      'vietnam': 'Vietnam',
+      'viet nam': 'Vietnam',
     };
     // Combine country and institution
     const country = this.country.value!.trim();

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -140,17 +140,17 @@ export class InstructorRequestFormComponent {
       holland: 'Netherlands',
 
       belgium: 'Belgium',
-      'belgië': 'Belgium',
+      belgië: 'Belgium',
       'belgique': 'Belgium',
 
       brazil: 'Brazil',
       brasil: 'Brazil',
 
       spain: 'Spain',
-      'españa': 'Spain',
+      españa: 'Spain',
 
       mexico: 'Mexico',
-      'méxico': 'Mexico',
+      méxico: 'Mexico',
 
       italy: 'Italy',
       italia: 'Italy',

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -118,6 +118,7 @@ export class InstructorRequestFormComponent {
     // Country Mapping
     const countryMapping: { [key: string]: string } = {
       'united states': 'USA',
+      'u.s.a': 'USA',
       'u.s.a.': 'USA',
       us: 'USA',
       america: 'USA',

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -138,11 +138,12 @@ export class InstructorRequestFormComponent {
       germany: 'Germany',
 
       netherlands: 'Netherlands',
+      'the netherlands': 'Netherlands',
+      nederland: 'Netherlands',
       holland: 'Netherlands',
 
       belgium: 'Belgium',
       belgië: 'Belgium',
-      belgique: 'Belgium',
 
       brazil: 'Brazil',
       brasil: 'Brazil',
@@ -164,10 +165,8 @@ export class InstructorRequestFormComponent {
       'republic of france': 'France',
 
       india: 'India',
-      bharat: 'India',
 
       japan: 'Japan',
-      nippon: 'Japan',
 
       russia: 'Russia',
       'russian federation': 'Russia',
@@ -183,19 +182,17 @@ export class InstructorRequestFormComponent {
       'republic of south africa': 'South Africa',
 
       switzerland: 'Switzerland',
-      schweiz: 'Switzerland',
-      suisse: 'Switzerland',
-      svizzera: 'Switzerland',
-      svizra: 'Switzerland',
 
       taiwan: 'Taiwan',
-      'republic of china': 'Taiwan',
 
       turkey: 'Turkey',
       'republic of turkey': 'Turkey',
+      'republic of türkiye': 'Turkey',
 
       vietnam: 'Vietnam',
       'viet nam': 'Vietnam',
+
+      malaysia: 'Malaysia',
     };
     // Combine country and institution
     const country = this.country.value!.trim();

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.ts
@@ -141,7 +141,7 @@ export class InstructorRequestFormComponent {
 
       belgium: 'Belgium',
       belgië: 'Belgium',
-      'belgique': 'Belgium',
+      belgique: 'Belgium',
 
       brazil: 'Brazil',
       brasil: 'Brazil',


### PR DESCRIPTION
Fixes #13104

**Outline of Solution**

Made the dictionary of mappings in [3f5f68d](https://github.com/TEAMMATES/teammates/commit/3f5f68dc971ebabc2eb0f5d8541a24b36d716807) more extensive, covering more countries and cases.

Updated mappings:
```javascript
    const countryMapping: { [key: string]: string } = {
      'united states': 'USA',
      'u.s.a': 'USA',
      'u.s.a.': 'USA',
      us: 'USA',
      america: 'USA',
      'united states of america': 'USA',

      'united kingdom': 'UK',
      uk: 'UK',
      britain: 'UK',
      'great britain': 'UK',
      england: 'UK',

      'united arab emirates': 'UAE',
      uae: 'UAE',
      emirates: 'UAE',

      deutschland: 'Germany',
      germany: 'Germany',

      netherlands: 'Netherlands',
      'the netherlands': 'Netherlands',
      nederland: 'Netherlands',
      holland: 'Netherlands',

      belgium: 'Belgium',
      belgië: 'Belgium',

      brazil: 'Brazil',
      brasil: 'Brazil',

      spain: 'Spain',
      españa: 'Spain',

      mexico: 'Mexico',
      méxico: 'Mexico',

      italy: 'Italy',
      italia: 'Italy',

      china: 'China',
      'peoples republic of china': 'China',
      prc: 'China',

      france: 'France',
      'republic of france': 'France',

      india: 'India',

      japan: 'Japan',

      russia: 'Russia',
      'russian federation': 'Russia',

      'south korea': 'South Korea',
      'republic of korea': 'South Korea',
      korea: 'South Korea',

      'north korea': 'North Korea',
      'democratic peoples republic of korea': 'North Korea',

      'south africa': 'South Africa',
      'republic of south africa': 'South Africa',

      switzerland: 'Switzerland',

      taiwan: 'Taiwan',

      turkey: 'Turkey',
      'republic of turkey': 'Turkey',
      'republic of türkiye': 'Turkey',

      vietnam: 'Vietnam',
      'viet nam': 'Vietnam',

      malaysia: 'Malaysia',
    };
```