### PR TITLE
[#11967] Add dark mode toggle

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -22,6 +22,12 @@
     </ul>
     <ul class="nav navbar-nav me-auto" *ngIf="!isValidUser"></ul>
     <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
+      
+      <li class="nav-item">
+        <button class="btn btn-link nav-link text-white" (click)="toggleDarkMode()">
+          Dark Mode
+        </button>
+      </li>
       <li class="nav-item dropdown" ngbDropdown placement="bottom-end" *ngIf="!user">
         <button class="bg-transparent btn btn-link nav-link dropdown-toggle"
            data-toggle="dropdown" tabindex="0" ngbDropdownToggle>Login</button>

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -169,6 +169,13 @@ export class PageComponent {
   }
 
   /**
+ * Method to toggle dark mode.
+ */
+toggleDarkMode(): void {
+  document.body.classList.toggle('dark-mode');
+}
+
+  /**
    * Method that checks if current page has active modals and close them.
    */
   closeModal(): void {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -333,3 +333,26 @@ a i.fa-info-circle {
 .table-responsive {
   -webkit-overflow-scrolling: auto;
 }
+
+.dark-mode {
+  background-color: #121212;
+  color: white;
+}
+
+.dark-mode .navbar {
+  background-color: #1e1e1e !important;
+}
+
+.dark-mode .card {
+  background-color: #1e1e1e;
+  color: white;
+}
+
+.dark-mode table {
+  color: white;
+}
+
+.dark-mode .btn-light {
+  background-color: #333;
+  color: white;
+}

--- a/src/web/types/index.ts
+++ b/src/web/types/index.ts
@@ -1,0 +1,2 @@
+export * from './api-request';
+// export * from './api-output';


### PR DESCRIPTION
A simple dark mode toggle for the TEAMMATES web interface. The feature allows users to switch between the default light theme and a darker color scheme that is easier on the eyes in low light environments.

The implementation uses a lightweight approach by toggling a dark-mode CSS class on the global <body> element. When enabled, global styles adjust background colors and text colors for key UI components such as the navbar, cards, tables, and buttons.

Changes:

- Added a Dark Mode toggle button to the navigation bar.
- Users can enable or disable dark mode directly from the navbar.

Logic

- Implemented a toggleDarkMode() method in PageComponent.
- The method toggles a dark-mode class on the document body.

Before: 
<img width="1919" height="908" alt="Screenshot 2026-03-08 173026" src="https://github.com/user-attachments/assets/a3927829-0006-46db-8922-d392837085ed" />

After: 
<img width="1919" height="905" alt="Screenshot 2026-03-08 173042" src="https://github.com/user-attachments/assets/4bdc0803-c3af-48be-a94d-a2101a90cd46" />

Fixes #11967 