### PR TITLE
Add validation to ensure printCycle is greater than 0 in LoopHelper constructor

### DIFF
--- a/src/client/java/teammates/client/util/LoopHelper.java
+++ b/src/client/java/teammates/client/util/LoopHelper.java
@@ -21,6 +21,10 @@ public class LoopHelper {
      * Constructs a {@link LoopHelper} object which prints {@code message} for every {@code printCycle} iterations.
      */
     public LoopHelper(int printCycle, String message) {
+           if (printCycle <= 0) {
+        throw new IllegalArgumentException("printCycle must be greater than 0");
+    }
+
         this.printCycle = printCycle;
         this.message = message;
         count = 0;


### PR DESCRIPTION
Added validation in the LoopHelper constructor to ensure printCycle is greater than 0.

This prevents potential divide-by-zero issues when checking loop count using modulo operation.
