### PR TITLE
[#12596] Instructor extending individual deadlines: table doesn't sort by team

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
@@ -58,7 +58,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
 
         ______TS("verify extend some deadlines, notifyUsers enabled");
 
-        individualExtensionPage.selectStudents(0, 2); // alice and charlie
+        individualExtensionPage.selectStudents(0, 3); // alice and charlie
         individualExtensionPage.selectInstructor(0); // instructor 1
 
         individualExtensionPage.extendDeadlineByTwelveHours(true);
@@ -69,7 +69,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         Map<String, Instant> updatedInstructorDeadlines = updatedSession.getInstructorDeadlines();
         Instant expectedDeadline = feedbackSession.getEndTime().plus(Duration.ofHours(12));
 
-        verifyUpdatedDeadlinesMap(updatedStudentDeadlines, TestProperties.TEST_EMAIL, "charlie.tmms@gmail.tmt");
+        verifyUpdatedDeadlinesMap(updatedStudentDeadlines, testEmail, "charlie.tmms@gmail.tmt");
         verifyUpdatedDeadlinesMap(updatedInstructorDeadlines, "instructor1.tmms@gmail.tmt");
         verifyDeadlineExtensionsPresentOrAbsent(updatedStudentDeadlines, updatedInstructorDeadlines, expectedDeadline);
 
@@ -92,7 +92,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         updatedStudentDeadlines = updatedSession.getStudentDeadlines();
         updatedInstructorDeadlines = updatedSession.getInstructorDeadlines();
 
-        verifyUpdatedDeadlinesMap(updatedStudentDeadlines, TestProperties.TEST_EMAIL, "charlie.tmms@gmail.tmt");
+        verifyUpdatedDeadlinesMap(updatedStudentDeadlines, testEmail, "charlie.tmms@gmail.tmt");
         verifyUpdatedDeadlinesMap(updatedInstructorDeadlines, "instructor1.tmms@gmail.tmt");
         verifyDeadlineExtensionsPresentOrAbsent(updatedStudentDeadlines, updatedInstructorDeadlines, expectedDeadline);
 

--- a/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
+++ b/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
@@ -258,8 +258,8 @@ export class ExtensionConfirmModalComponent implements OnInit {
           strB = b.sectionName;
           break;
         case SortBy.TEAM_NAME:
-          strA = a.sectionName;
-          strB = b.sectionName;
+          strA = a.teamName;
+          strB = b.teamName;
           break;
         case SortBy.RESPONDENT_NAME:
           strA = a.name;

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -531,8 +531,8 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
           strB = b.sectionName;
           break;
         case SortBy.TEAM_NAME:
-          strA = a.sectionName;
-          strB = b.sectionName;
+          strA = a.teamName;
+          strB = b.teamName;
           break;
         case SortBy.RESPONDENT_NAME:
           strA = a.name;


### PR DESCRIPTION
Fixes #12596

Fix sorting of tables with students by using the correct property of a student class.
Previously for sorting by a "team" a "section"  field was used which led to incorrect sorting.