### PR TITLE
[#12048] Migrate Tests for InstructorCourseJoinConfirmationPageE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/BaseE2ETestCase.java
@@ -330,6 +330,13 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
         return getInstructor(instructor.getCourseId(), instructor.getEmail());
     }
 
+    /**
+     * Gets registration key for a given instructor.
+     */
+    protected String getKeyForInstructor(String courseId, String instructorEmail) {
+        return getInstructor(courseId, instructorEmail).getKey();
+    }
+
     NotificationData getNotification(String notificationId) {
         return BACKDOOR.getNotificationData(notificationId);
     }
@@ -364,5 +371,12 @@ public abstract class BaseE2ETestCase extends BaseTestCaseWithSqlDatabaseAccess 
     @Override
     protected StudentData getStudent(Student student) {
         return getStudent(student.getCourseId(), student.getEmail());
+    }
+
+    /**
+     * Gets registration key for a given student.
+     */
+    protected String getKeyForStudent(Student student) {
+        return getStudent(student).getKey();
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/sql/InstructorCourseJoinConfirmationPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/InstructorCourseJoinConfirmationPageE2ETest.java
@@ -1,0 +1,83 @@
+package teammates.e2e.cases.sql;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.AppUrl;
+import teammates.common.util.Const;
+import teammates.e2e.pageobjects.CourseJoinConfirmationPage;
+import teammates.e2e.pageobjects.InstructorHomePageSql;
+import teammates.storage.sqlentity.Instructor;
+
+/**
+ * SUT: {@link Const.WebPageURIs#JOIN_PAGE}.
+ */
+public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
+    private Instructor newInstructor;
+
+    @Override
+    protected void prepareTestData() {
+        testData = removeAndRestoreDataBundle(
+                loadSqlDataBundle("/InstructorCourseJoinConfirmationPageE2ETestSql.json"));
+
+        newInstructor = testData.instructors.get("ICJoinConf.instr.CS1101");
+    }
+
+    @Test
+    @Override
+    public void testAll() {
+        ______TS("Click join link: invalid key");
+        String invalidKey = "invalidKey";
+        AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withRegistrationKey(invalidKey)
+                .withEntityType(Const.EntityType.INSTRUCTOR);
+        String newInstructorId = "tm.e2e.ICJoinConf.instr2";
+        CourseJoinConfirmationPage confirmationPage = loginToPage(
+                joinLink, CourseJoinConfirmationPage.class, newInstructorId);
+
+        confirmationPage.verifyDisplayedMessage("The course join link is invalid. You may have "
+                + "entered the URL incorrectly or the URL may correspond to a/an instructor that does not exist.");
+
+        ______TS("Click join link: valid key");
+        String courseId = testData.courses.get("ICJoinConf.CS1101").getId();
+        String instructorEmail = newInstructor.getEmail();
+        joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withRegistrationKey(getKeyForInstructor(courseId, instructorEmail))
+                .withEntityType(Const.EntityType.INSTRUCTOR);
+        confirmationPage = getNewPageInstance(joinLink, CourseJoinConfirmationPage.class);
+
+        confirmationPage.verifyJoiningUser(newInstructorId);
+        confirmationPage.confirmJoinCourse(InstructorHomePageSql.class);
+
+        ______TS("Already joined, no confirmation page");
+
+        getNewPageInstance(joinLink, InstructorHomePageSql.class);
+
+        logout();
+
+        ______TS("Click join link: invalid key");
+        joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withIsCreatingAccount("true")
+                .withRegistrationKey(invalidKey);
+        confirmationPage = loginToPage(joinLink, CourseJoinConfirmationPage.class, "ICJoinConf.newinstr");
+
+        confirmationPage.verifyDisplayedMessage("The course join link is invalid. You may have "
+                + "entered the URL incorrectly or the URL may correspond to a/an instructor that does not exist.");
+
+        ______TS("Click join link: valid account request key");
+
+        String regKey = BACKDOOR
+                .getRegKeyForAccountRequest(testData.accountRequests.get("ICJoinConf.newinstr").getId());
+
+        joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
+                .withIsCreatingAccount("true")
+                .withRegistrationKey(regKey);
+
+        confirmationPage = getNewPageInstance(joinLink, CourseJoinConfirmationPage.class);
+        confirmationPage.verifyJoiningUser("ICJoinConf.newinstr");
+        confirmationPage.confirmJoinCourse(InstructorHomePageSql.class);
+
+        ______TS("Regkey for account request used, no confirmation page");
+
+        getNewPageInstance(joinLink, InstructorHomePageSql.class);
+    }
+}

--- a/src/e2e/java/teammates/e2e/cases/sql/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/InstructorHomePageE2ETest.java
@@ -43,7 +43,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadSqlDataBundle("/InstructorHomePageSqlE2ETestSql.json");
+        testData = loadSqlDataBundle("/InstructorHomePageE2ETestSql.json");
         studentToEmail = testData.students.get("IHome.charlie.d.tmms@IHome.CS2104");
         studentToEmail.setEmail(TestProperties.TEST_EMAIL);
         testData = removeAndRestoreDataBundle(testData);

