### PR TITLE
[#12048] Migrate Tests for AdminNotificationsPageE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/AdminNotificationsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/AdminNotificationsPageE2ETest.java
@@ -1,0 +1,107 @@
+package teammates.e2e.cases.sql;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.NotificationStyle;
+import teammates.common.datatransfer.NotificationTargetUser;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.pageobjects.AdminNotificationsPage;
+import teammates.storage.sqlentity.Notification;
+import teammates.ui.output.NotificationData;
+
+/**
+ * SUT: {@link Const.WebPageURIs#ADMIN_NOTIFICATIONS_PAGE}.
+ */
+public class AdminNotificationsPageE2ETest extends BaseE2ETestCase {
+    private Notification[] notifications = new Notification[2];
+
+    @Override
+    protected void prepareTestData() {
+        testData = doRemoveAndRestoreDataBundle(loadSqlDataBundle("/AdminNotificationsPageE2ETestSql.json"));
+        notifications[0] = testData.notifications.get("notification1");
+        notifications[1] = testData.notifications.get("notification2");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        ______TS("verify loaded data");
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.ADMIN_NOTIFICATIONS_PAGE);
+        AdminNotificationsPage notificationsPage = loginAdminToPage(url, AdminNotificationsPage.class);
+        // Only validates that the notifications are present in the notifications table instead of checking every row
+        // This is because the page will display all notifications in the database, which is not predictable
+        notificationsPage.verifyNotificationsTableRow(notifications[0]);
+        notificationsPage.verifyNotificationsTableRow(notifications[1]);
+        NotificationData notif = getNotification(notifications[0].getId().toString());
+        assertEquals(notif.getNotificationId(), notifications[0].getId().toString());
+        assertEquals(notif.getMessage(), notifications[0].getMessage());
+        assertEquals(notif.getTitle(), notifications[0].getTitle());
+        notif = getNotification(notifications[1].getId().toString());
+        assertEquals(notif.getNotificationId(), notifications[1].getId().toString());
+        assertEquals(notif.getMessage(), notifications[1].getMessage());
+        assertEquals(notif.getTitle(), notifications[1].getTitle());
+
+        ______TS("add new notification");
+        int currentYear = LocalDate.now().getYear();
+        Notification newNotification = new Notification(
+                LocalDateTime.of(currentYear + 5, 2, 2, 12, 0).atZone(ZoneId.of("UTC")).toInstant(),
+                LocalDateTime.of(currentYear + 5, 2, 3, 12, 0).atZone(ZoneId.of("UTC")).toInstant(),
+                NotificationStyle.INFO,
+                NotificationTargetUser.STUDENT,
+                "New E2E test notification 1",
+                "<p>New E2E test notification message</p>"
+                );
+
+        notificationsPage.addNotification(newNotification);
+        notificationsPage.verifyStatusMessage("Notification created successfully.");
+
+        // Replace placeholder ID with actual ID of created notification
+        notificationsPage.sortNotificationsTableByDescendingCreateTime();
+        String newestNotificationId = notificationsPage.getFirstRowNotificationId();
+        newNotification.setId(UUID.fromString(newestNotificationId));
+
+        // Checks that notification is in the database first
+        // so that newNotification is updated with the created time before checking table row
+        notif = getNotification(newestNotificationId);
+        assertEquals(notif.getNotificationId(), newestNotificationId);
+        assertEquals(notif.getMessage(), newNotification.getMessage());
+        assertEquals(notif.getTitle(), newNotification.getTitle());
+        notificationsPage.verifyNotificationsTableRow(newNotification);
+
+        ______TS("edit notification");
+        newNotification.setStartTime(LocalDateTime.of(currentYear + 7, 2, 2, 12, 0).atZone(ZoneId.of("UTC")).toInstant());
+        newNotification.setEndTime(LocalDateTime.of(currentYear + 7, 2, 3, 12, 0).atZone(ZoneId.of("UTC")).toInstant());
+        newNotification.setStyle(NotificationStyle.DANGER);
+        newNotification.setTargetUser(NotificationTargetUser.INSTRUCTOR);
+        newNotification.setTitle("Edited E2E test notification 1");
+        newNotification.setMessage("<p>Edited E2E test notification message</p>");
+
+        notificationsPage.editNotification(newNotification);
+        notificationsPage.verifyStatusMessage("Notification updated successfully.");
+        notificationsPage.verifyNotificationsTableRow(newNotification);
+
+        // verify that notification is present in database by reloading
+        notificationsPage.reloadPage();
+        notificationsPage.verifyNotificationsTableRow(newNotification);
+
+        ______TS("delete notification");
+        notificationsPage.deleteNotification(newNotification);
+        notificationsPage.verifyStatusMessage("Notification has been deleted.");
+        notif = getNotification(newestNotificationId);
+        assertNull(notif);
+    }
+
+    @AfterClass
+    public void classTeardown() {
+        for (Notification notification : testData.notifications.values()) {
+            deleteNotification(notification.getId().toString());
+        }
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 
 import org.testng.ITestContext;
 import org.testng.annotations.AfterClass;
@@ -250,6 +251,20 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
         }
     }
 
