### PR TITLE
[#13054] Make substrings of the name in dropdown selections of recipient to be searchable 

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -70,15 +70,23 @@
                 <b>{{ getRecipientName(recipientSubmissionFormModel.recipientIdentifier) }} </b> <span>({{ model.recipientType | recipientTypeName:model.giverType }})</span>
               </div>
               <div class="row evaluee-select align-items-center" *ngIf="formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT">
-                <select id="recipient-dropdown-qn-{{ model.questionNumber }}-idx-{{ i }}" class="form-control form-select fw-bold col" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
-                        (ngModelChange)="triggerRecipientSubmissionFormChange(i, 'recipientIdentifier', $event)"
-                        [disabled]="isFormsDisabled"
-                        [attr.aria-label]="'Select recipient dropdown question ' + model.questionNumber + ' index ' + i">
-                  <option value=""></option>
-                  <ng-container *ngFor="let recipient of model.recipientList">
-                    <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ getSelectionOptionLabel(recipient) }}</option>
-                  </ng-container>
-                </select>
+                <div class="row form-control select-editable col">
+                  <select id="recipient-dropdown-qn-{{ model.questionNumber }}-idx-{{ i }}" class="form-control form-select fw-bold" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
+                          (ngModelChange)="triggerRecipientIdentifierChange(i, $event)"
+                          [disabled]="isFormsDisabled"
+                          [attr.aria-label]="'Select recipient dropdown question ' + model.questionNumber + ' index ' + i">
+                    <option value=""></option>
+                    <ng-container *ngFor="let recipient of filterRecipientsBySearchText(searchNameTexts[i],model.recipientList)">
+                      <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ getSelectionOptionLabel(recipient) }}</option>
+                    </ng-container>
+                  </select>
+                  <input type="text" class="select-input fw-bold form-control"
+                          [(ngModel)]="searchNameTexts[i]"
+                          (ngModelChange)="triggerSelectInputChange(i)"
+                          [disabled]="isFormsDisabled"
+                          [attr.aria-label]="'Recipient names filter ' + model.questionNumber + ' index ' + i"
+                          [ngClass]="filterRecipientsBySearchText(searchNameTexts[i],model.recipientList).length === 0 ? 'no-match' : ''" />
+                </div>
                 <div class="col-auto text-start">
                   ({{ model.recipientType | recipientTypeName: model.giverType }})
                 </div>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.scss
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.scss
@@ -54,3 +54,26 @@
 .collapse-caret {
   margin-right: 10px;
 }
+
+.select-editable {
+  position: relative;
+  border: 0;
+}
+
+.select-input {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 75%;
+  border: 0;
+  background-color: transparent;
+  padding: .75rem 1.5rem;
+}
+
+.select-input:focus {
+  box-shadow: none;
+}
+
+.no-match {
+  color: var(--bs-danger)
+}

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -498,12 +498,14 @@ describe('QuestionSubmissionFormComponent', () => {
     expect(component.filterRecipientsBySearchText('', recipients)).toStrictEqual(recipients);
     expect(component.filterRecipientsBySearchText('  ', recipients)).toStrictEqual(recipients);
     expect(component.filterRecipientsBySearchText('Lucy', recipients)).toStrictEqual([doubleLucy, lucy]);
-    expect(component.filterRecipientsBySearchText('s', recipients)).toStrictEqual([sally, snoopy, linus, benny, charlieDavis, francis]);
+    expect(component.filterRecipientsBySearchText('s', recipients))
+      .toStrictEqual([sally, snoopy, linus, benny, charlieDavis, francis]);
     expect(component.filterRecipientsBySearchText('Brow', recipients)).toStrictEqual([charlie, sally]);
     expect(component.filterRecipientsBySearchText('van pel', recipients)).toStrictEqual([lucy, linus]);
     expect(component.filterRecipientsBySearchText('van Pelt', recipients)).toStrictEqual([lucy, linus]);
     expect(component.filterRecipientsBySearchText('cy', recipients)).toStrictEqual([doubleLucy, lucy]);
-    expect(component.filterRecipientsBySearchText('char', recipients)).toStrictEqual([charlie, benny, charlieDavis]);
+    expect(component.filterRecipientsBySearchText('char', recipients))
+      .toStrictEqual([charlie, benny, charlieDavis]);
     expect(component.filterRecipientsBySearchText('is', recipients)).toStrictEqual([charlieDavis, francis]);
   });
 

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -483,6 +483,30 @@ describe('QuestionSubmissionFormComponent', () => {
     expect(component.isRecipientSelected(feedbackResponseRecipient)).toBeFalsy();
   });
 
