### PR TITLE
[#12048] Migrate Tests for FeedbackConstSumOptionQuestionE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackConstSumOptionQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackConstSumOptionQuestionE2ETest.java
@@ -1,0 +1,127 @@
+package teammates.e2e.cases.sql;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.questions.FeedbackConstantSumQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackConstantSumResponseDetails;
+import teammates.e2e.pageobjects.FeedbackSubmitPageSql;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Team;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_EDIT_PAGE}, {@link Const.WebPageURIs#SESSION_SUBMISSION_PAGE}
+ *      specifically for ConstSumOption questions.
+ */
+public class FeedbackConstSumOptionQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
+    // Recipient of responses
+    Team otherTeam;
+
+    @Override
+    protected void prepareTestData() {
+        testData = doRemoveAndRestoreDataBundle(
+                loadSqlDataBundle("/FeedbackConstSumOptionQuestionE2ETestSql.json"));
+
+        instructor = testData.instructors.get("instructor");
+        course = testData.courses.get("course");
+        feedbackSession = testData.feedbackSessions.get("openSession");
+        student = testData.students.get("alice.tmms@FCSumOptQn.CS2104");
+        otherTeam = testData.teams.get("ProgrammingLanguageConceptsTeam2");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        testEditPage();
+        logout();
+        testSubmitPage();
+    }
+
+    @Override
+    protected void testEditPage() {
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
+
+        ______TS("verify loaded question");
+        FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession")
+                .makeDeepCopy(feedbackSession);
+        FeedbackConstantSumQuestionDetails questionDetails =
+                (FeedbackConstantSumQuestionDetails) loadedQuestion.getQuestionDetailsCopy();
+        feedbackEditPage.verifyConstSumQuestionDetails(1, questionDetails);
+
+        ______TS("add new question");
+        // add new question exactly like loaded question
+        loadedQuestion.setQuestionNumber(2);
+        feedbackEditPage.addConstSumOptionQuestion(loadedQuestion);
+
+        feedbackEditPage.verifyConstSumQuestionDetails(2, questionDetails);
+        verifyPresentInDatabase(loadedQuestion);
+
+        ______TS("copy question");
+        FeedbackQuestion copiedQuestion = testData.feedbackQuestions.get("qn1ForSecondSession");
+        questionDetails = (FeedbackConstantSumQuestionDetails) copiedQuestion.getQuestionDetailsCopy();
+        feedbackEditPage.copyQuestion(copiedQuestion.getCourseId(),
+                copiedQuestion.getQuestionDetailsCopy().getQuestionText());
+        copiedQuestion.getFeedbackSession().setCourse(course);
+        copiedQuestion.setFeedbackSession(feedbackSession);
+        copiedQuestion.setQuestionNumber(3);
+
+        feedbackEditPage.verifyConstSumQuestionDetails(3, questionDetails);
+        verifyPresentInDatabase(copiedQuestion);
+
+        ______TS("edit question");
+        questionDetails = (FeedbackConstantSumQuestionDetails) loadedQuestion.getQuestionDetailsCopy();
+        List<String> options = questionDetails.getConstSumOptions();
+        options.add("Edited option.");
+        questionDetails.setConstSumOptions(options);
+        questionDetails.setPointsPerOption(true);
+        questionDetails.setPoints(1000);
+        questionDetails.setDistributePointsFor("At least some options");
+        loadedQuestion.setQuestionDetails(questionDetails);
+        feedbackEditPage.editConstSumQuestion(2, questionDetails);
+        feedbackEditPage.waitForPageToLoad();
+
+        feedbackEditPage.verifyConstSumQuestionDetails(2, questionDetails);
+        verifyPresentInDatabase(loadedQuestion);
+    }
+
+    @Override
+    protected void testSubmitPage() {
+        FeedbackSubmitPageSql feedbackSubmitPage = loginToFeedbackSubmitPage();
+
+        ______TS("verify loaded question");
+        FeedbackQuestion question = testData.feedbackQuestions.get("qn1ForFirstSession");
+        feedbackSubmitPage.verifyConstSumQuestion(1, "",
+                (FeedbackConstantSumQuestionDetails) question.getQuestionDetailsCopy());
+
+        ______TS("submit response");
+        FeedbackResponse response = getResponse(question, Arrays.asList(50, 20, 30));
+        feedbackSubmitPage.fillConstSumOptionResponse(1, "", response);
+        feedbackSubmitPage.clickSubmitQuestionButton(1);
+
+        verifyPresentInDatabase(response);
+
+        ______TS("check previous response");
+        feedbackSubmitPage = getFeedbackSubmitPage();
+        feedbackSubmitPage.verifyConstSumOptionResponse(1, "", response);
+
+        ______TS("edit response");
+        response = getResponse(question, Arrays.asList(23, 47, 30));
+        feedbackSubmitPage.fillConstSumOptionResponse(1, "", response);
+        feedbackSubmitPage.clickSubmitQuestionButton(1);
+
+        feedbackSubmitPage = getFeedbackSubmitPage();
+        feedbackSubmitPage.verifyConstSumOptionResponse(1, "", response);
+        verifyPresentInDatabase(response);
+    }
+
+    private FeedbackResponse getResponse(FeedbackQuestion question, List<Integer> answers) {
+        FeedbackConstantSumResponseDetails details = new FeedbackConstantSumResponseDetails();
+        details.setAnswers(answers);
+        return FeedbackResponse.makeResponse(question, student.getEmail(),
+                student.getSection(), otherTeam.getName(), student.getSection(), details);
+    }
+}

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETestSql.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETestSql.json
@@ -1,0 +1,305 @@
+{
+  "accounts": {
+    "instructorWithSessions": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "googleId": "tm.e2e.FCSumOptQn.instructor",
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt"
+    },
+    "tm.e2e.FMcqQn.alice.tmms": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "googleId": "tm.e2e.FCSumOptQn.alice.tmms",
+      "name": "Alice Betsy",
+      "email": "alice.b.tmms@gmail.tmt"
+    },
+    "tm.e2e.FMcqQn.benny.tmms": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "googleId": "tm.e2e.FCSumOptQn.benny.tmms",
+      "name": "Benny Charles",
+      "email": "benny.c.tmms@gmail.tmt"
+    }
+  },
+  "courses": {
+    "course": {
+      "id": "tm.e2e.FCSumOptQn.CS2104",
+      "name": "Programming Language Concepts",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg"
+    },
+    "course2": {
+      "id": "tm.e2e.FCSumOptQn.CS1101",
+      "name": "Programming Methodology",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg"
+    }
+  },
+  "instructors": {
+    "instructor": {
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000501",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "displayName": "Co-owner"
+    },
+    "instructor2": {
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000502",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS1101"
+      },
+      "displayName": "Co-owner"
+    }
+  },
+  "students": {
+    "alice.tmms@FCSumOptQn.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000601",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000002"
+      },
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "alice.b.tmms@gmail.tmt",
+      "name": "Alice Betsy",
+      "comments": "This student's name is Alice Betsy"
+    },
+    "benny.tmms@FCSumOptQn.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000602",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000003"
+      },
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "email": "benny.tmms@gmail.tmt",
+      "name": "Benny Charles",
+      "comments": "This student's name is Benny Charles"
+    },
+    "charlie.tmms@FCSumOptQn.CS1101": {
+      "id": "00000000-0000-4000-8000-000000000603",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS1101"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000203"
+      },
+      "email": "charlie.tmms@gmail.tmt",
+      "name": "Charlie Davis",
+      "comments": "This student's name is Charlie Davis"
+    }
+  },
+  "sections": {
+    "ProgrammingLanguageConceptsNone": {
+      "id": "00000000-0000-4000-8000-000000000101",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "name": "None"
+    },
+    "ProgrammingMethodologyNone": {
+      "id": "00000000-0000-4000-8000-000000000102",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS1101"
+      },
+      "name": "None"
+    }
+  },
+  "teams": {
+    "ProgrammingLanguageConceptsTeam1": {
+      "id": "00000000-0000-4000-8000-000000000201",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000101"
+      },
+      "name": "Team 1"
+    },
+    "ProgrammingLanguageConceptsTeam2": {
+      "id": "00000000-0000-4000-8000-000000000202",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000101"
+      },
+      "name": "Team 2"
+    },
+    "ProgrammingMethodologyTeam1": {
+      "id": "00000000-0000-4000-8000-000000000203",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000102"
+      },
+      "name": "Team 1"
+    }
+  },
+  "feedbackSessions": {
+    "openSession": {
+      "creatorEmail": "tmms.test@gmail.tmt",
+      "instructions": "<p>Instructions for first session</p>",
+      "createdAt": "2012-04-01T23:59:00Z",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2026-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-04-01T22:00:00Z",
+      "resultsVisibleFromTime": "2026-05-01T22:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {},
+      "instructorDeadlines": {},
+      "id": "00000000-0000-4000-8000-000000000701",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "name": "First Session"
+    },
+    "openSession2": {
+      "creatorEmail": "tmms.test@gmail.tmt",
+      "instructions": "<p>Instructions for second session</p>",
+      "createdAt": "2012-04-01T23:59:00Z",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2026-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-04-01T22:00:00Z",
+      "resultsVisibleFromTime": "2026-05-01T22:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {},
+      "instructorDeadlines": {},
+      "id": "00000000-0000-4000-8000-000000000702",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS1101"
+      },
+      "name": "Second Session"
+    }
+  },
+  "feedbackQuestions": {
+    "qn1ForFirstSession": {
+      "id": "00000000-0000-4000-8000-000000000801",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionDetails": {
+        "questionText": "How well did you do in each area? Give points accordingly.",
+        "questionType": "CONSTSUM_OPTIONS",
+        "points": 100,
+        "constSumOptions": [
+          "Teamwork",
+          "Creativity",
+          "Leadership"
+        ],
+        "distributeToRecipients": false,
+        "forceUnevenDistribution": true,
+        "distributePointsFor": "All options",
+        "pointsPerOption": false
+      },
+      "description": "<p>Testing description for first session</p>",
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    },
+    "qn1ForSecondSession": {
+      "id": "00000000-0000-4000-8000-000000000802",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000702"
+      },
+      "questionDetails": {
+        "questionText": "How much did you contribute to this area? Give points accordingly.",
+        "questionType": "CONSTSUM_OPTIONS",
+        "points": 20,
+        "constSumOptions": [
+          "Algo",
+          "UI",
+          "Testing"
+        ],
+        "distributeToRecipients": false,
+        "forceUnevenDistribution": false,
+        "distributePointsFor": "None",
+        "pointsPerOption": true
+      },
+      "description": "<p>Testing description for second session</p>",
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "TEAMS_EXCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    }
+  },
+  "feedbackResponses": {},
+  "feedbackResponseComments": {}
+}

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETestSql.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETestSql.json
@@ -6,13 +6,13 @@
       "name": "Teammates Test",
       "email": "tmms.test@gmail.tmt"
     },
