### PR TITLE
[#12048] Migrate Tests for DeleteStudentActionTest

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -231,6 +231,14 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
         loginAsStudent(student.getGoogleId());
         verifyCannotAccess(params);
+    }
+
+    @Test
+    public void testSpecificAccessControl_loggedOut_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_ID, student.getGoogleId(),
+        };
 
         logoutUser();
         verifyCannotAccess(params);

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -34,7 +34,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
         Student student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
 
-        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -52,28 +52,27 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
         Student student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
 
-        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+        when(mockLogic.getStudentByGoogleId(course.getId(), googleId)).thenReturn(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, student.getGoogleId(),
+                Const.ParamsNames.STUDENT_ID, googleId,
         };
 
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
+        assertNotNull(actionOutput);
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
     void testExecute_courseDoesNotExist_failSilently() {
-        String studentId = "student-id";
-
-        when(mockLogic.getStudentByGoogleId("RANDOM_COURSE", studentId)).thenReturn(null);
+        when(mockLogic.getStudentByGoogleId("RANDOM_COURSE", googleId)).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "RANDOM_COURSE",
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.STUDENT_ID, googleId,
         };
 
         DeleteStudentAction action = getAction(params);
@@ -130,7 +129,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void testExecute_randomEmail_failSilently() {
         String courseId = "course-id";
 
-        when(mockLogic.getStudentByGoogleId(courseId, "RANDOM_EMAIL")).thenReturn(null);
+        when(mockLogic.getStudentForEmail(courseId, "RANDOM_EMAIL")).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, courseId,
@@ -150,11 +149,11 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
         loginAsAdmin();
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+        when(mockLogic.getStudentByGoogleId(course.getId(), googleId)).thenReturn(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, student.getGoogleId(),
+                Const.ParamsNames.STUDENT_ID, googleId,
         };
 
         verifyCanAccess(params);
@@ -164,7 +163,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void testSpecificAccessControl_instructorWithPermission_canAccess() {
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, true);
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, instructorPrivileges);
 
@@ -184,7 +183,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
         Course course = new Course("course-id", "Course Name", Const.DEFAULT_TIME_ZONE, "institute");
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, false);
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, instructorPrivileges);
 

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -98,6 +98,11 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     }
 
     @Test
+    void testExecute_noParameters_throwsInvalidParametersException() {
+        verifyHttpParameterFailure();
+    }
+
+    @Test
     void testExecute_missingStudentIdOrEmail_throwsInvalidHttpParameterException() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course-id",

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -1,0 +1,215 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Student;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.webapi.DeleteStudentAction;
+
+/**
+ * SUT: {@link DeleteStudentAction}.
+ */
+public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction> {
+
+    String googleId = "user-googleId";
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.STUDENT;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return DELETE;
+    }
+
+    @Test
+    void testExecute_deleteStudentByEmail_success() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        Student student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
+
+        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+        };
+
+        DeleteStudentAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_deleteStudentById_success() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        Student student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
+
+        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_ID, student.getGoogleId(),
+        };
+
+        DeleteStudentAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_courseDoesNotExist_failSilently() {
+        String studentId = "student-id";
+
+        when(mockLogic.getStudentByGoogleId("RANDOM_COURSE", studentId)).thenReturn(null);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "RANDOM_COURSE",
+                Const.ParamsNames.STUDENT_ID, studentId,
+        };
+
+        DeleteStudentAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_studentDoesNotExist_failSilently() {
+        String courseId = "course-id";
+
+        when(mockLogic.getStudentByGoogleId(courseId, "RANDOM_STUDENT")).thenReturn(null);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_ID, "RANDOM_STUDENT",
+        };
+
+        DeleteStudentAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_missingStudentIdOrEmail_throwsInvalidHttpParameterException() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_missingCourseIdWithStudentId_throwsInvalidHttpParameterException() {
+        String[] params = {
+                Const.ParamsNames.STUDENT_ID, "student-id",
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_missingCourseIdWithStudentEmail_throwsInvalidHttpParameterException() {
+        String[] params = {
+                Const.ParamsNames.STUDENT_EMAIL, "studentEmail@gmail.tmt",
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_randomEmail_failSilently() {
+        String courseId = "course-id";
+
+        when(mockLogic.getStudentByGoogleId(courseId, "RANDOM_EMAIL")).thenReturn(null);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.STUDENT_EMAIL, "RANDOM_EMAIL",
+        };
+
+        DeleteStudentAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
+    }
+
+    @Test
+    void testSpecificAccessControl_admin_canAccess() {
+        Course course = new Course("course-id", "Course Name", Const.DEFAULT_TIME_ZONE, "institute");
+        Student student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
+
+        loginAsAdmin();
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getStudentByGoogleId(course.getId(), student.getGoogleId())).thenReturn(student);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_ID, student.getGoogleId(),
+        };
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorWithPermission_canAccess() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, true);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_ID, "student-id",
+        };
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
+        Course course = new Course("course-id", "Course Name", Const.DEFAULT_TIME_ZONE, "institute");
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, false);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.STUDENT_ID, "student-id",
+        };
+
+        verifyCannotAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_student_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+                Const.ParamsNames.STUDENT_ID, "student-id",
+        };
+
+        loginAsStudent(googleId);
+        verifyCannotAccess(params);
+
+        logoutUser();
+        verifyCannotAccess(params);
+    }
+}

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -62,7 +62,6 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        assertNotNull(actionOutput);
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -138,6 +138,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
         verify(mockLogic, never()).getStudentByGoogleId(any(), any());
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), "RANDOM_EMAIL");
+        verify(mockLogic, times(1)).deleteStudentCascade(any(), any());
         verify(mockLogic, never()).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -1,5 +1,7 @@
 package teammates.sqlui.webapi;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,6 +70,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
+        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
@@ -82,12 +85,13 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
+        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), studentId);
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
-    void testExecute_courseDoesNotExist_failSilently() {
+    void testExecute_nonExistentCourse_failSilently() {
         when(mockLogic.getCourse("RANDOM_COURSE")).thenReturn(null);
 
         String[] params = {
@@ -98,7 +102,8 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(0)).deleteStudentCascade(course.getId(), student.getEmail());
+        verify(mockLogic, times(1)).getStudentByGoogleId("RANDOM_COURSE", studentId);
+        verify(mockLogic, never()).deleteStudentCascade(any(), any());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
@@ -114,7 +119,8 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(0)).deleteStudentCascade(course.getId(), student.getEmail());
+        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), "RANDOM_STUDENT");
+        verify(mockLogic, never()).deleteStudentCascade(any(), any());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
@@ -130,7 +136,9 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(0)).deleteStudentCascade(course.getId(), student.getEmail());
+        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
+        verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), "RANDOM_EMAIL");
+        verify(mockLogic, never()).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -43,12 +43,9 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void setUp() {
         Mockito.reset(mockLogic);
 
-        course = new Course("course-id", "Course Name", Const.DEFAULT_TIME_ZONE, "institute");
-        student = new Student(course, "Student Name", "studentEmail@gmail.tmt", "Some comments");
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        instructor = new Instructor(course, "Instructor Name", "instructorEmail@tm.tmt",
-                false, "", null, instructorPrivileges);
+        course = getTypicalCourse();
+        student = getTypicalStudent();
+        instructor = getTypicalInstructor();
 
         setupMockLogic();
     }


### PR DESCRIPTION
Part of [#12048](https://github.com/TEAMMATES/teammates/issues/12048)

**Outline of Solution**
Migrated `DeleteStudentActionTest` to use SQL-based logic instead of the previous Datastore model.