+    /**
+     * Puts the documents in the database using BACKDOOR.
+     * @param dataBundle the data to be put in the database
+     * @return the result of the operation
+     */
+    protected String putDocuments(SqlDataBundle dataBundle) {
+        try {
+            return BACKDOOR.putSqlDocuments(dataBundle);
+        } catch (HttpRequestFailedException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     AccountData getAccount(String googleId) {
         return BACKDOOR.getAccountData(googleId);
     }
@@ -295,6 +310,17 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
         return getFeedbackSession(feedbackSession.getCourse().getId(), feedbackSession.getName());
     }
 
+    /**
+     * Checks if the feedback session is published.
+     */
+    protected boolean isFeedbackSessionPublished(FeedbackSessionPublishStatus status) {
+        return status == FeedbackSessionPublishStatus.PUBLISHED;
+    }
+
+    FeedbackSessionData getSoftDeletedSession(String feedbackSessionName, String instructorId) {
+        return BACKDOOR.getSoftDeletedSessionData(feedbackSessionName, instructorId);
+    }
+
     InstructorData getInstructor(String courseId, String instructorEmail) {
         return BACKDOOR.getInstructorData(courseId, instructorEmail);
     }
@@ -313,6 +339,24 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
         return getNotification(notification.getId().toString());
     }
 
+    /**
+     * Deletes the notification with the given ID.
+     *
+     * @param notificationId the ID of the notification to delete
+     */
+    protected void deleteNotification(UUID notificationId) {
+        BACKDOOR.deleteNotification(notificationId);
+    }
+
+    /**
+     * Deletes the notification with the given ID.
+     *
+     * @param notificationId the ID of the notification to delete
+     */
+    protected void deleteNotification(String notificationId) {
+        BACKDOOR.deleteNotification(notificationId);
+    }
+
     StudentData getStudent(String courseId, String studentEmailAddress) {
         return BACKDOOR.getStudentData(courseId, studentEmailAddress);
     }
@@ -320,30 +364,5 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
     @Override
     protected StudentData getStudent(Student student) {
         return getStudent(student.getCourseId(), student.getEmail());
-    }
-
-    /**
-     * Checks if the feedback session is published.
-     */
-    protected boolean isFeedbackSessionPublished(FeedbackSessionPublishStatus status) {
-        return status == FeedbackSessionPublishStatus.PUBLISHED;
-    }
-
-    FeedbackSessionData getSoftDeletedSession(String feedbackSessionName, String instructorId) {
-        return BACKDOOR.getSoftDeletedSessionData(feedbackSessionName, instructorId);
-    }
-
-    /**
-     * Puts the documents in the database using BACKDOOR.
-     * @param dataBundle the data to be put in the database
-     * @return the result of the operation
-     */
-    protected String putDocuments(SqlDataBundle dataBundle) {
-        try {
-            return BACKDOOR.putSqlDocuments(dataBundle);
-        } catch (HttpRequestFailedException e) {
-            e.printStackTrace();
-            return null;
-        }
     }
 }

--- a/src/e2e/resources/data/AdminNotificationsPageE2ETestSql.json
+++ b/src/e2e/resources/data/AdminNotificationsPageE2ETestSql.json
@@ -1,0 +1,26 @@
+{
+  "notifications": {
+    "notification1": {
+      "id": "00000000-0000-4000-8000-000000001103",
+      "startTime": "2011-01-01T00:00:00Z",
+      "endTime": "2099-01-01T00:00:00Z",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "style": "DANGER",
+      "targetUser": "GENERAL",
+      "title": "A deprecation note",
+      "message": "<p>Deprecation happens in three minutes</p>",
+      "shown": false
+    },
+    "notification2": {
+      "id": "00000000-0000-4000-8000-000000001103",
+      "startTime": "2011-02-02T00:00:00Z",
+      "endTime": "2099-02-02T00:00:00Z",
+      "createdAt": "2011-01-01T00:00:00Z",
+      "style": "SUCCESS",
+      "targetUser": "STUDENT",
+      "title": "A note for update",
+      "message": "<p>Exciting features</p>",
+      "shown": false
+    }
+  }
+}

--- a/src/e2e/resources/testng-e2e-sql.xml
+++ b/src/e2e/resources/testng-e2e-sql.xml
@@ -6,30 +6,32 @@
             <package name="teammates.e2e.util" />
         </packages>
         <classes>
-            <class name="teammates.e2e.cases.sql.FeedbackResultsPageE2ETest" />
+            <!-- Keep E2E tests in alphabetical order -->
+            <class name="teammates.e2e.cases.sql.AdminAccountsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.AdminHomePageE2ETest" />
+            <class name="teammates.e2e.cases.sql.AdminNotificationsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.AdminSearchPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackConstSumRecipientQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackMcqQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackMsqQuestionE2ETest" />
-            <class name="teammates.e2e.cases.sql.FeedbackTextQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackNumScaleQuestionE2ETest" />
-            <class name="teammates.e2e.cases.sql.FeedbackRubricQuestionE2ETest" />
-            <class name="teammates.e2e.cases.sql.FeedbackConstSumRecipientQuestionE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorStudentRecordsPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorCourseDetailsPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorFeedbackEditPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorStudentListPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.StudentHomePageE2ETest" />
-            <class name="teammates.e2e.cases.sql.StudentCourseJoinConfirmationPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.AdminSearchPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.AdminHomePageE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackRankOptionQuestionE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorHomePageE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackResultsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackRubricQuestionE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackTextQuestionE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorCourseDetailsPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseEnrollPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.InstructorNotificationsPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.StudentCourseDetailsPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.RequestPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsEditPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsPageE2ETest" />
-            <class name="teammates.e2e.cases.sql.AdminAccountsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorFeedbackEditPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorHomePageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorNotificationsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorStudentListPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorStudentRecordsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.RequestPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.StudentCourseDetailsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.StudentCourseJoinConfirmationPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.StudentHomePageE2ETest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

- Migrated `AdminNotificationsPageE2ETest` to use SQL-based logic instead of the previous Datastore model.

- Alphabetize E2E tests in `testng-e2e-sql.xml`.