### PR TITLE
[#12679] Copying feedback session: Name for copied session should not be whitespace

### DIFF
--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -12,7 +12,7 @@
         <label><b>Name for copied session*</b></label>
         <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
                required #newSessionName="ngModel">
-        <div [hidden]="newSessionName.valid || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
+        <div [hidden]="isValidSessionName || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             The field "Name for copied session" should not be empty.
         </div>

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -35,5 +35,5 @@
 <div class="modal-footer">
   <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">Cancel</button>
   <button id="btn-confirm-copy-course" type="button" class="btn btn-primary" (click)="copy()"
-          [disabled]="!newFeedbackSessionName || copyToCourseSet.size < 1">Copy</button>
+          [disabled]="!isValidSessionName || copyToCourseSet.size < 1">Copy</button>
 </div>

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -146,4 +146,13 @@ describe('CopySessionModalComponent', () => {
     expect(component.copyToCourseSet.has(courseId)).toBe(false);
   });
 
+  it('should disable copy button if session name is only whitespace', () => {
+    component.newFeedbackSessionName = '     ';
+    component.courseCandidates = [courseCopyTo];
+    component.copyToCourseSet.add(courseCopyTo.courseId);
+    fixture.detectChanges();
+
+    const copyButton: HTMLButtonElement = fixture.debugElement.query(By.css('#btn-confirm-copy-course')).nativeElement;
+    expect(copyButton.disabled).toBe(true);
+  })
 });

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -48,4 +48,11 @@ export class CopySessionModalComponent {
       this.copyToCourseSet.add(courseId);
     }
   }
+
+  /**
+   * Checks if session name is valid.
+   */
+  get isValidSessionName(): boolean {
+    return this.newFeedbackSessionName.trim().length > 0;
+  }
 }


### PR DESCRIPTION
Fixes #12679

**Outline of Solution**

- Added frontend validation to disable the "Copy" button when the copied session name only consists of whitespace.
- Adjusted the validation logic of the modal input to use trimming.
- Improved error display to show error when copied session name only consists of whitespace.
- Added the corresponding unit test in 'copy-session-modal.component.spec.ts'.

![telegram-cloud-photo-size-5-6253740732988901207-y](https://github.com/user-attachments/assets/81041b61-a201-4cf9-861a-a3d826d1d7ce)
