### PR TITLE
[#13304] Refactoring for Unit Test Access Controls

### DIFF
--- a/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
@@ -1,7 +1,5 @@
 package teammates.sqlui.webapi;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
Part of #13304 

**Outline of Solution**
This PR refactors access-control unit tests to rely on the high-level and mid-level helper methods from BaseActionTest, reducing duplication and clarifying intent. I also split scenarios into narrowly scoped tests so each file exercises one behavior per test.

The refactored files are:
- GetStudentActionTest.java
- GetStudentsActionTest.java

&nbsp;

**Notes for reviewers**
Introduced focused stubbing utilities in GetStudentActionTest to ensure consistent entity ↔ course binding during self-lookup flows:
- stubSelfLookupAsSameCourse(...)
- stubSelfLookupAsOtherCourse(...)
- regKeyParams(...)

Open to moving/renaming the new stubbing helpers to a shared location if preferred. If there are more appropriate BaseActionTest helpers I missed, I’m happy to switch over. Feedback on test naming and assertion granularity is welcome😄