### PR TITLE
[#13291] PostgreSQL port conflict when running dev server

### DIFF
--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -30,6 +30,12 @@ This is possible if a part of API input/output definition changes.
 Simply rerun the command to build the type definitions to resolve the problem.
 </panel>
 
+<panel header="When running ./gradlew serverRun, the authentication fails with 'org.postgresql.util.PSQLException: FATAL: password authentication failed for user &quot;teammates&quot;'" no-close>
+
+This is possible if a local PostgreSQL instance is already running on port 5432. 
+This can be fixed by manually killing the local PostgreSQL server process before running ./gradlew serverRun again.
+</panel>
+
 <br>
 
 ## Common test errors and solutions


### PR DESCRIPTION
Fixes #13291 
Ready for review

**Outline of Solution**

Added issue with PostgreSQL authentication failures to 'Common setup errors and solutions' section of the troubleshooting guide in dev docs (according to the first suggested solution in the issue). 

I followed a similar structure to the other panels in this section, but let me know if I should include more detail.