--- a/src/e2e/java/teammates/e2e/cases/sql/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/InstructorHomePageE2ETest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
-import teammates.e2e.pageobjects.InstructorHomePage;
+import teammates.e2e.pageobjects.InstructorHomePageSql;
 import teammates.e2e.util.TestProperties;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -43,7 +43,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
 
     @Override
     protected void prepareTestData() {
-        testData = loadSqlDataBundle("/InstructorHomePageE2ETestSql.json");
+        testData = loadSqlDataBundle("/InstructorHomePageSqlE2ETestSql.json");
         studentToEmail = testData.students.get("IHome.charlie.d.tmms@IHome.CS2104");
         studentToEmail.setEmail(TestProperties.TEST_EMAIL);
         testData = removeAndRestoreDataBundle(testData);
@@ -72,7 +72,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
-        InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class, instructor.getGoogleId());
+        InstructorHomePageSql homePage = loginToPage(url, InstructorHomePageSql.class, instructor.getGoogleId());
 
         ______TS("verify loaded data");
         homePage.sortCoursesById();
@@ -115,7 +115,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         homePage.copySession(courseIndex, sessionIndex, otherCourse, newName);
 
         homePage.waitForConfirmationModalAndClickOk();
-        homePage = getNewPageInstance(url, InstructorHomePage.class);
+        homePage = getNewPageInstance(url, InstructorHomePageSql.class);
         homePage.sortCoursesByName();
         // flip index after sorting
         courseIndex = 0;
@@ -134,7 +134,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
 
         homePage.verifyStatusMessage("The feedback session has been copied. "
                 + "Please modify settings/questions as necessary.");
-        homePage = getNewPageInstance(url, InstructorHomePage.class);
+        homePage = getNewPageInstance(url, InstructorHomePageSql.class);
         homePage.sortCoursesByName();
         FeedbackSession[] otherCourseSessionsWithTwoCopies = { copiedSession, copiedSession2, otherCourseSession };
         homePage.verifyCourseTabDetails(otherCourseIndex, otherCourse, otherCourseSessionsWithTwoCopies);

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorHomePageSql.java
@@ -9,16 +9,16 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
-import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.storage.sqlentity.Course;
+import teammates.storage.sqlentity.FeedbackSession;
+import teammates.storage.sqlentity.Student;
 
 /**
  * Represents the instructor home page.
  */
