### PR TITLE
[#12048] Migrate tests for GetAuthInfoActionTest

### DIFF
--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -15,7 +15,7 @@ import teammates.ui.output.AuthInfo;
  *
  * <p>This does not log in or log out the user.
  */
-class GetAuthInfoAction extends Action {
+public class GetAuthInfoAction extends Action {
 
     @Override
     public AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -67,7 +67,10 @@ public class GetAuthInfoAction extends Action {
         return new JsonResult(output, cookieList);
     }
 
-    String createLoginUrl(String frontendUrl, String nextUrl) {
+    /**
+     * Returns a LoginURL based on the frontendURL and nextURL.
+     */
+    public static String createLoginUrl(String frontendUrl, String nextUrl) {
         return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
     }
 

--- a/src/main/java/teammates/ui/webapi/JsonResult.java
+++ b/src/main/java/teammates/ui/webapi/JsonResult.java
@@ -64,7 +64,7 @@ public class JsonResult extends ActionResult {
         JsonUtils.toCompactJson(output, pw);
     }
 
-    List<Cookie> getCookies() {
+    public List<Cookie> getCookies() {
         return cookies;
     }
 

--- a/src/test/java/teammates/sqlui/webapi/GetAuthInfoActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetAuthInfoActionTest.java
@@ -1,5 +1,7 @@
 package teammates.sqlui.webapi;
 
+import static teammates.ui.webapi.GetAuthInfoAction.createLoginUrl;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -109,9 +111,11 @@ public class GetAuthInfoActionTest extends BaseActionTest<GetAuthInfoAction> {
     }
 
     @Test
-    void testExecute_addCsrfTokenCookies_noLoggedInUser() {
+    public void testExecute_addCsrfTokenCookies_shouldAddToResponseAccordingToExistingCsrfToken() {
         String expectedCsrfToken = StringHelper.encrypt("1234");
         String[] emptyParams = new String[] {};
+
+        ______TS("No logged in user");
 
         logoutUser();
 
@@ -119,47 +123,34 @@ public class GetAuthInfoActionTest extends BaseActionTest<GetAuthInfoAction> {
         JsonResult r = getJsonResult(a);
 
         assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
-    }
 
-    @Test
-    void testExecute_addCsrfTokenCookies_fakeCsrfToken() {
-        String expectedCsrfToken = StringHelper.encrypt("1234");
-        String[] emptyParams = new String[] {};
-
-        loginAsInstructor("idOfInstructor1OfCourse1");
+        ______TS("User logged in with fake csrf token");
 
         Cookie cookieToAdd = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, "someFakeCsrfToken");
 
-        GetAuthInfoAction a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
-        JsonResult r = getJsonResult(a);
+        a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
+        r = getJsonResult(a);
 
         assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
-    }
 
-    @Test
-    void testExecute_addCsrfTokenCookies_userLoggedInWithNonExistingCsrfToken() {
-        String expectedCsrfToken = StringHelper.encrypt("1234");
-        String[] emptyParams = new String[] {};
+        ______TS("User logged in with non existing csrf token");
 
         loginAsInstructor("idOfInstructor1OfCourse1");
 
-        GetAuthInfoAction a = getAction(emptyParams);
-        JsonResult r = getJsonResult(a);
+        a = getAction(emptyParams);
+        r = getJsonResult(a);
 
         assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
-    }
 
-    @Test
-    void testExecute_addCsrfTokenCookies_userLoggedInWithMatchedCsrfToken() {
-        String[] emptyParams = new String[] {};
+        ______TS("User logged in with matched CSRF token cookies");
 
         loginAsInstructor("idOfInstructor1OfCourse1");
 
-        Cookie cookieToAdd = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME,
+        cookieToAdd = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME,
                 StringHelper.encrypt("1234"));
 
-        GetAuthInfoAction a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
-        JsonResult r = getJsonResult(a);
+        a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
+        r = getJsonResult(a);
 
         assertEquals(0, r.getCookies().size());
     }
@@ -186,10 +177,6 @@ public class GetAuthInfoActionTest extends BaseActionTest<GetAuthInfoAction> {
     void testAccessControl_nonAdminCannotMasquerade() {
         loginAsInstructor("idOfInstructor1OfCourse1");
         verifyCannotMasquerade("idOfAnotherInstructor");
-    }
-
-    String createLoginUrl(String frontendUrl, String nextUrl) {
-        return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
     }
 
 }

--- a/src/test/java/teammates/sqlui/webapi/GetAuthInfoActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetAuthInfoActionTest.java
@@ -1,0 +1,195 @@
+package teammates.sqlui.webapi;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import jakarta.servlet.http.Cookie;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.UserInfo;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.ui.output.AuthInfo;
+import teammates.ui.webapi.GetAuthInfoAction;
+import teammates.ui.webapi.JsonResult;
+
+/**
+ * SUT: {@link GetAuthInfoAction}.
+ */
+public class GetAuthInfoActionTest extends BaseActionTest<GetAuthInfoAction> {
+
+    @Override
+    String getActionUri() {
+        return Const.ResourceURIs.AUTH;
+    }
+
+    @Override
+    String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    void testExecute_noLoggedInUser() {
+        logoutUser();
+
+        GetAuthInfoAction a = getAction();
+        JsonResult r = getJsonResult(a);
+
+        AuthInfo output = (AuthInfo) r.getOutput();
+        assertEquals(createLoginUrl("", Const.WebPageURIs.STUDENT_HOME_PAGE), output.getStudentLoginUrl());
+        assertEquals(createLoginUrl("", Const.WebPageURIs.INSTRUCTOR_HOME_PAGE), output.getInstructorLoginUrl());
+        assertEquals(createLoginUrl("", Const.WebPageURIs.ADMIN_HOME_PAGE), output.getAdminLoginUrl());
+        assertEquals(createLoginUrl("", Const.WebPageURIs.MAINTAINER_HOME_PAGE), output.getMaintainerLoginUrl());
+        assertNull(output.getUser());
+        assertFalse(output.isMasquerade());
+    }
+
+    @Test
+    void testExecute_noLoggedInUser_hasNextUrlParameter() {
+        logoutUser();
+        String nextUrl = "/web/join";
+
+        String[] params = new String[] {
+                "nextUrl", nextUrl,
+        };
+
+        GetAuthInfoAction a = getAction(params);
+        JsonResult r = getJsonResult(a);
+
+        AuthInfo output = (AuthInfo) r.getOutput();
+        assertEquals(createLoginUrl("", nextUrl), output.getStudentLoginUrl());
+        assertEquals(createLoginUrl("", nextUrl), output.getInstructorLoginUrl());
+        assertEquals(createLoginUrl("", nextUrl), output.getAdminLoginUrl());
+        assertEquals(createLoginUrl("", nextUrl), output.getMaintainerLoginUrl());
+        assertNull(output.getUser());
+        assertFalse(output.isMasquerade());
+    }
+
+    @Test
+    void testExecute_loggedInAsInstructor() {
+        loginAsInstructor("idOfInstructor1OfCourse1");
+
+        GetAuthInfoAction a = getAction();
+        JsonResult r = getJsonResult(a);
+
+        AuthInfo output = (AuthInfo) r.getOutput();
+        assertNull(output.getStudentLoginUrl());
+        assertNull(output.getInstructorLoginUrl());
+        assertNull(output.getAdminLoginUrl());
+        assertNull(output.getMaintainerLoginUrl());
+        assertFalse(output.isMasquerade());
+
+        UserInfo user = output.getUser();
+        assertFalse(user.isAdmin);
+        assertTrue(user.isInstructor);
+        assertFalse(user.isStudent);
+        assertEquals("idOfInstructor1OfCourse1", user.id);
+    }
+
+    @Test
+    void testExecute_loggedInAsUnregisteredUser() {
+        loginAsUnregistered("unregisteredId");
+
+        GetAuthInfoAction a = getAction();
+        JsonResult r = getJsonResult(a);
+
+        AuthInfo output = (AuthInfo) r.getOutput();
+        assertNull(output.getStudentLoginUrl());
+        assertNull(output.getInstructorLoginUrl());
+        assertNull(output.getAdminLoginUrl());
+        assertNull(output.getMaintainerLoginUrl());
+        assertFalse(output.isMasquerade());
+
+        UserInfo user = output.getUser();
+        assertFalse(user.isAdmin);
+        assertFalse(user.isInstructor);
+        assertFalse(user.isStudent);
+        assertEquals("unregisteredId", user.id);
+    }
+
+    @Test
+    void testExecute_addCsrfTokenCookies_noLoggedInUser() {
+        String expectedCsrfToken = StringHelper.encrypt("1234");
+        String[] emptyParams = new String[] {};
+
+        logoutUser();
+
+        GetAuthInfoAction a = getAction(emptyParams);
+        JsonResult r = getJsonResult(a);
+
+        assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
+    }
+
+    @Test
+    void testExecute_addCsrfTokenCookies_fakeCsrfToken() {
+        String expectedCsrfToken = StringHelper.encrypt("1234");
+        String[] emptyParams = new String[] {};
+
+        loginAsInstructor("idOfInstructor1OfCourse1");
+
+        Cookie cookieToAdd = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, "someFakeCsrfToken");
+
+        GetAuthInfoAction a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
+        JsonResult r = getJsonResult(a);
+
+        assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
+    }
+
+    @Test
+    void testExecute_addCsrfTokenCookies_userLoggedInWithNonExistingCsrfToken() {
+        String expectedCsrfToken = StringHelper.encrypt("1234");
+        String[] emptyParams = new String[] {};
+
+        loginAsInstructor("idOfInstructor1OfCourse1");
+
+        GetAuthInfoAction a = getAction(emptyParams);
+        JsonResult r = getJsonResult(a);
+
+        assertEquals(expectedCsrfToken, r.getCookies().get(0).getValue());
+    }
+
+    @Test
+    void testExecute_addCsrfTokenCookies_userLoggedInWithMatchedCsrfToken() {
+        String[] emptyParams = new String[] {};
+
+        loginAsInstructor("idOfInstructor1OfCourse1");
+
+        Cookie cookieToAdd = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME,
+                StringHelper.encrypt("1234"));
+
+        GetAuthInfoAction a = getActionWithCookie(new ArrayList<>(Arrays.asList(cookieToAdd)), emptyParams);
+        JsonResult r = getJsonResult(a);
+
+        assertEquals(0, r.getCookies().size());
+    }
+
+    @Test
+    void testAccessControl_adminCanAccess() {
+        loginAsAdmin();
+        verifyCanAccess();
+    }
+
+    @Test
+    void testAccessControl_unRegisteredUserCanAccess() {
+        loginAsUnregistered("unregistered user");
+        verifyCanAccess();
+    }
+
+    @Test
+    void testAccessControl_noLoginCanAccess() {
+        logoutUser();
+        verifyCanAccess();
+    }
+
+    @Test
+    void testAccessControl_nonAdminCannotMasquerade() {
+        loginAsInstructor("idOfInstructor1OfCourse1");
+        verifyCannotMasquerade("idOfAnotherInstructor");
+    }
+
+    String createLoginUrl(String frontendUrl, String nextUrl) {
+        return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
+    }
+
+}


### PR DESCRIPTION
Part of #12048 

Outline of Solution

Change GetAuthInfoActionTest.java to ensure compatibility with the PostgreSQL database following the database migration.

Excluded tests where admin masquerades as user, because the user database cannot be accessed in the test.