### PR TITLE
Feat/empty weights for mcq msq

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -105,7 +105,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
             // trigger this error.
             if (hasAssignedWeights && !mcqWeights.isEmpty()) {
                 mcqWeights.stream()
-                        .filter(weight -> weight < 0)
+                        .filter(weight -> weight != null && weight < 0)
                         .forEach(weight -> errors.add(MCQ_ERROR_INVALID_WEIGHT));
             }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -150,7 +150,7 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
             // If weights are negative, trigger this error.
             if (hasAssignedWeights && !msqWeights.isEmpty()) {
                 msqWeights.stream()
-                        .filter(weight -> weight < 0)
+                        .filter(weight -> weight != null && weight < 0)
                         .forEach(weight -> errors.add(MSQ_ERROR_INVALID_WEIGHT));
             }
 

--- a/src/web/app/components/question-types/question-edit-details-form/__snapshots__/mcq-question-edit-details-form.component.spec.ts.snap
+++ b/src/web/app/components/question-types/question-edit-details-form/__snapshots__/mcq-question-edit-details-form.component.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`McqQuestionEditDetailsFormComponent should snap when questionDropdownEn
           <label
             class="form-check-label ngb-tooltip-class fw-bold"
             container="body"
-            ngbtooltip="Assign weights to the choices for calculating statistics."
+            ngbtooltip="Assign weights to the choices for calculating statistics. An empty weight (i.e. Not enough information to evaluate) can be assigned by leaving the input box empty."
           >
             <input
               class="form-check-input ng-untouched ng-pristine ng-valid"
@@ -204,7 +204,7 @@ exports[`McqQuestionEditDetailsFormComponent should snap when questionDropdownEn
           <label
             class="form-check-label ngb-tooltip-class fw-bold"
             container="body"
-            ngbtooltip="Assign weights to the choices for calculating statistics."
+            ngbtooltip="Assign weights to the choices for calculating statistics. An empty weight (i.e. Not enough information to evaluate) can be assigned by leaving the input box empty."
           >
             <input
               class="form-check-input ng-untouched ng-pristine ng-valid"
@@ -366,7 +366,7 @@ exports[`McqQuestionEditDetailsFormComponent should snap with default view i.e. 
           <label
             class="form-check-label ngb-tooltip-class fw-bold"
             container="body"
-            ngbtooltip="Assign weights to the choices for calculating statistics."
+            ngbtooltip="Assign weights to the choices for calculating statistics. An empty weight (i.e. Not enough information to evaluate) can be assigned by leaving the input box empty."
           >
             <input
               class="form-check-input ng-untouched ng-pristine ng-valid"

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
@@ -11,7 +11,7 @@
   <div class="col-md-6">
     <div class="col-md-12">
       <div class="form-check form-check-inline" *ngIf="!isGeneratedOptionsEnabled">
-        <label class="form-check-label ngb-tooltip-class fw-bold" ngbTooltip="Assign weights to the choices for calculating statistics."
+        <label class="form-check-label ngb-tooltip-class fw-bold" ngbTooltip="Assign weights to the choices for calculating statistics. An empty weight (i.e. Not enough information to evaluate) can be assigned by leaving the input box empty."
                container="body">
           <input id="weights-checkbox" class="form-check-input" type="checkbox" [ngModel]="model.hasAssignedWeights"
                  [disabled]="!isEditable"

--- a/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <div class="col-md-12">
       <div class="form-check form-check-inline" *ngIf="!isGeneratedOptionsEnabled">
-        <label class="form-check-label ngb-tooltip-class fw-bold" ngbTooltip="Assign weights to the choices for calculating statistics."
+        <label class="form-check-label ngb-tooltip-class fw-bold" ngbTooltip="Assign weights to the choices for calculating statistics. An empty weight (i.e. Not enough information to evaluate) can be assigned by leaving the input box empty."
               container="body">
           <input id="weights-checkbox" class="form-check-input" type="checkbox" [ngModel]="model.hasAssignedWeights"
                 [disabled]="!isEditable" (ngModelChange)="triggerWeightsColumn($event)">

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class McqQuestionStatisticsComponent extends McqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key}[${(this.weightPerOption[key]).toFixed(2)}]`,
+          header: `${key}[${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : ''}]`,
           sortBy: SortBy.MCQ_OPTION_SELECTED_TIMES,
         };
       }),

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class McqQuestionStatisticsComponent extends McqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key}[${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
+          header: `${key}[${this.weightPerOption[key] !== null ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
           sortBy: SortBy.MCQ_OPTION_SELECTED_TIMES,
         };
       }),
@@ -83,8 +83,8 @@ export class McqQuestionStatisticsComponent extends McqQuestionStatisticsCalcula
             value: this.perRecipientResponses[key].responses[option],
           };
         }),
-        { value: (this.perRecipientResponses[key].total).toFixed(2) },
-        { value: (this.perRecipientResponses[key].average).toFixed(2) },
+        { value: this.perRecipientResponses[key].total !== null ? (this.perRecipientResponses[key].total).toFixed(2) : '-' },
+        { value: this.perRecipientResponses[key].average !== null ? (this.perRecipientResponses[key].average).toFixed(2) : '-' },
       ];
     });
   }

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class McqQuestionStatisticsComponent extends McqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key}[${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : ''}]`,
+          header: `${key}[${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
           sortBy: SortBy.MCQ_OPTION_SELECTED_TIMES,
         };
       }),

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key} [${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
+          header: `${key} [${this.weightPerOption[key] !== null ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
           sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),
@@ -83,10 +83,9 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
             value: this.perRecipientResponses[key].responses[option],
           };
         }),
