### PR TITLE
[#13324] Migrate to InstructorFeedbackEditPageSql

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/BaseFeedbackQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/BaseFeedbackQuestionE2ETest.java
@@ -3,7 +3,7 @@ package teammates.e2e.cases.sql;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
@@ -32,12 +32,12 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
 
     abstract void testSubmitPage();
 
-    InstructorFeedbackEditPage loginToFeedbackEditPage() {
+    InstructorFeedbackEditPageSql loginToFeedbackEditPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withCourseId(course.getId())
                 .withSessionName(feedbackSession.getName());
 
-        return loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
+        return loginToPage(url, InstructorFeedbackEditPageSql.class, instructor.getGoogleId());
     }
 
     FeedbackSubmitPage loginToFeedbackSubmitPage() {

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackMcqQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackMcqQuestionE2ETest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.questions.FeedbackMcqQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackMcqResponseDetails;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 
@@ -40,7 +40,7 @@ public class FeedbackMcqQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession");

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackMsqQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackMsqQuestionE2ETest.java
@@ -11,7 +11,7 @@ import teammates.common.datatransfer.questions.FeedbackMsqQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackMsqResponseDetails;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Student;
@@ -42,7 +42,7 @@ public class FeedbackMsqQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession")

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackNumScaleQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackNumScaleQuestionE2ETest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleResponseDetails;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Student;
@@ -36,7 +36,7 @@ public class FeedbackNumScaleQuestionE2ETest extends BaseFeedbackQuestionE2ETest
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession");

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankOptionQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankOptionQuestionE2ETest.java
@@ -10,7 +10,7 @@ import teammates.common.datatransfer.questions.FeedbackRankOptionsResponseDetail
 import teammates.common.datatransfer.questions.FeedbackRankQuestionDetails;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Student;
@@ -42,7 +42,7 @@ public class FeedbackRankOptionQuestionE2ETest extends BaseFeedbackQuestionE2ETe
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession")

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackRubricQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackRubricQuestionE2ETest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.questions.FeedbackRubricQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackRubricResponseDetails;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Student;
@@ -42,7 +42,7 @@ public class FeedbackRubricQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession");

--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackTextQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackTextQuestionE2ETest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
-import teammates.e2e.pageobjects.InstructorFeedbackEditPage;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.Instructor;
@@ -36,7 +36,7 @@ public class FeedbackTextQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
 
     @Override
     protected void testEditPage() {
-        InstructorFeedbackEditPage feedbackEditPage = loginToFeedbackEditPage();
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
 
         ______TS("verify loaded question");
         FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession");

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseStudentDetailsEditPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseStudentDetailsEditPageSql.java
@@ -49,14 +49,14 @@ public class InstructorCourseStudentDetailsEditPageSql extends AppPage {
     }
 
     public void verifyStudentDetails(Student student) {
-        assertEquals(student.getCourse().getId(), courseId.getText());
+        assertEquals(student.getCourseId(), courseId.getText());
         assertEquals(student.getName(), studentNameTextbox.getAttribute("value"));
         if (student.getSection() == null) {
             assertEquals("None", sectionNameTextbox.getAttribute("value"));
         } else {
-            assertEquals(student.getSection().getName(), sectionNameTextbox.getAttribute("value"));
+            assertEquals(student.getSectionName(), sectionNameTextbox.getAttribute("value"));
         }
-        assertEquals(student.getTeam().getName(), teamNameTextbox.getAttribute("value"));
+        assertEquals(student.getTeamName(), teamNameTextbox.getAttribute("value"));
         assertEquals(student.getEmail(), studentEmailTextbox.getAttribute("value"));
         if (student.getComments() != null) {
             assertEquals(student.getComments(), commentsTextbox.getAttribute("value"));
@@ -65,8 +65,8 @@ public class InstructorCourseStudentDetailsEditPageSql extends AppPage {
 
     public void editStudentDetails(Student newStudent) {
         fillTextBox(studentNameTextbox, newStudent.getName());
-        fillTextBox(sectionNameTextbox, newStudent.getSection().getName());
-        fillTextBox(teamNameTextbox, newStudent.getTeam().getName());
+        fillTextBox(sectionNameTextbox, newStudent.getSectionName());
+        fillTextBox(teamNameTextbox, newStudent.getTeamName());
         if (newStudent.getComments() != null) {
             fillTextBox(commentsTextbox, newStudent.getComments());
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseStudentDetailsViewPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseStudentDetailsViewPageSql.java
@@ -49,8 +49,8 @@ public class InstructorCourseStudentDetailsViewPageSql extends AppPage {
         verifyDetail(student.getName(), studentName);
 
         verifyDetail(student.getCourseId(), courseId);
-        verifyDetail(student.getSection().getName(), studentSectionName);
-        verifyDetail(student.getTeam().getName(), studentTeamName);
+        verifyDetail(student.getSectionName(), studentSectionName);
+        verifyDetail(student.getTeamName(), studentTeamName);
         verifyDetail(student.getEmail(), studentOfficialEmail);
         verifyDetail(student.getComments(), studentComments);
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -33,9 +33,6 @@ import teammates.common.datatransfer.questions.FeedbackRankQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackRubricQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.util.Const;
-import teammates.storage.sqlentity.Course;
-import teammates.storage.sqlentity.FeedbackQuestion;
-import teammates.storage.sqlentity.FeedbackSession;
 import teammates.test.ThreadHelper;
 
 /**
@@ -178,25 +175,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         verifyEmailSettings(feedbackSession);
     }
 
-    public void verifySessionDetails(Course course, FeedbackSession feedbackSession) {
-        waitForElementPresence(By.id("instructions"));
-        assertEquals(getCourseId(), course.getId());
-        assertEquals(getCourseName(), course.getName());
-        assertEquals("UTC", getTimeZone());
-        assertEquals(getFeedbackSessionName(), feedbackSession.getName());
-        assertEquals(getInstructions(), feedbackSession.getInstructions());
-        assertEquals(getStartDate(), getDateString(feedbackSession.getStartTime(), "UTC"));
-        assertEquals(getStartTime(), getTimeString(feedbackSession.getStartTime(), "UTC"));
-        assertEquals(getEndDate(), getDateString(feedbackSession.getEndTime(), "UTC"));
-        assertEquals(getEndTime(), getTimeString(feedbackSession.getEndTime(), "UTC"));
-        assertEquals(getGracePeriod(), feedbackSession.getGracePeriod().toMinutes() + " min");
-        verifySubmissionStatus(feedbackSession);
-        verifyPublishedStatus(feedbackSession);
-        verifyVisibilitySettings(feedbackSession);
-        verifyEmailSettings(feedbackSession);
-
-    }
-
     private void verifySubmissionStatus(FeedbackSessionAttributes feedbackSession) {
         String submissionStatus = getSubmissionStatus();
         if (feedbackSession.isClosed()) {
@@ -208,26 +186,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
     }
 
-    private void verifySubmissionStatus(FeedbackSession feedbackSession) {
-        String submissionStatus = getSubmissionStatus();
-        if (feedbackSession.isClosed()) {
-            assertEquals(submissionStatus, "Closed");
-        } else if (feedbackSession.isVisible() && (feedbackSession.isOpened() || feedbackSession.isInGracePeriod())) {
-            assertEquals(submissionStatus, "Open");
-        } else {
-            assertEquals(submissionStatus, "Awaiting");
-        }
-    }
-
-    private void verifyPublishedStatus(FeedbackSession feedbackSession) {
-        String publishedStatus = getPublishedStatus();
-        if (feedbackSession.isPublished()) {
-            assertEquals(publishedStatus, "Published");
-        } else {
-            assertEquals(publishedStatus, "Not Published");
-        }
-    }
-
     private void verifyPublishedStatus(FeedbackSessionAttributes feedbackSession) {
         String publishedStatus = getPublishedStatus();
         if (feedbackSession.isPublished()) {
@@ -235,20 +193,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         } else {
             assertEquals(publishedStatus, "Not Published");
         }
-    }
-
-    private void verifyVisibilitySettings(FeedbackSession feedbackSession) {
-        Instant sessionVisibleTime = feedbackSession.getSessionVisibleFromTime();
-        Instant responseVisibleTime = feedbackSession.getResultsVisibleFromTime();
-
-        // Default settings, assert setting section not expanded
-        if (sessionVisibleTime.equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)
-                && responseVisibleTime.equals(Const.TIME_REPRESENTS_LATER)) {
-            assertTrue(isElementPresent("btn-change-visibility"));
-            return;
-        }
-        verifySessionVisibilitySettings(sessionVisibleTime, feedbackSession);
-        verifyResponseVisibilitySettings(responseVisibleTime, feedbackSession);
     }
 
     private void verifyVisibilitySettings(FeedbackSessionAttributes feedbackSession) {
@@ -263,19 +207,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
         verifySessionVisibilitySettings(sessionVisibleTime, feedbackSession);
         verifyResponseVisibilitySettings(responseVisibleTime, feedbackSession);
-    }
-
-    private void verifySessionVisibilitySettings(Instant sessionVisibleTime,
-                                                 FeedbackSession feedbackSession) {
-        if (sessionVisibleTime.equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
-            assertTrue(openSessionVisibleTimeButton.isSelected());
-        } else {
-            assertTrue(customSessionVisibleTimeButton.isSelected());
-            assertEquals(getSessionVisibilityDate(), getDateString(feedbackSession.getSessionVisibleFromTime(),
-                    "UTC"));
-            assertEquals(getSessionVisibilityTime(), getTimeString(feedbackSession.getSessionVisibleFromTime(),
-                    "UTC"));
-        }
     }
 
     private void verifySessionVisibilitySettings(Instant sessionVisibleTime,
@@ -303,42 +234,6 @@ public class InstructorFeedbackEditPage extends AppPage {
                     feedbackSession.getTimeZone()));
             assertEquals(getResponseVisibilityTime(), getTimeString(feedbackSession.getResultsVisibleFromTime(),
                     feedbackSession.getTimeZone()));
-        }
-    }
-
-    private void verifyResponseVisibilitySettings(Instant responseVisibleTime,
-                                                  FeedbackSession feedbackSession) {
-        if (responseVisibleTime.equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)) {
-            assertTrue(immediateResponseVisibleTimeButton.isSelected());
-        } else if (responseVisibleTime.equals(Const.TIME_REPRESENTS_LATER)) {
-            assertTrue(manualResponseVisibleTimeButton.isSelected());
-        } else {
-            assertTrue(customSessionVisibleTimeButton.isSelected());
-            assertEquals(getResponseVisibilityDate(), getDateString(feedbackSession.getResultsVisibleFromTime(),
-                    "UTC"));
-            assertEquals(getResponseVisibilityTime(), getTimeString(feedbackSession.getResultsVisibleFromTime(),
-                    "UTC"));
-        }
-    }
-
-    private void verifyEmailSettings(FeedbackSession feedbackSession) {
-        boolean isOpenedEmailEnabled = feedbackSession.isOpenedEmailEnabled();
-        boolean isClosingSoonEmailEnabled = feedbackSession.isClosingSoonEmailEnabled();
-        boolean isPublishedEmailEnabled = feedbackSession.isPublishedEmailEnabled();
-
-        // Default settings, assert setting section not expanded
-        if (isOpenedEmailEnabled && isClosingSoonEmailEnabled && isPublishedEmailEnabled) {
-            assertTrue(isElementPresent("btn-change-email"));
-            return;
-        }
-        if (isOpenedEmailEnabled) {
-            assertTrue(openedSessionEmailCheckbox.isSelected());
-        }
-        if (isClosingSoonEmailEnabled) {
-            assertTrue(closingSoonSessionEmailCheckbox.isSelected());
-        }
-        if (isPublishedEmailEnabled) {
-            assertTrue(publishedSessionEmailCheckbox.isSelected());
         }
     }
 
@@ -374,34 +269,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         click(fsSaveButton);
     }
 
-    public void editSessionDetails(FeedbackSession feedbackSessionDetails, Course course) {
-        click(fsEditButton);
-        setInstructions(feedbackSessionDetails.getInstructions());
-        setSessionStartDateTime(feedbackSessionDetails.getStartTime(), course.getTimeZone());
-        setSessionEndDateTime(feedbackSessionDetails.getEndTime(), course.getTimeZone());
-        selectGracePeriod((int) feedbackSessionDetails.getGracePeriod().toMinutes());
-        setVisibilitySettings(feedbackSessionDetails, course);
-        setEmailSettings(feedbackSessionDetails);
-        click(fsSaveButton);
-    }
-
     public void copySessionToOtherCourse(CourseAttributes otherCourse, String sessionName) {
-        click(fsCopyButton);
-        WebElement copyFsModal = waitForElementPresence(By.id("copy-course-modal"));
-
-        fillTextBox(copyFsModal.findElement(By.id("copy-session-name")), sessionName);
-        List<WebElement> options = copyFsModal.findElements(By.className("form-check"));
-        for (WebElement option : options) {
-            String courseId = option.findElement(By.cssSelector("label span")).getText();
-            if (courseId.equals(otherCourse.getId())) {
-                click(option.findElement(By.tagName("input")));
-                break;
-            }
-        }
-        click(browser.driver.findElement(By.id("btn-confirm-copy-course")));
-    }
-
-    public void copySessionToOtherCourse(Course otherCourse, String sessionName) {
         click(fsCopyButton);
         WebElement copyFsModal = waitForElementPresence(By.id("copy-course-modal"));
 
@@ -465,16 +333,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         verifyQuestionVisibilitySettings(questionNum, feedbackQuestion);
     }
 
-    public void verifyQuestionDetails(int questionNum, FeedbackQuestion feedbackQuestion) {
-        scrollElementToCenter(getQuestionForm(questionNum));
-        assertEquals(feedbackQuestion.getQuestionDetailsCopy().getQuestionType(), getQuestionType(questionNum));
-        assertEquals(feedbackQuestion.getQuestionNumber(), getQuestionNumber(questionNum));
-        assertEquals(feedbackQuestion.getQuestionDetailsCopy().getQuestionText(), getQuestionBrief(questionNum));
-        assertEquals(getQuestionDescription(questionNum), feedbackQuestion.getDescription());
-        verifyFeedbackPathSettings(questionNum, feedbackQuestion);
-        verifyQuestionVisibilitySettings(questionNum, feedbackQuestion);
-    }
-
     private void verifyFeedbackPathSettings(int questionNum, FeedbackQuestionAttributes feedbackQuestion) {
         assertEquals(getDisplayGiverName(feedbackQuestion.getGiverType()), getFeedbackGiver(questionNum));
         String feedbackReceiver = getFeedbackReceiver(questionNum);
@@ -487,17 +345,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
     }
 
-    private void verifyFeedbackPathSettings(int questionNum, FeedbackQuestion feedbackQuestion) {
-        String feedbackPath = getFeedbackPath(questionNum);
-        if (CUSTOM_FEEDBACK_PATH_OPTION.equals(feedbackPath)) {
-            assertEquals(CUSTOM_FEEDBACK_PATH_OPTION, getFeedbackPath(questionNum));
-            return;
-        }
-        String[] feedbackPathParts = feedbackPath.split(FEEDBACK_PATH_SEPARATOR);
-        assertEquals(feedbackPathParts[0], getDisplayGiverName(feedbackQuestion.getGiverType()));
-        assertEquals(feedbackPathParts[1], getDisplayRecipientName(feedbackQuestion.getRecipientType()));
-    }
-
     private void verifyNumberOfEntitiesToGiveFeedbackTo(int questionNum, int numberOfEntitiesToGiveFeedbackTo) {
         WebElement questionForm = getQuestionForm(questionNum);
         WebElement feedbackPathPanel = questionForm.findElement(By.tagName("tm-feedback-path-panel"));
@@ -507,100 +354,6 @@ public class InstructorFeedbackEditPage extends AppPage {
             assertTrue(feedbackPathPanel.findElement(By.id("custom-recipients")).isSelected());
             assertEquals(feedbackPathPanel.findElement(By.id("custom-recipients-number")).getAttribute("value"),
                     Integer.toString(numberOfEntitiesToGiveFeedbackTo));
-        }
-    }
-
-    private void verifyQuestionVisibilitySettings(int questionNum, FeedbackQuestion feedbackQuestion) {
-        WebElement questionForm = getQuestionForm(questionNum);
-        WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
-        String visibility = visibilityPanel.findElement(By.cssSelector("#btn-question-visibility span")).getText();
-        List<FeedbackParticipantType> showResponsesTo = feedbackQuestion.getShowResponsesTo();
-        List<FeedbackParticipantType> showGiverNameTo = feedbackQuestion.getShowGiverNameTo();
-        List<FeedbackParticipantType> showRecipientNameTo = feedbackQuestion.getShowRecipientNameTo();
-
-        switch (visibility) {
-        case "Shown anonymously to recipient and giver's team members, visible to instructors":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.OWN_TEAM_MEMBERS));
-            assertEquals(showResponsesTo.size(), 3);
-
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showGiverNameTo.size(), 1);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showRecipientNameTo.size(), 2);
-            break;
-
-        case "Visible to instructors only":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showResponsesTo.size(), 1);
-
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showGiverNameTo.size(), 1);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showRecipientNameTo.size(), 1);
-            break;
-
-        case "Shown anonymously to recipient and instructors":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showResponsesTo.size(), 2);
-
-            assertEquals(showGiverNameTo.size(), 0);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showRecipientNameTo.size(), 2);
-            break;
-
-        case "Shown anonymously to recipient, visible to instructors":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showResponsesTo.size(), 2);
-
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showGiverNameTo.size(), 1);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showRecipientNameTo.size(), 2);
-            break;
-
-        case "Shown anonymously to recipient and giver/recipient's team members, visible to instructors":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.OWN_TEAM_MEMBERS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS));
-            assertEquals(showResponsesTo.size(), 4);
-
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertEquals(showGiverNameTo.size(), 1);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showRecipientNameTo.size(), 2);
-            break;
-
-        case "Visible to recipient and instructors":
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showResponsesTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showResponsesTo.size(), 2);
-
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showGiverNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showGiverNameTo.size(), 2);
-
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS));
-            assertTrue(showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER));
-            assertEquals(showRecipientNameTo.size(), 2);
-            break;
-
-        default:
-            verifyCustomQuestionVisibility(questionNum, feedbackQuestion);
-            break;
         }
     }
 
@@ -698,20 +451,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
     }
 
-    private void verifyCustomQuestionVisibility(int questionNum, FeedbackQuestion feedbackQuestion) {
-        WebElement questionForm = getQuestionForm(questionNum);
-        WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
-        String visibility = visibilityPanel.findElement(By.cssSelector("#btn-question-visibility span")).getText();
-        assertEquals(visibility, CUSTOM_VISIBILITY_OPTION);
-
-        FeedbackParticipantType giver = feedbackQuestion.getGiverType();
-        FeedbackParticipantType receiver = feedbackQuestion.getRecipientType();
-        WebElement customVisibilityTable = visibilityPanel.findElement(By.id("custom-visibility-table"));
-        assertVisibilityBoxesSelected(customVisibilityTable, giver, receiver, feedbackQuestion.getShowResponsesTo(), 1);
-        assertVisibilityBoxesSelected(customVisibilityTable, giver, receiver, feedbackQuestion.getShowGiverNameTo(), 2);
-        assertVisibilityBoxesSelected(customVisibilityTable, giver, receiver, feedbackQuestion.getShowRecipientNameTo(), 3);
-    }
-
     private void verifyCustomQuestionVisibility(int questionNum, FeedbackQuestionAttributes feedbackQuestion) {
         WebElement questionForm = getQuestionForm(questionNum);
         WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
@@ -800,26 +539,10 @@ public class InstructorFeedbackEditPage extends AppPage {
         clickSaveQuestionButton(questionNum);
     }
 
-    public void editQuestionDetails(int questionNum, FeedbackQuestion feedbackQuestion) {
-        clickEditQuestionButton(questionNum);
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        clickSaveQuestionButton(questionNum);
-    }
-
     private void inputQuestionDetails(int questionNum, FeedbackQuestionAttributes feedbackQuestion) {
         setQuestionBrief(questionNum, feedbackQuestion.getQuestionDetailsCopy().getQuestionText());
         setQuestionDescription(questionNum, feedbackQuestion.getQuestionDescription());
         FeedbackQuestionType questionType = feedbackQuestion.getQuestionType();
-        if (!questionType.equals(FeedbackQuestionType.CONTRIB)) {
-            setFeedbackPath(questionNum, feedbackQuestion);
-            setQuestionVisibility(questionNum, feedbackQuestion);
-        }
-    }
-
-    private void inputQuestionDetails(int questionNum, FeedbackQuestion feedbackQuestion) {
-        setQuestionBrief(questionNum, feedbackQuestion.getQuestionDetailsCopy().getQuestionText());
-        setQuestionDescription(questionNum, feedbackQuestion.getDescription());
-        FeedbackQuestionType questionType = feedbackQuestion.getQuestionDetailsCopy().getQuestionType();
         if (!questionType.equals(FeedbackQuestionType.CONTRIB)) {
             setFeedbackPath(questionNum, feedbackQuestion);
             setQuestionVisibility(questionNum, feedbackQuestion);
@@ -840,16 +563,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public void addTextQuestion(FeedbackQuestionAttributes feedbackQuestion) {
-        addNewQuestion(2);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackTextQuestionDetails questionDetails =
-                (FeedbackTextQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        fillTextBox(getRecommendedTextLengthField(questionNum), questionDetails.getRecommendedLength().toString());
-        clickSaveNewQuestionButton();
-    }
-
-    public void addTextQuestion(FeedbackQuestion feedbackQuestion) {
         addNewQuestion(2);
         int questionNum = getNumQuestions();
         inputQuestionDetails(questionNum, feedbackQuestion);
@@ -885,15 +598,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         clickSaveNewQuestionButton();
     }
 
-    public void addMcqQuestion(FeedbackQuestion feedbackQuestion) {
-        addNewQuestion(3);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackMcqQuestionDetails questionDetails = (FeedbackMcqQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        inputMcqDetails(questionNum, questionDetails);
-        clickSaveNewQuestionButton();
-    }
-
     public void editMcqQuestion(int questionNum, FeedbackMcqQuestionDetails questionDetails) {
         clickEditQuestionButton(questionNum);
         inputMcqDetails(questionNum, questionDetails);
@@ -920,15 +624,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         clickSaveNewQuestionButton();
     }
 
-    public void addMsqQuestion(FeedbackQuestion feedbackQuestion) {
-        addNewQuestion(4);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackMsqQuestionDetails questionDetails = (FeedbackMsqQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        inputMsqDetails(questionNum, questionDetails);
-        clickSaveNewQuestionButton();
-    }
-
     public void editMsqQuestion(int questionNum, FeedbackMsqQuestionDetails msqQuestionDetails) {
         clickEditQuestionButton(questionNum);
         inputMsqDetails(questionNum, msqQuestionDetails);
@@ -945,16 +640,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public void addNumScaleQuestion(FeedbackQuestionAttributes feedbackQuestion) {
-        addNewQuestion(5);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackNumericalScaleQuestionDetails questionDetails =
-                (FeedbackNumericalScaleQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        inputNumScaleDetails(questionNum, questionDetails);
-        clickSaveNewQuestionButton();
-    }
-
-    public void addNumScaleQuestion(FeedbackQuestion feedbackQuestion) {
         addNewQuestion(5);
         int questionNum = getNumQuestions();
         inputQuestionDetails(questionNum, feedbackQuestion);
@@ -1089,16 +774,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         clickSaveNewQuestionButton();
     }
 
-    public void addRubricQuestion(FeedbackQuestion feedbackQuestion) {
-        addNewQuestion(9);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackRubricQuestionDetails questionDetails =
-                (FeedbackRubricQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        inputRubricDetails(questionNum, questionDetails);
-        clickSaveNewQuestionButton();
-    }
-
     public void editRubricQuestion(int questionNum, FeedbackRubricQuestionDetails questionDetails) {
         clickEditQuestionButton(questionNum);
         inputRubricDetails(questionNum, questionDetails);
@@ -1116,16 +791,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public void addRankOptionsQuestion(FeedbackQuestionAttributes feedbackQuestion) {
-        addNewQuestion(10);
-        int questionNum = getNumQuestions();
-        inputQuestionDetails(questionNum, feedbackQuestion);
-        FeedbackRankOptionsQuestionDetails questionDetails =
-                (FeedbackRankOptionsQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
-        inputRankDetails(questionNum, questionDetails);
-        clickSaveNewQuestionButton();
-    }
-
-    public void addRankOptionsQuestion(FeedbackQuestion feedbackQuestion) {
         addNewQuestion(10);
         int questionNum = getNumQuestions();
         inputQuestionDetails(questionNum, feedbackQuestion);
@@ -1265,23 +930,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         setResponseVisibilitySettings(newFeedbackSession);
     }
 
-    private void setVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
-        showVisibilitySettings();
-
-        setSessionVisibilitySettings(newFeedbackSession, course);
-        setResponseVisibilitySettings(newFeedbackSession, course);
-    }
-
-    private void setSessionVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
-        Instant sessionDateTime = newFeedbackSession.getSessionVisibleFromTime();
-        if (sessionDateTime.equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
-            click(openSessionVisibleTimeButton);
-        } else {
-            click(customSessionVisibleTimeButton);
-            setVisibilityDateTime(sessionDateTime, course.getTimeZone());
-        }
-    }
-
     private void setSessionVisibilitySettings(FeedbackSessionAttributes newFeedbackSession) {
         Instant sessionDateTime = newFeedbackSession.getSessionVisibleFromTime();
         if (sessionDateTime.equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
@@ -1289,18 +937,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         } else {
             click(customSessionVisibleTimeButton);
             setVisibilityDateTime(sessionDateTime, newFeedbackSession.getTimeZone());
-        }
-    }
-
-    private void setResponseVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
-        Instant responseDateTime = newFeedbackSession.getResultsVisibleFromTime();
-        if (responseDateTime.equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)) {
-            click(immediateResponseVisibleTimeButton);
-        } else if (responseDateTime.equals(Const.TIME_REPRESENTS_LATER)) {
-            click(manualResponseVisibleTimeButton);
-        } else {
-            click(customResponseVisibleTimeButton);
-            setResponseDateTime(responseDateTime, course.getTimeZone());
         }
     }
 
@@ -1317,19 +953,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     private void setEmailSettings(FeedbackSessionAttributes newFeedbackSessionDetails) {
-        showEmailSettings();
-        if (newFeedbackSessionDetails.isOpenedEmailEnabled() != openedSessionEmailCheckbox.isSelected()) {
-            click(openedSessionEmailCheckbox);
-        }
-        if (newFeedbackSessionDetails.isClosingSoonEmailEnabled() != closingSoonSessionEmailCheckbox.isSelected()) {
-            click(closingSoonSessionEmailCheckbox);
-        }
-        if (newFeedbackSessionDetails.isPublishedEmailEnabled() != publishedSessionEmailCheckbox.isSelected()) {
-            click(publishedSessionEmailCheckbox);
-        }
-    }
-
-    private void setEmailSettings(FeedbackSession newFeedbackSessionDetails) {
         showEmailSettings();
         if (newFeedbackSessionDetails.isOpenedEmailEnabled() != openedSessionEmailCheckbox.isSelected()) {
             click(openedSessionEmailCheckbox);
@@ -1464,32 +1087,6 @@ public class InstructorFeedbackEditPage extends AppPage {
                 getDisplayRecipientName(newRecipient));
     }
 
-    private void setFeedbackPath(int questionNum, FeedbackQuestion feedbackQuestion) {
-        FeedbackParticipantType newGiver = feedbackQuestion.getGiverType();
-        FeedbackParticipantType newRecipient = feedbackQuestion.getRecipientType();
-        String feedbackPath = getFeedbackPath(questionNum);
-        WebElement questionForm = getQuestionForm(questionNum).findElement(By.tagName("tm-feedback-path-panel"));
-        if (!CUSTOM_FEEDBACK_PATH_OPTION.equals(feedbackPath)) {
-            selectFeedbackPathDropdownOption(questionNum, CUSTOM_FEEDBACK_PATH_OPTION + "...");
-        }
-        // Set to type STUDENT first to adjust NumberOfEntitiesToGiveFeedbackTo
-        selectDropdownOptionByText(questionForm.findElement(By.id("giver-type")),
-                getDisplayGiverName(FeedbackParticipantType.STUDENTS));
-        selectDropdownOptionByText(questionForm.findElement(By.id("receiver-type")),
-                getDisplayRecipientName(FeedbackParticipantType.STUDENTS_EXCLUDING_SELF));
-        if (feedbackQuestion.getNumOfEntitiesToGiveFeedbackTo() == Const.MAX_POSSIBLE_RECIPIENTS) {
-            click(questionForm.findElement(By.id("unlimited-recipients")));
-        } else {
-            click(questionForm.findElement(By.id("custom-recipients")));
-            fillTextBox(questionForm.findElement(By.id("custom-recipients-number")),
-                    Integer.toString(feedbackQuestion.getNumOfEntitiesToGiveFeedbackTo()));
-        }
-
-        selectDropdownOptionByText(questionForm.findElement(By.id("giver-type")), getDisplayGiverName(newGiver));
-        selectDropdownOptionByText(questionForm.findElement(By.id("receiver-type")),
-                getDisplayRecipientName(newRecipient));
-    }
-
     private void selectFeedbackPathDropdownOption(int questionNum, String text) {
         WebElement questionForm = getQuestionForm(questionNum);
         WebElement feedbackPathPanel = questionForm.findElement(By.tagName("tm-feedback-path-panel"));
@@ -1515,22 +1112,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     private void setQuestionVisibility(int questionNum, FeedbackQuestionAttributes feedbackQuestion) {
-        WebElement questionForm = getQuestionForm(questionNum);
-        WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
-        String visibility = visibilityPanel.findElement(By.cssSelector("#btn-question-visibility span")).getText();
-        if (!CUSTOM_VISIBILITY_OPTION.equals(visibility)) {
-            selectVisibilityDropdownOption(questionNum, CUSTOM_VISIBILITY_OPTION + "...");
-        }
-
-        FeedbackParticipantType giver = feedbackQuestion.getGiverType();
-        FeedbackParticipantType receiver = feedbackQuestion.getRecipientType();
-        WebElement customVisibilityTable = visibilityPanel.findElement(By.id("custom-visibility-table"));
-        selectVisibilityBoxes(customVisibilityTable, giver, receiver, feedbackQuestion.getShowResponsesTo(), 1);
-        selectVisibilityBoxes(customVisibilityTable, giver, receiver, feedbackQuestion.getShowGiverNameTo(), 2);
-        selectVisibilityBoxes(customVisibilityTable, giver, receiver, feedbackQuestion.getShowRecipientNameTo(), 3);
-    }
-
-    private void setQuestionVisibility(int questionNum, FeedbackQuestion feedbackQuestion) {
         WebElement questionForm = getQuestionForm(questionNum);
         WebElement visibilityPanel = questionForm.findElement(By.tagName("tm-visibility-panel"));
         String visibility = visibilityPanel.findElement(By.cssSelector("#btn-question-visibility span")).getText();

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPageSql.java
@@ -291,7 +291,7 @@ public class InstructorFeedbackEditPageSql extends AppPage {
     }
 
     public FeedbackSubmitPage previewAsStudent(Student student) {
-        selectDropdownOptionByText(previewAsStudentDropdown, String.format("[%s] %s", student.getTeam().getName(),
+        selectDropdownOptionByText(previewAsStudentDropdown, String.format("[%s] %s", student.getTeamName(),
                 student.getName()));
         return previewAsStudent();
     }
@@ -672,6 +672,25 @@ public class InstructorFeedbackEditPageSql extends AppPage {
         }
     }
 
+    public void addConstSumOptionQuestion(FeedbackQuestion feedbackQuestion) {
+        addNewQuestion(6);
+        addConstSumQuestion(feedbackQuestion);
+    }
+
+    public void addConstSumRecipientQuestion(FeedbackQuestion feedbackQuestion) {
+        addNewQuestion(7);
+        addConstSumQuestion(feedbackQuestion);
+    }
+
+    public void addConstSumQuestion(FeedbackQuestion feedbackQuestion) {
+        int questionNum = getNumQuestions();
+        inputQuestionDetails(questionNum, feedbackQuestion);
+        FeedbackConstantSumQuestionDetails questionDetails =
+                (FeedbackConstantSumQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
+        inputConstSumDetails(questionNum, questionDetails);
+        clickSaveNewQuestionButton();
+    }
+
     public void editConstSumQuestion(int questionNum, FeedbackConstantSumQuestionDetails csQuestionDetails) {
         clickEditQuestionButton(questionNum);
         inputConstSumDetails(questionNum, csQuestionDetails);
@@ -684,6 +703,16 @@ public class InstructorFeedbackEditPageSql extends AppPage {
         if (questionDetails.isZeroSum()) {
             assertFalse(questionDetails.isNotSureAllowed());
         }
+    }
+
+    public void addContributionQuestion(FeedbackQuestion feedbackQuestion) {
+        addNewQuestion(8);
+        int questionNum = getNumQuestions();
+        inputQuestionDetails(questionNum, feedbackQuestion);
+        FeedbackContributionQuestionDetails questionDetails =
+                (FeedbackContributionQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
+        inputContributionDetails(questionNum, questionDetails);
+        clickSaveNewQuestionButton();
     }
 
     public void editContributionQuestion(int questionNum, FeedbackContributionQuestionDetails questionDetails) {
@@ -757,6 +786,16 @@ public class InstructorFeedbackEditPageSql extends AppPage {
         inputQuestionDetails(questionNum, feedbackQuestion);
         FeedbackRankOptionsQuestionDetails questionDetails =
                 (FeedbackRankOptionsQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
+        inputRankDetails(questionNum, questionDetails);
+        clickSaveNewQuestionButton();
+    }
+
+    public void addRankRecipientsQuestion(FeedbackQuestion feedbackQuestion) {
+        addNewQuestion(11);
+        int questionNum = getNumQuestions();
+        inputQuestionDetails(questionNum, feedbackQuestion);
+        FeedbackRankQuestionDetails questionDetails =
+                (FeedbackRankQuestionDetails) feedbackQuestion.getQuestionDetailsCopy();
         inputRankDetails(questionNum, questionDetails);
         clickSaveNewQuestionButton();
     }
@@ -872,6 +911,13 @@ public class InstructorFeedbackEditPageSql extends AppPage {
 
     private void selectGracePeriod(long gracePeriodMinutes) {
         selectDropdownOptionByText(gracePeriodDropdown, gracePeriodMinutes + " min");
+    }
+
+    private void setVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
+        showVisibilitySettings();
+
+        setSessionVisibilitySettings(newFeedbackSession, course);
+        setResponseVisibilitySettings(newFeedbackSession, course);
     }
 
     private void setSessionVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
@@ -1101,13 +1147,6 @@ public class InstructorFeedbackEditPageSql extends AppPage {
         for (FeedbackParticipantType participant : participants) {
             markOptionAsSelected(rows.get(possibleTypes.indexOf(participant)).findElements(By.tagName("input")).get(index));
         }
-    }
-
-    private void setVisibilitySettings(FeedbackSession newFeedbackSession, Course course) {
-        showVisibilitySettings();
-
-        setSessionVisibilitySettings(newFeedbackSession, course);
-        setResponseVisibilitySettings(newFeedbackSession, course);
     }
 
     private void selectVisibilityDropdownOption(int questionNum, String text) {
@@ -1601,5 +1640,4 @@ public class InstructorFeedbackEditPageSql extends AppPage {
         inputMaxOptions(questionNum, questionDetails.getMaxOptionsToBeRanked());
         inputMinOptions(questionNum, questionDetails.getMinOptionsToBeRanked());
     }
-
 }


### PR DESCRIPTION
Part of #13324 

- Added missing methods to `InstructorFeedbackEditPageSql`.

- Removed SQL-based methods from `InstructorFeedbackEditPage`.

- Updated all migrated tests to reference `InstructorFeedbackEditPageSql` instead of `InstructorFeedbackEditPage`.

- Cleaned up code in `InstructorCourseStudentDetailsEditPageSql` and `InstructorCourseStudentDetailsViewPageSql`.