### PR TITLE
[#13275] Fix potential incorrect sending of closing soon email

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingSoonRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingSoonRemindersActionIT.java
@@ -98,6 +98,10 @@ public class FeedbackSessionClosingSoonRemindersActionIT extends BaseActionIT<Fe
 
         ______TS("Typical Success Case 5: No tasks queued -- session's closing-soon email disabled");
         textExecute_typicalSuccess5();
+
+        ______TS("Typical Success Case 6: No tasks queued -- "
+                + "session's closed email already sent, but closing-soon email not yet sent and still within time window");
+        textExecute_typicalSuccess6();
     }
 
     private void textExecute_typicalSuccess1() {
@@ -239,5 +243,41 @@ public class FeedbackSessionClosingSoonRemindersActionIT extends BaseActionIT<Fe
         assertTrue(!de.isClosingSoonEmailSent());
 
         verifyNoTasksAdded();
+    }
+
+    private void textExecute_typicalSuccess6() {
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        // Session has closing-soon email enabled (possibly just recently enabled)
+        session.setClosingSoonEmailEnabled(true);
+        // Closing-soon email was never sent (because it was disabled before)
+        session.setClosingSoonEmailSent(false);
+        // Session has already closed and sent closed emails
+        session.setClosedEmailSent(true);
+        // End time is still within the 2-day window checked by the query
+        session.setEndTime(now.minusSeconds(oneHour * 12));
+        session.setGracePeriod(noGracePeriod);
+
+        DeadlineExtension de = session.getDeadlineExtensions().get(0);
+        de.setEndTime(now.plusSeconds(oneHour * 16));
+        de.setClosingSoonEmailSent(false);
+
+        String[] params = {};
+
+        FeedbackSessionClosingSoonRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        // Should still be false as no closing-soon email should be sent for already closed sessions
+        assertFalse(session.isClosingSoonEmailSent());
+        // Closing-soon email for deadline extension should still be sent
+        assertTrue(de.isClosingSoonEmailSent());
+
+        // Only 1 email task should be added for the deadline extension
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
     }
 }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -367,9 +367,11 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, Feedba
 
     private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosingSoonEmail() {
         return load()
+                // Retrieve sessions with endTime within the past two days to prevent issues caused by time zone differences
                 .filter("endTime >", TimeHelper.getInstantDaysOffsetFromNow(-2))
                 .filter("sentClosingSoonEmail =", false)
                 .filter("isClosingSoonEmailEnabled =", true)
+                .filter("sentClosedEmail =", false)
                 .list();
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -367,7 +367,7 @@ public final class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, Feedba
 
     private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosingSoonEmail() {
         return load()
-                // Retrieve sessions with endTime within the past two days to prevent issues caused by time zone differences
+                // Retrieve sessions with endTime from 2 days ago onwards to prevent issues caused by time zone differences
                 .filter("endTime >", TimeHelper.getInstantDaysOffsetFromNow(-2))
                 .filter("sentClosingSoonEmail =", false)
                 .filter("isClosingSoonEmailEnabled =", true)

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -290,10 +290,13 @@ public final class FeedbackSessionsDb extends EntitiesDb {
 
         cr.select(root)
                 .where(cb.and(
+                        // Retrieve sessions with endTime within the past two days
+                        // to prevent issues caused by time zone differences
                         cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
                         cb.and(
                                 cb.equal(root.get("isClosingSoonEmailSent"), false),
-                                cb.equal(root.get("isClosingSoonEmailEnabled"), true))
+                                cb.equal(root.get("isClosingSoonEmailEnabled"), true),
+                                cb.equal(root.get("isClosedEmailSent"), false))
                ));
 
         return HibernateUtil.createQuery(cr).getResultList();

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionsDb.java
@@ -290,7 +290,7 @@ public final class FeedbackSessionsDb extends EntitiesDb {
 
         cr.select(root)
                 .where(cb.and(
-                        // Retrieve sessions with endTime within the past two days
+                        // Retrieve sessions with endTime from 2 days ago onwards
                         // to prevent issues caused by time zone differences
                         cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
                         cb.and(


### PR DESCRIPTION
Fixes #13275 

**Outline of Solution**
1. Add a comment to explain the rationale behind using a 2-day offset in `getInstantDaysOffsetFromNow(-2)`.
2. Update the query to check for `isClosedEmailSent`, preventing closing soon email from being sent if the closed email has previously been sent.