### PR TITLE
[#12679] Copying feedback session: Name for copied session should not be whitespace

### DIFF
--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
@@ -7,7 +7,7 @@ import { FeedbackSessionsService } from '../../../services/feedback-sessions.ser
 import { StatusMessageService } from '../../../services/status-message.service';
 import { SessionLinksRecoveryResponse } from '../../../types/api-output';
 import { ErrorMessageOutput } from '../../error-message-output';
-
+import { noWhitespaceValidator } from './validators/no-whitespace.validator';
 /**
  * Student recover session links page.
  */
@@ -36,7 +36,7 @@ export class SessionLinksRecoveryPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.formSessionLinksRecovery = this.formBuilder.group({
-      email: ['', Validators.required],
+      email: ['', [Validators.required, noWhitespaceValidator]],
       recaptcha: [''],
     });
   }


### PR DESCRIPTION
Part of #<12679>(https://github.com/TEAMMATES/teammates/issues/12679)
**Outline of Solution**
Fixes Whitespace error