### PR TITLE
[#13334] Fix NullPointerException while creating FeedbackSessionData

### DIFF
--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -11,6 +11,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
+import teammates.common.util.HibernateUtil;
 import teammates.common.util.Logger;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.TimeHelper;
@@ -110,6 +111,7 @@ public class CreateFeedbackSessionAction extends Action {
 
             try {
                 feedbackSession = sqlLogic.createFeedbackSession(feedbackSession);
+                HibernateUtil.flushSession();
             } catch (EntityAlreadyExistsException e) {
                 throw new InvalidOperationException("A session named " + feedbackSessionName
                         + " exists already in the course " + course.getName()


### PR DESCRIPTION
Fixes #13334

**Cause:**
When calling `sqlLogic.createFeedbackSession(feedbackSession)` in `CreateFeedbackSessionAction`, the `feedbackSession` entity is persisted but not flushed. As a result, the `createdAt` field, which is annotated with `@CreationTimestamp`, remains `null` in memory because the insert has not yet been committed to the database.

**Solution:**
Call `HibernateUtil.flushSession()` after the `sqlLogic` operation, which calls `persist()` in a function nested deep inside.