### PR TITLE
[#12679] Fix whitespace-only copied session name validation in copy modal

### DIFF
--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -12,7 +12,7 @@
         <label><b>Name for copied session*</b></label>
         <input id="copy-session-name" type="text" class="form-control" [(ngModel)]="newFeedbackSessionName" [maxlength]="FEEDBACK_SESSION_NAME_MAX_LENGTH"
                required #newSessionName="ngModel">
-        <div [hidden]="newSessionName.valid || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
+        <div [hidden]="(newSessionName.valid && isNewFeedbackSessionNameValid) || (newSessionName.pristine && newSessionName.untouched)" class="invalid-field">
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             The field "Name for copied session" should not be empty.
         </div>
@@ -35,5 +35,5 @@
 <div class="modal-footer">
   <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">Cancel</button>
   <button id="btn-confirm-copy-course" type="button" class="btn btn-primary" (click)="copy()"
-          [disabled]="!newFeedbackSessionName || copyToCourseSet.size < 1">Copy</button>
+          [disabled]="!isNewFeedbackSessionNameValid || copyToCourseSet.size < 1">Copy</button>
 </div>

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -116,6 +116,12 @@ describe('CopySessionModalComponent', () => {
     });
   });
 
+  it('should treat whitespace-only copied session name as invalid', () => {
+    component.newFeedbackSessionName = '   ';
+
+    expect(component.isNewFeedbackSessionNameValid).toBe(false);
+  });
+
   it('should add a courseId to copyToCourseSet when it is not already present', () => {
     const courseId = 'Course1';
     expect(component.copyToCourseSet.has(courseId)).toBe(false);

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -36,11 +36,18 @@ export class CopySessionModalComponent {
   constructor(public activeModal: NgbActiveModal) {}
 
   /**
+   * Whether copied session name is non-empty after trimming whitespace.
+   */
+  get isNewFeedbackSessionNameValid(): boolean {
+    return this.newFeedbackSessionName.trim().length > 0;
+  }
+
+  /**
    * Fires the copy event.
    */
   copy(): void {
     this.activeModal.close({
-      newFeedbackSessionName: this.newFeedbackSessionName,
+      newFeedbackSessionName: this.newFeedbackSessionName.trim(),
       sessionToCopyCourseId: this.sessionToCopyCourseId,
       copyToCourseList: Array.from(this.copyToCourseSet),
     });


### PR DESCRIPTION
## Summary
- disallow whitespace-only values for **Name for copied session** in the copy-session modal
- validate against trimmed input in the template so the Copy button stays disabled for blank/space-only names
- trim the session name before submit and add a focused unit test for whitespace-only input

Fixes #12679

## Testing
- Added unit test: `should treat whitespace-only copied session name as invalid`.
- Not run in this environment.
