### PR TITLE
[#12653] Copy course modal: Mandatory fields not highlighted

### DIFF
--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.html
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.html
@@ -14,13 +14,23 @@
       <div class="form-group">
         <label>Course ID:</label>
         <input [class.invalid]="newCourseIdIsConflicting" id="copy-course-id" type="text" class="form-control" placeholder="e.g. CS3215-2013Semester1"
-          [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false">
+          [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false"
+          required #newCourseIdInput="ngModel">
+        <div [hidden]="newCourseIdInput.valid || (newCourseIdInput.pristine && newCourseIdInput.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course ID should not be empty.
+        </div>
         <span>{{ COURSE_ID_MAX_LENGTH - newCourseId.length }} characters left</span>
       </div>
       <div class="form-group">
         <label>Course Name:</label>
         <input id="copy-course-name" class="form-control" type="text" placeholder="e.g. Software Engineering" [(ngModel)]="newCourseName"
-          [maxlength]="COURSE_NAME_MAX_LENGTH"/>
+          [maxlength]="COURSE_NAME_MAX_LENGTH"
+          required #newCourseNameInput="ngModel"/>
+        <div [hidden]="newCourseNameInput.valid || (newCourseNameInput.pristine && newCourseNameInput.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course Name should not be empty.
+        </div>
         <span>{{ COURSE_NAME_MAX_LENGTH - newCourseName.length }} characters left</span>
       </div>
       <div class="form-group">

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
@@ -7,3 +7,8 @@ hr.solid-divider {
 .invalid {
   border: red 1px solid;
 }
+
+.invalid-field {
+  padding-top: 5px;
+  color: #b50000;
+}

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.ts
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.ts
@@ -74,12 +74,6 @@ export class CopyCourseModalComponent implements OnInit {
    * Fires the copy event.
    */
   copy(): void {
-    if (!this.newCourseId || !this.newCourseName) {
-      this.statusMessageService.showErrorToast(
-          'Please make sure you have filled in both Course ID and Name before adding the course!');
-      return;
-    }
-
     this.newCourseIdIsConflicting = this.allCourses
       .filter((course: Course) => course.courseId === this.newCourseId).length > 0;
     if (this.newCourseIdIsConflicting) {


### PR DESCRIPTION
Fixes #12653

**Outline of Solution**
This pull request addresses the issue where mandatory fields in the "Copy Course" modal were not highlighted, and no clear message was shown when they were left empty.

**The following changes have been implemented:**
- Added inline validation for the "Course ID" and "Course Name" fields.
- If a user tries to proceed without filling in these fields, a descriptive error message ("The field '...' should not be empty.") now appears directly below the respective input box.
- The error message text is colored red to visually indicate an error, consistent with the rest of the application's UI for validation.

**UI:**
**Before (empty fields, no validation shown):**
<img width="300" height="366" alt="image" src="https://github.com/user-attachments/assets/6f786c81-b07c-4ca4-b3ff-bdf404714587" />

**After (validation messages shown for empty fields):**After (validation messages shown for empty fields):
<img width="300" height="366" alt="image" src="https://github.com/user-attachments/assets/174f6fa9-b15e-438a-b40a-fe3ac3686338" />
