### PR TITLE
[#13054] Added an input searching bar above the dropdown list

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -76,11 +76,11 @@
                   <!-- Defines a text input field for name search -->
                   <input type="text" class="form-control name-search-input"
                          placeholder="Enter the Name..."
-                         [(ngModel)]="searchNameTexts[i]"
+                         [(ngModel)]="searchName[i]"
                          (ngModelChange)="triggerSelectInputChange(i)"
                          [disabled]="isFormsDisabled"
                          [attr.aria-label]="'Recipient names filter ' + model.questionNumber + ' index ' + i"
-                         [ngClass]="filterRecipientsBySearchText(searchNameTexts[i],model.recipientList).length === 0 ? 'no-match' : ''" />
+                         [ngClass]="filterRecipientsBySearchText(searchName[i],model.recipientList).length === 0 ? 'no-match' : ''" />
 
                   <!-- Dropdown to Select a Recipient -->
                   <select id="recipient-dropdown-qn-{{ model.questionNumber }}-idx-{{ i }}" class="form-control form-select fw-bold" [ngModel]="recipientSubmissionFormModel.recipientIdentifier"
@@ -88,7 +88,7 @@
                           [disabled]="isFormsDisabled"
                           [attr.aria-label]="'Select recipient dropdown question ' + model.questionNumber + ' index ' + i">
                     <option value=""></option>
-                    <ng-container *ngFor="let recipient of filterRecipientsBySearchText(searchNameTexts[i],model.recipientList)">
+                    <ng-container *ngFor="let recipient of filterRecipientsBySearchText(searchName[i],model.recipientList)">
                       <option *ngIf="!isRecipientSelected(recipient) || recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier" [ngValue]="recipient.recipientIdentifier">{{ getSelectionOptionLabel(recipient) }}</option>
                     </ng-container>
                   </select>

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -325,6 +325,34 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     this.updateSubmissionFormIndexes();
   }
 
