### PR TITLE
Remove encryption on FeedbackResponse SQL entity UUID

### DIFF
--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -24,7 +24,6 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.util.Const;
-import teammates.common.util.StringHelper;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
@@ -901,12 +900,12 @@ public class SessionResultsData extends ApiOutput {
             }
 
             Builder withResponseId(String responseId) {
-                responseOutput.responseId = StringHelper.encrypt(responseId);
+                responseOutput.responseId = responseId;
                 return this;
             }
 
             Builder withResponse(FeedbackResponse response) {
-                responseOutput.responseId = StringHelper.encrypt(response.getId().toString());
+                responseOutput.responseId = response.getId().toString();
                 return this;
             }
 


### PR DESCRIPTION
**Issue**
- SQL-entity ID of FeedbackResponse does not need to be encrypted as it is a UUID. SessionResultsData (SQL) currently encrypts the UUID of the returned FeedbackResponse entity, causing the frontned to send this encrypted UUID when the backend expects a non-enrypted UUID
- This resulted in inability to comment on a feedback response

**Outline of Solution**
- Remove encryption of UUID