### PR TITLE
[#13202] Add a show all/collapse all button for students on their submission page 

### DIFF
--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -138,7 +138,24 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
+  </div><tm-loading-retry>
     <div
       class="text-center"
     >
@@ -299,7 +316,24 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
+  </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -457,7 +491,24 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
+  </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -748,6 +799,23 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
         </div>
       </div>
     </div>
+  </div><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
   </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
@@ -1004,6 +1072,23 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
           </div>
         </div>
       </div>
+    </div>
+  </div><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
     </div>
   </div><tm-loading-retry>
     <div>
@@ -4116,6 +4201,23 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
         </div>
       </div>
     </div>
+  </div><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
   </div><tm-loading-retry>
     <div>
       <tm-question-submission-form
@@ -7160,7 +7262,24 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
+  </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -7319,7 +7438,24 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
         Loading...
       </div>
     </div>
-  </tm-loading-spinner><tm-loading-retry>
+  </tm-loading-spinner><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12 text-end"
+    >
+      <button
+        class="btn btn-secondary btn-sm"
+      >
+         Show All 
+      </button>
+      <button
+        class="btn btn-secondary btn-sm ms-2"
+      >
+         Collapse All 
+      </button>
+    </div>
+  </div><tm-loading-retry>
     <tm-loading-spinner>
       <div
         class="loading-container"

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -100,7 +100,20 @@
     </div>
   </div>
 </div>
-
+<div class="row mb-3">
+  <div class="col-12 text-end">
+    <button
+      class="btn btn-secondary btn-sm"
+      (click)="showAllQuestions()">
+      Show All
+    </button>
+    <button
+      class="btn btn-secondary btn-sm ms-2"
+      (click)="collapseAllQuestions()">
+      Collapse All
+    </button>
+  </div>
+</div>
 <tm-loading-retry [shouldShowRetry]="hasFeedbackSessionQuestionsLoadingFailed" [message]="'Failed to load questions'" (retryEvent)="retryLoadingFeedbackSessionQuestions()">
   <div *tmIsLoading="isFeedbackSessionQuestionsLoading">
     <ng-container *ngIf="currentSelectedSessionView === allSessionViews.GROUP_RECIPIENTS">

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -73,6 +73,7 @@ import {
 } from '../../components/question-submission-form/question-submission-form.module';
 import { SimpleModalType } from '../../components/simple-modal/simple-modal-type';
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
+import { By } from '@angular/platform-browser';
 
 describe('SessionSubmissionPageComponent', () => {
   const deepCopy: <T>(obj: T) => T = <T>(obj: T) => JSON.parse(JSON.stringify(obj));
@@ -1314,5 +1315,47 @@ describe('SessionSubmissionPageComponent', () => {
     expect(component.questionSubmissionForms[0].hasResponseChangedForRecipients.get('r1')).toBe(true);
     expect(component.questionSubmissionForms[0].isTabExpandedForRecipients.get('r1')).toBe(true);
     expect(getItemSpy).toHaveBeenCalledWith('autosave');
+  });
+
+  beforeEach(() => {
+    component.questionSubmissionForms = [
+      { questionNumber: 1, isTabExpanded: false } as any,
+      { questionNumber: 2, isTabExpanded: true  } as any,
+      { questionNumber: 3, isTabExpanded: false } as any,
+    ];
+    fixture.detectChanges();
+  });
+
+  it('should show both Show All and Collapse All buttons', () => {
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const texts = buttons.map(b => b.nativeElement.textContent.trim());
+    expect(texts).toContain('Show All');
+    expect(texts).toContain('Collapse All');
+  });
+
+  it('should expand every question panel when Show All is clicked', () => {
+    component.questionSubmissionForms.forEach(q => q.isTabExpanded = false);
+    fixture.detectChanges();
+
+    const showAll = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find(b => b.nativeElement.textContent.includes('Show All'))!;
+    showAll.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.questionSubmissionForms.every(q => q.isTabExpanded)).toBe(true);
+  });
+
+  it('should collapse every question panel when Collapse All is clicked', () => {
+    component.questionSubmissionForms.forEach(q => q.isTabExpanded = true);
+    fixture.detectChanges();
+
+    const collapseAll = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find(b => b.nativeElement.textContent.includes('Collapse All'))!;
+    collapseAll.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.questionSubmissionForms.every(q => !q.isTabExpanded)).toBe(true);
   });
 });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -1216,6 +1216,30 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     }
   }
 
+  showAllQuestions(): void {
+    if (this.currentSelectedSessionView === this.allSessionViews.DEFAULT) {
+      this.questionSubmissionForms.forEach(q => q.isTabExpanded = true);
+    } else {
+      this.questionSubmissionForms.forEach(q => {
+        q.recipientList.forEach(recipient => {
+          q.isTabExpandedForRecipients.set(recipient.recipientIdentifier, true);
+        });
+      });
+    }
+  }
+
+  collapseAllQuestions(): void {
+    if (this.currentSelectedSessionView === this.allSessionViews.DEFAULT) {
+      this.questionSubmissionForms.forEach(q => q.isTabExpanded = false);
+    } else {
+      this.questionSubmissionForms.forEach(q => {
+        q.recipientList.forEach(recipient => {
+          q.isTabExpandedForRecipients.set(recipient.recipientIdentifier, false);
+        });
+      });
+    }
+  }
+  
   toggleViewChange(selectedView: SessionView): void {
     if (selectedView === this.currentSelectedSessionView) {
       return;


### PR DESCRIPTION
[#13202] Add a show all/collapse all button for students on their submission page

Fixes issuee #13202 

**Outline of Solution**

- Added the UI for the button just above the drop down questions
- Implemented the Show All and Collapse All logic with two functions
- Wrote test scripts to test the buttons and the controller logic
- Fixed snapshots to allow test cases to pass

An added future work would be grouping the Submit and Reset buttons with the question drop downs when grouped by Recipient. As seen from the screenshots, when the drop downs are collapsed, they are separate and causes the drop down to look different from grouping by Question.

See screenshots below for the utilisation of the buttons, for both group by Question and Recipient.
<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/4eca1f10-c1d3-4123-8b13-7da6f08cb8f0" />
<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/8afd3977-6bd4-463f-b0b5-d82986810ab0" />
Group by Question screenshots

<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/45f60b51-3620-4c85-b38d-b4fe6231be57" />
<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/7550feab-ed14-4e70-b881-a5c8dbe95d74" />
Group by Recipient screenshots