### PR TITLE
[#12679] Added noWhitespaceValidator

### DIFF
--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { ReCaptcha2Component } from 'ngx-captcha';
 import { finalize } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
@@ -39,6 +39,16 @@ export class SessionLinksRecoveryPageComponent implements OnInit {
       email: ['', Validators.required],
       recaptcha: [''],
     });
+  }
+
+   /**
+   * Custom validator to disallow whitespace-only values.
+   */
+   noWhitespaceValidator(control: AbstractControl): { [key: string]: boolean } | null {
+    if (control.value && control.value.trim().length === 0) {
+      return { 'whitespace': true };
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Fixes #12679

**Outline of Solution**

Added a custom validator to the email field to ensure it does not contain only whitespace.
**Custom Validator (noWhitespaceValidator)**: This validator checks if the input contains only whitespace and returns an error if it does.

**Form Group Initialization:** Updated the form group initialization in both ngOnInit and resetFormGroups to include the custom validator for the email field.

**Error Handling**: Ensure that the error messages are handled appropriately in the UI if the validator detects a whitespace-only value.

This approach ensures that any whitespace-only values for the email field are effectively handled both on the client side and before submission.

