### PR TITLE
[#12048] Migrate Tests for FeedbackRankRecipientQuestionE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankRecipientQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/FeedbackRankRecipientQuestionE2ETest.java
@@ -1,0 +1,131 @@
+package teammates.e2e.cases.sql;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.questions.FeedbackRankQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackRankRecipientsQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackRankRecipientsResponseDetails;
+import teammates.common.util.Const;
+import teammates.e2e.pageobjects.FeedbackSubmitPageSql;
+import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.FeedbackResponse;
+import teammates.storage.sqlentity.Instructor;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_SESSION_EDIT_PAGE}, {@link Const.WebPageURIs#SESSION_SUBMISSION_PAGE}
+ *      specifically for RankRecipient questions.
+ */
+public class FeedbackRankRecipientQuestionE2ETest extends BaseFeedbackQuestionE2ETest {
+
+    @Override
+    protected void prepareTestData() {
+        testData = doRemoveAndRestoreDataBundle(
+                loadSqlDataBundle("/FeedbackRankRecipientQuestionE2ETestSql.json"));
+
+        instructor = testData.instructors.get("instructor");
+        course = testData.courses.get("course");
+        feedbackSession = testData.feedbackSessions.get("openSession");
+        student = testData.students.get("alice.tmms@FRankRcptQn.CS2104");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        testEditPage();
+        logout();
+        testSubmitPage();
+    }
+
+    @Override
+    protected void testEditPage() {
+        InstructorFeedbackEditPageSql feedbackEditPage = loginToFeedbackEditPage();
+
+        ______TS("verify loaded question");
+        FeedbackQuestion loadedQuestion = testData.feedbackQuestions.get("qn1ForFirstSession")
+                .makeDeepCopy(feedbackSession);
+        FeedbackRankRecipientsQuestionDetails questionDetails =
+                (FeedbackRankRecipientsQuestionDetails) loadedQuestion.getQuestionDetailsCopy();
+        feedbackEditPage.verifyRankQuestionDetails(1, questionDetails);
+
+        ______TS("add new question");
+        // add new question exactly like loaded question
+        loadedQuestion.setQuestionNumber(2);
+        feedbackEditPage.addRankRecipientsQuestion(loadedQuestion);
+
+        feedbackEditPage.verifyRankQuestionDetails(2, questionDetails);
+        verifyPresentInDatabase(loadedQuestion);
+
+        ______TS("copy question");
+        FeedbackQuestion copiedQuestion = testData.feedbackQuestions.get("qn1ForSecondSession");
+        questionDetails = (FeedbackRankRecipientsQuestionDetails) copiedQuestion.getQuestionDetailsCopy();
+        feedbackEditPage.copyQuestion(copiedQuestion.getCourseId(),
+                copiedQuestion.getQuestionDetailsCopy().getQuestionText());
+        copiedQuestion.getFeedbackSession().setCourse(course);
+        copiedQuestion.setFeedbackSession(feedbackSession);
+        copiedQuestion.setQuestionNumber(3);
+
+        feedbackEditPage.verifyRankQuestionDetails(3, questionDetails);
+        verifyPresentInDatabase(copiedQuestion);
+
+        ______TS("edit question");
+        questionDetails = (FeedbackRankRecipientsQuestionDetails) loadedQuestion.getQuestionDetailsCopy();
+        questionDetails.setAreDuplicatesAllowed(false);
+        questionDetails.setMaxOptionsToBeRanked(3);
+        questionDetails.setMinOptionsToBeRanked(Const.POINTS_NO_VALUE);
+        loadedQuestion.setQuestionDetails(questionDetails);
+        feedbackEditPage.editRankQuestion(2, questionDetails);
+        feedbackEditPage.waitForPageToLoad();
+
+        feedbackEditPage.verifyRankQuestionDetails(2, questionDetails);
+        verifyPresentInDatabase(loadedQuestion);
+    }
+
+    @Override
+    protected void testSubmitPage() {
+        FeedbackSubmitPageSql feedbackSubmitPage = loginToFeedbackSubmitPage();
+
+        ______TS("verify loaded question");
+        FeedbackQuestion question = testData.feedbackQuestions.get("qn1ForFirstSession");
+        Instructor receiver = testData.instructors.get("instructor");
+        Instructor receiver2 = testData.instructors.get("instructor2");
+        feedbackSubmitPage.verifyRankQuestion(1, receiver.getName(),
+                (FeedbackRankQuestionDetails) question.getQuestionDetailsCopy());
+
+        ______TS("submit response");
+        FeedbackResponse response = getResponse(question, receiver, 1);
+        FeedbackResponse response2 = getResponse(question, receiver2, 2);
+        List<FeedbackResponse> responses = Arrays.asList(response, response2);
+        feedbackSubmitPage.fillRankRecipientResponse(1, responses);
+        feedbackSubmitPage.clickSubmitQuestionButton(1);
+
+        verifyPresentInDatabase(response);
+        verifyPresentInDatabase(response2);
+
+        ______TS("check previous response");
+        feedbackSubmitPage = getFeedbackSubmitPage();
+        feedbackSubmitPage.verifyRankRecipientResponse(1, responses);
+
+        ______TS("edit response");
+        response = getResponse(question, receiver, Const.POINTS_NOT_SUBMITTED);
+        response2 = getResponse(question, receiver2, 1);
+        responses = Arrays.asList(response, response2);
+        feedbackSubmitPage.fillRankRecipientResponse(1, responses);
+        feedbackSubmitPage.clickSubmitQuestionButton(1);
+
+        feedbackSubmitPage = getFeedbackSubmitPage();
+        feedbackSubmitPage.verifyRankRecipientResponse(1, responses);
+        verifyAbsentInDatabase(response);
+        verifyPresentInDatabase(response2);
+    }
+
+    private FeedbackResponse getResponse(FeedbackQuestion question, Instructor receiver, int answer) {
+        FeedbackRankRecipientsResponseDetails details = new FeedbackRankRecipientsResponseDetails();
+        details.setAnswer(answer);
+        return FeedbackResponse.makeResponse(question, student.getEmail(),
+                student.getSection(), receiver.getEmail(), receiver.getSection(), details);
+    }
+}

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETestSql.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETestSql.json
@@ -1,0 +1,343 @@
+{
+  "accounts": {
+    "instructor": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "googleId": "tm.e2e.FRankRcptQn.instructor",
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt"
+    },
+    "instructor2": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "googleId": "tm.e2e.FRankRcptQn.instructor2",
+      "name": "Teammates Test 2",
+      "email": "tmms.test2@gmail.tmt"
+    },
+    "tm.e2e.FRankRcptQn.alice.tmms": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "googleId": "tm.e2e.FRankRcptQn.alice.tmms",
+      "name": "Alice Betsy",
+      "email": "alice.b.tmms@gmail.tmt"
+    },
+    "tm.e2e.FRankRcptQn.benny.tmms": {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "googleId": "tm.e2e.FRankRcptQn.benny.tmms",
+      "name": "Benny Charles",
+      "email": "benny.c.tmms@gmail.tmt"
+    },
+    "tm.e2e.FRankRcptQn.charlie.tmms": {
+      "id": "00000000-0000-4000-8000-000000000005",
+      "googleId": "tm.e2e.FRankRcptQn.charlie.tmms",
+      "name": "Charlie Davis",
+      "email": "charlie.d.tmms@gmail.tmt"
+    },
+    "tm.e2e.FRankRcptQn.danny.tmms": {
+      "id": "00000000-0000-4000-8000-000000000006",
+      "googleId": "tm.e2e.FRankRcptQn.danny.tmms",
+      "name": "Danny Engrid",
+      "email": "danny.e.tmms@gmail.tmt"
+    }
+  },
+  "courses": {
+    "course": {
+      "id": "tm.e2e.FRankRcptQn.CS2104",
+      "name": "Programming Language Concepts",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg"
+    },
+    "course2": {
+      "id": "tm.e2e.FRankRcptQn.CS1101",
+      "name": "Programming Methodology",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg"
+    }
+  },
+  "instructors": {
+    "instructor": {
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor2": {
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000002"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "name": "Teammates Test 2",
+      "email": "tmms.test2@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor3": {
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS1101"
+      },
+      "name": "Teammates Test",
+      "email": "tmms.test@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    }
+  },
+  "students": {
+    "alice.tmms@FRankRcptQn.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000601",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000003"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "alice.b.tmms@gmail.tmt",
+      "name": "Alice Betsy",
+      "comments": "This student's name is Alice Betsy"
+    },
+    "benny.tmms@FRankRcptQn.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000602",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000004"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "benny.tmms@gmail.tmt",
+      "name": "Benny Charles",
+      "comments": "This student's name is Benny Charles"
+    },
+    "charlie.tmms@FRankRcptQn.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000603",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000005"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "FRankRcptQn.charlie.tmms@gmail.tmt",
+      "name": "Charlie Davis",
+      "comments": "This student's name is Charlie Davis"
+    },
+    "danny.tmms@FRankRcptQn.CS1101": {
+      "id": "00000000-0000-4000-8000-000000000604",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000006"
+      },
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS1101"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "email": "FRankRcptQn.danny.tmms@gmail.tmt",
+      "name": "Danny Engrid",
+      "comments": "This student's name is Danny Engrid"
+    }
+  },
+  "sections": {
+    "CS2104None": {
+      "id": "00000000-0000-4000-8000-000000000101",
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "name": "None"
+    },
+    "CS1101None": {
+      "id": "00000000-0000-4000-8000-000000000102",
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS1101"
+      },
+      "name": "None"
+    }
+  },
+  "teams": {
+    "CS2104Team1": {
+      "id": "00000000-0000-4000-8000-000000000201",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000101"
+      },
+      "name": "Team 1"
+    },
+    "CS1101Team1": {
+      "id": "00000000-0000-4000-8000-000000000202",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000102"
+      },
+      "name": "Team 1"
+    }
+  },
+  "feedbackSessions": {
+    "openSession": {
+      "id": "00000000-0000-4000-8000-000000000701",
+      "name": "First Session",
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS2104"
+      },
+      "creatorEmail": "tmms.test@gmail.tmt",
+      "instructions": "<p>Instructions for first session</p>",
+      "createdAt": "2012-04-01T23:59:00Z",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2026-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-04-01T22:00:00Z",
+      "resultsVisibleFromTime": "2026-05-01T22:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
+    },
+    "openSession2": {
+      "id": "00000000-0000-4000-8000-000000000702",
+      "name": "Second Session",
+      "course": {
+        "id": "tm.e2e.FRankRcptQn.CS1101"
+      },
+      "creatorEmail": "tmms.test@gmail.tmt",
+      "instructions": "<p>Instructions for Second session</p>",
+      "createdAt": "2012-04-01T23:59:00Z",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2026-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-04-01T22:00:00Z",
+      "resultsVisibleFromTime": "2026-05-01T22:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
+    }
+  },
+  "feedbackQuestions": {
+    "qn1ForFirstSession": {
+      "id": "00000000-0000-4000-8000-000000000801",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionDetails": {
+        "areDuplicatesAllowed": true,
+        "questionType": "RANK_RECIPIENTS",
+        "questionText": "Rank your instructors by approachability.",
+        "minOptionsToBeRanked": 1
+      },
+      "description": "<p>Testing description for first session</p>",
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "INSTRUCTORS",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    },
+    "qn1ForSecondSession": {
+      "id": "00000000-0000-4000-8000-000000000802",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000702"
+      },
+      "questionDetails": {
+        "areDuplicatesAllowed": false,
+        "questionType": "RANK_RECIPIENTS",
+        "questionText": "Rank your instructors by knowledge.",
+        "maxOptionsToBeRanked": 3
+      },
+      "description": "<p>Testing description for second session</p>",
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "INSTRUCTORS",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    }
+  },
+  "feedbackResponses": {},
+  "feedbackResponseComments": {}
+}

