### PR TITLE
[#12048] Migrate tests for MarkNotificationAsReadActionTest

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -15,7 +15,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 
-import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -56,7 +55,6 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     static final String PUT = HttpPut.METHOD_NAME;
     static final String DELETE = HttpDelete.METHOD_NAME;
 
-    DataBundle typicalBundle = getTypicalDataBundle();
     Logic mockLogic = mock(Logic.class);
     teammates.logic.api.Logic mockDatastoreLogic = mock(teammates.logic.api.Logic.class);
     MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();

--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -15,6 +15,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 
+import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -55,6 +56,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     static final String PUT = HttpPut.METHOD_NAME;
     static final String DELETE = HttpDelete.METHOD_NAME;
 
+    DataBundle typicalBundle = getTypicalDataBundle();
     Logic mockLogic = mock(Logic.class);
     teammates.logic.api.Logic mockDatastoreLogic = mock(teammates.logic.api.Logic.class);
     MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -7,10 +7,9 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.datatransfer.attributes.NotificationAttributes;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
 import teammates.ui.output.ReadNotificationsData;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -22,9 +21,8 @@ import teammates.ui.webapi.MarkNotificationAsReadAction;
  * SUT: {@link MarkNotificationAsReadAction}.
  */
 public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotificationAsReadAction> {
-    InstructorAttributes instructor;
+    Instructor instructor;
     String instructorId;
-    NotificationAttributes notification;
     Notification testNotification;
 
     @Override
@@ -39,17 +37,10 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
 
     @BeforeMethod
     void setUp() {
-        instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        instructor = getTypicalInstructor();
         instructorId = instructor.getGoogleId();
-        notification = typicalBundle.notifications.get("notification5");
+        testNotification = getTypicalNotificationWithId();
         loginAsInstructor(instructorId);
-        testNotification = new Notification(
-                notification.getStartTime(),
-                notification.getEndTime(),
-                notification.getStyle(),
-                notification.getTargetUser(),
-                notification.getTitle(),
-                notification.getMessage());
     }
 
     @Test
@@ -57,7 +48,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
         when(mockLogic.updateReadNotifications(
                 instructorId,
                 testNotification.getId(),
-                notification.getEndTime()
+                testNotification.getEndTime()
         )).thenReturn(List.of(testNotification.getId()));
 
         MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
@@ -75,7 +66,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
     @Test
     protected void testExecute_markNonExistentNotificationAsRead_shouldFail() {
         MarkNotificationAsReadRequest reqBody =
-                new MarkNotificationAsReadRequest("invalid id", notification.getEndTime().toEpochMilli());
+                new MarkNotificationAsReadRequest("invalid id", testNotification.getEndTime().toEpochMilli());
 
         MarkNotificationAsReadAction action = getAction(reqBody);
 

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -1,0 +1,108 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.NotificationAttributes;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.storage.sqlentity.Notification;
+import teammates.ui.output.ReadNotificationsData;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.request.MarkNotificationAsReadRequest;
+import teammates.ui.webapi.JsonResult;
+import teammates.ui.webapi.MarkNotificationAsReadAction;
+
+/**
+ * SUT: {@link MarkNotificationAsReadAction}.
+ */
+public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotificationAsReadAction> {
+    InstructorAttributes instructor;
+    String instructorId;
+    NotificationAttributes notification;
+    Notification testNotification;
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.NOTIFICATION_READ;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return POST;
+    }
+
+    @BeforeMethod
+    void setUp() {
+        instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        instructorId = instructor.getGoogleId();
+        notification = typicalBundle.notifications.get("notification5");
+        loginAsInstructor(instructorId);
+        testNotification = new Notification(
+                notification.getStartTime(),
+                notification.getEndTime(),
+                notification.getStyle(),
+                notification.getTargetUser(),
+                notification.getTitle(),
+                notification.getMessage());
+    }
+
+    @Test
+    protected void testExecute_markNotificationAsRead_shouldSucceed() throws Exception {
+        when(mockLogic.updateReadNotifications(
+                instructorId,
+                testNotification.getId(),
+                notification.getEndTime()
+        )).thenReturn(List.of(testNotification.getId()));
+
+        MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
+                testNotification.getId().toString(), testNotification.getEndTime().toEpochMilli());
+
+        MarkNotificationAsReadAction action = getAction(reqBody);
+        JsonResult actionOutput = getJsonResult(action);
+
+        ReadNotificationsData response = (ReadNotificationsData) actionOutput.getOutput();
+        List<String> readNotifications = response.getReadNotifications();
+
+        assertTrue(readNotifications.contains(testNotification.getId().toString()));
+    }
+
+    @Test
+    protected void testExecute_markNonExistentNotificationAsRead_shouldFail() {
+        MarkNotificationAsReadRequest reqBody =
+                new MarkNotificationAsReadRequest("invalid id", notification.getEndTime().toEpochMilli());
+
+        MarkNotificationAsReadAction action = getAction(reqBody);
+
+        assertThrows(IllegalArgumentException.class, () -> action.execute());
+    }
+
+    @Test
+    protected void testExecute_notificationEndTimeIsZero_shouldFail() {
+        MarkNotificationAsReadRequest reqBody =
+                new MarkNotificationAsReadRequest(testNotification.getId().toString(), 0L);
+        verifyHttpRequestBodyFailure(reqBody);
+    }
+
+    @Test
+    protected void testExecute_markExpiredNotificationAsRead_shouldFail() throws Exception {
+        when(mockLogic.updateReadNotifications(
+                instructorId,
+                testNotification.getId(),
+                testNotification.getEndTime()
+        )).thenThrow(new InvalidParametersException("Trying to mark an expired notification as read."));
+
+        MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
+                testNotification.getId().toString(),
+                testNotification.getEndTime().toEpochMilli());
+
+        MarkNotificationAsReadAction action = getAction(reqBody);
+
+        assertThrows(InvalidHttpRequestBodyException.class, () -> action.execute());
+    }
+}


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #12048

**Outline of Solution**
Added the unit tests for MarkNotificationAsReadActionTest for PostgreSQL.

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 