### PR TITLE
[#13144] Implement 'Copy' button in course enroll page

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -108,6 +108,16 @@
                   <tm-ajax-loading *ngIf="isEnrolling"></tm-ajax-loading>
                   Enroll students
                 </button>
+
+                <button
+                        type="button"
+                        title="Copy"
+                        id="btn-copy"
+                        name="button-copy"
+                        class="btn btn-secondary float-end me-2"
+                        (click)="copyToClipboard()">
+                  Copy
+                </button>
               </div>
             </div>
             <div class="row mt-3" style="align-items: center;">

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -660,7 +660,12 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
   /**
    * Implement the copy method
    */
-  copyToClipboard() {
-    alert("Copy the student information")
+  copyToClipboard(): void {
+    const existingStudentsHOTInstance: Handsontable = this.hotRegisterer.getInstance(this.existingStudentsHOT);
+    const newStudentsHOTInstance: Handsontable = this.hotRegisterer.getInstance(this.newStudentsHOT);
+
+    const existingStudentsData = existingStudentsHOTInstance.getData();
+
+    newStudentsHOTInstance.loadData(existingStudentsData);
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -656,4 +656,11 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       scrollOffset: 70,
     });
   }
+
+  /**
+   * Implement the copy method
+   */
+  copyToClipboard() {
+    alert("Copy the student information")
+  }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #13144 

**Outline of Solution**
Added a 'Copy' button in course enroll page to let instructors to import existing students into new students sheet below to support the feature proposed in [#13144](https://github.com/TEAMMATES/teammates/issues/13144). 

Before implementation:
<img width="1920" alt="2024-10-20_152410" src="https://github.com/user-attachments/assets/e354de30-f58f-47d3-b448-59499b5dd59a">
After implementation the new page looks like this with the 'Copy' button:
<img width="1920" alt="2024-10-20_152429" src="https://github.com/user-attachments/assets/de86d4b0-4082-4855-babd-e375a4832c02">
After clicking 'Copy', students are copied with information shows up:
<img width="1920" alt="2024-10-20_152433" src="https://github.com/user-attachments/assets/013dbf45-2885-410b-b813-1943af510d68">
<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
