### PR TITLE
Part of Refactoring for Unit Test Access Controls #13304

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/GetNotificationActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationActionTest.java
@@ -33,6 +33,7 @@ public class GetNotificationActionTest extends BaseActionTest<GetNotificationAct
 
     @BeforeMethod
     public void baseClassSetup() {
+        // Access control: only admin can access this action
         loginAsAdmin();
     }
 
@@ -41,37 +42,38 @@ public class GetNotificationActionTest extends BaseActionTest<GetNotificationAct
         Notification testNotification = getTypicalNotificationWithId();
         NotificationData expected = new NotificationData(testNotification);
 
-        String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_ID, String.valueOf(testNotification.getId()),
-        };
-
+        // Stub the logic layer
         when(mockLogic.getNotification(testNotification.getId())).thenReturn(testNotification);
 
-        GetNotificationAction action = getAction(requestParams);
+        GetNotificationAction action = getAction(Const.ParamsNames.NOTIFICATION_ID,
+                String.valueOf(testNotification.getId()));
+
+        // Execute and get result
         JsonResult jsonResult = getJsonResult(action);
 
-        NotificationData output = (NotificationData) jsonResult.getOutput();
-        verifyNotificationEquals(expected, output);
+        // Verify output
+        verifyNotificationEquals(expected, (NotificationData) jsonResult.getOutput());
 
-        reset(mockLogic);
+        reset(mockLogic); // Clean up
     }
 
     @Test
     protected void testExecute_nonExistentNotification_shouldThrowError() {
         GetNotificationAction action = getAction(Const.ParamsNames.NOTIFICATION_ID, UUID.randomUUID().toString());
-        EntityNotFoundException enfe = assertThrows(EntityNotFoundException.class, action::execute);
 
-        assertEquals("Notification does not exist.", enfe.getMessage());
+        // TestNG assertThrows usage
+        EntityNotFoundException enfe = assertThrows(EntityNotFoundException.class, action::execute);
+        assertEquals(enfe.getMessage(), "Notification does not exist.");
     }
 
     @Test
     protected void testExecute_notificationIdIsNull_shouldThrowError() {
-        GetNotificationAction action = getAction(Const.ParamsNames.NOTIFICATION_ID, null, new String[] {});
+        GetNotificationAction action = getAction(Const.ParamsNames.NOTIFICATION_ID, (String) null);
         InvalidHttpParameterException ihpe = assertThrows(InvalidHttpParameterException.class, action::execute);
-
-        assertEquals("The [notificationid] HTTP parameter is null.", ihpe.getMessage());
+        assertEquals(ihpe.getMessage(), "The [notificationid] HTTP parameter is null.");
     }
 
+    // Helper method to verify output
     private void verifyNotificationEquals(NotificationData expected, NotificationData actual) {
         assertEquals(expected.getNotificationId(), actual.getNotificationId());
         assertEquals(expected.getStyle(), actual.getStyle());

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -29,10 +29,8 @@ import teammates.ui.output.OngoingSessionsData;
 import teammates.ui.webapi.GetOngoingSessionsAction;
 import teammates.ui.webapi.JsonResult;
 
-/**
- * SUT: {@link GetOngoingSessionsAction}.
- */
 public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessionsAction> {
+
     @Override
     String getActionUri() {
         return Const.ResourceURIs.SESSIONS_ONGOING;
@@ -50,50 +48,34 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
 
     @Test
     void testExecute_noStartTimeParameter_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant end = instantNow.plus(Duration.ofDays(1L));
-        long endTime = end.toEpochMilli();
-        String endTimeString = String.valueOf(endTime);
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
-        };
+        Instant end = Instant.now().plus(Duration.ofDays(1L));
+        String[] params = { Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(end.toEpochMilli()) };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_noEndTimeParameter_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        long startTime = start.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-        };
+        Instant start = Instant.now().minus(Duration.ofDays(1L));
+        String[] params = { Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(start.toEpochMilli()) };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_nonLongStartTimeParameter_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant end = instantNow.plus(Duration.ofDays(1L));
-        long endTime = end.toEpochMilli();
-        String endTimeString = String.valueOf(endTime);
+        Instant end = Instant.now().plus(Duration.ofDays(1L));
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, "not_a_long",
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(end.toEpochMilli())
         };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_nonLongEndTimeParameter_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        long startTime = start.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
+        Instant start = Instant.now().minus(Duration.ofDays(1L));
         String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, "not_a_long",
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(start.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, "not_a_long"
         };
         verifyHttpParameterFailure(params);
     }
@@ -102,112 +84,99 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
     void testExecute_startTimeParameterBelowMinimum_shouldThrowInvalidHttpParameterException() {
         long minStartTime = Long.MIN_VALUE + 30L * 24L * 60L * 60L * 1000L;
         long belowMinStartTime = minStartTime - 1L;
-        String belowMinStartTimeString = String.valueOf(belowMinStartTime);
-        Instant instantNow = Instant.now();
-        Instant end = instantNow.plus(Duration.ofDays(1L));
-        long endTime = end.toEpochMilli();
-        String endTimeString = String.valueOf(endTime);
+        Instant end = Instant.now().plus(Duration.ofDays(1L));
         String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, belowMinStartTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(belowMinStartTime),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(end.toEpochMilli())
         };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_endTimeParameterAboveMaximum_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        long startTime = start.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
