### PR TITLE
[#12588] Improve test code coverage of visibility message pipes

### DIFF
--- a/src/web/app/components/visibility-messages/visibility-capability.pipe.spec.ts
+++ b/src/web/app/components/visibility-messages/visibility-capability.pipe.spec.ts
@@ -1,8 +1,51 @@
 import { VisibilityCapabilityPipe } from './visibility-capability.pipe';
+import { VisibilityControl } from '../../../types/visibility-control';
 
 describe('VisibilityCapabilityPipe', () => {
-  it('create an instance', () => {
-    const pipe: VisibilityCapabilityPipe = new VisibilityCapabilityPipe();
-    expect(pipe).toBeTruthy();
-  });
+    let pipe: VisibilityCapabilityPipe;
+
+    beforeEach(() => {
+        pipe = new VisibilityCapabilityPipe();
+    });
+
+    it('should create', () => {
+        expect(pipe).toBeTruthy();
+    });
+
+    it('transform: should return correct message when both recipient and giver name are shown', () => {
+        const controls = {
+            [VisibilityControl.SHOW_RECIPIENT_NAME]: true,
+            [VisibilityControl.SHOW_GIVER_NAME]: true,
+        } as any;
+        expect(pipe.transform(controls)).toBe('can see your response, the name of the recipient, and your name');
+    });
+
+    it('transform: should return correct message when only recipient name is shown', () => {
+        const controls = {
+            [VisibilityControl.SHOW_RECIPIENT_NAME]: true,
+            [VisibilityControl.SHOW_GIVER_NAME]: false,
+        } as any;
+        expect(pipe.transform(controls)).toBe('can see your response, the name of the recipient, but not your name');
+    });
+
+    it('transform: should return correct message when only giver name is shown', () => {
+        const controls = {
+            [VisibilityControl.SHOW_RECIPIENT_NAME]: false,
+            [VisibilityControl.SHOW_GIVER_NAME]: true,
+        } as any;
+        expect(pipe.transform(controls)).toBe('can see your response, and your name, but not the name of the recipient');
+    });
+
+    it('transform: should return correct message when neither names are shown', () => {
+        const controls = {
+            [VisibilityControl.SHOW_RECIPIENT_NAME]: false,
+            [VisibilityControl.SHOW_GIVER_NAME]: false,
+        } as any;
+        expect(pipe.transform(controls)).toBe('can see your response, but not the name of the recipient, or your name');
+    });
+
+    it('transform: should handle empty visibility controls gracefully', () => {
+        const controls = {} as any;
+        expect(pipe.transform(controls)).toBe('can see your response, but not the name of the recipient, or your name');
+    });
 });

--- a/src/web/app/components/visibility-messages/visibility-entity-name.pipe.spec.ts
+++ b/src/web/app/components/visibility-messages/visibility-entity-name.pipe.spec.ts
@@ -1,8 +1,76 @@
 import { VisibilityEntityNamePipe } from './visibility-entity-name.pipe';
+import {
+    FeedbackParticipantType,
+    FeedbackVisibilityType,
+    NumberOfEntitiesToGiveFeedbackToSetting,
+} from '../../../types/api-output';
 
 describe('VisibilityEntityNamePipe', () => {
-  it('create an instance', () => {
-    const pipe: VisibilityEntityNamePipe = new VisibilityEntityNamePipe();
-    expect(pipe).toBeTruthy();
-  });
+    let pipe: VisibilityEntityNamePipe;
+
+    beforeEach(() => {
+        pipe = new VisibilityEntityNamePipe();
+    });
+
+    it('should create', () => {
+        expect(pipe).toBeTruthy();
+    });
+
+    it('transform: should return "Your team members" when visibilityType is GIVER_TEAM_MEMBERS', () => {
+        expect(pipe.transform(FeedbackVisibilityType.GIVER_TEAM_MEMBERS)).toBe('Your team members');
+    });
+
+    it('transform: should return "Instructors in this course" when visibilityType is INSTRUCTORS', () => {
+        expect(pipe.transform(FeedbackVisibilityType.INSTRUCTORS)).toBe('Instructors in this course');
+    });
+
+    it('transform: should return "Other students in the course" when visibilityType is STUDENTS', () => {
+        expect(pipe.transform(FeedbackVisibilityType.STUDENTS)).toBe('Other students in the course');
+    });
+
+    it('transform: should return "Unknown" for invalid visibility types (default case)', () => {
+        expect(pipe.transform('INVALID' as any)).toBe('Unknown');
+    });
+
+    it('transform: should return "unknown" for invalid participant types when visibility is RECIPIENT', () => {
+        expect(pipe.transform(FeedbackVisibilityType.RECIPIENT, 'INVALID' as any)).toBe('unknown');
+    });
+
+    it('transform: should return singular "The receiving instructor" when setting is CUSTOM with count 1', () => {
+        const result = pipe.transform(
+            FeedbackVisibilityType.RECIPIENT,
+            FeedbackParticipantType.INSTRUCTORS,
+            NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM,
+            1
+        );
+        expect(result).toBe('The receiving instructor');
+    });
+
+    it('transform: should pluralize to "The receiving students" when setting is UNLIMITED', () => {
+        const result = pipe.transform(
+            FeedbackVisibilityType.RECIPIENT,
+            FeedbackParticipantType.STUDENTS,
+            NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED
+        );
+        expect(result).toBe('The receiving students');
+    });
+
+    it('transform: should pluralize to "The receiving teams" when setting is CUSTOM with count > 1', () => {
+        const result = pipe.transform(
+            FeedbackVisibilityType.RECIPIENT,
+            FeedbackParticipantType.TEAMS,
+            NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM,
+            2
+        );
+        expect(result).toBe('The receiving teams');
+    });
+
+    it('transform: should pluralize "STUDENTS_EXCLUDING_SELF" correctly', () => {
+        const result = pipe.transform(
+            FeedbackVisibilityType.RECIPIENT,
+            FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
+            NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED
+        );
+        expect(result).toBe('The receiving students');
+    });
 });


### PR DESCRIPTION
Part of #12588 

Description
This PR improves the test coverage for the VisibilityCapabilityPipe and VisibilityEntityNamePipe.

Changes
Added unit tests to visibility-capability.pipe.spec.ts covering all logical branches.
Added unit tests to visibility-entity-name.pipe.spec.ts covering entity pluralization and default "unknown" cases.

Verification Results
All tests passed locally using npm test.
