### PR TITLE
[#13304] Refactoring for Unit Test Access Controls (60 - 70)

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/RegenerateInstructorKeyActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RegenerateInstructorKeyActionTest.java
@@ -194,50 +194,11 @@ public class RegenerateInstructorKeyActionTest extends BaseActionTest<Regenerate
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
+    void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
         };
-
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_instructor_cannotAccess() {
-        loginAsInstructor("instructor-googleId");
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_student_cannotAccess() {
-        loginAsStudent("student-googleId");
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_loggedOut_cannotAccess() {
-        logoutUser();
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
-        };
-
-        verifyCannotAccess(params);
+        verifyOnlyAdminsCanAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/RegenerateStudentKeyActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RegenerateStudentKeyActionTest.java
@@ -199,7 +199,7 @@ public class RegenerateStudentKeyActionTest extends BaseActionTest<RegenerateStu
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, student.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, student.getEmail(),
+                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
         };
         verifyOnlyAdminsCanAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/RegenerateStudentKeyActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RegenerateStudentKeyActionTest.java
@@ -196,50 +196,11 @@ public class RegenerateStudentKeyActionTest extends BaseActionTest<RegenerateStu
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
+    void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, student.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.INSTRUCTOR_EMAIL, student.getEmail(),
         };
-
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_instructor_cannotAccess() {
-        loginAsInstructor("instructor-googleId");
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, student.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_student_cannotAccess() {
-        loginAsStudent("student-googleId");
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, student.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_loggedOut_cannotAccess() {
-        logoutUser();
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, student.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-        };
-
-        verifyCannotAccess(params);
+        verifyOnlyAdminsCanAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
@@ -277,70 +277,33 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
-        String[] params1 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+    void testAccessControl() {
+        String[][] paramSets = new String[][] {
+                {
+                        Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
+                        Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+                },
+                {},
+                {
+                        Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
+                },
+                {
+                        Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
+                },
+                {
+                        Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
+                        Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
+                },
+                {
+                        Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
+                },
+                {
+                        "random-params", "random-value",
+                }
         };
-        verifyCanAccess(params1);
 
-        String[] params2 = {};
-        verifyCanAccess(params2);
-
-        String[] params3 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-        };
-        verifyCanAccess(params3);
-
-        String[] params4 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        verifyCanAccess(params4);
-
-        String[] params5 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        verifyCanAccess(params5);
-
-        String[] params6 = {
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
-        };
-        verifyCanAccess(params6);
-
-        String[] params7 = {
-                "random-params", "random-value",
-        };
-        verifyCanAccess(params7);
-    }
-
-    @Test
-    void testSpecificAccessControl_notAdmin_cannotAccess() {
-        String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
-        };
-        verifyCannotAccess(params);
-
-        loginAsInstructor(stubInstructor.getGoogleId());
-        verifyCannotAccess(params);
-
-        logoutUser();
-        loginAsStudent(stubStudent.getGoogleId());
-        verifyCannotAccess(params);
-
-        logoutUser();
-        loginAsMaintainer();
-        verifyCannotAccess(params);
-
-        logoutUser();
-        loginAsStudentInstructor(stubStudent.getGoogleId());
-        verifyCannotAccess(params);
-
-        logoutUser();
-        loginAsUnregistered(stubInstructor.getGoogleId());
-        verifyCannotAccess(params);
+        for (String[] params : paramSets) {
+            verifyOnlyAdminsCanAccess(params);
+        }
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/ResetAccountRequestActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/ResetAccountRequestActionTest.java
@@ -119,32 +119,11 @@ public class ResetAccountRequestActionTest extends BaseActionTest<ResetAccountRe
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
+    void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.getId().toString(),
         };
 
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_notAdmin_cannotAccess() {
-        String[] params = {
-                Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.getId().toString(),
-        };
-
-        loginAsUnregistered("unregistered");
-        verifyCannotAccess(params);
-
-        loginAsStudent("student");
-        verifyCannotAccess(params);
-
-        loginAsInstructor("instructor");
-        verifyCannotAccess(params);
-
-        logoutUser();
-        verifyCannotAccess(params);
+        verifyOnlyAdminsCanAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/RestoreFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RestoreFeedbackSessionActionTest.java
@@ -151,89 +151,32 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
     }
 
     @Test
-    void testAccessControl_notLoggedIn_cannotAccess() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, COURSE_ID,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
-        };
-
-        logoutUser();
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testAccessControl_unregisteredUser_cannotAccess() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, COURSE_ID,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
-        };
-
-        loginAsUnregistered(GOOGLE_ID);
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testAccessControl_student_cannotAccess() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, COURSE_ID,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
-        };
-
-        loginAsStudent(GOOGLE_ID);
-        verifyCannotAccess(params);
-    }
-
-    @Test
     void testAccessControl_instructorOfOtherCourses_cannotAccess() {
         when(mockLogic.getFeedbackSessionFromRecycleBin(FEEDBACK_SESSION_NAME, COURSE_ID))
                 .thenReturn(stubFeedbackSession);
-        Course otherCourse = getTypicalCourse();
-        otherCourse.setId("other-course-id");
-        stubInstructor.setCourse(otherCourse);
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, GOOGLE_ID)).thenReturn(stubInstructor);
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, COURSE_ID,
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
         };
 