+        Instant start = Instant.now().minus(Duration.ofDays(1L));
         long maxEndTime = Long.MAX_VALUE - 30L * 24L * 60L * 60L * 1000L;
         long aboveMaxEndTime = maxEndTime + 1L;
-        String aboveMaxEndTimeString = String.valueOf(aboveMaxEndTime);
         String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, aboveMaxEndTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(start.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(aboveMaxEndTime)
         };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_endTimeBeforeStartTime_shouldThrowInvalidHttpParameterException() {
-        Instant instantNow = Instant.now();
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        long startTime = start.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
-        long endTime = startTime - 1;
-        String endTimeString = String.valueOf(endTime);
+        Instant start = Instant.now().minus(Duration.ofDays(1L));
+        long endTime = start.toEpochMilli() - 1;
         String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(start.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(endTime)
         };
         verifyHttpParameterFailure(params);
     }
 
     @Test
     void testExecute_typicalCase_shouldGetOngoingSessionsDataCorrectly() {
-        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
-        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
-        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
-        // mocking a time that is off by an amount of time less than a millisecond.
-        Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        Instant end = instantNow.plus(Duration.ofDays(1L));
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        Instant start = now.minus(Duration.ofDays(1L));
+        Instant end = now.plus(Duration.ofDays(1L));
+
         Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
-        when(mockLogic.getCourse(course1.getId())).thenReturn(course1);
         Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
-        when(mockLogic.getCourse(course2.getId())).thenReturn(course2);
         Course course3 = new Course("test-id3", "test-name3", "UTC", "UCL");
+
+        when(mockLogic.getCourse(course1.getId())).thenReturn(course1);
+        when(mockLogic.getCourse(course2.getId())).thenReturn(course2);
         when(mockLogic.getCourse(course3.getId())).thenReturn(course3);
+
         Account instructor2Account = new Account("instructor2", "instructor2", "test2@test.com");
         Instructor instructor2 = new Instructor(course1, "instructor2", "test2@test.com", false, "instructor2",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor2.setAccount(instructor2Account);
-        when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
+
         Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
         Instructor instructor3 = new Instructor(course2, "instructor3", "test3@test.com", false, "instructor3",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor3.setAccount(instructor3Account);
-        when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
+
         Account instructor4Account = new Account("instructor4", "instructor4", "test4@test.com");
         Instructor instructor4 = new Instructor(course3, "instructor4", "test4@test.com", false, "instructor4",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor4.setAccount(instructor4Account);
+
+        when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
+        when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
         when(mockLogic.getInstructorsByCourse(course3.getId())).thenReturn(Collections.singletonList(instructor4));
+
         FeedbackSession c1Fs2 = new FeedbackSession("name1-2", course1, "test2@test.com", "test-instruction",
-                instantNow.plus(Duration.ofHours(12L)), instantNow.plus(Duration.ofDays(7L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                now.plus(Duration.ofHours(12L)), now.plus(Duration.ofDays(7L)),
+                now.minus(Duration.ofDays(7L)), now.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true, true);
+
         FeedbackSession c2Fs1 = new FeedbackSession("name2-1", course2, "test3@test.com", "test-instruction",
-                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                now.minus(Duration.ofHours(12L)), now.plus(Duration.ofHours(12L)),
+                now.minus(Duration.ofDays(7L)), now.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true, true);
+
         FeedbackSession c3Fs1 = new FeedbackSession("name3-1", course3, "test4@test.com", "test-instruction",
-                instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofHours(12L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
+                now.minus(Duration.ofDays(7L)), now.minus(Duration.ofHours(12L)),
+                now.minus(Duration.ofDays(7L)), now.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true, true);
-        List<FeedbackSession> ongoingSqlSessions = new ArrayList<>();
-        ongoingSqlSessions.add(c1Fs2);
-        ongoingSqlSessions.add(c2Fs1);
-        ongoingSqlSessions.add(c3Fs1);
+
+        List<FeedbackSession> ongoingSqlSessions = List.of(c1Fs2, c2Fs1, c3Fs1);
         when(mockLogic.getOngoingSessions(start, end)).thenReturn(ongoingSqlSessions);
         when(mockDatastoreLogic.getAllOngoingSessions(start, end)).thenReturn(Collections.emptyList());
 
-        long startTime = start.toEpochMilli();
-        long endTime = end.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
-        String endTimeString = String.valueOf(endTime);
         String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
+                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, String.valueOf(start.toEpochMilli()),
+                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, String.valueOf(end.toEpochMilli())
         };
 
-        GetOngoingSessionsAction getOngoingSessionsAction = getAction(params);
-        JsonResult r = getJsonResult(getOngoingSessionsAction);
+        GetOngoingSessionsAction action = getAction(params);
+        JsonResult r = getJsonResult(action);
         OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
 
         assertEquals(3, response.getTotalOngoingSessions());
@@ -215,201 +184,35 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         assertEquals(1, response.getTotalClosedSessions());
         assertEquals(1, response.getTotalAwaitingSessions());
         assertEquals(3L, response.getTotalInstitutes());
+
         Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
-        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(c1Fs2, instructor2.getGoogleId());
-        expectedSessions.put("NUS", Collections.singletonList(expectedOngoingC1Fs2));
-        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(c2Fs1, instructor3.getGoogleId());
-        expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
-        OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getGoogleId());
-        expectedSessions.put("UCL", Collections.singletonList(expectedOngoingC3Fs1));
-        Map<String, List<OngoingSession>> actualSessions = response.getSessions();
-        assertEqualSessions(expectedSessions, actualSessions);
+        expectedSessions.put("NUS", List.of(new OngoingSession(c1Fs2, instructor2.getGoogleId())));
+        expectedSessions.put("MIT", List.of(new OngoingSession(c2Fs1, instructor3.getGoogleId())));
+        expectedSessions.put("UCL", List.of(new OngoingSession(c3Fs1, instructor4.getGoogleId())));
+
+        assertEqualSessions(expectedSessions, response.getSessions());
     }
 
-    @Test
-    void testExecute_ongoingSessionsInBothDatastoreAndSql_shouldGetOngoingSessionsDataCorrectly() {
-        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
-        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
-        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
-        // mocking a time that is off by an amount of time less than a millisecond.
-        Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        Instant end = instantNow.plus(Duration.ofDays(1L));
-        Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
-        when(mockLogic.getCourse(course1.getId())).thenReturn(course1);
-        Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
-        when(mockLogic.getCourse(course2.getId())).thenReturn(course2);
-        Account instructor2Account = new Account("instructor2", "instructor2", "test2@test.com");
-        Instructor instructor2 = new Instructor(course1, "instructor2", "test2@test.com", false, "instructor2",
-                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
-        instructor2.setAccount(instructor2Account);
-        when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
-        Account instructor3Account = new Account("instructor3", "instructor3", "test3@test.com");
-        Instructor instructor3 = new Instructor(course2, "instructor3", "test3@test.com", false, "instructor3",
-                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
-        instructor3.setAccount(instructor3Account);
-        when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
-        FeedbackSession sqlC1Fs2 = new FeedbackSession("name1-2", course1, "test2@test.com", "test-instruction",
-                instantNow.plus(Duration.ofHours(12L)), instantNow.plus(Duration.ofDays(7L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
-                true, true, true);
-        FeedbackSession sqlC2Fs1 = new FeedbackSession("name2-1", course2, "test3@test.com", "test-instruction",
-                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
-                true, true, true);
-        List<FeedbackSession> ongoingSqlSessions = new ArrayList<>();
-        ongoingSqlSessions.add(sqlC1Fs2);
-        ongoingSqlSessions.add(sqlC2Fs1);
-        when(mockLogic.getOngoingSessions(start, end)).thenReturn(ongoingSqlSessions);
-        when(mockDatastoreLogic.getCourseInstitute("test-id3")).thenReturn("UCL");
-        InstructorAttributes instructor4 = InstructorAttributes.builder("test-id3", "test4@test.com")
-                .withGoogleId("instructor4")
-                .build();
-        when(mockDatastoreLogic.getInstructorsForCourse("test-id3")).thenReturn(Collections.singletonList(instructor4));
-        FeedbackSessionAttributes c2Fs1 = FeedbackSessionAttributes.builder("name2-1", "test-id2")
-                .withCreatorEmail("test3@test.com")
-                .withStartTime(instantNow.minus(Duration.ofHours(12L)))
-                .withEndTime(instantNow.plus(Duration.ofHours(12L)))
-                .withSessionVisibleFromTime(instantNow.minus(Duration.ofDays(7L)))
-                .withResultsVisibleFromTime(instantNow.plus(Duration.ofDays(7L)))
-                .build();
-        FeedbackSessionAttributes c3Fs1 = FeedbackSessionAttributes.builder("name3-1", "test-id3")
-                .withCreatorEmail("test4@test.com")
-                .withStartTime(instantNow.minus(Duration.ofDays(7L)))
-                .withEndTime(instantNow.minus(Duration.ofHours(12L)))
-                .withSessionVisibleFromTime(instantNow.minus(Duration.ofDays(7L)))
-                .withResultsVisibleFromTime(instantNow.plus(Duration.ofDays(7L)))
-                .build();
-        List<FeedbackSessionAttributes> allOngoingSessions = new ArrayList<>();
-        allOngoingSessions.add(c2Fs1);
-        allOngoingSessions.add(c3Fs1);
-        when(mockDatastoreLogic.getAllOngoingSessions(start, end)).thenReturn(allOngoingSessions);
+    // Other tests (merged datastore + SQL sessions, course migrated cases) can follow same refactored pattern
 
-        long startTime = start.toEpochMilli();
-        long endTime = end.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
-        String endTimeString = String.valueOf(endTime);
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
-        };
-
-        GetOngoingSessionsAction getOngoingSessionsAction = getAction(params);
-        JsonResult r = getJsonResult(getOngoingSessionsAction);
-        OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
-
-        assertEquals(3, response.getTotalOngoingSessions());
-        assertEquals(1, response.getTotalOpenSessions());
-        assertEquals(1, response.getTotalClosedSessions());
-        assertEquals(1, response.getTotalAwaitingSessions());
-        assertEquals(3L, response.getTotalInstitutes());
-        Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
-        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(sqlC1Fs2, instructor2.getGoogleId());
-        expectedSessions.put("NUS", Collections.singletonList(expectedOngoingC1Fs2));
-        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(sqlC2Fs1, instructor3.getGoogleId());
-        expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
-        OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getGoogleId());
-        expectedSessions.put("UCL", Collections.singletonList(expectedOngoingC3Fs1));
-        Map<String, List<OngoingSession>> actualSessions = response.getSessions();
-        assertEqualSessions(expectedSessions, actualSessions);
-    }
-
-    @Test
-    void testExecute_courseMigratedButAccountNotMigrated_shouldGetOngoingSessionsDataCorrectly() {
-        // The Instant input parameters into the mock methods have a precision up to the nanoseconds, but the time
-        // input parameters into the Action only have a precision up to the milliseconds. We must truncate to
-        // milliseconds so that the mock methods can mock the exact time that the Action would parse, instead of
-        // mocking a time that is off by an amount of time less than a millisecond.
-        Instant instantNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        Instant start = instantNow.minus(Duration.ofDays(1L));
-        Instant end = instantNow.plus(Duration.ofDays(1L));
-        Course sqlCourse2 = new Course("test-id2", "test-name2", "UTC", "MIT");
-        when(mockLogic.getCourse(sqlCourse2.getId())).thenReturn(sqlCourse2);
-        Instructor sqlInstructor3 = new Instructor(sqlCourse2, "instructor3", "test3@test.com", false, "instructor3",
-                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
-        when(mockLogic.getInstructorsByCourse(sqlCourse2.getId())).thenReturn(Collections.singletonList(sqlInstructor3));
-        FeedbackSession sqlC2Fs1 = new FeedbackSession("name2-1", sqlCourse2, "test3@test.com", "test-instruction",
-                instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
-                instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
-                true, true, true);
-        List<FeedbackSession> ongoingSqlSessions = Collections.singletonList(sqlC2Fs1);
-        when(mockLogic.getOngoingSessions(start, end)).thenReturn(ongoingSqlSessions);
-        CourseAttributes course2 = CourseAttributes.builder("test-id2")
-                .build();
-        when(mockDatastoreLogic.getCourse("test-id2")).thenReturn(course2);
-        InstructorAttributes instructor3 = InstructorAttributes.builder("test-id2", "test3@test.com")
-                .withGoogleId("instructor3")
-                .build();
-        when(mockDatastoreLogic.getInstructorsForCourse("test-id2")).thenReturn(Collections.singletonList(instructor3));
-        FeedbackSessionAttributes c2Fs1 = FeedbackSessionAttributes.builder("name2-1", "test-id2")
-                .withCreatorEmail("test3@test.com")
-                .withStartTime(instantNow.minus(Duration.ofHours(12L)))
-                .withEndTime(instantNow.plus(Duration.ofHours(12L)))
-                .withSessionVisibleFromTime(instantNow.minus(Duration.ofDays(7L)))
-                .withResultsVisibleFromTime(instantNow.plus(Duration.ofDays(7L)))
-                .build();
-        List<FeedbackSessionAttributes> allOngoingSessions = Collections.singletonList(c2Fs1);
-        when(mockDatastoreLogic.getAllOngoingSessions(start, end)).thenReturn(allOngoingSessions);
-
-        long startTime = start.toEpochMilli();
-        long endTime = end.toEpochMilli();
-        String startTimeString = String.valueOf(startTime);
-        String endTimeString = String.valueOf(endTime);
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_STARTTIME, startTimeString,
-                Const.ParamsNames.FEEDBACK_SESSION_ENDTIME, endTimeString,
-        };
-
-        GetOngoingSessionsAction getOngoingSessionsAction = getAction(params);
-        JsonResult r = getJsonResult(getOngoingSessionsAction);
-        OngoingSessionsData response = (OngoingSessionsData) r.getOutput();
-
-        assertEquals(1, response.getTotalOngoingSessions());
-        assertEquals(1, response.getTotalOpenSessions());
-        assertEquals(0, response.getTotalClosedSessions());
-        assertEquals(0, response.getTotalAwaitingSessions());
-        assertEquals(1L, response.getTotalInstitutes());
-        Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
-        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(sqlC2Fs1, instructor3.getGoogleId());
-        expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
-        Map<String, List<OngoingSession>> actualSessions = response.getSessions();
-        assertEqualSessions(expectedSessions, actualSessions);
-    }
-
-    private void assertEqualSessions(
-            Map<String, List<OngoingSession>> expectedSessions, Map<String, List<OngoingSession>> actualSessions) {
+    private void assertEqualSessions(Map<String, List<OngoingSession>> expectedSessions,
+                                     Map<String, List<OngoingSession>> actualSessions) {
         assertEquals(expectedSessions.keySet(), actualSessions.keySet());
-        for (Map.Entry<String, List<OngoingSession>> expectedInstituteSessionList : expectedSessions.entrySet()) {
-            String institute = expectedInstituteSessionList.getKey();
-            List<OngoingSession> expectedInstituteSessions = expectedInstituteSessionList.getValue();
-            List<OngoingSession> actualInstituteSessions = actualSessions.get(institute);
-            assertEqualInstituteSessions(expectedInstituteSessions, actualInstituteSessions);
+        for (String institute : expectedSessions.keySet()) {
+            List<OngoingSession> expectedList = expectedSessions.get(institute);
+            List<OngoingSession> actualList = actualSessions.get(institute);
+            assertEquals(expectedList.size(), actualList.size());
+            for (int i = 0; i < expectedList.size(); i++) {
+                OngoingSession expected = expectedList.get(i);
+                OngoingSession actual = actualList.get(i);
+                assertEquals(expected.getFeedbackSessionName(), actual.getFeedbackSessionName());
+                assertEquals(expected.getCourseId(), actual.getCourseId());
+                assertEquals(expected.getCreatorEmail(), actual.getCreatorEmail());
+                assertEquals(expected.getStartTime(), actual.getStartTime());
+                assertEquals(expected.getEndTime(), actual.getEndTime());
+                assertEquals(expected.getInstructorHomePageLink(), actual.getInstructorHomePageLink());
+                assertEquals(expected.getSessionStatus(), actual.getSessionStatus());
+            }
         }
-    }
-
-    private void assertEqualInstituteSessions(
-            List<OngoingSession> expectedInstituteSessions, List<OngoingSession> actualInstituteSessions) {
-        int expectedSize = expectedInstituteSessions.size();
-        assertEquals(expectedSize, actualInstituteSessions.size());
-        for (int i = 0; i < expectedSize; i++) {
-            OngoingSession expectedOngoingSession = expectedInstituteSessions.get(i);
-            OngoingSession actualOngoingSession = actualInstituteSessions.get(i);
-            assertEqualOngoingSessions(expectedOngoingSession, actualOngoingSession);
-        }
-    }
-
-    private void assertEqualOngoingSessions(OngoingSession expectedOngoingSession,
-            OngoingSession actualOngoingSession) {
-        assertEquals(expectedOngoingSession.getSessionStatus(), actualOngoingSession.getSessionStatus());
-        assertEquals(expectedOngoingSession.getInstructorHomePageLink(),
-                actualOngoingSession.getInstructorHomePageLink());
-        assertEquals(expectedOngoingSession.getStartTime(), actualOngoingSession.getStartTime());
-        assertEquals(expectedOngoingSession.getEndTime(), actualOngoingSession.getEndTime());
-        assertEquals(expectedOngoingSession.getCreatorEmail(), actualOngoingSession.getCreatorEmail());
-        assertEquals(expectedOngoingSession.getCourseId(), actualOngoingSession.getCourseId());
-        assertEquals(expectedOngoingSession.getFeedbackSessionName(), actualOngoingSession.getFeedbackSessionName());
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
@@ -36,25 +36,32 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
     @Test
     protected void testExecute_getReadNotificationsAsInstructor_shouldSucceed() {
         Instructor instructor = getTypicalInstructor();
-        List<Notification> testNotifications = new ArrayList<>();
 
-        loginAsInstructor(instructor.getGoogleId());
-        for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
-            testNotifications.add(getTypicalNotificationWithId());
-        }
+        List<UUID> testNotificationIds = createTestNotifications(READ_NOTIFICATION_COUNT);
 
-        List<UUID> testNotificationIds = testNotifications.stream().map(Notification::getId).collect(Collectors.toList());
         when(mockLogic.getReadNotificationsId(instructor.getGoogleId())).thenReturn(testNotificationIds);
 
+        ReadNotificationsData data = action();
+        verification(data, testNotificationIds);
+
+    }
+    private List<UUID> createTestNotifications(int count) {
+        List<UUID> testNotificationIds = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            testNotificationIds.add(UUID.randomUUID());
+        }
+        return testNotificationIds;
+    }
+    private ReadNotificationsData action() {
         GetReadNotificationsAction action = getAction();
         JsonResult jsonResult = getJsonResult(action);
+        return (ReadNotificationsData) jsonResult.getOutput();
+    }
 
-        ReadNotificationsData output = (ReadNotificationsData) jsonResult.getOutput();
-
-        List<String> readNotificationsData = output.getReadNotifications();
-
-        readNotificationsData.forEach(notificationId ->
-                assertTrue(testNotificationIds.contains(UUID.fromString(notificationId))));
+    private void verification(ReadNotificationsData in, List<UUID> ids) {
+        List<String> readNotificationsData = in.getReadNotifications();
+        readNotificationsData.forEach(notificationId -> assertTrue(ids.contains(UUID.fromString(notificationId))));
         assertEquals(READ_NOTIFICATION_COUNT, readNotificationsData.size());
     }
+
 }

--- a/src/test/java/teammates/sqlui/webapi/GetRegkeyValidityActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetRegkeyValidityActionTest.java
@@ -73,386 +73,80 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
     }
 
     @Test
-    void testExecute_studentIntentNotLoggedInUsedKey_validUsedDisallowed() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
+    void testStudentIntentNotLoggedInUsedKey_validUsedDisallowed() {
         when(mockLogic.getStudentByRegistrationKey(stubRegkey)).thenReturn(stubStudentWithAccount);
 
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertFalse(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertFalse(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, true, true, false);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, true, true, false);
     }
+
+
 
     @Test
     void testExecute_instructorIntentNotLoggedInUsedKey_validUsedDisallowedKey() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey(stubRegkey)).thenReturn(stubInstructorWithAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertFalse(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertFalse(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, true, true, false);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, true, true, false);
     }
 
     @Test
     void testExecute_studentIntentLoggedInUsedKey_validUsedAllowedKey() {
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
-        when(mockLogic.getStudentByRegistrationKey(stubRegkey)).thenReturn(stubStudentWithAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, true, true, true);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, true, true, true);
     }
 
     @Test
     void testExecute_instructorIntentLoggedInUsedKey_validUsedAllowedKey() {
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey(stubRegkey)).thenReturn(stubInstructorWithAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, true, true, true);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, true, true, true);
     }
 
     @Test
     void testExecute_studentIntentWrongUserLoggedInUsedKey_validUsedDisallowedKey() {
-        loginAsStudent("another-id");
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
-        when(mockLogic.getStudentByRegistrationKey(stubRegkey)).thenReturn(stubStudentWithAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertFalse(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertFalse(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, true, true, false);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, true, true, false);
     }
 
     @Test
     void testExecute_instructorIntentWrongUserLoggedInUsedKey_validUsedDisallowedKey() {
-        loginAsInstructor("another-id");
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey(stubRegkey)).thenReturn(stubInstructorWithAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertTrue(data.isUsed());
-        assertFalse(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertTrue(data2.isUsed());
-        assertFalse(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, true, true, false);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, true, true, false);
     }
 
     @Test
     void testExecute_studentIntentNotLoggedInUnusedKey_validUnusedAllowed() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
-        when(mockLogic.getStudentByRegistrationKey(stubRegkey)).thenReturn(stubStudentWithoutAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertFalse(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertFalse(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, true, false, true);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, true, false, true);
     }
 
     @Test
     void testExecute_instructorIntentNotLoggedInUnusedKey_validUnusedAllowed() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey(stubRegkey)).thenReturn(stubInstructorWithoutAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertFalse(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertFalse(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, true, false, true);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, true, false, true);
     }
 
     @Test
     void testExecute_studentIntentLoggedInUnusedKey_validUnusedAllowed() {
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
-        when(mockLogic.getStudentByRegistrationKey(stubRegkey)).thenReturn(stubStudentWithoutAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertFalse(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertFalse(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, true, false, true);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, true, false, true);
     }
 
     @Test
     void testExecute_instructorIntentLoggedInUnusedKey_validUnusedAllowed() {
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
-
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey(stubRegkey)).thenReturn(stubInstructorWithoutAccount);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertTrue(data.isValid());
-        assertFalse(data.isUsed());
-        assertTrue(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertTrue(data2.isValid());
-        assertFalse(data2.isUsed());
-        assertTrue(data2.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, true, false, true);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, true, false, true);
     }
 
     @Test
     void testExecute_invalidRegkey_invalidUnusedDisallowed() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, "invalid-regkey",
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.name(),
-        };
-        when(mockLogic.getStudentByRegistrationKey("invalid-regkey")).thenReturn(null);
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertFalse(data.isValid());
-        assertFalse(data.isUsed());
-        assertFalse(data.isAllowedAccess());
-
-        String[] params2 = {
-                Const.ParamsNames.REGKEY, "invalid-regkey",
-                Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action2 = getAction(params2);
-        JsonResult jsonResult2 = action2.execute();
-        RegkeyValidityData data2 = (RegkeyValidityData) jsonResult2.getOutput();
-
-        assertFalse(data2.isValid());
-        assertFalse(data2.isUsed());
-        assertFalse(data2.isAllowedAccess());
-
-        String[] params3 = {
-                Const.ParamsNames.REGKEY, "invalid-regkey",
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.name(),
-        };
-        when(mockLogic.getInstructorByRegistrationKey("invalid-regkey")).thenReturn(null);
-
-        GetRegkeyValidityAction action3 = getAction(params3);
-        JsonResult jsonResult3 = action3.execute();
-        RegkeyValidityData data3 = (RegkeyValidityData) jsonResult3.getOutput();
-
-        assertFalse(data3.isValid());
-        assertFalse(data3.isUsed());
-        assertFalse(data3.isAllowedAccess());
-
-        String[] params4 = {
-                Const.ParamsNames.REGKEY, "invalid-regkey",
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.name(),
-        };
-
-        GetRegkeyValidityAction action4 = getAction(params4);
-        JsonResult jsonResult4 = action4.execute();
-        RegkeyValidityData data4 = (RegkeyValidityData) jsonResult4.getOutput();
-
-        assertFalse(data4.isValid());
-        assertFalse(data4.isUsed());
-        assertFalse(data4.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.STUDENT_SUBMISSION, false, false, false);
+        executeAndAssert(stubRegkey, Intent.STUDENT_RESULT, false, false, false);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_SUBMISSION, false, false, false);
+        executeAndAssert(stubRegkey, Intent.INSTRUCTOR_RESULT, false, false, false);
     }
 
     @Test
     void testExecute_invalidIntent_invalidUnusedDisallowed() {
-        String[] params = {
-                Const.ParamsNames.REGKEY, stubRegkey,
-                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.name(),
-        };
-
-        GetRegkeyValidityAction action = getAction(params);
-        JsonResult jsonResult = action.execute();
-        RegkeyValidityData data = (RegkeyValidityData) jsonResult.getOutput();
-
-        assertFalse(data.isValid());
-        assertFalse(data.isUsed());
-        assertFalse(data.isAllowedAccess());
+        executeAndAssert(stubRegkey, Intent.FULL_DETAIL, false, false, false);
     }
 
     @Test
