### PR TITLE
[#13545] Application crashes due to empty build chunk with wrong MIME type

### DIFF
--- a/src/main/appengine/app.template.yaml
+++ b/src/main/appengine/app.template.yaml
@@ -36,9 +36,15 @@ handlers:
   - url: /assets
     static_dir: assets
     expiration: 90d
-  - url: /(.*\.(js|css))$
+  - url: /(.*\.js)$
     static_files: \1
-    upload: .*\.(js|css)$
+    upload: .*\.js$
+    mime_type: application/javascript
+    expiration: 90d
+  - url: /(.*\.css)$
+    static_files: \1
+    upload: .*\.css$
+    mime_type: text/css
     expiration: 90d
 
   # Progressive web app files


### PR DESCRIPTION
Fixes #13545 

**Outline of Solution**
- Separate js and css files handling to ensure mime type of js files is always application/javascript. Tree shaking caused some JS chunks to be empty. Without this change, the server will serve this empty JS file with mime type application/octet-stream, which crashes the app