### PR TITLE
Test date

### DIFF
--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -845,6 +845,34 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
+        public void testIsValidStartEndDate() {
+        FeedbackSessionsLogic logic = FeedbackSessionsLogic.inst();
+        ZoneId timeZone = ZoneId.of("UTC");
+
+        // CT1: TestNullStartDate
+        assertFalse(logic.isValidStartEndDate(null, Instant.parse("2023-12-31T23:59:59Z"), timeZone));
+
+        // CT2: TestNullEndDate
+        assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), null, timeZone));
+
+        // CT3: TestNullTimeZone
+        assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-12-31T23:59:59Z"), null));
+
+        // CT4: TestValidDates
+        assertTrue(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));
+
+        // CT5: TestStartDateAfterEndDate
+        assertFalse(logic.isValidStartEndDate(Instant.parse("2023-12-31T23:59:59Z"), Instant.parse("2023-01-01T00:00:00Z"), timeZone));
+
+        // CT6: TestStartYearBefore1970
+        assertFalse(logic.isValidStartEndDate(Instant.parse("1969-12-31T23:59:59Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));
+
+        // CT7: TestEndYearAfter9999
+        assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("10000-01-01T00:00:00Z"), timeZone));
+        }
+
+
+    @Test
     public void testDeleteFeedbackSessionsDeadlinesForStudent() {
         StudentAttributes student4InCourse1 = dataBundle.students.get("student4InCourse1");
         verifyPresentInDatabase(student4InCourse1);

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -845,9 +845,10 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
-        public void testIsValidStartEndDate() {
+    public void testIsValidStartEndDate() {
         FeedbackSessionsLogic logic = FeedbackSessionsLogic.inst();
         ZoneId timeZone = ZoneId.of("UTC");
+    
 
         // CT1: TestNullStartDate
         assertFalse(logic.isValidStartEndDate(null, Instant.parse("2023-12-31T23:59:59Z"), timeZone));
@@ -869,6 +870,48 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         // CT7: TestEndYearAfter9999
         assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("10000-01-01T00:00:00Z"), timeZone));
+
+         // CT8: TestStartDateEqualEndDate
+        assertFalse(logic.isValidStartEndDate(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-01-01T00:00:00Z"),
+                timeZone
+        ));
+
+        // CT9: TestStartDateJustBeforeEndDate
+        assertTrue(logic.isValidStartEndDate(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-01-01T00:00:01Z"),
+                timeZone
+        ));
+
+        // CT10: TestStartYear1970
+        assertTrue(logic.isValidStartEndDate(
+                Instant.parse("1970-01-01T00:00:00Z"),
+                Instant.parse("2023-12-31T23:59:59Z"),
+                timeZone
+        ));
+
+        // CT11: TestEndYear9999
+        assertTrue(logic.isValidStartEndDate(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("9999-12-31T23:59:59Z"),
+                timeZone
+        ));
+
+        // CT12: TestStartYearJustBefore1970
+        assertFalse(logic.isValidStartEndDate(
+                Instant.parse("1969-12-31T23:59:59Z"),
+                Instant.parse("2023-12-31T23:59:59Z"),
+                timeZone
+        ));
+
+        // CT13: TestEndYearJustAfter9999
+        assertFalse(logic.isValidStartEndDate(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("10000-01-01T00:00:00Z"),
+                timeZone
+        ));
         }
 
 


### PR DESCRIPTION
[#XXXX] Implementar testes adicionais para o método isValidStartEndDate

Fixes #XXXX

**Resumo da Solução**

Para resolver este problema, implementei testes adicionais para o método `isValidStartEndDate` da classe `FeedbackSessionsLogic`. As principais alterações incluem:

1. Adição de novos casos de teste para cobrir cenários não testados anteriormente.
2. Implementação de testes para verificar comportamento em casos limítrofes.
3. Garantia de cobertura completa de todas as condições do método.

Os novos testes incluem:

- Verificação de datas de início e fim iguais
- Teste de data de início logo antes da data de fim
- Verificação dos anos limite (1970 e 9999)
- Testes para anos imediatamente antes de 1970 e após 9999

Essas adições garantem uma cobertura mais abrangente e robusta do método `isValidStartEndDate`, melhorando a confiabilidade do código.

## Implementação dos Testes

```java
@Test
public void testIsValidStartEndDate() {
    FeedbackSessionsLogic logic = FeedbackSessionsLogic.inst();
    ZoneId timeZone = ZoneId.of("UTC");

    // CT1: TestNullStartDate
    assertFalse(logic.isValidStartEndDate(null, Instant.parse("2023-12-31T23:59:59Z"), timeZone));

    // CT2: TestNullEndDate
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), null, timeZone));

    // CT3: TestNullTimeZone
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-12-31T23:59:59Z"), null));

    // CT4: TestValidDates
    assertTrue(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));

    // CT5: TestStartDateAfterEndDate
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-12-31T23:59:59Z"), Instant.parse("2023-01-01T00:00:00Z"), timeZone));

    // CT6: TestStartYearBefore1970
    assertFalse(logic.isValidStartEndDate(Instant.parse("1969-12-31T23:59:59Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));

    // CT7: TestEndYearAfter9999
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("10000-01-01T00:00:00Z"), timeZone));

    // CT8: TestStartDateEqualEndDate
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-01-01T00:00:00Z"), timeZone));

    // CT9: TestStartDateJustBeforeEndDate
    assertTrue(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2023-01-01T00:00:01Z"), timeZone));

    // CT10: TestStartYear1970
    assertTrue(logic.isValidStartEndDate(Instant.parse("1970-01-01T00:00:00Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));

    // CT11: TestEndYear9999
    assertTrue(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("9999-12-31T23:59:59Z"), timeZone));

    // CT12: TestStartYearJustBefore1970
    assertFalse(logic.isValidStartEndDate(Instant.parse("1969-12-31T23:59:59Z"), Instant.parse("2023-12-31T23:59:59Z"), timeZone));

    // CT13: TestEndYearJustAfter9999
    assertFalse(logic.isValidStartEndDate(Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("10000-01-01T00:00:00Z"), timeZone));
}
```

Esta implementação cobre todos os cenários necessários para garantir uma cobertura MC/DC completa do método `isValidStartEndDate`.