### PR TITLE
[#13119] Admin: Unable to create an instructor account if the same email was used for a student account

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -131,8 +131,9 @@ public class UpdateAccountRequestActionIT extends BaseActionIT<UpdateAccountRequ
 
         InvalidOperationException ipe = verifyInvalidOperation(requestBody, params);
 
-        assertEquals(String.format("An instructor account with email %s already exists. "
-                        + "Please reject or delete the account request instead.", account.getEmail()), ipe.getMessage());
+        assertEquals(String.format("An instructor account with email %s under the institute %s "
+                        + "already exists. Please reject or delete the account request instead.",
+                        accountRequest.getEmail(), accountRequest.getInstitute()), ipe.getMessage());
 
         ______TS("non-existent but valid uuid");
         requestBody = new AccountRequestUpdateRequest("name", "email",

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import jakarta.annotation.Nullable;
+
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackQuestionRecipient;
 import teammates.common.datatransfer.FeedbackResultFetchType;
@@ -113,6 +114,14 @@ public class Logic {
         return accountsLogic.updateReadNotifications(googleId, notificationId, endTime);
     }
 
+    /**
+     * Returns the institute of the course with ID {@code courseId}.
+     *
+     * <p>Preconditions:</p>
+     * * All parameters are non-null.
+     *
+     * @return The institute of the course, or null if no such course exists.
+     */
     public String getCourseInstitute(String courseId) {
         return coursesLogic.getCourseInstitute(courseId);
     }

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 
 import jakarta.annotation.Nullable;
-
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackQuestionRecipient;
 import teammates.common.datatransfer.FeedbackResultFetchType;
@@ -295,6 +294,22 @@ public class Logic {
         assert email != null;
 
         return instructorsLogic.getInstructorById(courseId, email);
+    }
+
+    /**
+     * Checks whether an instructor with the given email exists in any course that belongs to the given institute.
+     *
+     * <p>Preconditions: <br>
+     * * All parameters are non-null.
+     *
+     * @return true if exists, false otherwise.
+     */
+    public boolean isInstructorWithEmailInInstitute(String email, String institute) {
+
+        assert email != null;
+        assert institute != null;
+
+        return instructorsLogic.isExistingInstructorWithEmailInInstitute(email, institute);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
-import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -171,6 +170,14 @@ public final class InstructorsLogic {
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId) {
         return getInstructorsForGoogleId(googleId, false);
     }
+
+    /**
+     * Gets all instructors associated with an email.
+     */
+    public List<InstructorAttributes> getInstructorsForEmail(String email) {
+        return instructorsDb.getInstructorsForEmail(email);
+    }
+    
 
     /**
      * Gets all instructors associated with a googleId.
@@ -435,18 +442,13 @@ public final class InstructorsLogic {
         assert email != null;
         assert institute != null;
 
-        try {
-            List<InstructorAttributes> instructors = searchInstructorsInWholeSystem(email);
-            for (InstructorAttributes instructor : instructors) {
-                if (instructor.getEmail().equals(email)) {
-                    CourseAttributes course = coursesLogic.getCourse(instructor.getCourseId());
-                    if (course != null && institute.equals(course.getInstitute())) {
-                        return true;
-                    }
+        List<InstructorAttributes> instructors = getInstructorsForEmail(email);
+        for (InstructorAttributes instructor : instructors) {
+            if (instructor.getEmail().equals(email)) {
+                if (institute.equals(coursesLogic.getCourseInstitute(instructor.getCourseId()))) {
+                    return true;
                 }
             }
-        } catch (SearchServiceException e) {
-            log.warning("Failed to search for instructors with email " + email + ": " + e.getMessage());
         }
         return false;
     }

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -33,6 +34,7 @@ public final class InstructorsLogic {
     private static final InstructorsLogic instance = new InstructorsLogic();
 
     private final InstructorsDb instructorsDb = InstructorsDb.inst();
+    private final CoursesLogic coursesLogic = CoursesLogic.inst();
 
     private FeedbackResponsesLogic frLogic;
     private FeedbackResponseCommentsLogic frcLogic;
@@ -424,6 +426,29 @@ public final class InstructorsLogic {
      */
     public boolean isInstructorInAnyCourse(String googleId) {
         return instructorsDb.hasInstructorsForGoogleId(googleId);
+    }
+
+    /**
+     * Checks if there is an existing instructor with the given email in the specified institute.
+     */
+    public boolean isExistingInstructorWithEmailInInstitute(String email, String institute) {
+        assert email != null;
+        assert institute != null;
+
+        try {
+            List<InstructorAttributes> instructors = searchInstructorsInWholeSystem(email);
+            for (InstructorAttributes instructor : instructors) {
+                if (instructor.getEmail().equals(email)) {
+                    CourseAttributes course = coursesLogic.getCourse(instructor.getCourseId());
+                    if (course != null && institute.equals(course.getInstitute())) {
+                        return true;
+                    }
+                }
+            }
+        } catch (SearchServiceException e) {
+            log.warning("Failed to search for instructors with email " + email + ": " + e.getMessage());
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -172,20 +172,19 @@ public final class InstructorsLogic {
     }
 
     /**
-     * Gets all instructors associated with an email.
-     */
-    public List<InstructorAttributes> getInstructorsForEmail(String email) {
-        return instructorsDb.getInstructorsForEmail(email);
-    }
-    
-
-    /**
      * Gets all instructors associated with a googleId.
      *
      * @param omitArchived whether archived instructors should be omitted or not
      */
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId, boolean omitArchived) {
         return instructorsDb.getInstructorsForGoogleId(googleId, omitArchived);
+    }
+
+    /**
+     * Gets all instructors associated with an email.
+     */
+    public List<InstructorAttributes> getInstructorsForEmail(String email) {
+        return instructorsDb.getInstructorsForEmail(email);
     }
 
     /**
@@ -444,10 +443,9 @@ public final class InstructorsLogic {
 
         List<InstructorAttributes> instructors = getInstructorsForEmail(email);
         for (InstructorAttributes instructor : instructors) {
-            if (instructor.getEmail().equals(email)) {
-                if (institute.equals(coursesLogic.getCourseInstitute(instructor.getCourseId()))) {
-                    return true;
-                }
+            if (instructor.getEmail().equals(email)
+                    && institute.equals(coursesLogic.getCourseInstitute(instructor.getCourseId()))) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -156,6 +156,15 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
     }
 
     /**
+     * Gets all instructors associated with an email.
+     */
+    public List<InstructorAttributes> getInstructorsForEmail(String email) {
+        assert email != null;
+
+        return makeAttributes(getInstructorEntitiesForEmail(email));
+    }
+
+    /**
      * Gets all instructors associated with a googleId.
      *
      * @param omitArchived whether archived instructors should be omitted or not
@@ -395,6 +404,13 @@ public final class InstructorsDb extends EntitiesDb<Instructor, InstructorAttrib
 
     private Query<Instructor> getInstructorsForGoogleIdQuery(String googleId) {
         return load().filter("googleId =", googleId);
+    }
+
+    /**
+     * Returns all instructor entities associated with the email.
+     */
+    private List<Instructor> getInstructorEntitiesForEmail(String email) {
+        return load().filter("email =", email).list();
     }
 
     private List<Instructor> getInstructorEntitiesForGoogleId(String googleId) {

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -42,9 +42,9 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
                 || accountRequest.getStatus() == AccountRequestStatus.REJECTED)) {
 
             if (logic.isInstructorWithEmailInInstitute(accountRequest.getEmail(), accountRequest.getInstitute())) {
-                throw new InvalidOperationException(String.format("An instructor account with email %s already exists. "
-                        + "Please reject or delete the account request instead.",
-                        accountRequest.getEmail()));
+                throw new InvalidOperationException(String.format("An instructor account with email %s "
+                        + "under the institute %s already exists. Please reject or delete the account request instead.",
+                        accountRequest.getEmail(), accountRequest.getInstitute()));
             }
 
             if (!sqlLogic.getApprovedAccountRequestsForEmailWithTransaction(accountRequest.getEmail()).isEmpty()) {

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -42,7 +42,7 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
                 || accountRequest.getStatus() == AccountRequestStatus.REJECTED)) {
 
             if (logic.isInstructorWithEmailInInstitute(accountRequest.getEmail(), accountRequest.getInstitute())) {
-                throw new InvalidOperationException(String.format("An account with email %s already exists. "
+                throw new InvalidOperationException(String.format("An instructor account with email %s already exists. "
                         + "Please reject or delete the account request instead.",
                         accountRequest.getEmail()));
             }

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -41,7 +41,7 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
                 && (accountRequest.getStatus() == AccountRequestStatus.PENDING
                 || accountRequest.getStatus() == AccountRequestStatus.REJECTED)) {
 
-            if (!sqlLogic.getAccountsForEmailWithTransaction(accountRequest.getEmail()).isEmpty()) {
+            if (logic.isInstructorWithEmailInInstitute(accountRequest.getEmail(), accountRequest.getInstitute())) {
                 throw new InvalidOperationException(String.format("An account with email %s already exists. "
                         + "Please reject or delete the account request instead.",
                         accountRequest.getEmail()));


### PR DESCRIPTION
Fixes #13119 

**Cause**
Previously, admins could not approve an account request if any account with the same email existed, including student accounts. This was due to the `UpdateAccountRequestAction` class calling the `getAccountsForEmailWithTransaction`method from `sqlLogic`, which gets all accounts (regardless of if those were student-only or instructor accounts) linked to a particular email. This was too restrictive, as only instructor accounts in the same institute should block approval.

**Outline of Solution**
- The approval logic now only prevents approval if there is an existing instructor account with the same email in the same institute as the account request.
- Introduced a new method `isInstructorWithEmailInInstitute(email, institute)` into the `Logic` class, which searches for instructors with the given email and verifies if it belongs to any course under the specified institute.
- Admins can now approve instructor account requests even if a student account with the same email exists, as long as there is no conflicting instructor account in the same institute.
