### PR TITLE
[#13524] When copying from previous feedback sessions, unable to type more than 38 characters in feedback session name 

### DIFF
--- a/src/web/app/pages-instructor/instructor-sessions-page/copy-from-other-sessions-modal/copy-from-other-sessions-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-sessions-page/copy-from-other-sessions-modal/copy-from-other-sessions-modal.component.html
@@ -14,7 +14,7 @@
       </div>
       <div class="form-group">
         <label><b>Name for new session*</b></label>
-        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" maxlength="38"
+        <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" maxlength="64"
                placeholder="e.g. Feedback for Project Presentation 1" required #newSessionName="ngModel">
         <div [hidden]="newSessionName.valid || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
           <i class="fa fa-exclamation-circle" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #13524 