### PR TITLE
[#13469] Fix broken styling on Style column in Admin Notifications page

### DIFF
--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.scss
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.scss
@@ -40,3 +40,33 @@
 #notifications-table {
   min-width: 650px;
 }
+
+#notifications-table thead tr.bg-primary th {
+  background-color: var(--bs-primary) !important;
+  color: white !important;
+}
+
+#notifications-table tbody td.alert-danger {
+  background-color: var(--bs-danger) !important;
+  color: white !important;
+}
+
+#notifications-table tbody td.alert-primary {
+  background-color: var(--bs-primary) !important;
+  color: white !important;
+}
+
+#notifications-table tbody td.alert-info {
+  background-color: var(--bs-info) !important;
+  color: white !important;
+}
+
+#notifications-table tbody td.alert-success {
+  background-color: var(--bs-success) !important;
+  color: white !important;
+}
+
+#notifications-table tbody td.alert-warning {
+  background-color: var(--bs-warning) !important;
+  color: black !important;
+}


### PR DESCRIPTION
Fixes #13469

The Style column in the Admin Notifications page previously applied
Bootstrap alert classes (e.g., `alert alert-success`) inside table cells,
which resulted in inconsistent and visually broken styling.

This change replaces alert classes with Bootstrap background utility
classes (`bg-* text-white`), ensuring proper color rendering inside
table cells without layout side effects.

Additionally, header styling override was adjusted to ensure
Bootstrap table styles do not wash out the header background.

Before
<img width="1583" height="335" alt="Screenshot 2026-02-13 102719" src="https://github.com/user-attachments/assets/62575b26-fad7-4294-9529-e8025e24448a" />

After
<img width="1671" height="368" alt="Screenshot 2026-02-13 105639" src="https://github.com/user-attachments/assets/0da09975-c6eb-4382-a248-4d55f6b64a7e" />
