### PR TITLE
[#13458] Query selector syntax error on page navigation

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -73,7 +73,9 @@ export class InstructorHelpPageComponent implements AfterViewInit {
         }
       }
     });
-    this.scrollTo(target);
+    if (target) {
+      this.scrollTo(target);
+    }
   }
 
   expandQuestionTab(): void {


### PR DESCRIPTION
[#13458] Query selector syntax error on page navigation

Fixes #13458 

Added an if (target) condition to this.scrollTo(target) as it was always running even when there was no target