### PR TITLE
[#12048] Migrate Tests for DeleteStudentsActionTest

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -94,10 +94,31 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
                 false, "", null, instructorPrivileges);
 
         loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        verifyCannotAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorInDifferentCourse_cannotAccess() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), "instructor-googleId")).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.INSTRUCTOR_ID, "instructor-googleId",
         };
 
         verifyCannotAccess(params);

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -139,4 +139,14 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
         logoutUser();
         verifyCannotAccess(params);
     }
+
+    @Test
+    public void testSpecificAccessControl_loggedOut_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        logoutUser();
+        verifyCannotAccess(params);
+    }
 }

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -1,5 +1,6 @@
 package teammates.sqlui.webapi;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,7 +69,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     }
 
     @Test
-    void testExecute_courseDoesNotExist_failSilently() {
+    void testExecute_nonExistentCourse_failSilently() {
         when(mockLogic.getCourse("RANDOM_ID")).thenReturn(null);
 
         String[] params = {
@@ -79,7 +80,8 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
         DeleteStudentsAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(0)).deleteStudentsInCourseCascade(course.getId());
+        verify(mockLogic, times(1)).deleteStudentsInCourseCascade("RANDOM_ID");
+        verify(mockLogic, never()).deleteStudentsInCourseCascade(course.getId());
         assertEquals("Successful", actionOutput.getMessage());
     }
 

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -90,11 +90,30 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     }
 
     @Test
+    void testExecute_missingCourseId_throwsInvalidParametersException() {
+        String[] params = {
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_missingLimit_throwsInvalidParametersException() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
     void testSpecificAccessControl_instructorWithPermission_canAccess() {
         loginAsInstructor(instructor.getGoogleId());
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
         };
 
         verifyCanAccess(params);
@@ -110,6 +129,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
         };
 
         verifyCannotAccess(params);
@@ -121,7 +141,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
         };
 
         verifyCannotAccess(params);
@@ -131,6 +151,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     void testSpecificAccessControl_student_cannotAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
         };
 
         loginAsStudent("student-googleId");
@@ -144,6 +165,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     public void testSpecificAccessControl_loggedOut_cannotAccess() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.LIMIT, String.valueOf(DELETE_LIMIT),
         };
 
         logoutUser();

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -156,9 +156,6 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
 
         loginAsStudent("student-googleId");
         verifyCannotAccess(params);
-
-        logoutUser();
-        verifyCannotAccess(params);
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -1,0 +1,118 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.ui.output.MessageOutput;
+import teammates.ui.webapi.DeleteStudentsAction;
+
+/**
+ * SUT: {@link DeleteStudentsAction}.
+ */
+public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsAction> {
+
+    String googleId = "user-googleId";
+    int deleteLimit = 3;
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.STUDENTS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return DELETE;
+    }
+
+    @Test
+    void testExecute_deleteLimitedStudents_success() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+                Const.ParamsNames.LIMIT, String.valueOf(deleteLimit),
+        };
+
+        DeleteStudentsAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Successful", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_randomCourse_failSilently() {
+        when(mockLogic.getCourse("RANDOM_ID")).thenReturn(null);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "RANDOM_ID",
+                Const.ParamsNames.LIMIT, String.valueOf(deleteLimit),
+        };
+
+        DeleteStudentsAction action = getAction(params);
+        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
+
+        assertEquals("Successful", actionOutput.getMessage());
+    }
+
+    @Test
+    void testExecute_noParameters_throwsInvalidParametersException() {
+        verifyHttpParameterFailure();
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorWithPermission_canAccess() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        verifyCanAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
+        Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
+        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
+        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
+        Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
+                false, "", null, instructorPrivileges);
+
+        loginAsInstructor(googleId);
+        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, course.getId(),
+        };
+
+        verifyCannotAccess(params);
+    }
+
+    @Test
+    void testSpecificAccessControl_student_cannotAccess() {
+        String[] params = {
+                Const.ParamsNames.COURSE_ID, "course-id",
+        };
+
+        loginAsStudent(googleId);
+        verifyCannotAccess(params);
+
+        logoutUser();
+        verifyCannotAccess(params);
+    }
+}

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -159,7 +159,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     }
 
     @Test
-    public void testSpecificAccessControl_loggedOut_cannotAccess() {
+    void testSpecificAccessControl_loggedOut_cannotAccess() {
         logoutUser();
 
         String[] params = {

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -41,11 +41,8 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
     void setUp() {
         Mockito.reset(mockLogic);
 
-        course = new Course("course-id", "Course Name", Const.DEFAULT_TIME_ZONE, "institute");
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        instructor = new Instructor(course, "Instructor Name", "instructoremail@tm.tmt",
-                false, "", null, instructorPrivileges);
+        course = getTypicalCourse();
+        instructor = getTypicalInstructor();
 
         setupMockLogic();
     }

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -1,5 +1,6 @@
 package teammates.sqlui.webapi;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -81,6 +82,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
         verify(mockLogic, times(1)).deleteStudentsInCourseCascade("RANDOM_ID");
+        verify(mockLogic, times(1)).deleteStudentsInCourseCascade(any());
         verify(mockLogic, never()).deleteStudentsInCourseCascade(course.getId());
         assertEquals("Successful", actionOutput.getMessage());
     }

--- a/src/web/app/pages-static/contact-page/contact-page.component.html
+++ b/src/web/app/pages-static/contact-page/contact-page.component.html
@@ -3,16 +3,21 @@
 </h1>
 <img src="assets/images/contact.png">
 <p>
-  <b>Email:</b> You can contact us at the following email address: <a href="mailto:{{ supportEmail }}">{{ supportEmail }}</a>.
+  <b>Email:</b> You can contact us at the following email address:
+  <a href="mailto:{{ supportEmail }}"><span aria-hidden="true" class="fas fa-envelope"></span>{{ supportEmail }}</a>.
 </p>
 <p>
-  <b>Blog:</b> Visit the <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer">TEAMMATES Blog</a> to see our latest updates and information.
+  <b>Blog:</b> Visit the
+  <a href="http://teammatesonline.blogspot.sg/" target="_blank" rel="noopener noreferrer"><span aria-hidden="true" class="fab fa-blogger"></span>TEAMMATES Blog</a>
+  to see our latest updates and information.
 </p>
 <p>
   <b>Bug reports and feature requests:</b> Any bug reports or feature requests can be submitted to above email address.
 </p>
 <p>
-  <b>Interested in joining us?</b> Visit our <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">Developer Website</a>.
+  <b>Interested in joining us?</b> Visit our
+  <a href="https://github.com/TEAMMATES/teammates" target="_blank" rel="noopener noreferrer">
+    <span aria-hidden="true" class="fab fa-github"></span>TEAMMATES Github</a>.
 </p>
 <p>
   <b>Becoming a sponsor</b>:


### PR DESCRIPTION
Part of [#12048](https://github.com/TEAMMATES/teammates/issues/12048)

**Outline of Solution**
Migrated `DeleteStudentsActionTest` to use SQL-based logic instead of the previous Datastore model.