### PR TITLE
[#13287] Fix GetHasResponsesAction

### DIFF
--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -146,11 +146,12 @@ public class GetHasResponsesAction extends Action {
             return new JsonResult(new HasResponsesData(sessionsHasResponses));
         }
 
-        FeedbackSessionAttributes feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = getNonNullSqlFeedbackSession(feedbackSessionName, courseId);
 
-        StudentAttributes student = logic.getStudentForGoogleId(courseId, userInfo.getId());
+        Student student = sqlLogic.getStudentByGoogleId(courseId, userInfo.getId());
         return new JsonResult(new HasResponsesData(
-                logic.isFeedbackSessionAttemptedByStudent(feedbackSession, student.getEmail(), student.getTeam())));
+                sqlLogic.isFeedbackSessionAttemptedByStudent(
+                        feedbackSession, student.getEmail(), student.getTeamName())));
     }
 
     private JsonResult handleInstructorReq() {


### PR DESCRIPTION
Fixes #13287 

**Outline of Solution**

Modified the code that uses `logic` instead of `sqlLogic`, when it is supposed to use `sqlLogic`, along the path where the `Course` is migrated.
