### PR TITLE
[#12653] Highlight mandatory fields in Copy Course modal

### DIFF
--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.html
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.html
@@ -13,16 +13,22 @@
       </div>
       <div class="form-group">
         <label>Course ID:</label>
-        <input [class.invalid]="newCourseIdIsConflicting" id="copy-course-id" type="text" class="form-control" placeholder="e.g. CS3215-2013Semester1"
-          [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false">
-        <span>{{ COURSE_ID_MAX_LENGTH - newCourseId.length }} characters left</span>
+        <input [class.invalid]="newCourseIdIsConflicting" id="copy-course-id" name="courseId" type="text" class="form-control" placeholder="e.g. CS3215-2013Semester1"
+          #courseId="ngModel" [(ngModel)]="newCourseId" [maxlength]="COURSE_ID_MAX_LENGTH" (focus)="this.newCourseIdIsConflicting = false" required>
+          <div [hidden]="courseId.valid || (courseId.pristine && courseId.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course ID should not be empty.
+          </div>
+          <span>{{ COURSE_ID_MAX_LENGTH - newCourseId.length }} characters left</span>
       </div>
       <div class="form-group">
         <label>Course Name:</label>
-        <input id="copy-course-name" class="form-control" type="text" placeholder="e.g. Software Engineering" [(ngModel)]="newCourseName"
-          [maxlength]="COURSE_NAME_MAX_LENGTH"/>
-        <span>{{ COURSE_NAME_MAX_LENGTH - newCourseName.length }} characters left</span>
-      </div>
+        <input id="copy-course-name" name="courseName" class="form-control" type="text" placeholder="e.g. Software Engineering" [(ngModel)]="newCourseName"
+          [maxlength]="COURSE_NAME_MAX_LENGTH" #courseName="ngModel" required/>
+          <div [hidden]="courseName.valid || (courseName.pristine && courseName.untouched)" class="invalid-field">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            The field Course Name should not be empty.
+          </div>
       <div class="form-group">
         <label class="ngb-tooltip-class">
           <span ngbTooltip="Note that you can only create a new course under an institute in which you are already a course co-owner.">

--- a/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
+++ b/src/web/app/components/copy-course-modal/copy-course-modal.component.scss
@@ -7,3 +7,8 @@ hr.solid-divider {
 .invalid {
   border: red 1px solid;
 }
+
+.invalid-field {
+  padding-top: 5px;
+  color: #B50000;
+}


### PR DESCRIPTION
Fixes #12653 

Outline of Solution
Added validation and visual feedback for Course ID and Course Name fields in the Copy Course modal to ensure consistency with the Create Course page. Empty fields now display red warning text and an exclamation icon when left blank.

<img width="2559" height="1412" alt="fixed" src="https://github.com/user-attachments/assets/c10bbea8-fad6-4ab4-bdab-4dbbaf8ba83f" />