-        loginAsInstructor(GOOGLE_ID);
-        verifyCannotAccess(params);
+        verifyInstructorsOfOtherCoursesCannotAccess(params);
     }
 
     @Test
-    void testAccessControl_instructorOfSameCourseWithoutCorrectCoursePrivilege_cannotAccess() {
+    void testAccessControl() {
         when(mockLogic.getFeedbackSessionFromRecycleBin(FEEDBACK_SESSION_NAME, COURSE_ID))
                 .thenReturn(stubFeedbackSession);
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, false);
-        stubInstructor.setPrivileges(privileges);
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, GOOGLE_ID)).thenReturn(stubInstructor);
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, COURSE_ID,
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
         };
 
-        loginAsInstructor(GOOGLE_ID);
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testAccessControl_instructorOfSameCourseWithCorrectCoursePrivilege_canAccess() {
-        when(mockLogic.getFeedbackSessionFromRecycleBin(FEEDBACK_SESSION_NAME, COURSE_ID))
-                .thenReturn(stubFeedbackSession);
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, true);
-        stubInstructor.setPrivileges(privileges);
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, GOOGLE_ID)).thenReturn(stubInstructor);
-
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, COURSE_ID,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
-        };
-
-        loginAsInstructor(GOOGLE_ID);
-        verifyCanAccess(params);
+        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
+                stubFeedbackSession.getCourse(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION,
+                params
+        );
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/SearchAccountRequestsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchAccountRequestsActionTest.java
@@ -139,32 +139,11 @@ public class SearchAccountRequestsActionTest extends BaseActionTest<SearchAccoun
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
+    void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.SEARCH_KEY, searchKey,
         };
 
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_notAdmin_cannotAccess() {
-        String[] params = {
-                Const.ParamsNames.SEARCH_KEY, searchKey,
-        };
-
-        loginAsUnregistered("unregistered");
-        verifyCannotAccess(params);
-
-        loginAsStudent("student");
-        verifyCannotAccess(params);
-
-        loginAsInstructor("instructor");
-        verifyCannotAccess(params);
-
-        logoutUser();
-        verifyCannotAccess(params);
+        verifyOnlyAdminsCanAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
@@ -139,46 +139,11 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
     }
 
     @Test
-    void testSpecificAccessControl_admin_canAccess() {
-        loginAsAdmin();
-
+    void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.SEARCH_KEY, searchKey,
         };
 
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_instructor_cannotAccess() {
-        loginAsInstructor("instructor-googleId");
-
-        String[] params = {
-                Const.ParamsNames.SEARCH_KEY, searchKey,
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_student_cannotAccess() {
-        loginAsStudent("student-googleId");
-
-        String[] params = {
-                Const.ParamsNames.SEARCH_KEY, searchKey,
-        };
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_loggedOut_cannotAccess() {
-        logoutUser();
-
-        String[] params = {
-                Const.ParamsNames.SEARCH_KEY, searchKey,
-        };
-
-        verifyCannotAccess(params);
+        verifyOnlyAdminsCanAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
@@ -322,4 +322,21 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
 
         verifyCannotAccess(params);
     }
+
+    @Test
+    void testAccessControl() {
+        String[] adminParams = {
+                Const.ParamsNames.SEARCH_KEY, searchKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.ADMIN,
+        };
+        String[] instructorParams = {
+                Const.ParamsNames.SEARCH_KEY, searchKey,
+                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
+        };
+
+        verifyAdminsCanAccess(adminParams);
+        verifyInstructorsCanAccess(getTypicalCourse(), instructorParams);
+        verifyStudentsCannotAccess(adminParams);
+        verifyWithoutLoginCannotAccess(adminParams);
+    }
 }

--- a/src/test/java/teammates/sqlui/webapi/SendErrorReportActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendErrorReportActionTest.java
@@ -99,38 +99,7 @@ public class SendErrorReportActionTest extends BaseActionTest<SendErrorReportAct
     }
 
     @Test
-    void testAccessControl_admin_canAccess() {
-        loginAsAdmin();
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_maintainer_canAccess() {
-        loginAsMaintainer();
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_instructor_canAccess() {
-        loginAsInstructor(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_student_canAccess() {
-        loginAsStudent(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_unregistered_canAccess() {
-        loginAsUnregistered(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_loggedOut_canAccess() {
-        logoutUser();
-        verifyCanAccess();
+    void testAccessControl() {
+        verifyAnyUserCanAccess();
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/SendLoginEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendLoginEmailActionTest.java
@@ -193,38 +193,7 @@ public class SendLoginEmailActionTest extends BaseActionTest<SendLoginEmailActio
     }
 
     @Test
-    void testAccessControl_admin_canAccess() {
-        loginAsAdmin();
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_maintainer_canAccess() {
-        loginAsMaintainer();
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_instructor_canAccess() {
-        loginAsInstructor(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_student_canAccess() {
-        loginAsStudent(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_unregistered_canAccess() {
-        loginAsUnregistered(GOOGLE_ID);
-        verifyCanAccess();
-    }
-
-    @Test
-    void testAccessControl_loggedOut_canAccess() {
-        logoutUser();
-        verifyCanAccess();
+    void testAccessControl() {
+        verifyAnyUserCanAccess();
     }
 }


### PR DESCRIPTION
Part of #13304 

The code refactors the unit test access controls for methods 60–70 in `sqlui/webapi`, replacing individual permission checks with the abstract helper methods defined in `BaseActionTest.java`.