### PR TITLE
[#13326] Add null check to AdminSearchPageE2ETest to prevent Null Pointer Exception

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/sql/AdminSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/AdminSearchPageE2ETest.java
@@ -275,7 +275,6 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
 
     @AfterClass
     public void classTeardown() {
-        System.out.printf("testData is", testData);
         if (testData != null) {
             for (AccountRequest request : testData.accountRequests.values()) {
                 BACKDOOR.deleteAccountRequest(request.getId());

--- a/src/e2e/java/teammates/e2e/cases/sql/AdminSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/sql/AdminSearchPageE2ETest.java
@@ -275,8 +275,11 @@ public class AdminSearchPageE2ETest extends BaseE2ETestCase {
 
     @AfterClass
     public void classTeardown() {
-        for (AccountRequest request : testData.accountRequests.values()) {
-            BACKDOOR.deleteAccountRequest(request.getId());
+        System.out.printf("testData is", testData);
+        if (testData != null) {
+            for (AccountRequest request : testData.accountRequests.values()) {
+                BACKDOOR.deleteAccountRequest(request.getId());
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13326

It is kind of part of it as the error appears in a lot of runs but was never resolved due to insufficient handling of null data during cleanup. It is also an attempt to fix the failing e2eSqlTest now that the error has ballooned to more than just a NullPointerException

**Outline of Solution**
Added a null check wrapper before initiating the clean up

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 
