### PR TITLE
[#13338] Use Unique IDs for ContSum components

### DIFF
--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.html
@@ -32,7 +32,7 @@
         <div class="row form-check">
           <label class="row form-check-label">
             <div class="col-sm-6">
-              <input id="total-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="false"
+              <input id="total-points-radio" class="form-check-input" type="radio" [name]="uniqueId" [ngModel]="model.pointsPerOption" [value]="false"
                      (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Checkbox">
               <input id="total-points" type="number" class="form-control" (keypress)="onIntegerInput($event)" (paste)="onPaste($event)" min="1" max="999999999" (input)="restrictIntegerInputLength($event, 'points')"
                      [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption" aria-label="Total Points Input">
@@ -45,7 +45,7 @@
         <div class="row form-check">
           <label class="row form-check-label">
             <div class="col-sm-6">
-              <input id="per-option-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="true"
+              <input id="per-option-points-radio" class="form-check-input" type="radio" [name]="uniqueId" [ngModel]="model.pointsPerOption" [value]="true"
                      (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Times Number of Options Checkbox">
               <input id="per-option-points" type="number" class="form-control" (keypress)="onIntegerInput($event)" (paste)="onPaste($event)" min="1" max="999999999" (input)="restrictIntegerInputLength($event, 'points')"
                      [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption" aria-label="Points Input">

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
@@ -1,5 +1,5 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { QuestionEditDetailsFormComponent } from './question-edit-details-form.component';
 import { StatusMessageService } from '../../../../services/status-message.service';
 import {
@@ -18,6 +18,10 @@ import { DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS } from '../../../../types/def
 })
 export class ConstsumOptionsQuestionEditDetailsFormComponent
     extends QuestionEditDetailsFormComponent<FeedbackConstantSumQuestionDetails> {
+
+  private static nextId = 0;
+
+  @Input() uniqueId = `constsum-options-${ConstsumOptionsQuestionEditDetailsFormComponent.nextId++}`;
 
   // enum
   FeedbackConstantSumDistributePointsType: typeof FeedbackConstantSumDistributePointsType =

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
@@ -7,7 +7,7 @@
     <div class="row form-check">
       <label class="row form-check-label">
         <div class="col-sm-3">
-          <input id="total-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="false"
+          <input id="total-points-radio" class="form-check-input" type="radio" [name]="uniqueId" [ngModel]="model.pointsPerOption" [value]="false"
                  (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Checkbox">
           <input id="total-points" type="number" class="form-control" (keypress)="onIntegerInput($event)" (paste)="onPaste($event)" min="1" max="999999999" (input)="restrictIntegerInputLength($event, 'points')"
                  [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption" aria-label="Total Points Input">
@@ -20,7 +20,7 @@
     <div class="form-check">
       <label class="form-check-label row">
         <div class="col-sm-3">
-          <input id="per-option-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="true"
+          <input id="per-option-points-radio" class="form-check-input" type="radio" [name]="uniqueId" [ngModel]="model.pointsPerOption" [value]="true"
                  (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Times Number of Recipients Checkbox">
           <input id="per-option-points" type="number" class="form-control" (keypress)="onIntegerInput($event)" (paste)="onPaste($event)" min="1" max="999999999" (input)="restrictIntegerInputLength($event, 'points')"
                  [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption" aria-label="Points Input">

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { QuestionEditDetailsFormComponent } from './question-edit-details-form.component';
 import {
   FeedbackConstantSumDistributePointsType,
@@ -18,6 +18,10 @@ import {
 })
 export class ConstsumRecipientsQuestionEditDetailsFormComponent
     extends QuestionEditDetailsFormComponent<FeedbackConstantSumQuestionDetails> {
+
+  private static nextId = 0;
+
+  @Input() uniqueId = `constsum-recipients-${ConstsumRecipientsQuestionEditDetailsFormComponent.nextId++}`;
 
   // enum
   FeedbackConstantSumDistributePointsType: typeof FeedbackConstantSumDistributePointsType =


### PR DESCRIPTION
Fixes #13338

Previously, when multiple instances of the`ConstsumOptionsQuestionEditDetailsFormComponent` and `ConstsumRecipientsQuestionEditDetailsFormComponent` were used on the same page, the radio buttons were grouped together, causing selecting one to affect all others.


**Outline of Solution**
This commit introduces unique IDs for each instance of the `ConstsumOptionsQuestionEditDetailsFormComponent` and `ConstsumRecipientsQuestionEditDetailsFormComponent`. This ID is then used to create unique `name` attributes within each component's template, ensuring that each instance is unique and properly isolated.

1. Added @Input() uniqueId: Both `ConstsumOptionsQuestionEditDetailsFormComponent` and `ConstsumRecipientsQuestionEditDetailsFormComponent` now have a `uniqueId` property. This property is assigned a unique default value using a static counter, ensuring uniqueness even when not explicitly provided.
2. Updated Component Templates: The templates for both components have been updated to use this uniqueId to generate unique name attributes for their form controls. Radio buttons are now correctly scoped using a unique `name`, e.g. `[name]="uniqueId"`.

https://github.com/user-attachments/assets/33e12729-ba08-42d6-a075-b928880f1765