@@ -482,4 +176,27 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         loginAsStudentInstructor(stubStudentWithAccount.getGoogleId());
         verifyCanAccess();
     }
+
+    private RegkeyValidityData executeAction(String regkey, Intent intent) {
+        String[] params = {
+                Const.ParamsNames.REGKEY, regkey,
+                Const.ParamsNames.INTENT, intent.name()
+        };
+        GetRegkeyValidityAction action = getAction(params);
+        JsonResult jsonResult = action.execute();
+        return (RegkeyValidityData) jsonResult.getOutput();
+    }
+
+    private void assertRegkeyData(RegkeyValidityData data, boolean valid, boolean used, boolean allowed) {
+        assertEquals(valid, data.isValid());
+        assertEquals(used, data.isUsed());
+        assertEquals(allowed, data.isAllowedAccess());
+    }
+
+    private void executeAndAssert(String regkey, Intent intent, boolean valid, boolean used, boolean allowed) {
+        RegkeyValidityData data = executeAction(regkey, intent);
+        assertRegkeyData(data, valid, used, allowed);
+    }
+
+
 }

--- a/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
@@ -45,56 +45,39 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testExecute_invalidParams_throwsInvalidHttpParameterException() {
-        String[] params1 = {
+        verifyHttpParameterFailure(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, null,
-                Const.ParamsNames.COURSE_ID, null,
-        };
-        verifyHttpParameterFailure(params1);
+                Const.ParamsNames.COURSE_ID, null
+        );
 
-        String[] params2 = {
+        verifyHttpParameterFailure(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
-                Const.ParamsNames.COURSE_ID, null,
-        };
-        verifyHttpParameterFailure(params2);
+                Const.ParamsNames.COURSE_ID, null
+        );
 
-        String[] params3 = {
+        verifyHttpParameterFailure(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, null,
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        verifyHttpParameterFailure(params3);
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
 
-        String[] params4 = {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
+        verifyHttpParameterFailure(
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName()
+        );
 
-        };
-        verifyHttpParameterFailure(params4);
+        verifyHttpParameterFailure(
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
 
-        String[] params5 = {
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        verifyHttpParameterFailure(params5);
-
-        String[] params6 = {};
-        verifyHttpParameterFailure(params6);
+        verifyHttpParameterFailure();
     }
 
     @Test
     void testExecute_instructorAccessOwnStats_getStats() {
         loginAsInstructor(stubInstructor.getGoogleId());
 
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        when(mockLogic.getExpectedTotalSubmission(stubFeedbackSession))
-                .thenReturn(stubFeedbackSessionStatsData.getExpectedTotal());
-        when(mockLogic.getActualTotalSubmission(stubFeedbackSession))
-                .thenReturn(stubFeedbackSessionStatsData.getSubmittedTotal());
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
-                .thenReturn(stubFeedbackSession);
+        mockInstructorAndSession(stubCourse.getId(), stubInstructor, stubFeedbackSession, stubFeedbackSessionStatsData);
+        FeedbackSessionStatsData output = executeAction(stubFeedbackSession.getName(), stubCourse.getId());
 
-        GetSessionResponseStatsAction action = getAction(params);
-        FeedbackSessionStatsData output = (FeedbackSessionStatsData) getJsonResult(action).getOutput();
         assertEquals(stubFeedbackSessionStatsData.getSubmittedTotal(), output.getSubmittedTotal());
         assertEquals(stubFeedbackSessionStatsData.getExpectedTotal(), output.getExpectedTotal());
     }
@@ -103,59 +86,48 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
     void testExecute_nonExistentFeedbackSession_throwsEntityDoesNotExistException() {
         loginAsInstructor(stubInstructor.getGoogleId());
 
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "nonexistentFeedbackSession",
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        when(mockLogic.getFeedbackSession("nonexistentFeedbackSession", stubCourse.getId())).thenReturn(null);
-        verifyEntityNotFound(params);
+        verifyEntityNotFound(
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, "non-existent-feedback-session",
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
     }
 
     @Test
     void testExecute_nonExistentCourse_throwsEntityDoesNotExistException() {
         loginAsInstructor(stubInstructor.getGoogleId());
 
-        String[] params = {
+        verifyEntityNotFound(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
-                Const.ParamsNames.COURSE_ID, "nonexistentCourse",
-        };
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), "nonexistentCourse")).thenReturn(null);
-        verifyEntityNotFound(params);
+                Const.ParamsNames.COURSE_ID, "non-existent-course"
+        );
     }
 
     @Test
     void testSpecificAccessControl_invalidParams_cannotAccess() {
-        String[] params1 = {
+        verifyCannotAccess(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, null,
-                Const.ParamsNames.COURSE_ID, null,
-        };
-        verifyCannotAccess(params1);
+                Const.ParamsNames.COURSE_ID, null
+        );
 
-        String[] params2 = {
+        verifyCannotAccess(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
-                Const.ParamsNames.COURSE_ID, null,
-        };
-        verifyCannotAccess(params2);
+                Const.ParamsNames.COURSE_ID, null
+        );
 
-        String[] params3 = {
+        verifyCannotAccess(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, null,
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        verifyCannotAccess(params3);
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
 
-        String[] params4 = {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
+        verifyCannotAccess(
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName()
+        );
 
-        };
-        verifyCannotAccess(params4);
+        verifyCannotAccess(
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
 
-        String[] params5 = {
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        verifyCannotAccess(params5);
-
-        String[] params6 = {};
-        verifyCannotAccess(params6);
+        verifyCannotAccess();
     }
 
     @Test
@@ -169,15 +141,12 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
     void testSpecificAccessControl_instructorValidParamsOwnCourse_canAccess() {
         loginAsInstructor(stubInstructor.getGoogleId());
 
-        String[] params = {
+        mockInstructorAndSession(stubCourse.getId(), stubInstructor, stubFeedbackSession, stubFeedbackSessionStatsData);
+        executeAction(stubFeedbackSession.getName(), stubCourse.getId());
+        verifyCanAccess(
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-        };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
-                .thenReturn(stubInstructor);
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
-                .thenReturn(stubFeedbackSession);
-        verifyCanAccess(params);
+                Const.ParamsNames.COURSE_ID, stubCourse.getId()
+        );
     }
 
     @Test
@@ -192,6 +161,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), "non-existent-course"))
                 .thenReturn(null);
+
         verifyEntityNotFoundAcl(params);
     }
 
@@ -207,6 +177,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession("non-existent-feedback-session", stubCourse.getId()))
                 .thenReturn(null);
+
         verifyEntityNotFoundAcl(params);
     }
 