-public class InstructorHomePage extends AppPage {
+public class InstructorHomePageSql extends AppPage {
 
-    public InstructorHomePage(Browser browser) {
+    public InstructorHomePageSql(Browser browser) {
         super(browser);
     }
 
@@ -27,7 +27,7 @@ public class InstructorHomePage extends AppPage {
         return getPageTitle().contains("Home");
     }
 
-    public void verifyCourseTabDetails(int courseTabIndex, CourseAttributes course, FeedbackSessionAttributes[] sessions) {
+    public void verifyCourseTabDetails(int courseTabIndex, Course course, FeedbackSession[] sessions) {
         String expectedDetails = "[" + course.getId() + "]: " + course.getName();
         assertEquals(getCourseDetails(courseTabIndex), expectedDetails);
 
@@ -38,7 +38,7 @@ public class InstructorHomePage extends AppPage {
         verifyTableBodyValues(getSessionsTable(courseTabIndex), expectedValues);
     }
 
-    public void verifySessionDetails(int courseTabIndex, int sessionIndex, FeedbackSessionAttributes session) {
+    public void verifySessionDetails(int courseTabIndex, int sessionIndex, FeedbackSession session) {
         String[] expectedValues = getExpectedSessionDetails(session);
         WebElement sessionRow = getSessionsTable(courseTabIndex).findElements(By.cssSelector("tbody tr")).get(sessionIndex);
         verifyTableRowValues(sessionRow, expectedValues);
@@ -52,7 +52,7 @@ public class InstructorHomePage extends AppPage {
         assertEquals(expectedResponseRate, getResponseRate(courseTabIndex, sessionIndex));
     }
 
-    public void copySession(int courseTabIndex, int sessionIndex, CourseAttributes copyToCourse, String newSessionName) {
+    public void copySession(int courseTabIndex, int sessionIndex, Course copyToCourse, String newSessionName) {
         WebElement copyFsModal = clickCopyButtonInTable(courseTabIndex, sessionIndex);
         fillTextBox(copyFsModal.findElement(By.id("copy-session-name")), newSessionName);
         selectCourseToCopyToInModal(copyFsModal, copyToCourse.getId());
@@ -73,7 +73,7 @@ public class InstructorHomePage extends AppPage {
         clickAndConfirm(unpublishButtons.get(unpublishButtons.size() - 1));
     }
 
-    public void sendReminderEmailToSelectedStudent(int courseTabIndex, int sessionIndex, StudentAttributes student) {
+    public void sendReminderEmailToSelectedStudent(int courseTabIndex, int sessionIndex, Student student) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-remind-" + sessionIndex)));
         List<WebElement> remindSelectedButtons = browser.driver.findElements(
@@ -96,7 +96,7 @@ public class InstructorHomePage extends AppPage {
         click(courseTab.findElement(By.className("btn-remind-" + sessionIndex)));
     }
 
-    public void resendResultsLink(int courseTabIndex, int sessionIndex, StudentAttributes student) {
+    public void resendResultsLink(int courseTabIndex, int sessionIndex, Student student) {
         WebElement courseTab = getCourseTab(courseTabIndex);
         click(courseTab.findElement(By.className("btn-results-" + sessionIndex)));
         click(waitForElementPresence(By.className("btn-resend-" + sessionIndex)));
@@ -166,11 +166,11 @@ public class InstructorHomePage extends AppPage {
         return getDisplayedDateTime(instant, timeZone, "d MMM h:mm a");
     }
 
-    private String[] getExpectedSessionDetails(FeedbackSessionAttributes session) {
+    private String[] getExpectedSessionDetails(FeedbackSession session) {
         String[] details = new String[5];
-        details[0] = session.getFeedbackSessionName();
-        details[1] = getDateString(session.getStartTime(), session.getTimeZone());
-        details[2] = getDateString(session.getEndTime(), session.getTimeZone());
+        details[0] = session.getName();
+        details[1] = getDateString(session.getStartTime(), session.getCourse().getTimeZone());
+        details[2] = getDateString(session.getEndTime(), session.getCourse().getTimeZone());
 
         if (session.isClosed()) {
             details[3] = "Closed";

--- a/src/e2e/resources/data/InstructorCourseJoinConfirmationPageE2ETestSql.json
+++ b/src/e2e/resources/data/InstructorCourseJoinConfirmationPageE2ETestSql.json
@@ -1,0 +1,94 @@
+{
+  "accounts": {
+    "ICJoinConf.instr": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "googleId": "tm.e2e.ICJoinConf.instr",
+      "name": "Teammates Test",
+      "email": "ICJoinConf.instr@gmail.tmt"
+    }
+  },
+  "accountRequests": {
+    "ICJoinConf.instr.CS1101": {
+      "id": "00000000-0000-4000-8000-000000000101",
+      "name": "Teammates Test 2",
+      "email": "ICJoinConf.instr2@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "registeredAt": "1970-02-14T00:00:00Z"
+    },
+    "ICJoinConf.newinstr": {
+      "id": "00000000-0000-4000-8000-000000000201",
+      "name": "Teammates Test 3",
+      "email": "ICJoinConf.newinstr@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    }
+  },
+  "courses": {
+    "ICJoinConf.CS1101": {
+      "id": "tm.e2e.ICJoinConf.CS1101",
+      "name": "Programming Methodology",
+      "institute": "TEAMMATES Test Institute 1",
+      "timeZone": "UTC"
+    }
+  },
+  "instructors": {
+    "ICJoinConf.instr.CS1101": {
+      "id": "00000000-0000-4000-8000-000000000501",
+      "account": {},
+      "course": {
+        "id": "tm.e2e.ICJoinConf.CS1101"
+      },
+      "name": "Teammates Test 2",
+      "email": "ICJoinConf.instr2@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": false,
+      "displayName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "ICJoinConf.instr2.CS1101": {
+      "id": "00000000-0000-4000-8000-000000000502",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "course": {
+        "id": "tm.e2e.ICJoinConf.CS1101"
+      },
+      "name": "Teammates Test",
+      "email": "ICJoinConf.instr@gmail.tmt",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "isDisplayedToStudents": true,
+      "displayName": "Co-owner",
+      "privileges": {
+        "courseLevel": {
+          "canViewStudentInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true,
+          "canModifyCourse": true,
+          "canViewSessionInSections": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canModifyInstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    }
+  },
+  "students": {},
+  "feedbackSessions": {},
+  "feedbackQuestions": {},
+  "feedbackResponses": {},
+  "feedbackResponseComments": {}
+}

--- a/src/e2e/resources/testng-e2e-sql.xml
+++ b/src/e2e/resources/testng-e2e-sql.xml
@@ -26,6 +26,7 @@
             <class name="teammates.e2e.cases.sql.FeedbackTextQuestionE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseDetailsPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseEnrollPageE2ETest" />
+            <class name="teammates.e2e.cases.sql.InstructorCourseJoinConfirmationPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsEditPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorCourseStudentDetailsPageE2ETest" />
             <class name="teammates.e2e.cases.sql.InstructorFeedbackEditPageE2ETest" />


### PR DESCRIPTION
Part of #12048

**Outline of Solution**

- Migrated `InstructorCourseJoinConfirmationPageE2ETest` to use SQL-based logic instead of the previous Datastore model.

- Migrated `InstructorHomePage` to `InstructorHomePageSql`.

- Add methods to get registration key for `Instructor` and `Student` in `sql\BaseE2ETestCase`.