### PR TITLE
Fix table sorting by normalizing values to lowercase

### DIFF
--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -156,7 +156,7 @@ export class SortableTableComponent implements OnInit, OnChanges {
     this.sortEvent.emit({ sortBy, sortOrder: this.sortOrder });
     this.tableRows.sort((row1: any[], row2: any[]) => {
       return this.tableComparatorService.compare(
-          sortBy, this.sortOrder, String(row1[columnIndex].value), String(row2[columnIndex].value));
+          sortBy, this.sortOrder, String(row1[columnIndex].value).toLowerCase(), String(row2[columnIndex].value).toLowerCase());
     });
   }
 


### PR DESCRIPTION
Fixes sorting inconsistency in sortable-table by normalizing both compared values to lowercase before comparison.

This ensures consistent sorting for columns such as team names where case differences could affect order.