### PR TITLE
[#12048] Migrate Tests for InstructorCourseEditPageE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/InstructorCourseEditPageE2ETest.java
@@ -1,0 +1,158 @@
+package teammates.e2e.cases.sql;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.InstructorPermissionRole;
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.pageobjects.InstructorCourseEditPageSql;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+
+/**
+ * SUT: {@link Const.WebPageURIs#INSTRUCTOR_COURSE_EDIT_PAGE}.
+ */
+public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
+    Course course;
+    Instructor[] instructors = new Instructor[5];
+
+    @Override
+    protected void prepareTestData() {
+        testData = removeAndRestoreDataBundle(loadSqlDataBundle("/InstructorCourseEditPageE2ETestSql.json"));
+
+        course = testData.courses.get("ICEdit.CS2104");
+        instructors[0] = testData.instructors.get("ICEdit.helper.CS2104");
+        instructors[1] = testData.instructors.get("ICEdit.manager.CS2104");
+        instructors[2] = testData.instructors.get("ICEdit.observer.CS2104");
+        instructors[3] = testData.instructors.get("ICEdit.coowner.CS2104");
+        instructors[4] = testData.instructors.get("ICEdit.tutor.CS2104");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        ______TS("verify cannot edit without privilege");
+        // log in as instructor with no edit privilege
+        AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
+                .withCourseId(course.getId());
+        InstructorCourseEditPageSql editPage =
+                loginToPage(url, InstructorCourseEditPageSql.class, instructors[2].getGoogleId());
+
+        editPage.verifyCourseNotEditable();
+        editPage.verifyInstructorsNotEditable();
+        editPage.verifyAddInstructorNotAllowed();
+        editPage.verifyCopyInstructorsNotAllowed();
+
+        ______TS("verify loaded data");
+        // re-log in as instructor with edit privilege
+        logout();
+        url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
+                .withCourseId(course.getId());
+        editPage = loginToPage(url, InstructorCourseEditPageSql.class, instructors[3].getGoogleId());
+
+        editPage.verifyCourseDetails(course);
+        editPage.verifyInstructorDetails(instructors[0]);
+        editPage.verifyInstructorDetails(instructors[1]);
+        editPage.verifyInstructorDetails(instructors[2]);
+        editPage.verifyInstructorDetails(instructors[3]);
+        editPage.verifyInstructorDetails(instructors[4]);
+
+        ______TS("add instructor");
+        Instructor newInstructor = getTypicalInstructor();
+        newInstructor.setCourse(course);
+        newInstructor.setEmail("ICEdit.test@gmail.tmt");
+        newInstructor.setName("Teammates Test");
+        newInstructor.setDisplayedToStudents(true);
+        newInstructor.setDisplayName("Instructor");
+        InstructorPermissionRole role = InstructorPermissionRole
+                .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR);
+        newInstructor.setRole(role);
+
+        editPage.addInstructor(newInstructor);
+        editPage.verifyStatusMessage("The instructor " + newInstructor.getName() + " has been added successfully. "
+                + "An email containing how to 'join' this course will be sent to " + newInstructor.getEmail()
+                + " in a few minutes.");
+        editPage.verifyInstructorDetails(newInstructor);
+        verifyPresentInDatabase(newInstructor);
+
+        ______TS("copy instructors from other courses");
+        Instructor instructorToCopy1 = testData.instructors.get("ICEdit.coowner.CS2103T");
+        Instructor instructorToCopy2 = testData.instructors.get("ICEdit.observer.CS2103T");
+        Instructor instructorToCopy3 = testData.instructors.get("ICEdit.manager.CS2105");
+        List<Instructor> instructorsToCopy = List.of(instructorToCopy1, instructorToCopy2, instructorToCopy3);
+
+        editPage.copyInstructors(instructorsToCopy);
+
+        editPage.verifyStatusMessage("The selected instructor(s) have been added successfully. "
+                + "An email containing how to 'join' this course will be sent to them in a few minutes.");
+        for (Instructor i : instructorsToCopy) {
+            newInstructor.setCourse(course);
+            newInstructor.setEmail(i.getEmail());
+            newInstructor.setName(i.getName());
+            newInstructor.setDisplayedToStudents(i.isDisplayedToStudents());
+            newInstructor.setDisplayName(i.getDisplayName());
+            newInstructor.setRole(i.getRole());
+
+            editPage.verifyInstructorDetails(newInstructor);
+            verifyPresentInDatabase(newInstructor);
+        }
+
+        ______TS("cannot copy instructors whose email already exists");
+        instructorToCopy1 = testData.instructors.get("ICEdit.tutor.CS2106");
+
+        editPage.verifyCopyInstructorWithExistingEmailNotAllowed(instructorToCopy1);
+
+        ______TS("resend invite");
+        editPage.resendInstructorInvite(newInstructor);
+        editPage.verifyStatusMessage("An email has been sent to " + newInstructor.getEmail());
+
+        ______TS("edit instructor");
+        instructors[0].setName("Edited Name");
+        instructors[0].setEmail("ICEdit.edited@gmail.tmt");
+        instructors[0].getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, true);
+        instructors[0].getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
+        instructors[0].getPrivileges().updatePrivilege("Section 2",
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        instructors[0].getPrivileges().updatePrivilege("Section 1", "First feedback session",
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+
+        editPage.editInstructor(2, instructors[0]);
+        editPage.toggleCustomCourseLevelPrivilege(2, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        editPage.toggleCustomCourseLevelPrivilege(2, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        editPage.toggleCustomSectionLevelPrivilege(2, 1, "Section 2",
+                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+        editPage.toggleCustomSessionLevelPrivilege(2, 2, "Section 1", "First feedback session",
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
+        editPage.verifyStatusMessage("The instructor " + instructors[0].getName() + " has been updated.");
+        editPage.verifyInstructorDetails(instructors[0]);
+
+        // verify in database by reloading
+        editPage.reloadPage();
+        editPage.verifyInstructorDetails(instructors[0]);
+
+        ______TS("delete instructor");
+        editPage.deleteInstructor(newInstructor);
+        editPage.verifyStatusMessage("Instructor is successfully deleted.");
+        editPage.verifyNumInstructorsEquals(8);
+        verifyAbsentInDatabase(newInstructor);
+
+        ______TS("edit course");
+        String newName = "New Course Name";
+        String newTimeZone = "Asia/Singapore";
+        course.setName(newName);
+        course.setTimeZone(newTimeZone);
+
+        editPage.editCourse(course);
+        editPage.verifyStatusMessage("The course has been edited.");
+        editPage.verifyCourseDetails(course);
+        verifyPresentInDatabase(course);
+
+        ______TS("delete course");
+        editPage.deleteCourse();
+        editPage.verifyStatusMessage("The course " + course.getId() + " has been deleted. "
+                + "You can restore it from the Recycle Bin manually.");
+        assertTrue(BACKDOOR.isCourseInRecycleBin(course.getId()));
+    }
+}

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -664,6 +664,3 @@ public class InstructorCourseEditPage extends AppPage {
         return -1;
     }
 }
-
-
-

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPageSql.java
@@ -1,0 +1,666 @@
+package teammates.e2e.pageobjects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.util.Const;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.Instructor;
+import teammates.test.ThreadHelper;
+
+/**
+ * Represents the instructor course edit page of the website.
+ */
+public class InstructorCourseEditPageSql extends AppPage {
+    private static final int INSTRUCTOR_TYPE_COOWNER = 0;
+    private static final int INSTRUCTOR_TYPE_MANAGER = 1;
+    private static final int INSTRUCTOR_TYPE_OBSERVER = 2;
+    private static final int INSTRUCTOR_TYPE_TUTOR = 3;
+    private static final int INSTRUCTOR_TYPE_CUSTOM = 4;
+
+    private static final int COURSE_MODIFY_COURSE = 0;
+    private static final int COURSE_MODIFY_INSTRUCTORS = 1;
+    private static final int COURSE_MODIFY_SESSIONS = 2;
+    private static final int COURSE_MODIFY_STUDENTS = 3;
+    private static final int COURSE_VIEW_STUDENTS = 4;
+    private static final int COURSE_GIVE_RESPONSES_IN_SESSION = 5;
+    private static final int COURSE_VIEW_RESPONSES_IN_SESSION = 6;
+    private static final int COURSE_MODIFY_RESPONSES_IN_SESSION = 7;
+
+    private static final int SECTION_VIEW_STUDENTS = 0;
+    private static final int SECTION_GIVE_RESPONSES_IN_SESSION = 1;
+    private static final int SECTION_VIEW_RESPONSES_IN_SESSION = 2;
+    private static final int SECTION_MODIFY_RESPONSES_IN_SESSION = 3;
+
+    private static final int SESSION_GIVE_RESPONSES = 0;
+    private static final int SESSION_VIEW_RESPONSES = 1;
+    private static final int SESSION_MODIFY_RESPONSES = 2;
+
+    @FindBy(id = "course-id")
+    private WebElement courseIdTextBox;
+
+    @FindBy(id = "course-name")
+    private WebElement courseNameTextBox;
+
+    @FindBy(id = "course-institute")
+    private WebElement courseInstituteTextBox;
+
+    @FindBy(id = "time-zone")
+    private WebElement timeZoneDropDown;
+
+    @FindBy(id = "btn-edit-course")
+    private WebElement editCourseButton;
+
+    @FindBy(id = "btn-delete-course")
+    private WebElement deleteCourseButton;
+
+    @FindBy(id = "btn-save-course")
+    private WebElement saveCourseButton;
+
+    @FindBy(id = "btn-add-instructor")
+    private WebElement addInstructorButton;
+
+    @FindBy(id = "btn-copy-instructor")
+    private WebElement copyInstructorsButton;
+
+    public InstructorCourseEditPageSql(Browser browser) {
+        super(browser);
+    }
+
+    @Override
+    protected boolean containsExpectedPageContents() {
+        return getPageTitle().contains("Edit Course Details");
+    }
+
+    public void verifyCourseDetails(Course course) {
+        assertEquals(course.getId(), getCourseId());
+        assertEquals(course.getName(), getCourseName());
+        assertEquals(course.getInstitute(), getCourseInstitute());
+        assertEquals(course.getTimeZone(), getTimeZone());
+    }
+
+    public void verifyInstructorDetails(Instructor instructor) {
+        int instrNum = getIntrNum(instructor.getEmail());
+        if (instructor.getGoogleId() != null) {
+            assertEquals(instructor.getGoogleId(), getInstructorGoogleId(instrNum));
+        }
+        assertEquals(instructor.getName(), getInstructorName(instrNum));
+        assertEquals(instructor.getEmail(), getInstructorEmail(instrNum));
+        assertEquals(instructor.isDisplayedToStudents(), getInstructorDisplayedToStudents(instrNum));
+        if (instructor.isDisplayedToStudents()) {
+            assertEquals(instructor.getDisplayName(), getInstructorDisplayName(instrNum));
+        } else {
+            assertEquals("(This instructor will NOT be displayed to students)", getInstructorDisplayName(instrNum));
+        }
+        assertEquals(instructor.getRole().getRoleName(), getInstructorRole(instrNum));
+        if (Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM.equals(instructor.getRole().getRoleName())
+                && getEditInstructorButton(instrNum).isEnabled()) {
+            verifyCustomPrivileges(instrNum, instructor.getPrivileges());
+        }
+    }
+
+    public void verifyCustomPrivileges(int instrNum, InstructorPrivileges privileges) {
+        clickEditInstructorButton(instrNum);
+
+        InstructorPermissionSet courseLevelPrivileges = privileges.getCourseLevelPrivileges();
+        Map<String, InstructorPermissionSet> sectionLevelPrivileges = privileges.getSectionLevelPrivileges();
+        Map<String, Map<String, InstructorPermissionSet>> sessionLevelPrivileges = privileges.getSessionLevelPrivileges();
+
+        verifyCourseLevelPrivileges(instrNum, courseLevelPrivileges);
+        verifySectionLevelPrivileges(instrNum, sectionLevelPrivileges);
+        verifySessionLevelPrivileges(instrNum, sessionLevelPrivileges);
+
+        clickCancelInstructorButton(instrNum);
+    }
+
+    private void verifyCourseLevelPrivileges(int instrNum, InstructorPermissionSet courseLevelPrivileges) {
+        List<WebElement> checkboxes = getCourseLevelPanelCheckBoxes(instrNum);
+        for (Map.Entry<String, Boolean> privilege : courseLevelPrivileges.toLegacyMapFormat().entrySet()) {
+            if (!InstructorPrivileges.isPrivilegeNameValid(privilege.getKey())) {
+                continue;
+            }
+            if (privilege.getValue()) {
+                assertTrue(checkboxes.get(getCourseLevelPrivilegeIndex(privilege.getKey())).isSelected());
+            } else {
+                assertFalse(checkboxes.get(getCourseLevelPrivilegeIndex(privilege.getKey())).isSelected());
+            }
+        }
+    }
+
+    private void verifySectionLevelPrivileges(int instrNum, Map<String, InstructorPermissionSet> sectionLevelPrivileges) {
+        for (Map.Entry<String, InstructorPermissionSet> section : sectionLevelPrivileges.entrySet()) {
+            int panelNum = getSectionLevelPanelNumWithSectionSelected(instrNum, section.getKey());
+            for (Map.Entry<String, Boolean> privilege : section.getValue().toLegacyMapFormat().entrySet()) {
+                if (!InstructorPrivileges.isPrivilegeNameValidForSectionLevel(section.getKey())) {
+                    continue;
+                }
+                if (privilege.getValue()) {
+                    assertTrue(getSectionLevelCheckBox(instrNum, panelNum,
+                            getSectionLevelPrivilegeIndex(privilege.getKey())).isSelected());
+                } else {
+                    assertFalse(getSectionLevelCheckBox(instrNum, panelNum,
+                            getSectionLevelPrivilegeIndex(privilege.getKey())).isSelected());
+                }
+            }
+        }
+    }
+
+    private void verifySessionLevelPrivileges(
+            int instrNum, Map<String, Map<String, InstructorPermissionSet>> sessionLevelPrivileges) {
+        for (Map.Entry<String, Map<String, InstructorPermissionSet>> section : sessionLevelPrivileges.entrySet()) {
+            int panelNum = getSectionLevelPanelNumWithSectionSelected(instrNum, section.getKey());
+            for (Map.Entry<String, InstructorPermissionSet> session : section.getValue().entrySet()) {
+                int sessionIndex = getSessionIndex(instrNum, session.getKey());
+                for (Map.Entry<String, Boolean> privilege : session.getValue().toLegacyMapFormat().entrySet()) {
+                    if (!InstructorPrivileges.isPrivilegeNameValidForSessionLevel(privilege.getKey())) {
+                        continue;
+                    }
+                    if (privilege.getValue()) {
+                        assertTrue(getSessionLevelCheckbox(instrNum, panelNum, sessionIndex,
+                                getSessionLevelPrivilegeIndex(privilege.getKey())).isSelected());
+                    } else {
+                        assertFalse(getSessionLevelCheckbox(instrNum, panelNum, sessionIndex,
+                                getSessionLevelPrivilegeIndex(privilege.getKey())).isSelected());
+                    }
+                }
+            }
+        }
+    }
+
+    public void verifyCourseNotEditable() {
+        assertFalse(editCourseButton.isEnabled());
+        assertFalse(deleteCourseButton.isEnabled());
+    }
+
+    public void verifyInstructorsNotEditable() {
+        for (int i = 1; i <= getNumInstructors(); i++) {
+            assertFalse(getEditInstructorButton(i).isEnabled());
+            assertFalse(getDeleteInstructorButton(i).isEnabled());
+        }
+    }
+
+    public void verifyAddInstructorNotAllowed() {
+        clickAddNewInstructorButton();
+        clickSaveInstructorButton(getNumInstructors());
+        verifyStatusMessage("You are not authorized to access this resource.");
+        clickCancelInstructorButton(getNumInstructors());
+    }
+
+    public void verifyCopyInstructorsNotAllowed() {
+        verifyUnclickable(copyInstructorsButton);
+    }
+
+    public void verifyNumInstructorsEquals(int expectedNum) {
+        assertEquals(getNumInstructors(), expectedNum);
+    }
+
+    public void editCourse(Course newCourse) {
+        clickEditCourseButton();
+        fillTextBox(courseNameTextBox, newCourse.getName());
+        selectNewTimeZone(newCourse.getTimeZone());
+        clickSaveCourseButton();
+    }
+
+    public void deleteCourse() {
+        click(deleteCourseButton);
+    }
+
+    public void addInstructor(Instructor newInstructor) {
+        clickAddNewInstructorButton();
+        int instructorIndex = getNumInstructors();
+
+        fillTextBox(getNameField(instructorIndex), newInstructor.getName());
+        fillTextBox(getEmailField(instructorIndex), newInstructor.getEmail());
+        if (newInstructor.isDisplayedToStudents()) {
+            markOptionAsSelected(getDisplayedToStudentCheckBox(instructorIndex));
+            fillTextBox(getDisplayNameField(instructorIndex), newInstructor.getDisplayName());
+        } else {
+            markOptionAsUnselected(getDisplayedToStudentCheckBox(instructorIndex));
+        }
+        selectRoleForInstructor(instructorIndex, getRoleIndex(newInstructor.getRole().getRoleName()));
+        clickSaveInstructorButton(instructorIndex);
+    }
+
+    public void copyInstructors(List<Instructor> newInstructors) {
+        Map<String, List<String>> courseInstructorEmailsMap = new HashMap<>();
+        for (Instructor instructor : newInstructors) {
+            courseInstructorEmailsMap.putIfAbsent(instructor.getCourseId(), new ArrayList<>());
+            courseInstructorEmailsMap.get(instructor.getCourseId()).add(instructor.getEmail());
+        }
+
+        clickCopyInstructorsButton();
+        WebElement copyInstructorModal = waitForElementPresence(By.id("copy-instructor-modal"));
+
+        List<WebElement> cards = copyInstructorModal.findElements(By.className("card"));
+        for (WebElement card : cards) {
+            WebElement cardHeader = card.findElement(By.className("card-header"));
+            String cardHeaderText = cardHeader.getText();
+            String courseId = cardHeaderText.substring(1, cardHeaderText.indexOf(']'));
+            if (courseInstructorEmailsMap.containsKey(courseId)) {
+                click(cardHeader);
+                WebElement cardBody = waitForElementPresence(By.className("card-body"));
+                // reload instructors
+                WebElement reloadBtn = cardBody.findElement(By.tagName("button"));
+                click(reloadBtn);
+                WebElement table = waitForElementPresence(By.id("copy-instructor-table"));
+                List<WebElement> rows = table.findElements(By.cssSelector("tbody tr"));
+                for (WebElement row : rows) {
+                    List<WebElement> cells = row.findElements(By.tagName("td"));
+                    if (courseInstructorEmailsMap.get(courseId).contains(cells.get(2).getText())) {
+                        markOptionAsSelected(cells.get(0).findElement(By.id("enabled-checkbox")));
+                    }
+                }
+                // collapse tab
+                click(cardHeader);
+            }
+        }
+        click(browser.driver.findElement(By.id("btn-confirm-copy-instructor")));
+        waitUntilAnimationFinish();
+    }
+
+    public void verifyCopyInstructorWithExistingEmailNotAllowed(Instructor newInstructor) {
+        copyInstructors(List.of(newInstructor));
+        verifyStatusMessage("An instructor with email address " + newInstructor.getEmail()
+                + " already exists in the course and/or you have selected more than one instructor "
+                + "with this email address.");
+        click(browser.driver.findElement(By.id("btn-cancel-copy-instructor")));
+    }
+
+    public void resendInstructorInvite(Instructor instructor) {
+        int instrNum = getIntrNum(instructor.getEmail());
+        clickAndConfirm(getInviteInstructorButton(instrNum));
+    }
+
+    public void deleteInstructor(Instructor instructor) {
+        int instrNum = getIntrNum(instructor.getEmail());
+        clickAndConfirm(getDeleteInstructorButton(instrNum));
+    }
+
+    public void editInstructor(int instrNum, Instructor instructor) {
+        clickEditInstructorButton(instrNum);
+
+        fillTextBox(getNameField(instrNum), instructor.getName());
+        fillTextBox(getEmailField(instrNum), instructor.getEmail());
+        if (instructor.isDisplayedToStudents()) {
+            markOptionAsSelected(getDisplayedToStudentCheckBox(instrNum));
+            fillTextBox(getDisplayNameField(instrNum), instructor.getDisplayName());
+        } else {
+            markOptionAsUnselected(getDisplayedToStudentCheckBox(instrNum));
+        }
+        selectRoleForInstructor(instrNum, getRoleIndex(instructor.getRole().getRoleName()));
+        clickSaveInstructorButton(instrNum);
+    }
+
+    public void toggleCustomCourseLevelPrivilege(int instrNum, String privilege) {
+        if (!Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM.equals(getInstructorRole(instrNum))) {
+            return;
+        }
+
+        clickEditInstructorButton(instrNum);
+        click(getCourseLevelPanelCheckBox(instrNum, getCourseLevelPrivilegeIndex(privilege)));
+        clickSaveInstructorButton(instrNum);
+    }
+
+    public void toggleCustomSectionLevelPrivilege(int instrNum, int panelNum, String section,
+                                                  String privilege) {
+        if (!Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM.equals(getInstructorRole(instrNum))) {
+            return;
+        }
+
+        clickEditInstructorButton(instrNum);
+        clickAddSectionPrivilegeLink(instrNum);
+
+        click(getSectionSelectionCheckBox(instrNum, panelNum, getSectionIndex(instrNum, section)));
+        click(getSectionLevelCheckBox(instrNum, panelNum, getSectionLevelPrivilegeIndex(privilege)));
+        clickSaveInstructorButton(instrNum);
+    }
+
+    public void toggleCustomSessionLevelPrivilege(int instrNum, int panelNum, String section, String session,
+                                                  String privilege) {
+        if (!Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM.equals(getInstructorRole(instrNum))) {
+            return;
+        }
+
+        clickEditInstructorButton(instrNum);
+        clickAddSectionPrivilegeLink(instrNum);
+        clickAddSessionPrivilegeLink(instrNum, panelNum);
+
+        click(getSectionSelectionCheckBox(instrNum, panelNum, getSectionIndex(instrNum, section)));
+        click(getSessionLevelCheckbox(instrNum, panelNum, getSessionIndex(instrNum, session),
+                getSessionLevelPrivilegeIndex(privilege)));
+        clickSaveInstructorButton(instrNum);
+    }
+
+    private int getNumInstructors() {
+        return browser.driver.findElements(By.cssSelector(".card-header")).size() - 1;
+    }
+
+    // Methods for clicking buttons and links
+
+    private void clickEditCourseButton() {
+        click(editCourseButton);
+    }
+
+    private void clickSaveCourseButton() {
+        click(saveCourseButton);
+    }
+
+    private void selectNewTimeZone(String timeZone) {
+        scrollElementToCenter(timeZoneDropDown);
+        Select dropdown = new Select(timeZoneDropDown);
+        dropdown.selectByValue(timeZone);
+    }
+
+    private void clickAddNewInstructorButton() {
+        click(addInstructorButton);
+    }
+
+    private void clickCopyInstructorsButton() {
+        click(copyInstructorsButton);
+    }
+
+    private void clickEditInstructorButton(int instrNum) {
+        click(getEditInstructorButton(instrNum));
+        waitUntilAnimationFinish();
+    }
+
+    private void clickCancelInstructorButton(int instrNum) {
+        click(getCancelInstructorButton(instrNum));
+    }
+
+    private void clickSaveInstructorButton(int instrNum) {
+        click(getSaveInstructorButton(instrNum));
+        ThreadHelper.waitFor(1000);
+    }
+
+    private void clickAddSectionPrivilegeLink(int instrNum) {
+        click(getAddSectionLevelPrivilegesLink(instrNum));
+    }
+
+    private void clickAddSessionPrivilegeLink(int instrNum, int panelNum) {
+        click(getAddSessionLevelPrivilegesLink(instrNum, panelNum));
+    }
+
+    // Methods that return WebElements of the page
+
+    public String getCourseId() {
+        return courseIdTextBox.getAttribute("value");
+    }
+
+    public String getCourseName() {
+        return courseNameTextBox.getAttribute("value");
+    }
+
+    public String getCourseInstitute() {
+        return courseInstituteTextBox.getAttribute("value");
+    }
+
+    public String getTimeZone() {
+        return timeZoneDropDown.getAttribute("value");
+    }
+
+    private WebElement getEditInstructorButton(int instrNum) {
+        return browser.driver.findElement(By.id("btn-edit-instructor-" + instrNum));
+    }
+
+    private WebElement getInviteInstructorButton(int instrNum) {
+        return browser.driver.findElement(By.id("btn-resend-invite-" + instrNum));
+    }
+
+    private WebElement getDeleteInstructorButton(int instrNum) {
+        return browser.driver.findElement(By.id("btn-delete-instructor-" + instrNum));
+    }
+
+    private WebElement getCancelInstructorButton(int instrNum) {
+        return browser.driver.findElement(By.id("btn-cancel-instructor-" + instrNum));
+    }
+
+    private WebElement getSaveInstructorButton(int instrNum) {
+        return browser.driver.findElement(By.id("btn-save-instructor-" + instrNum));
+    }
+
+    private WebElement getNameField(int instrNum) {
+        return browser.driver.findElement(By.id("name-instructor-" + instrNum));
+    }
+
+    private WebElement getEmailField(int instrNum) {
+        return browser.driver.findElement(By.id("email-instructor-" + instrNum));
+    }
+
+    private WebElement getDisplayedToStudentCheckBox(int instrNum) {
+        return browser.driver.findElement(By.id("checkbox-display-instructor-" + instrNum));
+    }
+
+    private WebElement getDisplayNameField(int instrNum) {
+        return browser.driver.findElement(By.id("displayed-name-instructor-" + instrNum));
+    }
+
+    public String getInstructorGoogleId(int instrNum) {
+        return browser.driver.findElement(By.id("google-id-instructor-" + instrNum)).getAttribute("value");
+    }
+
+    public String getInstructorName(int instrNum) {
+        return browser.driver.findElement(By.id("name-instructor-" + instrNum)).getAttribute("value");
+    }
+
+    public String getInstructorEmail(int instrNum) {
+        return browser.driver.findElement(By.id("email-instructor-" + instrNum)).getAttribute("value");
+    }
+
+    public boolean getInstructorDisplayedToStudents(int instrNum) {
+        return browser.driver.findElement(By.id("checkbox-display-instructor-" + instrNum)).isSelected();
+    }
+
+    public String getInstructorDisplayName(int instrNum) {
+        return browser.driver.findElement(By.id("displayed-name-instructor-" + instrNum)).getAttribute("value");
+    }
+
+    public String getInstructorRole(int instrNum) {
+        String roleAndDescription = browser.driver.findElement(By.id("role-instructor-" + instrNum)).getText();
+        return roleAndDescription.split(":")[0];
+    }
+
+    private WebElement getAccessLevels(int instrNum) {
+        return browser.driver.findElement(By.id("access-levels-instructor-" + instrNum));
+    }
+
+    private WebElement getAccessLevelsRadioButton(int instrNum, int radioNum) {
+        WebElement accessLevels = getAccessLevels(instrNum);
+        return accessLevels.findElements(By.cssSelector("input[type='radio']")).get(radioNum);
+    }
+
+    public void selectRoleForInstructor(int instrNum, int roleIndex) {
+        click(getAccessLevelsRadioButton(instrNum, roleIndex));
+    }
+
+    private WebElement getCourseLevelPanel(int instrNum) {
+        return browser.driver.findElement(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #custom-course"));
+    }
+
+    private List<WebElement> getCourseLevelPanelCheckBoxes(int instrNum) {
+        WebElement courseLevelPanel = getCourseLevelPanel(instrNum);
+        return courseLevelPanel.findElements(By.cssSelector("input[type='checkbox']"));
+    }
+
+    private WebElement getCourseLevelPanelCheckBox(int instrNum, int checkboxNum) {
+        WebElement courseLevelPanel = getCourseLevelPanel(instrNum);
+        return courseLevelPanel.findElements(By.cssSelector("input[type='checkbox']")).get(checkboxNum);
+    }
+
+    private WebElement getAddSectionLevelPrivilegesLink(int instrNum) {
+        return browser.driver.findElement(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #btn-add-section-level"));
+    }
+
+    private WebElement getAddSessionLevelPrivilegesLink(int instrNum, int panelNum) {
+        return browser.driver.findElements(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #btn-add-session-level")).get(panelNum - 1);
+    }
+
+    private WebElement getSectionSelections(int instrNum, int panelNum) {
+        return browser.driver.findElements(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #custom-sections")).get(panelNum - 1);
+    }
+
+    private WebElement getSectionLevelPanelBody(int instrNum, int panelNum) {
+        return browser.driver.findElements(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #custom-sections-access-levels")).get(panelNum - 1);
+    }
+
+    private int getNumSectionLevelPanels(int instrNum) {
+        return browser.driver.findElements(By.cssSelector("#custom-access-instructor-" + instrNum
+                + " #custom-sections-access-levels")).size();
+    }
+
+    private int getSectionLevelPanelNumWithSectionSelected(int instrNum, String section) {
+        int sectionIndex = getSectionIndex(instrNum, section);
+        int numPanels = getNumSectionLevelPanels(instrNum);
+        for (int i = 0; i < numPanels; i++) {
+            if (getSectionSelectionCheckBox(instrNum, i + 1, sectionIndex).isSelected()) {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+
+    private WebElement getSectionSelectionCheckBox(int instrNum, int panelNum, int sectionNum) {
+        WebElement sectionPanel = getSectionSelections(instrNum, panelNum);
+        return sectionPanel.findElements(By.cssSelector("input[type='checkbox']")).get(sectionNum);
+    }
+
+    private WebElement getSectionLevelCheckBox(int instrNum, int panelNum, int checkBoxIndex) {
+        WebElement sectionPanelBody = getSectionLevelPanelBody(instrNum, panelNum);
+        return sectionPanelBody.findElements(By.cssSelector("input[type='checkbox']")).get(checkBoxIndex);
+    }
+
+    private WebElement getSessionLevelTable(int instrNum, int panelNum) {
+        WebElement sectionPanelBody = getSectionLevelPanelBody(instrNum, panelNum);
+        return sectionPanelBody.findElement(By.id("custom-sessions"));
+    }
+
+    private WebElement getSessionLevelTableRow(int instrNum, int panelNum, int sessionIndex) {
+        WebElement sessionLevelTableBody = getSessionLevelTable(instrNum, panelNum);
+        return sessionLevelTableBody.findElements(By.cssSelector("tbody tr")).get(sessionIndex);
+    }
+
+    private WebElement getSessionLevelCheckbox(int instrNum, int panelNum, int sessionIndex,
+                                               int checkBoxIndex) {
+        WebElement sessionLevelTableRow = getSessionLevelTableRow(instrNum, panelNum, sessionIndex);
+        return sessionLevelTableRow.findElements(By.cssSelector("input[type='checkbox']")).get(checkBoxIndex);
+    }
+
+    // Methods for indexing
+
+    private int getRoleIndex(String role) {
+        switch (role) {
+            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER:
+                return INSTRUCTOR_TYPE_COOWNER;
+            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER:
+                return INSTRUCTOR_TYPE_MANAGER;
+            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER:
+                return INSTRUCTOR_TYPE_OBSERVER;
+            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR:
+                return INSTRUCTOR_TYPE_TUTOR;
+            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM:
+                return INSTRUCTOR_TYPE_CUSTOM;
+            default:
+                return -1;
+        }
+    }
+
+    private int getCourseLevelPrivilegeIndex(String privilege) {
+        switch (privilege) {
+            case Const.InstructorPermissions.CAN_MODIFY_COURSE:
+                return COURSE_MODIFY_COURSE;
+            case Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR:
+                return COURSE_MODIFY_INSTRUCTORS;
+            case Const.InstructorPermissions.CAN_MODIFY_SESSION:
+                return COURSE_MODIFY_SESSIONS;
+            case Const.InstructorPermissions.CAN_MODIFY_STUDENT:
+                return COURSE_MODIFY_STUDENTS;
+            case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
+                return COURSE_VIEW_STUDENTS;
+            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+                return COURSE_GIVE_RESPONSES_IN_SESSION;
+            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+                return COURSE_VIEW_RESPONSES_IN_SESSION;
+            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+                return COURSE_MODIFY_RESPONSES_IN_SESSION;
+            default:
+                return -1;
+        }
+    }
+
+    private int getSectionLevelPrivilegeIndex(String privilege) {
+        switch (privilege) {
+            case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
+                return SECTION_VIEW_STUDENTS;
+            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+                return SECTION_GIVE_RESPONSES_IN_SESSION;
+            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+                return SECTION_VIEW_RESPONSES_IN_SESSION;
+            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+                return SECTION_MODIFY_RESPONSES_IN_SESSION;
+            default:
+                return -1;
+        }
+    }
+
+    private int getSessionLevelPrivilegeIndex(String privilege) {
+        switch (privilege) {
+            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+                return SESSION_GIVE_RESPONSES;
+            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+                return SESSION_VIEW_RESPONSES;
+            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+                return SESSION_MODIFY_RESPONSES;
+            default:
+                return -1;
+        }
+    }
+
+    private int getIntrNum(String email) {
+        for (int i = 1; i <= getNumInstructors(); i++) {
+            if (getInstructorEmail(i).equals(email)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int getSectionIndex(int instrNum, String section) {
+        List<WebElement> accessLevelCheckboxes = browser.driver.findElements(
+                By.cssSelector("#custom-access-instructor-" + instrNum + " #custom-sections div"));
+        for (int i = 0; i < accessLevelCheckboxes.size(); i++) {
+            if (accessLevelCheckboxes.get(i).getText().equals(section)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int getSessionIndex(int instrNum, String session) {
+        List<WebElement> tableHeaders = browser.driver.findElements(
+                By.cssSelector("#custom-access-instructor-" + instrNum + " tbody th"));
+        for (int i = 0; i < tableHeaders.size(); i++) {
+            if (tableHeaders.get(i).getText().equals(session)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPageSql.java
@@ -567,69 +567,69 @@ public class InstructorCourseEditPageSql extends AppPage {
 
     private int getRoleIndex(String role) {
         switch (role) {
-            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER:
-                return INSTRUCTOR_TYPE_COOWNER;
-            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER:
-                return INSTRUCTOR_TYPE_MANAGER;
-            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER:
-                return INSTRUCTOR_TYPE_OBSERVER;
-            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR:
-                return INSTRUCTOR_TYPE_TUTOR;
-            case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM:
-                return INSTRUCTOR_TYPE_CUSTOM;
-            default:
-                return -1;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER:
+            return INSTRUCTOR_TYPE_COOWNER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER:
+            return INSTRUCTOR_TYPE_MANAGER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER:
+            return INSTRUCTOR_TYPE_OBSERVER;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR:
+            return INSTRUCTOR_TYPE_TUTOR;
+        case Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM:
+            return INSTRUCTOR_TYPE_CUSTOM;
+        default:
+            return -1;
         }
     }
 
     private int getCourseLevelPrivilegeIndex(String privilege) {
         switch (privilege) {
-            case Const.InstructorPermissions.CAN_MODIFY_COURSE:
-                return COURSE_MODIFY_COURSE;
-            case Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR:
-                return COURSE_MODIFY_INSTRUCTORS;
-            case Const.InstructorPermissions.CAN_MODIFY_SESSION:
-                return COURSE_MODIFY_SESSIONS;
-            case Const.InstructorPermissions.CAN_MODIFY_STUDENT:
-                return COURSE_MODIFY_STUDENTS;
-            case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
-                return COURSE_VIEW_STUDENTS;
-            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
-                return COURSE_GIVE_RESPONSES_IN_SESSION;
-            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
-                return COURSE_VIEW_RESPONSES_IN_SESSION;
-            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
-                return COURSE_MODIFY_RESPONSES_IN_SESSION;
-            default:
-                return -1;
+        case Const.InstructorPermissions.CAN_MODIFY_COURSE:
+            return COURSE_MODIFY_COURSE;
+        case Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR:
+            return COURSE_MODIFY_INSTRUCTORS;
+        case Const.InstructorPermissions.CAN_MODIFY_SESSION:
+            return COURSE_MODIFY_SESSIONS;
+        case Const.InstructorPermissions.CAN_MODIFY_STUDENT:
+            return COURSE_MODIFY_STUDENTS;
+        case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
+            return COURSE_VIEW_STUDENTS;
+        case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+            return COURSE_GIVE_RESPONSES_IN_SESSION;
+        case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+            return COURSE_VIEW_RESPONSES_IN_SESSION;
+        case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+            return COURSE_MODIFY_RESPONSES_IN_SESSION;
+        default:
+            return -1;
         }
     }
 
     private int getSectionLevelPrivilegeIndex(String privilege) {
         switch (privilege) {
-            case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
-                return SECTION_VIEW_STUDENTS;
-            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
-                return SECTION_GIVE_RESPONSES_IN_SESSION;
-            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
-                return SECTION_VIEW_RESPONSES_IN_SESSION;
-            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
-                return SECTION_MODIFY_RESPONSES_IN_SESSION;
-            default:
-                return -1;
+        case Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS:
+            return SECTION_VIEW_STUDENTS;
+        case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+            return SECTION_GIVE_RESPONSES_IN_SESSION;
+        case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+            return SECTION_VIEW_RESPONSES_IN_SESSION;
+        case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+            return SECTION_MODIFY_RESPONSES_IN_SESSION;
+        default:
+            return -1;
         }
     }
 
     private int getSessionLevelPrivilegeIndex(String privilege) {
         switch (privilege) {
-            case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
-                return SESSION_GIVE_RESPONSES;
-            case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
-                return SESSION_VIEW_RESPONSES;
-            case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
-                return SESSION_MODIFY_RESPONSES;
-            default:
-                return -1;
+        case Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS:
+            return SESSION_GIVE_RESPONSES;
+        case Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS:
+            return SESSION_VIEW_RESPONSES;
+        case Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS:
+            return SESSION_MODIFY_RESPONSES;
+        default:
+            return -1;
         }
     }
 

--- a/src/e2e/resources/data/InstructorCourseEditPageE2ETestSql.json
+++ b/src/e2e/resources/data/InstructorCourseEditPageE2ETestSql.json
@@ -1,0 +1,584 @@
+{
+  "accounts": {
+    "ICEdit.coowner": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "googleId": "tm.e2e.ICEdit.coowner",
+      "name": "Teammates Test",
+      "email": "ICEdit.coowner@gmail.tmt"
+    },
+    "ICEdit.observer": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "googleId": "tm.e2e.ICEdit.observer",
+      "name": "Teammates Instructor",
+      "email": "ICEdit.observer@gmail.tmt"
+    },
+    "ICEdit.manager.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "googleId": "tm.e2e.ICEdit.manager.CS2104",
+      "name": "CS2104 Manager",
+      "email": "ICEdit.manager.CS2104@gmail.tmt"
+    },
+    "ICEdit.tutor.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "googleId": "tm.e2e.ICEdit.tutor.CS2104",
+      "name": "CS2104 Tutor",
+      "email": "ICEdit.tutor.CS2104@gmail.tmt"
+    },
+    "ICEdit.helper.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000005",
+      "googleId": "tm.e2e.ICEdit.helper.CS2104",
+      "name": "CS2104 Helper",
+      "email": "ICEdit.helper.CS2104@gmail.tmt"
+    },
+    "ICEdit.helper.CS2103T": {
+      "id": "00000000-0000-4000-8000-000000000006",
+      "googleId": "tm.e2e.ICEdit.helper.CS2103T",
+      "name": "CS2103T Helper",
+      "email": "ICEdit.helper.CS2103T@gmail.tmt"
+    },
+    "ICEdit.manager.CS2105": {
+      "id": "00000000-0000-4000-8000-000000000007",
+      "googleId": "tm.e2e.ICEdit.manager.CS2105",
+      "name": "CS2105 Manager",
+      "email": "ICEdit.manager.CS2105@gmail.tmt"
+    },
+    "ICEdit.tutor.CS2106": {
+      "id": "00000000-0000-4000-8000-000000000008",
+      "googleId": "tm.e2e.ICEdit.tutor.CS2106",
+      "name": "CS2106 Tutor",
+      "email": "ICEdit.tutor.CS2106@gmail.tmt"
+    },
+    "tm.e2e.ICEdit.alice.tmms": {
+      "id": "00000000-0000-4000-8000-000000000009",
+      "googleId": "tm.e2e.ICEdit.alice.tmms",
+      "name": "Alice Betsy",
+      "email": "alice.b.tmms@gmail.tmt"
+    },
+    "tm.e2e.ICEdit.charlie.tmms": {
+      "id": "00000000-0000-4000-8000-000000000010",
+      "googleId": "tm.e2e.ICEdit.charlie.tmms",
+      "name": "Charlie Davis",
+      "email": "charlie.d.tmms@gmail.tmt"
+    },
+    "tm.e2e.ICEdit.danny.tmms": {
+      "id": "00000000-0000-4000-8000-000000000011",
+      "googleId": "tm.e2e.ICEdit.danny.tmms",
+      "name": "Danny Engrid",
+      "email": "danny.e.tmms@gmail.tmt"
+    }
+  },
+  "courses": {
+    "ICEdit.CS2104": {
+      "id": "tm.e2e.ICEdit.CS2104",
+      "name": "Programming Language Concepts",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg",
+      "createdAt": "2010-04-02T12:00:00Z"
+    },
+    "ICEdit.CS2103T": {
+      "id": "tm.e2e.ICEdit.CS2103T",
+      "name": "Software Engineering",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg",
+      "createdAt": "2017-04-21T12:00:00Z"
+    },
+    "ICEdit.CS2105": {
+      "id": "tm.e2e.ICEdit.CS2105",
+      "name": "Introduction to Computer Networks",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg",
+      "createdAt": "2014-04-02T12:00:00Z"
+    },
+    "ICEdit.CS2106": {
+      "id": "tm.e2e.ICEdit.CS2106",
+      "name": "Introduction to Operating Systems",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg",
+      "createdAt": "2012-04-02T12:00:00Z"
+    },
+    "ICEdit.CS2107": {
+      "id": "tm.e2e.ICEdit.CS2107",
+      "name": "Introduction to Information Security",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "Africa/Johannesburg",
+      "createdAt": "2014-04-10T12:00:00Z",
+      "deletedAt": "2014-04-12T12:00:00Z"
+    }
+  },
+  "instructors": {
+    "ICEdit.coowner.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000501",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "CS2104 Co-owner",
+      "email": "ICEdit.coowner.CS2104@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.manager.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000502",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000003"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "CS2104 Manager",
+      "email": "ICEdit.manager.CS2104@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_MANAGER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.observer.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000503",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000002"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "CS2104 Observer",
+      "email": "ICEdit.observer.CS2104@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_OBSERVER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": false,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": false,
+          "canModifyStudent": false,
+          "canModifyInstructor": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.tutor.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000504",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000004"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "CS2104 Tutor",
+      "email": "ICEdit.tutor.CS2104@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_TUTOR",
+      "isDisplayedToStudents": false,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": false,
+          "canModifyStudent": false,
+          "canModifyInstructor": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.helper.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000505",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000005"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "CS2104 Helper",
+      "email": "ICEdit.helper.CS2104@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_CUSTOM",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": false,
+          "canSubmitSessionInSections": false,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": false,
+          "canModifySession": false,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.coowner.CS2103T": {
+      "id": "00000000-0000-4000-8000-000000000506",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2103T"
+      },
+      "name": "CS2103T Co-owner",
+      "email": "ICEdit.coowner.CS2103T@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.observer.CS2103T": {
+      "id": "00000000-0000-4000-8000-000000000507",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000002"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2103T"
+      },
+      "name": "CS2103T Observer",
+      "email": "ICEdit.observer.CS2103T@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_OBSERVER",
+      "isDisplayedToStudents": false,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": false,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": false,
+          "canModifyStudent": false,
+          "canModifyInstructor": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.helper.CS2103T": {
+      "id": "00000000-0000-4000-8000-000000000508",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000006"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2103T"
+      },
+      "name": "CS2103T Helper",
+      "email": "ICEdit.helper.CS2103T@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_CUSTOM",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": false,
+          "canSubmitSessionInSections": false,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": false,
+          "canModifySession": false,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.coowner.CS2105": {
+      "id": "00000000-0000-4000-8000-000000000509",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2105"
+      },
+      "name": "CS2105 Co-owner",
+      "email": "ICEdit.coowner.CS2105@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "isArchived": true,
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.manager.CS2105": {
+      "id": "00000000-0000-4000-8000-000000000510",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000007"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2105"
+      },
+      "name": "CS2105 Manager",
+      "email": "ICEdit.manager.CS2105@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_MANAGER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.coowner.CS2106": {
+      "id": "00000000-0000-4000-8000-000000000511",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2106"
+      },
+      "name": "CS2106 Co-owner",
+      "email": "ICEdit.coowner.CS2106@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.tutor.CS2106": {
+      "id": "00000000-0000-4000-8000-000000000512",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000008"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2106"
+      },
+      "name": "Teammates Test",
+      "email": "ICEdit.test@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_TUTOR",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": false,
+          "canModifyCourse": false,
+          "canViewSessionInSections": true,
+          "canModifySession": false,
+          "canModifyStudent": false,
+          "canModifyInstructor": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICEdit.coowner.CS2107": {
+      "id": "00000000-0000-4000-8000-000000000513",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2107"
+      },
+      "name": "CS2107 Co-owner",
+      "email": "ICEdit.coowner.CS2107@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    }
+  },
+  "students": {
+    "alice.tmms@ICEdit.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000601",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000009"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "alice.b.tmms@gmail.tmt",
+      "name": "Alice Betsy</option></td></div>'\"",
+      "comments": "This student's name is Alice Betsy"
+    },
+    "charlie.tmms@ICEdit.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000602",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000010"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "email": "charlie.d.tmms@gmail.tmt",
+      "name": "Charlie Davis",
+      "comments": "This student's name is Charlie Davis"
+    },
+    "danny.tmms@ICEdit.CS2104": {
+      "id": "00000000-0000-4000-8000-000000000603",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000011"
+      },
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "email": "danny.e.tmms@gmail.tmt",
+      "name": "Danny Engrid",
+      "comments": "This student's name is Danny Engrid"
+    }
+  },
+  "sections": {
+    "ICEdit.Section1": {
+      "id": "00000000-0000-4000-8000-000000000101",
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "Section 1"
+    },
+    "ICEdit.Section2": {
+      "id": "00000000-0000-4000-8000-000000000102",
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "Section 2"
+    }
+  },
+  "teams": {
+    "ICEdit.Team1": {
+      "id": "00000000-0000-4000-8000-000000000201",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000101"
+      },
+      "name": "Team 1</option><option value=\"dump\"></td><td>'\""
+    },
+    "ICEdit.Team2": {
+      "id": "00000000-0000-4000-8000-000000000202",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000102"
+      },
+      "name": "Team 2"
+    }
+  },
+  "feedbackSessions": {
+    "session1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000701",
+      "course": {
+        "id": "tm.e2e.ICEdit.CS2104"
+      },
+      "name": "First feedback session",
+      "creatorEmail": "ICEdit.coowner.CS2104@gmail.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "createdAt": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "isOpenedEmailSent": true,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "studentDeadlines": {},
+      "instructorDeadlines": {}
+    }
+  },
+  "feedbackQuestions": {},
+  "feedbackResponses": {},
+  "feedbackResponseComments": {}
+}

--- a/src/e2e/resources/testng-e2e-sql.xml
+++ b/src/e2e/resources/testng-e2e-sql.xml
@@ -25,6 +25,7 @@
             <class name="teammates.e2e.cases.sql.FeedbackRubricQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.FeedbackTextQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseDetailsPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorCourseEditPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseEnrollPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsEditPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsPageE2ETest" />

--- a/src/test/java/teammates/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/test/java/teammates/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -146,7 +146,8 @@ public abstract class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
             assertEquals(expectedInstructor.getCourseId(), actualInstructor.getCourseId());
             assertEquals(expectedInstructor.getName(), actualInstructor.getName());
             assertEquals(expectedInstructor.getEmail(), actualInstructor.getEmail());
-            assertEquals(expectedInstructor.getRegKey(), actualInstructor.getKey());
+            // Cannot compare keys as actualInstructor's key is only generated before storing into the database.
+            assertNotNull(actualInstructor.getKey());
             assertEquals(expectedInstructor.isDisplayedToStudents(), actualInstructor.getIsDisplayedToStudents());
             assertEquals(expectedInstructor.getDisplayName(), actualInstructor.getDisplayedToStudentsAs());
             assertEquals(expectedInstructor.getRole(), actualInstructor.getRole());


### PR DESCRIPTION
Part of #12048

**Outline of Solution**

- Migrated `InstructorCourseEditPageE2ETest` to use SQL-based logic instead of the previous Datastore model.

- Migrated `InstructorCourseEditPage` to `InstructorCourseEditPageSql`.

- Replaced the assertion comparing expected and actual `Instructor` registration keys with a null check. This is because the actual `Instructor` registration key is only generated before storing into the database, and comparing it to an expected value will always result in a mismatch due to differing generation timing.