+  it('filterRecipientsBySearchText: should return correct filtered names', () => {
+    const doubleLucy = { recipientIdentifier: 'lucyLucy', recipientName: 'Lucy Lucy' };
+    const charlie = { recipientIdentifier: 'charlieBrown', recipientName: 'Charlie Brown' };
+    const lucy = { recipientIdentifier: 'lucyVanPelt', recipientName: 'Lucy van Pelt' };
+    const sally = { recipientIdentifier: 'sallyBrown', recipientName: 'Sally Brown' };
+    const snoopy = { recipientIdentifier: 'snoopy', recipientName: 'Snoopy' };
+    const linus = { recipientIdentifier: 'linusVanPelt', recipientName: 'Linus van Pelt' };
+    const benny = { recipientIdentifier: 'bennyCharles', recipientName: 'Benny Charles' };
+    const charlieDavis = { recipientIdentifier: 'charlieDavis', recipientName: 'Charlie Davis' };
+    const francis = { recipientIdentifier: 'francisGabriel', recipientName: 'Francis Gabriel' };
+
+    const recipients = [doubleLucy, charlie, lucy, sally, snoopy, linus, benny, charlieDavis, francis];
+    expect(component.filterRecipientsBySearchText('', recipients)).toStrictEqual(recipients);
+    expect(component.filterRecipientsBySearchText('  ', recipients)).toStrictEqual(recipients);
+    expect(component.filterRecipientsBySearchText('Lucy', recipients)).toStrictEqual([doubleLucy, lucy]);
+    expect(component.filterRecipientsBySearchText('s', recipients)).toStrictEqual([sally, snoopy, linus, benny, charlieDavis, francis]);
+    expect(component.filterRecipientsBySearchText('Brow', recipients)).toStrictEqual([charlie, sally]);
+    expect(component.filterRecipientsBySearchText('van pel', recipients)).toStrictEqual([lucy, linus]);
+    expect(component.filterRecipientsBySearchText('van Pelt', recipients)).toStrictEqual([lucy, linus]);
+    expect(component.filterRecipientsBySearchText('cy', recipients)).toStrictEqual([doubleLucy, lucy]);
+    expect(component.filterRecipientsBySearchText('char', recipients)).toStrictEqual([charlie, benny, charlieDavis]);
+    expect(component.filterRecipientsBySearchText('is', recipients)).toStrictEqual([charlieDavis, francis]);
+  });
+
   it('triggerDeleteCommentEvent: should emit the correct index to deleteCommentEvent', () => {
     let emittedIndex: number | undefined;
     testEventEmission(component.deleteCommentEvent, (index) => { emittedIndex = index; });

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -59,6 +59,8 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   isSaved: boolean = false;
   hasResponseChanged: boolean = false;
 
+  searchNameTexts: string[] = [];
+
   @Input()
   formMode: QuestionSubmissionFormMode = QuestionSubmissionFormMode.FIXED_RECIPIENT;
 
@@ -94,6 +96,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
       this.model.isTabExpandedForRecipients.set(recipient.recipientIdentifier, true);
     });
     this.hasResponseChanged = Array.from(this.model.hasResponseChangedForRecipients.values()).some((value) => value);
+    this.searchNameTexts = new Array(this.model.recipientSubmissionForms.length).fill('');
   }
 
   @Input()
@@ -320,6 +323,18 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     this.updateSubmissionFormIndexes();
   }
 
