### PR TITLE
[#12048] Refactor tests for DeleteFeedbackQuestionActionTest

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/DeleteFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteFeedbackQuestionActionTest.java
@@ -5,7 +5,7 @@ import static teammates.common.util.Const.InstructorPermissionRoleNames.INSTRUCT
 
 import java.util.UUID;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPrivileges;
@@ -37,7 +37,7 @@ public class DeleteFeedbackQuestionActionTest extends BaseActionTest<DeleteFeedb
         return DELETE;
     }
 
-    @BeforeEach
+    @BeforeMethod
     void setUp() {
         typicalInstructor = getTypicalInstructor();
         typicalCourse = typicalInstructor.getCourse();

--- a/src/test/java/teammates/sqlui/webapi/DeleteFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteFeedbackQuestionActionTest.java
@@ -5,6 +5,7 @@ import static teammates.common.util.Const.InstructorPermissionRoleNames.INSTRUCT
 
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPrivileges;
@@ -21,11 +22,10 @@ import teammates.ui.webapi.DeleteFeedbackQuestionAction;
  */
 public class DeleteFeedbackQuestionActionTest extends BaseActionTest<DeleteFeedbackQuestionAction> {
 
-    private final Instructor typicalInstructor = getTypicalInstructor();
-    private final Course typicalCourse = typicalInstructor.getCourse();
-    private final FeedbackSession typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
-    private final FeedbackQuestion typicalFeedbackQuestion =
-            getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
+    private Instructor typicalInstructor;
+    private Course typicalCourse;
+    private FeedbackSession typicalFeedbackSession;
+    private FeedbackQuestion typicalFeedbackQuestion;
 
     @Override
     protected String getActionUri() {
@@ -35,6 +35,14 @@ public class DeleteFeedbackQuestionActionTest extends BaseActionTest<DeleteFeedb
     @Override
     protected String getRequestMethod() {
         return DELETE;
+    }
+
+    @BeforeEach
+    void setUp() {
+        typicalInstructor = getTypicalInstructor();
+        typicalCourse = typicalInstructor.getCourse();
+        typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
+        typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
     }
 
     @Test


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

To address comments from #13231, changed `DeleteFeedbackQuestionActionTest.java` to remove dependencies between each test case by using a `setUp()` method instead of a shared variable.