### PR TITLE
[#12679] Solved the problem of space detection, and can prompt an error for illegal space input

### DIFF
--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -10,11 +10,8 @@
     <div class="col-12">
       <div class="form-group">
         <label><b>Name for copied session*</b></label>
-        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" (ngModelChange)="onNameChange()" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
+        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
                required #newSessionName="ngModel">
-        <div *ngIf="errorMessage" class="text-danger">
-          {{ errorMessage }}
-        </div>
         <div [hidden]="newSessionName.valid || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             The field "Name for copied session" should not be empty.

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { StatusMessageService } from '../../../services/status-message.service';
 import { Course } from '../../../types/api-output';
 import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator';
-import { StatusMessageService } from '../../../services/status-message.service';
 
 /**
  * Copy current session modal.
@@ -26,16 +26,14 @@ export class CopySessionModalComponent {
   newFeedbackSessionName: string = '';
   copyToCourseSet: Set<string> = new Set<string>();
 
-
-  constructor(public activeModal: NgbActiveModal,private statusMessageService: StatusMessageService) {}
-
+  constructor(public activeModal: NgbActiveModal, private statusMessageService: StatusMessageService) {}
 
   /**
    * Fires the copy event.
    */
   copy(): void {
     if (this.newFeedbackSessionName.trim().length === 0) {
-      this.statusMessageService.showErrorToast('The field "Name for copied session" should not be whitespace.')
+      this.statusMessageService.showErrorToast('The field "Name for copied session" should not be whitespace.');
       return;
     }
 

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -38,7 +38,7 @@ export class CopySessionModalComponent {
     }
     if (this.newFeedbackSessionName.length > this.FEEDBACK_SESSION_NAME_MAX_LENGTH) {
       this.statusMessageService.showErrorToast(
-      `The field "Name for copied session" should less than ${this.FEEDBACK_SESSION_NAME_MAX_LENGTH}.`
+      `The field "Name for copied session" should less than ${this.FEEDBACK_SESSION_NAME_MAX_LENGTH}.`,
       );
       return;
     }

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Course } from '../../../types/api-output';
 import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator';
+import { StatusMessageService } from '../../../services/status-message.service';
 
 /**
  * Copy current session modal.
@@ -25,24 +26,18 @@ export class CopySessionModalComponent {
   newFeedbackSessionName: string = '';
   copyToCourseSet: Set<string> = new Set<string>();
 
-  errorMessage: string = '';
 
-  constructor(public activeModal: NgbActiveModal) {}
+  constructor(public activeModal: NgbActiveModal,private statusMessageService: StatusMessageService) {}
 
-  onNameChange(): void {
-    this.errorMessage = '';
-  }
 
   /**
    * Fires the copy event.
    */
   copy(): void {
     if (this.newFeedbackSessionName.trim().length === 0) {
-      this.errorMessage = 'The field "Name for copied session" should not be whitespace.';
+      this.statusMessageService.showErrorToast('The field "Name for copied session" should not be whitespace.')
       return;
     }
-
-    this.errorMessage = '';
 
     this.activeModal.close({
       newFeedbackSessionName: this.newFeedbackSessionName,

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -38,7 +38,7 @@ export class CopySessionModalComponent {
    */
   copy(): void {
     if (this.newFeedbackSessionName.trim().length === 0) {
-      this.errorMessage = "The field \"Name for copied session\" should not be whitespace.";
+      this.errorMessage = 'The field \"Name for copied session\" should not be whitespace.';
       return;
     }
 

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -38,7 +38,7 @@ export class CopySessionModalComponent {
    */
   copy(): void {
     if (this.newFeedbackSessionName.trim().length === 0) {
-      this.errorMessage = 'The field \"Name for copied session\" should not be whitespace.';
+      this.errorMessage = 'The field "Name for copied session" should not be whitespace.';
       return;
     }
 

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -36,6 +36,10 @@ export class CopySessionModalComponent {
       this.statusMessageService.showErrorToast('The field "Name for copied session" should not be whitespace.');
       return;
     }
+        else if(this.newFeedbackSessionName.length > this.FEEDBACK_SESSION_NAME_MAX_LENGTH){
+          this.statusMessageService.showErrorToast('The field "Name for copied session" should less than ${this.FEEDBACK_SESSION_NAME_MAX_LENGTH}.');
+          return;
+        }
 
     this.activeModal.close({
       newFeedbackSessionName: this.newFeedbackSessionName,

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -36,10 +36,12 @@ export class CopySessionModalComponent {
       this.statusMessageService.showErrorToast('The field "Name for copied session" should not be whitespace.');
       return;
     }
-        else if(this.newFeedbackSessionName.length > this.FEEDBACK_SESSION_NAME_MAX_LENGTH){
-          this.statusMessageService.showErrorToast('The field "Name for copied session" should less than ${this.FEEDBACK_SESSION_NAME_MAX_LENGTH}.');
-          return;
-        }
+    if (this.newFeedbackSessionName.length > this.FEEDBACK_SESSION_NAME_MAX_LENGTH) {
+      this.statusMessageService.showErrorToast(
+      `The field "Name for copied session" should less than ${this.FEEDBACK_SESSION_NAME_MAX_LENGTH}.`
+      );
+      return;
+    }
 
     this.activeModal.close({
       newFeedbackSessionName: this.newFeedbackSessionName,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #12679 

**Outline of Solution**
My teammates and I analyzed and discussed the ts file for detecting the input of newfeedbacksessionname.
We found that the field was not checked for validity before the copy button was pressed. 
We have now added a series of methods such as trim() to determine whether there are illegal spaces in the field.
Before:
![微信图片_20241026185846](https://github.com/user-attachments/assets/32a52ea1-5e37-4ba4-bdf7-72a4ea2630fb)
After:
we can see the warning message has been showed if the input is invalid
![微信图片_20241026185843](https://github.com/user-attachments/assets/2ec7d713-c078-4376-a08b-279b5747ccdb)


<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