+/**
+ * Filters the recipients based on the provided search text.
+ * 
+ * This method searches through the list of recipients and returns those that match 
+ * the search criteria. The search is case-insensitive and supports both full names 
+ * and individual name parts. If the search text contains a space, it matches the 
+ * entire name; otherwise, it searches for any part of the name.
+ * 
+ * @param {string} searchText - The text to search for within recipient names. If empty or only whitespace, all recipients are returned.
+ * @param {FeedbackResponseRecipient[]} recipients - The list of recipients to filter.
+ * @returns {FeedbackResponseRecipient[]} - A filtered list of recipients that match the search criteria and are marked as selected.
+ */
+  filterRecipientsBySearchText(searchText: string, recipients: FeedbackResponseRecipient[]): FeedbackResponseRecipient[] {
+    if (!searchText) return recipients;
+    const searchName = searchText.trim().toLowerCase();
+    if (searchName.length === 0) return recipients;
+
+    const isSpaceIncluded = searchName.includes(' ');
+    return recipients.filter((r) => {
+        if (!this.isRecipientSelected(r)) return false;
+
+        const recipientName = r.recipientName.toLowerCase();
+        return isSpaceIncluded
+            ? recipientName.includes(searchName)
+            : recipientName.split(' ').some((s) => s.includes(searchName));
+    });
+}
+
   private sortRecipientsBySectionTeam(): void {
     if (this.recipientLabelType === FeedbackRecipientLabelType.INCLUDE_SECTION) {
       this.model.recipientList.sort((firstRecipient, secondRecipient) => {
@@ -365,7 +393,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
       (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) =>
         recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier);
   }
-  
+
   // Method to handle changes in the recipient identifier.
   triggerRecipientIdentifierChange(index: number, data: any): void {
     if (this.searchName[index] !== undefined) {
@@ -373,6 +401,11 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     }
     this.triggerRecipientSubmissionFormChange(index, 'recipientIdentifier', data);
 }
+
+  // Trigger to change the text input
+  triggerSelectInputChange(index: number): void {
+    this.model.recipientSubmissionForms[index].recipientIdentifier = '';
+  }
 
   /**
    * Triggers the change of the recipient submission form.

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -58,6 +58,8 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   isMCQDropDownEnabled: boolean = false;
   isSaved: boolean = false;
   hasResponseChanged: boolean = false;
+  // Initial a new array to store names
+  searchName: string[] = [];
 
   @Input()
   formMode: QuestionSubmissionFormMode = QuestionSubmissionFormMode.FIXED_RECIPIENT;
@@ -94,6 +96,9 @@ export class QuestionSubmissionFormComponent implements DoCheck {
       this.model.isTabExpandedForRecipients.set(recipient.recipientIdentifier, true);
     });
     this.hasResponseChanged = Array.from(this.model.hasResponseChangedForRecipients.values()).some((value) => value);
+    // Initialize the searchName array with empty strings, matching the length of recipientSubmissionForms.
+    this.searchName = Array.from({ length: this.model.recipientSubmissionForms.length }, () => "");
+
   }
 
   @Input()
@@ -360,6 +365,14 @@ export class QuestionSubmissionFormComponent implements DoCheck {
       (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) =>
         recipientSubmissionFormModel.recipientIdentifier === recipient.recipientIdentifier);
   }
+  
+  // Method to handle changes in the recipient identifier.
+  triggerRecipientIdentifierChange(index: number, data: any): void {
+    if (this.searchName[index] !== undefined) {
+        this.searchName[index] = "";
+    }
+    this.triggerRecipientSubmissionFormChange(index, 'recipientIdentifier', data);
+}
 
   /**
    * Triggers the change of the recipient submission form.

--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -3,16 +3,21 @@
 </h1>
 <img src="assets/images/contact.png">
 <p>
-  <b>Email:</b> You can contact us at the following email address: <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a>.
+  <b>Email:</b> You can contact us at the following email address:
+  <a href="mailto:{{ supportEmail }}"><span aria-hidden="true" class="fas fa-envelope"></span>{{ supportEmail }}</a>.
 </p>
 <p>
-  <b>Blog:</b> Visit the <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer">TEAMMATES Blog</a> to see our latest updates and information.
+  <b>Blog:</b> Visit the
+  <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fab fa-blogger"></span>TEAMMATES Blog</a>
+  to see our latest updates and information.
 </p>
 <p>
   <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
 </p>
 <p>
-  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Developer Website</a>.
+  <b>Interested in joining us?</b> Visit our
+  <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">
+    <span aria-hidden="true" class="fab fa-github"></span>TEAMMATES Github</a>.
 </p>
 <p>
   <b>Becoming a sponsor</b>:


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #13054 

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

### 1. Code Change Location:
The following files were updated to implement the feature:
- [`src/web/app/components/question-submission-form/question-submission-form.component.html`](https://github.com/TEAMMATES/teammates/blob/master/src/web/app/components/question-submission-form/question-submission-form.component.html)
- [`src/web/app/components/question-submission-form/question-submission-form.component.ts`](https://github.com/TEAMMATES/teammates/blob/master/src/web/app/components/question-submission-form/question-submission-form.component.ts)
- [`src/web/app/components/question-submission-form/question-submission-form.component.spec.ts`](https://github.com/TEAMMATES/teammates/blob/master/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts)

### 2. Details of the Changes:
- Added a text input field above the dropdown student list to facilitate search.
- Implemented logic to allow users to search for students by entering substrings of their names.
- Manually tested the new feature by inputting various substrings to ensure accurate search functionality.
- Added new test cases to cover the updated functionality.

### 3. Demonstration:
**Before:**
![Before](https://github.com/user-attachments/assets/ebea9401-b17b-46c4-82ea-b4b1422d9ee1)

**After:**
![After1](https://github.com/user-attachments/assets/59deb58c-20c5-41d5-a719-3a6e5cd8ca17)
![After2](https://github.com/user-attachments/assets/8066081d-2000-4700-97c5-fe13acc7c16c)

