### PR TITLE
[#13174] Option to hide self responses when viewing responses

### DIFF
--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
+  hideSelfResponses="false"
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
@@ -438,6 +439,7 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
+  hideSelfResponses="false"
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
@@ -745,6 +747,7 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
+  hideSelfResponses="false"
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -35,7 +35,7 @@
               <strong>Other responses (to you): </strong>Responses are not visible to you.
             </div>
           </ng-template>
-          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length">
+          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length && !hideSelfResponses">
             <strong>Your own responses (to others):</strong>
             <div *ngFor="let responseFromSelf of question.responsesFromSelf">
               <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone" [statistics]="question.questionStatistics"></tm-student-view-responses>

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -64,6 +64,9 @@ export class QuestionResponsePanelComponent {
   @Input()
   previewAsPerson: string = '';
 
+  @Input()
+  hideSelfResponses: boolean = false;
+
   canUserSeeResponses(question: FeedbackQuestionModel): boolean {
     const showResponsesTo: FeedbackVisibilityType[] = question.feedbackQuestion.showResponsesTo;
     if (this.intent === Intent.STUDENT_RESULT) {

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -128,6 +129,20 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div>
       <div
@@ -165,6 +180,7 @@ exports[`SessionResultPageComponent should snap when session results failed to l
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed={[Function Boolean]}
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -277,6 +293,20 @@ exports[`SessionResultPageComponent should snap when session results failed to l
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div
       class="text-center"
@@ -317,6 +347,7 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -429,6 +460,20 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div>
       <div
@@ -466,6 +511,7 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -578,6 +624,20 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div>
       <div
@@ -615,6 +675,7 @@ exports[`SessionResultPageComponent should snap with session details and results
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
@@ -676,7 +737,21 @@ exports[`SessionResultPageComponent should snap with session details and results
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
+  </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -713,6 +788,7 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -825,6 +901,20 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
@@ -862,6 +952,7 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -975,6 +1066,20 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div>
       <div
@@ -1012,6 +1117,7 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
+  hideSelfResponses="false"
   instructorService={[Function InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
@@ -1124,6 +1230,20 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
         </div>
       </div>
     </div>
+  </div><div
+    class="form-check form-switch"
+  >
+    <input
+      class="form-check-input"
+      id="hideOwnResponses"
+      type="checkbox"
+    />
+    <label
+      class="form-check-label"
+      for="hideOwnResponses"
+    >
+      Hide my own responses
+    </label>
   </div><tm-loading-retry>
     <div>
       <div

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -73,6 +73,11 @@
   </div>
 </div>
 
+<div class="form-check form-switch">
+  <input class="form-check-input" type="checkbox" id="hideOwnResponses" [(ngModel)]="hideSelfResponses">
+  <label class="form-check-label" for="hideOwnResponses">Hide my own responses</label>
+</div>
+
 <tm-loading-retry [shouldShowRetry]="hasFeedbackSessionResultsLoadingFailed" [message]="'Failed to load results'" (retryEvent)="retryLoadingFeedbackSessionResults()">
   <div *tmIsLoading="isFeedbackSessionResultsLoading">
     <div *ngIf="questions.length === 0" class="mt-4">
@@ -82,6 +87,7 @@
     </div>
     <tm-question-response-panel [questions]="questions" [session]="session"
                                 [intent]="intent" [regKey]="regKey" [previewAsPerson]="previewAsPerson"
+                                [hideSelfResponses]="hideSelfResponses"
     ></tm-question-response-panel>
   </div>
 </tm-loading-retry>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -106,6 +106,8 @@ export class SessionResultPageComponent implements OnInit {
   feedbackSessionId: string | undefined = '';
   studentId: string | undefined = '';
 
+  hideSelfResponses: boolean = false;
+
   private backendUrl: string = environment.backendUrl;
 
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,

--- a/src/web/app/pages-session/session-result-page/session-result-page.module.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.module.ts
@@ -11,6 +11,7 @@ import {
   StudentViewResponsesModule,
 } from '../../components/question-responses/student-view-responses/student-view-responses.module';
 import { QuestionTextWithInfoModule } from '../../components/question-text-with-info/question-text-with-info.module';
+import { FormsModule } from '@angular/forms';
 
 const routes: Routes = [
   {
@@ -25,6 +26,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     QuestionTextWithInfoModule,
     StudentViewResponsesModule,
     SingleStatisticsModule,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #13174 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
The solution consists in adding a control variable in the session results screen. That was accomplished by creating a switch in the session-result-page component. The switch's status is then passed to the question-response-panel with the angular Input annotation. This variable is used as a conditional for self responses rendering. 

The response view now has a switch controlling the self responses, as shown below:

![image](https://github.com/user-attachments/assets/89e04070-af86-405f-83dc-f79cf5cd6f54)

When the switch isn't toggled, the student can view their own responses:

![image](https://github.com/user-attachments/assets/cd952ed4-81de-4b87-bb04-89496d4e5867)

Once the switch is toggled:

![image](https://github.com/user-attachments/assets/22d3d3ee-eaa5-41f6-9d62-77551fae2fe5)

The student can't see their own responses:

![image](https://github.com/user-attachments/assets/c784c244-a047-4d7a-a650-2a33c5f6ccdc)

