### PR TITLE
[#12048] Migrate tests for UnpublishFeedbackSessionActionTest

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -1,0 +1,145 @@
+package teammates.sqlui.webapi;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.common.util.Const.TaskQueue;
+import teammates.common.util.TimeHelper;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Instructor;
+import teammates.ui.output.FeedbackSessionData;
+import teammates.ui.webapi.JsonResult;
+import teammates.ui.webapi.UnpublishFeedbackSessionAction;
+
+/**
+ * SUT: {@link UnpublishFeedbackSessionAction}.
+ */
+public class UnpublishFeedbackSessionActionTest extends BaseActionTest<UnpublishFeedbackSessionAction> {
+
+    private Course typicalCourse;
+    private FeedbackSession typicalFeedbackSession;
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.SESSION_PUBLISH;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return DELETE;
+    }
+
+    @BeforeMethod
+    void setUp() {
+        typicalInstructor = getTypicalInstructor();
+        typicalCourse = getTypicalCourse();
+        typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
+        typicalFeedbackSession.setCreatedAt(Instant.now());
+    }
+
+    @AfterMethod
+    void tearDown() {
+        reset(mockLogic);
+        mockTaskQueuer.clearTasks();
+    }
+
+    @Test
+    void testExecute_missingParameters_throwsInvalidHttpParameterException() {
+        verifyHttpParameterFailure();
+    }
+
+    @Test
+    void testExecute_unpublishedFeedbackSession_returnsEarly()
+            throws EntityDoesNotExistException, InvalidParametersException {
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+        };
+
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+                .thenReturn(typicalFeedbackSession);
+
+        UnpublishFeedbackSessionAction action = getAction(params);
+        JsonResult result = getJsonResult(action);
+        FeedbackSessionData feedbackSessionData = (FeedbackSessionData) result.getOutput();
+
+        verifyUnpublishFeedbackSession(feedbackSessionData, typicalFeedbackSession);
+        verify(mockLogic, never()).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verifyNoTasksAdded();
+    }
+
+    @Test
+    void testExecute_publishedFeedbackSessionWithEmailDisabled_succeedsWithNoTasksAdded()
+            throws EntityDoesNotExistException, InvalidParametersException {
+        typicalFeedbackSession.setResultsVisibleFromTime(Instant.now());
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+        };
+
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+                .thenReturn(typicalFeedbackSession);
+        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+                .thenReturn(typicalFeedbackSession);
+
+        UnpublishFeedbackSessionAction action = getAction(params);
+        JsonResult result = getJsonResult(action);
+        FeedbackSessionData feedbackSessionData = (FeedbackSessionData) result.getOutput();
+
+        verifyUnpublishFeedbackSession(feedbackSessionData, typicalFeedbackSession);
+        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verifyNoTasksAdded();
+    }
+
+    @Test
+    void testExecute_publishedFeedbackSessionWithEmailEnabled_succeedsWithTasksAdded()
+            throws EntityDoesNotExistException, InvalidParametersException {
+        typicalFeedbackSession.setResultsVisibleFromTime(Instant.now());
+        typicalFeedbackSession.setPublishedEmailEnabled(true);
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+        };
+
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+                .thenReturn(typicalFeedbackSession);
+        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+                .thenReturn(typicalFeedbackSession);
+
+        UnpublishFeedbackSessionAction action = getAction(params);
+        JsonResult result = getJsonResult(action);
+        FeedbackSessionData feedbackSessionData = (FeedbackSessionData) result.getOutput();
+
+        verifyUnpublishFeedbackSession(feedbackSessionData, typicalFeedbackSession);
+        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verifySpecifiedTasksAdded(TaskQueue.FEEDBACK_SESSION_UNPUBLISHED_EMAIL_QUEUE_NAME, 1);
+    }
+
+    private void verifyUnpublishFeedbackSession(FeedbackSessionData output, FeedbackSession session) {
+        assertEquals(output.getFeedbackSessionId(), session.getId());
+        assertEquals(output.getCourseId(), session.getCourseId());
+        assertEquals(output.getTimeZone(), session.getCourse().getTimeZone());
+        assertEquals(output.getFeedbackSessionName(), session.getName());
+        assertEquals(output.getInstructions(), session.getInstructions());
+        assertEquals(output.getSubmissionStartTimestamp(), TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                session.getStartTime(), session.getCourse().getTimeZone(), true).toEpochMilli());
+        assertEquals(output.getSubmissionEndTimestamp(), TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                session.getEndTime(), session.getCourse().getTimeZone(), true).toEpochMilli());
+        assertEquals(output.getSubmissionEndWithExtensionTimestamp(), TimeHelper.getMidnightAdjustedInstantBasedOnZone(
+                session.getEndTime(), session.getCourse().getTimeZone(), true).toEpochMilli());
+        assertEquals((long) output.getGracePeriod(), session.getGracePeriod().toMinutes());
+        // more
+    }
+}

--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -161,6 +161,42 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     }
 
     @Test
+    void testCheckSpecificAccessControl_nonExistentCourse_throwsEntityNotFoundException() {
+        String courseId = "abcRandomCourseId";
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, courseId,
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+        };
+
+        when(mockLogic.getInstructorByGoogleId(courseId, typicalInstructor.getGoogleId()))
+                .thenReturn(null);
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), courseId))
+                .thenReturn(null);
+
+        loginAsInstructor(typicalInstructor.getGoogleId());
+
+        verifyEntityNotFoundAcl(params);
+    }
+
+    @Test
+    void testCheckSpecificAccessControl_nonExistentFeedbackSession_throwsEntityNotFoundException() {
+        String feedbackSessionName = "abcRandomSession";
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
+        };
+
+        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+                .thenReturn(typicalInstructor);
+        when(mockLogic.getFeedbackSession(feedbackSessionName, typicalCourse.getId()))
+                .thenReturn(null);
+
+        loginAsInstructor(typicalInstructor.getGoogleId());
+
+        verifyEntityNotFoundAcl(params);
+    }
+
+    @Test
     void testCheckSpecificAccessControl_withoutLogin_throwsUnauthorizedAccessException() {
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalCourse.getId(),


### PR DESCRIPTION
Part of #12048 

Outline of Solution

Change UnpublishFeedbackSessionActionTest.java to ensure compatibility with the PostgreSQL database following the database migration.