+  filterRecipientsBySearchText(searchText: string, recipients: FeedbackResponseRecipient[])
+  : FeedbackResponseRecipient[] {
+    if (!searchText) return recipients;
+    const searchName = searchText.trim().toLowerCase();
+    if (searchName.length === 0) return recipients;
+    if (searchName.includes(' ')) {
+      return recipients.filter((s) => s.recipientName.toLowerCase().includes(searchName));
+    }
+    
+    return recipients.filter((r) => r.recipientName.split(' ').some((s) => s.toLowerCase().includes(searchName)));
+  }
+
   private sortRecipientsBySectionTeam(): void {
     if (this.recipientLabelType === FeedbackRecipientLabelType.INCLUDE_SECTION) {
       this.model.recipientList.sort((firstRecipient, secondRecipient) => {
@@ -359,6 +374,21 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     return this.model.recipientSubmissionForms.some(
       (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) =>
         recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier);
+  }
+
+  /**
+   * Triggers the changes of the recipient selection
+   */
+  triggerRecipientIdentifierChange(index: number, data: any): void {
+    this.searchNameTexts[index] = "";
+    this.triggerRecipientSubmissionFormChange(index, 'recipientIdentifier', data);
+  }
+
+  /**
+   * Triggers the changes of the recipient search text input
+   */
+  triggerSelectInputChange(index: number): void {
+    this.model.recipientSubmissionForms[index].recipientIdentifier = '';
   }
 
   /**

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -331,7 +331,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     if (searchName.includes(' ')) {
       return recipients.filter((s) => s.recipientName.toLowerCase().includes(searchName));
     }
-    
     return recipients.filter((r) => r.recipientName.split(' ').some((s) => s.toLowerCase().includes(searchName)));
   }
 
@@ -380,7 +379,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
    * Triggers the changes of the recipient selection
    */
   triggerRecipientIdentifierChange(index: number, data: any): void {
-    this.searchNameTexts[index] = "";
+    this.searchNameTexts[index] = '';
     this.triggerRecipientSubmissionFormChange(index, 'recipientIdentifier', data);
   }
 


### PR DESCRIPTION
Fixes #13054 (https://github.com/TEAMMATES/teammates/issues/13054)

**Outline of Solution**

Problem: Users were unable to easily search for specific substrings in the name when selecting recipients from a dropdown menu. The previous dropdown list did not have search functionality for substrings, which made it challenging to find and select specific recipients, especially in large lists.

Solution:
Modified the dropdown component to include a searchable input field.
Implemented logic that allows searching for substrings in the recipient names. This means users can now type partial names to filter down the options in the dropdown.
Updated related unit tests (question-submission-form.component.spec.ts) to verify that the new search functionality works correctly, including edge cases for partial name matches.

Changes Made:
Modified the component at src/web/app/components/question-submission-form/question-submission-form.component.ts to embed a text input. 
Added styling to the input field to highlight when a name doesn't match any results. (If the input does not match any filter results, it will turn red.)
Updated the HTML and CSS to style the input field appropriately.
Enhanced the dropdown functionality to filter names by any substring.
Added new test cases to question-submission-form.component.spec.ts to verify substring search functionality.
Adjusted other relevant UI logic to ensure compatibility with the new feature.

Screenshots of the New UI:
Screenshot 1: Demonstration of the substring filtering:
![image](https://github.com/user-attachments/assets/050a09c6-59c1-4172-8358-1dd64ac30efb)
Example 1: Typing "cha" will display all recipients whose names contain "cha", such as "Charlie Davis" and "Benny Charles".

![image](https://github.com/user-attachments/assets/ebdde578-bb5c-40ae-a2f1-4695e49e6cda)
Example 2: Typing "is" will filter to show all names containing the substring "is", like "Charlie Davis" and "Francis Gabriel".

Screenshot 2: Example of invalid input where there are no matching results:
![image](https://github.com/user-attachments/assets/2cde10af-cd78-48fd-9820-5f2d17de7837)
Typing "Jerry" results in the input field turning red, indicating that no recipients match the given name. This immediate visual feedback helps users adjust their search term.