--- a/src/e2e/resources/testng-e2e-sql.xml
+++ b/src/e2e/resources/testng-e2e-sql.xml
@@ -18,6 +18,7 @@
             <class name="teammates.e2e.cases.sql.FeedbackMsqQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackNumScaleQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackRankOptionQuestionE2ETest" />
+            <class name="teammates.e2e.cases.sql.FeedbackRankRecipientQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackResultsPageE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackRubricQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackTextQuestionE2ETest" />

--- a/src/main/java/teammates/storage/sqlentity/questions/FeedbackRankRecipientsQuestion.java
+++ b/src/main/java/teammates/storage/sqlentity/questions/FeedbackRankRecipientsQuestion.java
@@ -51,7 +51,7 @@ public class FeedbackRankRecipientsQuestion extends FeedbackQuestion {
                 newFeedbackSession, this.getQuestionNumber(), this.getDescription(), this.getGiverType(),
                 this.getRecipientType(), this.getNumOfEntitiesToGiveFeedbackTo(), new ArrayList<>(this.getShowResponsesTo()),
                 new ArrayList<>(this.getShowGiverNameTo()), new ArrayList<>(this.getShowRecipientNameTo()),
-                new FeedbackRankRecipientsQuestionDetails(this.questionDetails.getQuestionText())
+                this.questionDetails.getDeepCopy()
         );
     }
 


### PR DESCRIPTION
Part of #12048 

**Outline of Solution**

- Migrated `FeedbackRankRecipientQuestionE2ETest` to use SQL-based logic instead of the previous Datastore model.

- Changed `makeDeepCopy` in `FeedbackRankRecipientQuestion` to use `questionDetails.getDeepCopy()` to preserve all properties.