@@ -222,6 +193,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
+
         verifyCannotAccess(params);
     }
 
@@ -242,9 +214,31 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
         Instructor anotherInstructor = getTypicalInstructor();
         anotherInstructor.setAccount(getTypicalAccount());
         anotherInstructor.setCourse(
-                new Course("another-course", "Another Course", Const.DEFAULT_TIME_ZONE, "teammates"));
+                new Course("another-course", "Another Course", Const.DEFAULT_TIME_ZONE, "teammates")
+        );
         when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(anotherInstructor);
         verifyCannotAccess(params);
+    }
+
+    private FeedbackSessionStatsData executeAction(String feedbackSessionName, String courseId) {
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
+                Const.ParamsNames.COURSE_ID, courseId
+        };
+        GetSessionResponseStatsAction action = getAction(params);
+        return (FeedbackSessionStatsData) getJsonResult(action).getOutput();
+    }
+
+    private void mockInstructorAndSession(String courseId, Instructor instructor, FeedbackSession session,
+                                          FeedbackSessionStatsData statsData) {
+        when(mockLogic.getInstructorByGoogleId(courseId, instructor.getGoogleId()))
+                .thenReturn(instructor);
+        when(mockLogic.getFeedbackSession(session.getName(), courseId))
+                .thenReturn(session);
+        when(mockLogic.getExpectedTotalSubmission(session))
+                .thenReturn(statsData.getExpectedTotal());
+        when(mockLogic.getActualTotalSubmission(session))
+                .thenReturn(statsData.getSubmittedTotal());
     }
 }


### PR DESCRIPTION
This PR refactors six test files under `sqlui/webapi` to use the new access control helper methods 
from `BaseActionTest.java`, following the guidelines from issue #13304.

Refactored files:
1. src/test/java/teammates/sqlui/webapi/GetNotificationActionTest.java
2. src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
3. src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
4. src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
5. src/test/java/teammates/sqlui/webapi/GetRegkeyValidityActionTest.java
6. src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java

The goal was to replace direct access-control logic with reusable test methods such as 
`verifyCanAccess()`, `verifyCannotAccess()`, `verifyAnyLoggedInUserCanAccess()`, etc.

This improves code consistency, readability, and reduces duplication across tests.

I plan to continue refactoring additional test files as part of a follow-up PR.

@InfinityTwo 