-        { value: (this.perRecipientResponses[key].total).toFixed(2) },
-        { value: (this.perRecipientResponses[key].average).toFixed(2) },
+        { value: this.perRecipientResponses[key].total !== null ? (this.perRecipientResponses[key].total).toFixed(2) : '-' },
+        { value: this.perRecipientResponses[key].average !== null ? (this.perRecipientResponses[key].average).toFixed(2) : '-' },
       ];
     });
   }
-
 }

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key} [${(this.weightPerOption[key]).toFixed(2)}]`,
+          header: `${key} [${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : ''}]`,
           sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -62,7 +62,7 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
       { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key} [${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : ''}]`,
+          header: `${key} [${this.weightPerOption[key] ? (this.weightPerOption[key]).toFixed(2) : '-'}]`,
           sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
@@ -102,6 +102,9 @@ export class McqQuestionStatisticsCalculation
         for (const answer of Object.keys(responses)) {
           const responseCount: number = responses[answer];
           const weight: number = this.weightPerOption[answer];
+          if (weight === null) {
+            continue;
+          }
           total += responseCount * weight;
           numOfResponsesForRecipient += responseCount;
         }

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
@@ -61,6 +61,9 @@ export class McqQuestionStatisticsCalculation
 
       for (const answer of Object.keys(this.weightPerOption)) {
         const weight: number = this.weightPerOption[answer];
+        if (weight === null) {
+          continue;
+        }
         const frequency: number = this.answerFrequency[answer];
         const weightedPercentage: number = totalWeightedResponseCount === 0 ? 0
             : 100 * ((frequency * weight) / totalWeightedResponseCount);

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/mcq-question-statistics-calculation.ts
@@ -97,7 +97,21 @@ export class McqQuestionStatisticsCalculation
         perRecipientResponse[response.recipient][answer] += 1;
       }
 
+      const areAllOptionWeightsNull: boolean = this.question.mcqWeights.every(weight => weight === null);
+
       for (const recipient of Object.keys(perRecipientResponse)) {
+        if (areAllOptionWeightsNull) {
+          this.perRecipientResponses[recipient] = {
+            recipient,
+            recipientEmail: recipientEmails[recipient],
+            total: null,
+            average: null,
+            recipientTeam: recipientToTeam[recipient],
+            responses: perRecipientResponse[recipient],
+          };
+          continue;
+        }
+
         const responses: Record<string, number> = perRecipientResponse[recipient];
         let total: number = 0;
         let average: number = 0;

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
@@ -71,6 +71,9 @@ export class MsqQuestionStatisticsCalculation
 
       for (const answer of Object.keys(this.weightPerOption)) {
         const weight: number = this.weightPerOption[answer];
+        if (weight === null) {
+          continue;
+        }
         const frequency: number = this.answerFrequency[answer];
         const weightedPercentage: number = totalWeightedResponseCount === 0 ? 0
             : 100 * ((frequency * weight) / totalWeightedResponseCount);

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
@@ -124,6 +124,9 @@ export class MsqQuestionStatisticsCalculation
       for (const answer of Object.keys(responses)) {
         const responseCount: number = responses[answer];
         const weight: number = this.weightPerOption[answer];
+        if (weight === null) {
+          continue;
+        }
         total += responseCount * weight;
         numOfResponsesForRecipient += responseCount;
       }

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
@@ -119,7 +119,21 @@ export class MsqQuestionStatisticsCalculation
       this.updateResponseCountPerOptionForResponse(response.responseDetails, perRecipientResponse[email]);
     }
 
+    const areAllOptionWeightsNull: boolean = this.question.msqWeights.every(weight => weight === null);
+
     for (const recipient of Object.keys(perRecipientResponse)) {
+      if (areAllOptionWeightsNull) {
+        this.perRecipientResponses[recipient] = {
+          recipient,
+          recipientEmail: recipientEmails[recipient],
+          total: null,
+          average: null,
+          recipientTeam: recipientToTeam[recipient],
+          responses: perRecipientResponse[recipient],
+        };
+        continue;
+      }
+
       const responses: Record<string, number> = perRecipientResponse[recipient];
       let total: number = 0;
       let average: number = 0;


### PR DESCRIPTION
Fixes #12547

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->

1. Allow weights to be null in `validateQuestionDetails()`
2. Update tooltip for "Options are weighted" checkbox
3. Show '-' for `weighted percentages` for options with empty weights
4. Update `headers` in per recipient statistics to show empty weights (denoted by Option[-])
5. Calculate correct `total` and `average` scores (skip over empty weights)
6. Show '-' for `total` and `average` when all options have empty weights

**Screenshots**

MCQ with empty weights can be saved:

![image](https://github.com/user-attachments/assets/df3f8e03-418d-4b13-8898-7b06ff47f00d)

MSQ with empty weights can be saved:

![image](https://github.com/user-attachments/assets/2da1cce7-26df-4430-9470-a48080b5c61d)

**MCQ Feedback session results:**

When all weights are empty:

![image](https://github.com/user-attachments/assets/a2fe0ea3-d4a4-4702-804d-9bc02032b692)

With one or more non-empty weights:

![image](https://github.com/user-attachments/assets/53ffa42d-4ecc-4583-b43d-f062a679f002)

**MSQ Feedback session results:**

When all weights are empty:

![image](https://github.com/user-attachments/assets/1688c065-c3b7-4c71-b092-4058294f4d6f)

With one or more non-empty weights:

![image](https://github.com/user-attachments/assets/1e9b0e6c-c31b-4c0e-8ab8-d4dae2a99455)