-    "tm.e2e.FMcqQn.alice.tmms": {
+    "tm.e2e.FCSumOptQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FCSumOptQn.alice.tmms",
       "name": "Alice Betsy",
       "email": "alice.b.tmms@gmail.tmt"
     },
-    "tm.e2e.FMcqQn.benny.tmms": {
+    "tm.e2e.FCSumOptQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FCSumOptQn.benny.tmms",
       "name": "Benny Charles",
@@ -176,6 +176,11 @@
   },
   "feedbackSessions": {
     "openSession": {
+      "id": "00000000-0000-4000-8000-000000000701",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS2104"
+      },
+      "name": "First Session",
       "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
@@ -193,14 +198,14 @@
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
       "studentDeadlines": {},
-      "instructorDeadlines": {},
-      "id": "00000000-0000-4000-8000-000000000701",
-      "course": {
-        "id": "tm.e2e.FCSumOptQn.CS2104"
-      },
-      "name": "First Session"
+      "instructorDeadlines": {}
     },
     "openSession2": {
+      "id": "00000000-0000-4000-8000-000000000702",
+      "course": {
+        "id": "tm.e2e.FCSumOptQn.CS1101"
+      },
+      "name": "Second Session",
       "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
@@ -218,12 +223,7 @@
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
       "studentDeadlines": {},
-      "instructorDeadlines": {},
-      "id": "00000000-0000-4000-8000-000000000702",
-      "course": {
-        "id": "tm.e2e.FCSumOptQn.CS1101"
-      },
-      "name": "Second Session"
+      "instructorDeadlines": {}
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/testng-e2e-sql.xml
+++ b/src/e2e/resources/testng-e2e-sql.xml
@@ -13,6 +13,7 @@
             <class name="teammates.e2e.cases.sql.AdminSearchPageE2ETest" />
             <class name="teammates.e2e.cases.sql.AdminSessionsPageE2ETest" />
             <class name="teammates.e2e.cases.sql.AutomatedSessionRemindersE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackConstSumOptionQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackConstSumRecipientQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackMcqQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackMsqQuestionE2ETest" />


### PR DESCRIPTION
Part of #12048

**Outline of Solution**

- Migrated `FeedbackConstSumOptionQuestionE2ETest` to use SQL-based logic instead of the previous Datastore model.