### PR TITLE
[#12048] Migrate FeedbackQuestionDetails test classes to SQL

### DIFF
--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
@@ -12,8 +12,12 @@ import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.SessionResultsBundle;
+import teammates.common.datatransfer.SqlCourseRoster;
+import teammates.common.datatransfer.SqlDataBundle;
+import teammates.common.datatransfer.SqlSessionResultsBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.util.Const;
+import teammates.storage.sqlentity.questions.FeedbackContributionQuestion;
 import teammates.test.BaseTestCase;
 
 /**
@@ -718,6 +722,457 @@ public class FeedbackContributionQuestionDetailsTest extends BaseTestCase {
         assertEquals(Arrays.asList(FeedbackParticipantType.RECEIVER, FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
                 FeedbackParticipantType.OWN_TEAM_MEMBERS, FeedbackParticipantType.INSTRUCTORS),
                 feedbackQuestionAttributes.getShowResponsesTo());
+
+    }
+
+    @Test
+    public void testValidateGiverRecipientVisibilitySql() {
+        FeedbackContributionQuestionDetails details = new FeedbackContributionQuestionDetails();
+        FeedbackContributionQuestion feedbackQuestion = new FeedbackContributionQuestion(
+                null, 1, "description",
+                FeedbackParticipantType.STUDENTS,
+                FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
+                Const.MAX_POSSIBLE_RECIPIENTS,
+                Arrays.asList(FeedbackParticipantType.RECEIVER,
+                        FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
+                        FeedbackParticipantType.OWN_TEAM_MEMBERS,
+                        FeedbackParticipantType.INSTRUCTORS),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new FeedbackContributionQuestionDetails());
+
+        ______TS("success: valid giver recipient visibility");
+        assertEquals("", details.validateGiverRecipientVisibility(feedbackQuestion));
+
+        ______TS("failure: giver type is not STUDENT");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.SELF);
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_FEEDBACK_PATH,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.STUDENTS, feedbackQuestion.getGiverType());
+
+        ______TS("failure: recipient type can only be OWN_TEAM_MEMBERS_INCLUDING_SELF");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.SELF);
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_FEEDBACK_PATH,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF, feedbackQuestion.getRecipientType());
+
+        ______TS("failure: giver type is not STUDENT and recipient type is not OWN_TEAM_MEMBERS_INCLUDING_SELF");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.SELF);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.SELF);
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_FEEDBACK_PATH,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.STUDENTS, feedbackQuestion.getGiverType());
+        assertEquals(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF, feedbackQuestion.getRecipientType());
+
+        ______TS("failure: invalid restrictions on visibility options");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF);
+        feedbackQuestion.setShowResponsesTo(Arrays.asList(FeedbackParticipantType.RECEIVER));
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_VISIBILITY_OPTIONS,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(Arrays.asList(FeedbackParticipantType.RECEIVER, FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
+                FeedbackParticipantType.OWN_TEAM_MEMBERS, FeedbackParticipantType.INSTRUCTORS),
+                feedbackQuestion.getShowResponsesTo());
+
+        ______TS("failure: giver type is not STUDENT and invalid restrictions on visibility options");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.SELF);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF);
+        feedbackQuestion.setShowResponsesTo(Arrays.asList(FeedbackParticipantType.RECEIVER));
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_VISIBILITY_OPTIONS,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.STUDENTS, feedbackQuestion.getGiverType());
+        assertEquals(Arrays.asList(FeedbackParticipantType.RECEIVER, FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
+                FeedbackParticipantType.OWN_TEAM_MEMBERS, FeedbackParticipantType.INSTRUCTORS),
+                feedbackQuestion.getShowResponsesTo());
+
+        ______TS("failure: recipient type is not OWN_TEAM_MEMBERS_INCLUDING_SELF and invalid restrictions on "
+                + "visibility options");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.SELF);
+        feedbackQuestion.setShowResponsesTo(Arrays.asList(FeedbackParticipantType.RECEIVER));
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_VISIBILITY_OPTIONS,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF, feedbackQuestion.getRecipientType());
+        assertEquals(Arrays.asList(FeedbackParticipantType.RECEIVER, FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
+                FeedbackParticipantType.OWN_TEAM_MEMBERS, FeedbackParticipantType.INSTRUCTORS),
+                feedbackQuestion.getShowResponsesTo());
+
+        ______TS("failure: giver type is not STUDENT and recipient type is not OWN_TEAM_MEMBERS_INCLUDING_SELF"
+                + " and invalid restrictions on visibility options");
+        feedbackQuestion.setGiverType(FeedbackParticipantType.SELF);
+        feedbackQuestion.setRecipientType(FeedbackParticipantType.SELF);
+        feedbackQuestion.setShowResponsesTo(Arrays.asList(FeedbackParticipantType.RECEIVER));
+        assertEquals(FeedbackContributionQuestionDetails.CONTRIB_ERROR_INVALID_VISIBILITY_OPTIONS,
+                details.validateGiverRecipientVisibility(feedbackQuestion));
+        assertEquals(FeedbackParticipantType.STUDENTS, feedbackQuestion.getGiverType());
+        assertEquals(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF, feedbackQuestion.getRecipientType());
+        assertEquals(Arrays.asList(FeedbackParticipantType.RECEIVER, FeedbackParticipantType.RECEIVER_TEAM_MEMBERS,
+                FeedbackParticipantType.OWN_TEAM_MEMBERS, FeedbackParticipantType.INSTRUCTORS),
+                feedbackQuestion.getShowResponsesTo());
+
+    }
+
+    @Test
+    public void testGetQuestionResultStatisticsJsonSql() {
+        FeedbackContributionQuestionDetails feedbackContributionQuestionDetails = new FeedbackContributionQuestionDetails();
+
+        SqlDataBundle responseBundle = loadSqlDataBundle("/FeedbackContributionQuestionTestSql.json");
+
+        SqlSessionResultsBundle sqlBundle = new SqlSessionResultsBundle(
+                new ArrayList<>(responseBundle.feedbackQuestions.values()),
+                new HashSet<>(), new HashSet<>(),
+                new ArrayList<>(responseBundle.feedbackResponses.values()),
+                new ArrayList<>(),
+                new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                new SqlCourseRoster(new ArrayList<>(responseBundle.students.values()),
+                        new ArrayList<>(responseBundle.instructors.values())));
+
+        FeedbackContributionQuestion sqlFqa;
+
+        ______TS("(student email specified): all students have response");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        assertEquals("{\n"
+                + "  \"results\": {\n"
+                + "    \"student1InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": 10,\n"
+                + "      \"perceived\": 17,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student2InCourse1@gmail.tmt\": 20,\n"
+                + "        \"student3InCourse1@gmail.tmt\": 30\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        24,\n"
+                + "        19\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa,
+                        "student1InCourse1@gmail.tmt", sqlBundle));
+
+        ______TS("(student email specified): mix of students with responses and students without responses");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
+        assertEquals("{\n"
+                + "  \"results\": {\n"
+                + "    \"student5InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": 10,\n"
+                + "      \"perceived\": 15,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student6InCourse1@gmail.tmt\": 20,\n"
+                + "        \"student4InCourse1@gmail.tmt\": -999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        15,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa,
+                "student5InCourse1@gmail.tmt", sqlBundle));
+
+        ______TS("(student email specified): all students do not have responses");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
+        assertEquals("{\n"
+                + "  \"results\": {}\n"
+                + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa,
+                "student8InCourse1@gmail.tmt", sqlBundle));
+
+        ______TS("(student email not specified): qn1");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        assertEquals("{\n"
+                + "  \"results\": {\n"
+                + "    \"student6InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student5InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student7InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student8InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student8InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student7InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student2InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": 100,\n"
+                + "      \"perceived\": 93,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student1InCourse1@gmail.tmt\": 80,\n"
+                + "        \"student3InCourse1@gmail.tmt\": 120\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        107,\n"
+                + "        80\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student5InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student6InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student1InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": 50,\n"
+                + "      \"perceived\": 87,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student2InCourse1@gmail.tmt\": 80,\n"
+                + "        \"student3InCourse1@gmail.tmt\": 120\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        93,\n"
+                + "        80\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student4InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student6InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student5InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student3InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": 113,\n"
+                + "      \"perceived\": 120,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student2InCourse1@gmail.tmt\": 107,\n"
+                + "        \"student1InCourse1@gmail.tmt\": 93\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        120,\n"
+                + "        120\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa, null, sqlBundle));
+
+        ______TS("(student email not specified): qn2");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
+        assertEquals("{\n"
+                        + "  \"results\": {\n"
+                        + "    \"student6InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": 114,\n"
+                        + "      \"perceived\": 100,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student5InCourse1@gmail.tmt\": 100,\n"
+                        + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        100,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student7InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student8InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student8InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student7InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student2InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student1InCourse1@gmail.tmt\": -9999,\n"
+                        + "        \"student3InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student5InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": 67,\n"
+                        + "      \"perceived\": 100,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student6InCourse1@gmail.tmt\": 100,\n"
+                        + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        100,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student1InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student2InCourse1@gmail.tmt\": -9999,\n"
+                        + "        \"student3InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student4InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student6InCourse1@gmail.tmt\": -9999,\n"
+                        + "        \"student5InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    },\n"
+                        + "    \"student3InCourse1@gmail.tmt\": {\n"
+                        + "      \"claimed\": -999,\n"
+                        + "      \"perceived\": -9999,\n"
+                        + "      \"claimedOthers\": {\n"
+                        + "        \"student2InCourse1@gmail.tmt\": -9999,\n"
+                        + "        \"student1InCourse1@gmail.tmt\": -9999\n"
+                        + "      },\n"
+                        + "      \"perceivedOthers\": [\n"
+                        + "        -9999,\n"
+                        + "        -9999\n"
+                        + "      ]\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa, null, sqlBundle));
+
+        ______TS("(student email not specified): qn3");
+        sqlFqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
+        assertEquals("{\n"
+                + "  \"results\": {\n"
+                + "    \"student6InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student5InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student7InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student8InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student8InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student7InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student2InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student1InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student3InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student5InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student6InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student4InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student1InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student2InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student3InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student4InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student6InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student5InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    \"student3InCourse1@gmail.tmt\": {\n"
+                + "      \"claimed\": -999,\n"
+                + "      \"perceived\": -9999,\n"
+                + "      \"claimedOthers\": {\n"
+                + "        \"student2InCourse1@gmail.tmt\": -9999,\n"
+                + "        \"student1InCourse1@gmail.tmt\": -9999\n"
+                + "      },\n"
+                + "      \"perceivedOthers\": [\n"
+                + "        -9999,\n"
+                + "        -9999\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(sqlFqa, null, sqlBundle));
 
     }
 

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetailsTest.java
@@ -1,12 +1,16 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.questions.FeedbackRankRecipientsQuestion;
 import teammates.test.BaseTestCase;
 
 /**
@@ -178,5 +182,17 @@ public class FeedbackRankRecipientsQuestionDetailsTest extends BaseTestCase {
                 new FeedbackRankRecipientsQuestionDetails();
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder().build();
         assertEquals("", feedbackRankRecipientsQuestionDetails.validateGiverRecipientVisibility(feedbackQuestionAttributes));
+    }
+
+    @Test
+    public void testValidateGiverRecipientVisibilitySql() {
+        FeedbackRankRecipientsQuestionDetails feedbackRankRecipientsQuestionDetails =
+                new FeedbackRankRecipientsQuestionDetails();
+        FeedbackQuestion feedbackQuestion = new FeedbackRankRecipientsQuestion(
+                null, 1, null,
+                FeedbackParticipantType.STUDENTS, FeedbackParticipantType.OWN_TEAM_MEMBERS,
+                1, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new FeedbackRankRecipientsQuestionDetails());
+        assertEquals("", feedbackRankRecipientsQuestionDetails.validateGiverRecipientVisibility(feedbackQuestion));
     }
 }

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetailsTest.java
@@ -5,7 +5,10 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.storage.sqlentity.FeedbackQuestion;
+import teammates.storage.sqlentity.questions.FeedbackTextQuestion;
 import teammates.test.BaseTestCase;
 
 /**
@@ -91,6 +94,16 @@ public class FeedbackTextQuestionDetailsTest extends BaseTestCase {
     public void testValidateGiverRecipientVisibility_shouldReturnEmptyString() {
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder().build();
         assertEquals("", feedbackTextQuestionDetails.validateGiverRecipientVisibility(feedbackQuestionAttributes));
+    }
+
+    @Test
+    public void testValidateGiverRecipientVisibilitySql_shouldReturnEmptyString() {
+        FeedbackQuestion feedbackQuestion = new FeedbackTextQuestion(
+                null, 1, null,
+                FeedbackParticipantType.STUDENTS, FeedbackParticipantType.OWN_TEAM_MEMBERS,
+                1, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new FeedbackTextQuestionDetails());
+        assertEquals("", feedbackTextQuestionDetails.validateGiverRecipientVisibility(feedbackQuestion));
     }
 
     @Test

--- a/src/test/resources/data/FeedbackContributionQuestionTestSql.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTestSql.json
@@ -1,0 +1,1536 @@
+{
+  "accounts": {
+    "instructor1OfCourse1": {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "googleId": "idOfInstructor1OfCourse1",
+      "name": "Instructor 1 of Course 1",
+      "email": "instr1@course1.tmt"
+    },
+    "instructor2OfCourse1": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "googleId": "idOfInstructor2OfCourse1",
+      "name": "Instructor 2 of Course 1",
+      "email": "instr2@course1.tmt"
+    },
+    "helperOfCourse1": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "googleId": "idOfHelperOfCourse1",
+      "name": "Helper of Course 1",
+      "email": "helper@course1.tmt"
+    },
+    "instructor1OfCourse2": {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "googleId": "idOfInstructor1OfCourse2",
+      "name": "Instructor 1 of Course 2",
+      "email": "instr1@course2.tmt"
+    },
+    "instructor2OfCourse2": {
+      "id": "00000000-0000-4000-8000-000000000005",
+      "googleId": "idOfInstructor2OfCourse2",
+      "name": "Instructor 2 of Course 2",
+      "email": "instr2@course2.tmt"
+    },
+    "instructor1OfCourse3": {
+      "id": "00000000-0000-4000-8000-000000000006",
+      "googleId": "idOfInstructor1OfCourse3",
+      "name": "Instructor 1 of Course 3",
+      "email": "instr1@course3.tmt"
+    },
+    "instructor2OfCourse3": {
+      "id": "00000000-0000-4000-8000-000000000007",
+      "googleId": "idOfInstructor2OfCourse3",
+      "name": "Instructor 2 of Course 3",
+      "email": "instr2@course3.tmt"
+    },
+    "instructor3": {
+      "id": "00000000-0000-4000-8000-000000000008",
+      "googleId": "idOfInstructor3",
+      "name": "Instructor 3 of Course 1 and 2",
+      "email": "instr3@course1n2.tmt"
+    },
+    "instructor4": {
+      "id": "00000000-0000-4000-8000-000000000009",
+      "googleId": "idOfInstructor4",
+      "name": "Instructor 4 of CourseNoEvals",
+      "email": "instr4@coursenoevals.tmt"
+    },
+    "instructor5": {
+      "id": "00000000-0000-4000-8000-000000000010",
+      "googleId": "idOfInstructor5",
+      "name": "Instructor 5 of CourseNoRegister",
+      "email": "instructor5@courseNoRegister.tmt"
+    },
+    "instructorWithoutCourses": {
+      "id": "00000000-0000-4000-8000-000000000011",
+      "googleId": "instructorWithoutCourses",
+      "name": "Instructor Without Courses",
+      "email": "iwc@yahoo.tmt"
+    },
+    "instructorWithOnlyOneSampleCourse": {
+      "id": "00000000-0000-4000-8000-000000000012",
+      "googleId": "idOfInstructorWithOnlyOneSampleCourse",
+      "name": "Instructor With Only One Sample Course",
+      "email": "iwosc@yahoo.tmt"
+    },
+    "instructorOfArchivedCourse": {
+      "id": "00000000-0000-4000-8000-000000000013",
+      "googleId": "idOfInstructorOfArchivedCourse",
+      "name": "InstructorOfArchiveCourse name",
+      "email": "instructorOfArchiveCourse@archiveCourse.tmt"
+    },
+    "instructor1OfTestingSanitizationCourse": {
+      "id": "00000000-0000-4000-8000-000000000014",
+      "googleId": "idOfInstructor1OfTestingSanitizationCourse",
+      "name": "Instructor<script> alert('hi!'); </script>",
+      "email": "instructor1@sanitization.tmt"
+    },
+    "student1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000015",
+      "googleId": "student1InCourse1",
+      "name": "Student 1 in course 1",
+      "email": "student1InCourse1@gmail.tmt"
+    },
+    "student2InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000016",
+      "googleId": "student2InCourse1",
+      "name": "Student in two courses",
+      "email": "student2InCourse1@gmail.tmt"
+    },
+    "student1InArchivedCourse": {
+      "id": "00000000-0000-4000-8000-000000000017",
+      "googleId": "student1InArchivedCourse",
+      "name": "Student in Archived Course",
+      "email": "student1InCourse1@gmail.tmt"
+    },
+    "student1InTestingSanitizationCourse": {
+      "id": "00000000-0000-4000-8000-000000000018",
+      "googleId": "student1InTestingSanitizationCourse",
+      "name": "Stud1<script> alert('hi!'); </script>",
+      "email": "normal@sanitization.tmt"
+    }
+  },
+  "accountRequests": {},
+  "courses": {
+    "typicalCourse1": {
+      "id": "idOfTypicalCourse1",
+      "name": "Typical Course 1 with 2 Evals",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2012-04-01T23:58:00Z"
+    },
+    "typicalCourse2": {
+      "id": "idOfTypicalCourse2",
+      "name": "Typical Course 2 with 1 Evals",
+      "timeZone": "Asia/Singapore",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2012-04-01T23:59:00Z"
+    },
+    "typicalCourse3": {
+      "id": "idOfTypicalCourse3",
+      "name": "Typical Course 3 with 1 Evals",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1",
+      "deletedAt": "2012-04-12T23:58:00Z",
+      "createdAt": "2012-04-02T23:58:00Z"
+    },
+    "typicalCourse4": {
+      "id": "idOfTypicalCourse4",
+      "name": "Typical Course 4 with 1 Evals",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2012-04-02T23:58:00Z"
+    },
+    "courseNoEvals": {
+      "id": "idOfCourseNoEvals",
+      "name": "Typical Course 3 with 0 Evals",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "sampleCourse": {
+      "id": "idOfSampleCourse-demo",
+      "name": "Sample Course",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 7"
+    },
+    "archivedCourse": {
+      "id": "idOfArchivedCourse",
+      "name": "Archived Course",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 5"
+    },
+    "unregisteredCourse": {
+      "id": "idOfUnregisteredCourse",
+      "name": "Unregistered Course",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "testingInstructorsDisplayedCourse": {
+      "id": "idOfTestingInstructorsDisplayedCourse",
+      "name": "Testing<script> alert('hi!'); </script>",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "TEAMMATES Test Institute 1",
+      "createdAt": "2012-04-01T23:58:00Z"
+    },
+    "testingSanitizationCourse": {
+      "id": "idOfTestingSanitizationCourse",
+      "name": "Testing<script> alert('hi!'); </script>",
+      "timeZone": "Africa/Johannesburg",
+      "institute": "inst<script> alert('hi!'); </script>",
+      "createdAt": "2012-04-01T23:58:00Z"
+    }
+  },
+  "sections": {
+    "idOfTypicalCourse1-Section1": {
+      "id": "00000000-0000-4000-8000-000000000201",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Section 1"
+    },
+    "idOfTypicalCourse1-Section2": {
+      "id": "00000000-0000-4000-8000-000000000202",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Section 2"
+    }
+  },
+  "teams": {
+    "idOfTypicalCourse1-Section1-Team1.1</td></div>'\"": {
+      "id": "00000000-0000-4000-8000-000000000301",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "name": "Team 1.1</td></div>'\""
+    },
+    "idOfTypicalCourse1-Section1-Team1.2": {
+      "id": "00000000-0000-4000-8000-000000000302",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "name": "Team 1.2"
+    },
+    "idOfTypicalCourse1-Section2-Team1.2": {
+      "id": "00000000-0000-4000-8000-000000000303",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "name": "Team 1.2"
+    },
+    "idOfTypicalCourse1-Section2-Team1.3": {
+      "id": "00000000-0000-4000-8000-000000000304",
+      "section": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "name": "Team 1.3"
+    }
+  },
+  "deadlineExtensions": {},
+  "instructors": {
+    "instructor1OfCourse1": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000501",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000001"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Instructor1 Course1",
+      "email": "instructor1@course1.tmt",
+      "regKey": "1BE825FD60150723BA754A9A8AC16A69EA7549319F77AFA6FE3A7D414B3EAC0B90BF03999B51566B66401AF873CF99AFD4852F5D8CE0526B971AB962CE33B6C0"
+    },
+    "instructor2OfCourse1": {
+      "isDisplayedToStudents": true,
+      "displayName": "Manager",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_MANAGER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": false,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000502",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000002"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Instructor2 Course1",
+      "email": "instructor2@course1.tmt",
+      "regKey": "00FDB97D39D75C427A8D59294C0A3A9DEA7549319F77AFA6FE3A7D414B3EAC0B51919F0FD03E886B1F737C38043372BB0DA8CD324606402A9FEF6F18D3CA37E6"
+    },
+    "helperOfCourse1": {
+      "isDisplayedToStudents": false,
+      "displayName": "Helper",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_CUSTOM",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": false,
+          "canModifyInstructor": false,
+          "canModifySession": false,
+          "canModifyStudent": false,
+          "canViewStudentInSections": false,
+          "canViewSessionInSections": false,
+          "canSubmitSessionInSections": false,
+          "canModifySessionCommentsInSections": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000503",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000003"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Helper Course1",
+      "email": "helper@course1.tmt",
+      "regKey": "E78B8BE1C98B6C9C38A18EB8C11B9D4FBD5346A074C37B92491045C387E148517E25B04B0D429622236434D1D11903A0C89A7046D807814E294A39DF1D149867"
+    },
+    "instructorNotYetJoinCourse1": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000504",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Instructor Not Yet Joined Course 1",
+      "email": "instructorNotYetJoinedCourse1@email.tmt",
+      "regKey": "242E2ADAB346AC55A800B5612100D6DBEDA48640F2DCCB9D786343D2B6EBE609B64BD2FE11E947A1D10B3FA2230C4B2BAA111C03E85887E11C4DFC6B82E3BB6862F51BBC938FA59DFD2C7F80E749F6CC"
+    },
+    "instructor1OfCourse2": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000505",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000004"
+      },
+      "courseId": "idOfTypicalCourse2",
+      "course": {
+        "id": "idOfTypicalCourse2"
+      },
+      "name": "Instructor1 Course2",
+      "email": "instructor1@course2.tmt",
+      "regKey": "1BE825FD60150723BA754A9A8AC16A6960C42852D490FAD210C04FDD531D0DB5CE5DE5318D4C91888CCC19B9AE72B6355D66FBAC608005FD0AFF0275AB30EE5D"
+    },
+    "instructor2OfCourse2": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000506",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000005"
+      },
+      "courseId": "idOfTypicalCourse2",
+      "course": {
+        "id": "idOfTypicalCourse2"
+      },
+      "name": "Instructor2 Course2",
+      "email": "instructor2@course2.tmt",
+      "regKey": "00FDB97D39D75C427A8D59294C0A3A9D60C42852D490FAD210C04FDD531D0DB5AD65C0B08D10FF35866F552ABA0CB4086E4C115EFADF2CB109779020A89E5148"
+    },
+    "instructor1OfCourse3": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000507",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000006"
+      },
+      "courseId": "idOfTypicalCourse3",
+      "course": {
+        "id": "idOfTypicalCourse3"
+      },
+      "name": "Instructor1 Course3",
+      "email": "instructor1@course3.tmt",
+      "regKey": "1BE825FD60150723BA754A9A8AC16A698E034EFE9CAB8C85873A13B9BCF450DE7D0D50DE6751F0CAC9D7D765580CFCF973F7E0F590648C0734AE59FE507B630A"
+    },
+    "instructor2OfCourse3": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_CUSTOM",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": false,
+          "canModifyInstructor": true,
+          "canModifySession": false,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000508",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000007"
+      },
+      "courseId": "idOfTypicalCourse3",
+      "course": {
+        "id": "idOfTypicalCourse3"
+      },
+      "name": "Instructor2 Course3",
+      "email": "instructor2@course3.tmt",
+      "regKey": "00FDB97D39D75C427A8D59294C0A3A9D8E034EFE9CAB8C85873A13B9BCF450DE090F0CBA5F52491132580F5F9E56F6BA42D572B99E6402A6499D44F8C6D8AEEB"
+    },
+    "instructor1OfCourse4": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_CUSTOM",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": false,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000509",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000006"
+      },
+      "courseId": "idOfTypicalCourse4",
+      "course": {
+        "id": "idOfTypicalCourse4"
+      },
+      "name": "Instructor1 Course4",
+      "email": "instructor1@course3.tmt",
+      "regKey": "1BE825FD60150723BA754A9A8AC16A698E034EFE9CAB8C85873A13B9BCF450DE1682D1378E93C2BCE5741D85927860BE1312F4F1CAF434DB5971F1DE56C04F88"
+    },
+    "instructor3OfCourse1": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000510",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000008"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Instructor3 Course1",
+      "email": "instructor3@course1.tmt",
+      "regKey": "35403B1A86176F032E6358DC81A7E4BAEA7549319F77AFA6FE3A7D414B3EAC0B700587EBCFC3811102C9B8D7752B89E39ADBB1601C7D1BF9D5040F28FFB679E8"
+    },
+    "instructor3OfCourse2": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000511",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000008"
+      },
+      "courseId": "idOfTypicalCourse2",
+      "course": {
+        "id": "idOfTypicalCourse2"
+      },
+      "name": "Instructor3 Course2",
+      "email": "instructor3@course2.tmt",
+      "regKey": "35403B1A86176F032E6358DC81A7E4BA60C42852D490FAD210C04FDD531D0DB5B99A17570BE374FA0CC183B0F7E943F86EAA7C3B59A7BF4C4121E0DD19321281"
+    },
+    "instructor4": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000512",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000009"
+      },
+      "courseId": "idOfCourseNoEvals",
+      "course": {
+        "id": "idOfCourseNoEvals"
+      },
+      "name": "Instructor4 name",
+      "email": "instructor4@courseNoEvals.tmt",
+      "regKey": "25B73622704B00D696D59E76BC19224216790CB126FB9F960DD677CD7E77C40CBD3E2A6BB8BF12CA2CBBFEF783EF7356300961DED10D5DA38222F03A102D4C96"
+    },
+    "instructor5": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000513",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000010"
+      },
+      "courseId": "idOfUnregisteredCourse",
+      "course": {
+        "id": "idOfUnregisteredCourse"
+      },
+      "name": "Instructor 5 of CourseNoRegister",
+      "email": "instructor5@courseNoRegister.tmt",
+      "regKey": "46BBB8EFABAB52FFB84582CEDD93946625FD94CA2FBF54552E7D1B9CFC28D7DD912C9534360F208C46ED9A2E7F6881EB6BFAD0DBD46F6B00DE9C3C9CAA8017E7F797655139A2ACBBAF0DE05016DCC338"
+    },
+    "instructorWithOnlyOneSampleCourse": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000514",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000012"
+      },
+      "courseId": "idOfSampleCourse-demo",
+      "course": {
+        "id": "idOfSampleCourse-demo"
+      },
+      "name": "Instructor With Only One Sample Course",
+      "email": "iwosc@yahoo.tmt",
+      "regKey": "697E55515E376074F4C2C55490CEEA2265BA0D197F975664AE7ACCEB8C53CF6263E1E4AE1FE73F85A11A7803AB5FC4B2C89A7046D807814E294A39DF1D149867"
+    },
+    "instructorOfArchivedCourse": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000515",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000013"
+      },
+      "courseId": "idOfArchivedCourse",
+      "course": {
+        "id": "idOfArchivedCourse"
+      },
+      "name": "InstructorOfArchiveCourse name",
+      "email": "instructorOfArchiveCourse@archiveCourse.tmt",
+      "regKey": "CA31E9D6C04A525C8C8A9215731666342F9351B6937C1759F2CC4FD4594E3B683462A9A635F21C558A7917C87FBDD5DDDC94973078A00B2A79786EE9969109F480DC2B5F2449B6C8E51C1ED8355F89A9"
+    },
+    "instructorNotDisplayedToStudent1": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000516",
+      "courseId": "idOfTestingInstructorsDisplayedCourse",
+      "course": {
+        "id": "idOfTestingInstructorsDisplayedCourse"
+      },
+      "name": "name1",
+      "email": "instructorNotDisplayed@NotDisplayed.tmt",
+      "regKey": "4D79AC7E93AD943A5295A38506EF2AC2D5B0BD660999C961DB6710BBCAD87A7CFE84657B1340A725AB66BB5E7E239697BA0E59854753DF67113106128A3340C979D31A4BA6768ACFF40EC711DF505407AD428B22126C28E8D6D94BA40F5C1666"
+    },
+    "instructorNotDisplayedToStudent2": {
+      "isDisplayedToStudents": false,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000517",
+      "courseId": "idOfTestingInstructorsDisplayedCourse",
+      "course": {
+        "id": "idOfTestingInstructorsDisplayedCourse"
+      },
+      "name": "name2",
+      "email": "secondInstructorNotDisplayed@NotDisplayed.tmt",
+      "regKey": "3783E41EEB6A3CA07A457D7F593DBC28B5529A51540C7FDE19FDC5B1818C9FC93E06BAE6D4BAB46D30F761917EC5DB236BD13F8C72BAEEB91E357ABEE6203431F8D743DDDB28353DEEF2C58E1988CD153511D0EFE24424AE09E7CFD0182749DA"
+    },
+    "instructorNotYetJoinCourse": {
+      "isDisplayedToStudents": true,
+      "displayName": "Instructor",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000518",
+      "courseId": "idOfSampleCourse-demo",
+      "course": {
+        "id": "idOfSampleCourse-demo"
+      },
+      "name": "Instructor Not Yet Joined Course",
+      "email": "instructorNotYetJoined@email.tmt",
+      "regKey": "242E2ADAB346AC55A800B5612100D6DB4A2C6590D4E80B95442E137D4F645DD7EBB11B1887F9131F75C7C2D665B7E85AEA79DD8A0929F0DFC9D405790E8357B98EAE7E8128AC0F9336D55AF9C5A4147B"
+    },
+    "instructor1OfTestingSanitizationCourse": {
+      "isDisplayedToStudents": true,
+      "displayName": "inst'\"/><script>alert('hi!');</script>",
+      "role": "INSTRUCTOR_PERMISSION_ROLE_COOWNER",
+      "privileges": {
+        "courseLevel": {
+          "canModifyCourse": true,
+          "canModifyInstructor": true,
+          "canModifySession": true,
+          "canModifyStudent": true,
+          "canViewStudentInSections": true,
+          "canViewSessionInSections": true,
+          "canSubmitSessionInSections": true,
+          "canModifySessionCommentsInSections": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      },
+      "id": "00000000-0000-4000-8000-000000000519",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000014"
+      },
+      "courseId": "idOfTestingSanitizationCourse",
+      "course": {
+        "id": "idOfTestingSanitizationCourse"
+      },
+      "name": "Instructor<script> alert('hi!'); </script>",
+      "email": "instructor1@sanitization.tmt",
+      "regKey": "D4AAB9DE0EBA50263D1AD824A756699B6DCC102E1DF2102B20DD4C8862066F4A6C814323594D7E2D76FD1334DC0425024C07521ACA119034AE8A51EB5EA319341D53445610494A54652BE3CD07C073BE"
+    }
+  },
+  "students": {
+    "student1InCourse1": {
+      "comments": "comment for student1InCourse1</td></div>'\"",
+      "id": "00000000-0000-4000-8000-000000000601",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000015"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student1 In Course1</td></div>'\"",
+      "email": "student1InCourse1@gmail.tmt",
+      "regKey": "A0FE6AD6372398CA2959FCA124F6814400585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94C981353713EFE3302B8F442DC212734B3"
+    },
+    "student2InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000602",
+      "account": {
+        "id": "00000000-0000-4000-8000-000000000016"
+      },
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student2 In Course1",
+      "email": "student2InCourse1@gmail.tmt",
+      "regKey": "6EDAE0630DC4C5772312F20768F1450F00585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE201722978445EABC65144592472620CCDD91AF0492"
+    },
+    "student3InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000603",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student3 In Course1",
+      "email": "student3InCourse1@gmail.tmt",
+      "regKey": "2C3709A42937943398F6B1BD23B1069400585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94CA9C94B5562C701FED32326221D30FA7A"
+    },
+    "student4InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000604",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student4 In Course1",
+      "email": "student4InCourse1@gmail.tmt",
+      "regKey": "CBD0FE74AC7452D55EF332B427CB630300585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE2017229784A172CB294E11BF031D4275F15279B68D"
+    },
+    "student5InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000605",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student5 In Course1",
+      "email": "student5InCourse1@gmail.tmt",
+      "regKey": "D1C02A778883D257D6C7E8E8D03BB43300585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE2017229784CBA0206EEC9A4D9DE93519E8C4C99A37"
+    },
+    "student6InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000606",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student6 In Course1",
+      "email": "student6InCourse1@gmail.tmt",
+      "regKey": "E456D2D37DF53B098610C58FF71A67AD00585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94C748EF9DE10D496A68AADE22ADF666D03"
+    },
+    "student7InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000607",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student7 In Course1",
+      "email": "student7InCourse1@gmail.tmt",
+      "regKey": "A331C17E9E97668714303DF9ADF912A800585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94CBC61E006C4FAD4DE57B1C5704AFBBBBB"
+    },
+    "student8InCourse1": {
+      "comments": "",
+      "id": "00000000-0000-4000-8000-000000000608",
+      "courseId": "idOfTypicalCourse1",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "student8 In Course1",
+      "email": "student8InCourse1@gmail.tmt",
+      "regKey": "1DA4589DD42BDBA5861CAC4584E6368500585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE2017229784260F6ED2F9D56225DAE9205482DBBABE"
+    }
+  },
+  "feedbackSessions": {
+    "session1InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000701",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "First feedback session",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session2InCourse1": {
+      "id": "00000000-0000-4000-8000-000000000702",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Second feedback session",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2013-06-01T22:00:00Z",
+      "endTime": "2026-04-28T22:00:00Z",
+      "sessionVisibleFromTime": "2013-03-20T22:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T22:00:00Z",
+      "gracePeriod": 5,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-03-20T23:59:00Z"
+    },
+    "gracePeriodSession": {
+      "id": "00000000-0000-4000-8000-000000000703",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Grace Period Session",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2013-06-01T22:00:00Z",
+      "endTime": "2026-04-28T22:00:00Z",
+      "sessionVisibleFromTime": "2013-03-20T22:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T22:00:00Z",
+      "gracePeriod": 1440,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-03-20T23:59:00Z"
+    },
+    "closedSession": {
+      "id": "00000000-0000-4000-8000-000000000704",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Closed Session",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2013-06-01T22:00:00Z",
+      "endTime": "2013-06-01T22:00:00Z",
+      "sessionVisibleFromTime": "2013-03-20T22:00:00Z",
+      "resultsVisibleFromTime": "2013-04-29T22:00:00Z",
+      "gracePeriod": 5,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-03-20T23:59:00Z"
+    },
+    "empty.session": {
+      "id": "00000000-0000-4000-8000-000000000705",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "Empty session",
+      "creatorEmail": "instructor2@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2013-02-02T00:00:00Z",
+      "endTime": "2013-04-29T00:00:00Z",
+      "sessionVisibleFromTime": "2013-01-21T00:00:00Z",
+      "resultsVisibleFromTime": "2013-04-30T00:00:00Z",
+      "gracePeriod": 5,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-01-20T23:57:00Z"
+    },
+    "awaiting.session": {
+      "id": "00000000-0000-4000-8000-000000000706",
+      "course": {
+        "id": "idOfTypicalCourse1"
+      },
+      "name": "non visible session",
+      "creatorEmail": "instructor2@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2026-04-01T23:00:00Z",
+      "endTime": "2026-04-28T23:00:00Z",
+      "sessionVisibleFromTime": "2026-04-01T23:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T23:00:00Z",
+      "gracePeriod": 5,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-01-20T23:00:00Z"
+    },
+    "archiveCourse.session1": {
+      "id": "00000000-0000-4000-8000-000000000707",
+      "course": {
+        "id": "idOfArchivedCourse"
+      },
+      "name": "session without student questions",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2013-02-20T23:00:00Z",
+      "endTime": "2026-04-28T23:00:00Z",
+      "sessionVisibleFromTime": "2013-02-20T23:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T23:00:00Z",
+      "gracePeriod": 5,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2013-01-20T23:00:00Z"
+    },
+    "session1InCourse2": {
+      "id": "00000000-0000-4000-8000-000000000708",
+      "course": {
+        "id": "idOfTypicalCourse2"
+      },
+      "name": "Instructor feedback session",
+      "creatorEmail": "instructor1@course2.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T16:00:00Z",
+      "endTime": "2027-04-30T16:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T16:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T16:00:00Z",
+      "gracePeriod": 0,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session2InCourse2": {
+      "id": "00000000-0000-4000-8000-000000000709",
+      "course": {
+        "id": "idOfTypicalCourse2"
+      },
+      "name": "Not answerable feedback session",
+      "creatorEmail": "instructor1@course2.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T16:00:00Z",
+      "endTime": "2027-04-30T16:00:00Z",
+      "sessionVisibleFromTime": "1970-11-27T00:00:00Z",
+      "resultsVisibleFromTime": "1970-01-01T00:00:00Z",
+      "gracePeriod": 0,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session1InCourse3": {
+      "id": "00000000-0000-4000-8000-000000000710",
+      "course": {
+        "id": "idOfTypicalCourse3"
+      },
+      "name": "First feedback session",
+      "creatorEmail": "instructor1@course3.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session2InCourse3": {
+      "id": "00000000-0000-4000-8000-000000000711",
+      "course": {
+        "id": "idOfTypicalCourse3"
+      },
+      "name": "Second feedback session",
+      "creatorEmail": "instructor1@course3.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "deletedAt": "2012-05-20T23:59:00Z",
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session1InCourse4": {
+      "id": "00000000-0000-4000-8000-000000000712",
+      "course": {
+        "id": "idOfTypicalCourse4"
+      },
+      "name": "First feedback session",
+      "creatorEmail": "instructor1@course3.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "deletedAt": "2012-05-20T23:59:00Z",
+      "createdAt": "2012-03-20T23:59:00Z"
+    },
+    "session1InTestingSanitizationCourse": {
+      "id": "00000000-0000-4000-8000-000000000713",
+      "course": {
+        "id": "idOfTestingSanitizationCourse"
+      },
+      "name": "Normal feedback session name",
+      "creatorEmail": "instructor1@sanitization.tmt",
+      "instructions": "unclosed tags  Attempted script injection &#39;&#34; ",
+      "startTime": "2012-04-01T22:00:00Z",
+      "endTime": "2027-04-30T22:00:00Z",
+      "sessionVisibleFromTime": "2012-03-28T22:00:00Z",
+      "resultsVisibleFromTime": "2027-05-01T22:00:00Z",
+      "gracePeriod": 10,
+      "isOpenedEmailEnabled": true,
+      "isClosingSoonEmailEnabled": true,
+      "isPublishedEmailEnabled": true,
+      "isOpeningSoonEmailSent": false,
+      "isOpenedEmailSent": false,
+      "isClosingSoonEmailSent": false,
+      "isClosedEmailSent": false,
+      "isPublishedEmailSent": false,
+      "createdAt": "2012-03-20T23:59:00Z"
+    }
+  },
+  "feedbackQuestions": {
+    "qn1InSession1InCourse1": {
+      "questionDetails": {
+        "isZeroSum": true,
+        "isNotSureAllowed": false,
+        "questionType": "CONTRIB",
+        "questionText": "How much has each team member including yourself, contributed to the project?"
+      },
+      "id": "00000000-0000-4000-8000-000000000801",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionNumber": 1,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    },
+    "qn2InSession1InCourse1": {
+      "questionDetails": {
+        "isZeroSum": true,
+        "isNotSureAllowed": false,
+        "questionType": "CONTRIB",
+        "questionText": "How much has each team member including yourself, contributed to the project?"
+      },
+      "id": "00000000-0000-4000-8000-000000000802",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionNumber": 2,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    },
+    "qn3InSession1InCourse1": {
+      "questionDetails": {
+        "isZeroSum": true,
+        "isNotSureAllowed": false,
+        "questionType": "CONTRIB",
+        "questionText": "How much has each team member including yourself, contributed to the project?"
+      },
+      "id": "00000000-0000-4000-8000-000000000803",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionNumber": 3,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ]
+    },
+    "qn4InSession1InCourse1": {
+      "questionDetails": {
+        "isZeroSum": true,
+        "isNotSureAllowed": false,
+        "questionType": "CONTRIB",
+        "questionText": "How much has each team member including yourself, contributed to the project?"
+      },
+      "id": "00000000-0000-4000-8000-000000000804",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionNumber": 4,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ]
+    },
+    "qn5InSession1InCourse1": {
+      "questionDetails": {
+        "isZeroSum": true,
+        "isNotSureAllowed": false,
+        "questionType": "CONTRIB",
+        "questionText": "How much has each team member including yourself, contributed to the project?"
+      },
+      "id": "00000000-0000-4000-8000-000000000805",
+      "feedbackSession": {
+        "id": "00000000-0000-4000-8000-000000000701"
+      },
+      "questionNumber": 5,
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
+      "numOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    }
+  },
+  "feedbackResponses": {
+    "response1ForQ1S1C1": {
+      "answer": {
+        "answer": 10,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000901",
+      "giver": "student1InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student1InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response2ForQ1S1C1": {
+      "answer": {
+        "answer": 20,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000902",
+      "giver": "student1InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student2InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response3ForQ1S1C1": {
+      "answer": {
+        "answer": 30,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000903",
+      "giver": "student1InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student3InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response4ForQ1S1C1": {
+      "answer": {
+        "answer": 40,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000904",
+      "giver": "student2InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student1InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response5ForQ1S1C1": {
+      "answer": {
+        "answer": 50,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000905",
+      "giver": "student2InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student2InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response6ForQ1S1C1": {
+      "answer": {
+        "answer": 60,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000906",
+      "giver": "student2InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student3InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response7ForQ1S1C1": {
+      "answer": {
+        "answer": 70,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000907",
+      "giver": "student3InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student1InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response8ForQ1S1C1": {
+      "answer": {
+        "answer": 80,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000908",
+      "giver": "student3InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student2InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response9ForQ1S1C1": {
+      "answer": {
+        "answer": 90,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000909",
+      "giver": "student3InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student3InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response1ForQ2S1C1": {
+      "answer": {
+        "answer": 10,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000910",
+      "giver": "student5InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student5InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      }
+    },
+    "response2ForQ2S1C1": {
+      "answer": {
+        "answer": 20,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000911",
+      "giver": "student5InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      },
+      "recipient": "student6InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response3ForQ2S1C1": {
+      "answer": {
+        "answer": 30,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000912",
+      "giver": "student6InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student5InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      }
+    },
+    "response4ForQ2S1C1": {
+      "answer": {
+        "answer": 40,
+        "questionType": "CONTRIB"
+      },
+      "id": "00000000-0000-4000-8000-000000000913",
+      "giver": "student6InCourse1@gmail.tmt",
+      "giverSection": {
+        "id": "00000000-0000-4000-8000-000000000201"
+      },
+      "recipient": "student6InCourse1@gmail.tmt",
+      "recipientSection": {
+        "id": "00000000-0000-4000-8000-000000000202"
+      }
+    }
+  },
+  "feedbackResponseComments": {},
+  "feedbackSessionLogs": {},
+  "notifications": {},
+  "readNotifications": {}
+}

--- a/src/test/resources/data/FeedbackContributionQuestionTestSql.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTestSql.json
@@ -1364,7 +1364,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000901",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
@@ -1382,7 +1385,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000902",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
@@ -1400,7 +1406,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000903",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
@@ -1418,7 +1427,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000904",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
@@ -1436,7 +1448,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000905",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
@@ -1454,7 +1469,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000906",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
@@ -1472,7 +1490,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000907",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
@@ -1490,7 +1511,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000908",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
@@ -1508,7 +1532,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000909",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000801"
+        "id": "00000000-0000-4000-8000-000000000801",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
@@ -1526,7 +1553,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000910",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000802"
+        "id": "00000000-0000-4000-8000-000000000802",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student5InCourse1@gmail.tmt",
       "giverSection": {
@@ -1544,7 +1574,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000911",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000802"
+        "id": "00000000-0000-4000-8000-000000000802",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student5InCourse1@gmail.tmt",
       "giverSection": {
@@ -1562,7 +1595,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000912",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000802"
+        "id": "00000000-0000-4000-8000-000000000802",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student6InCourse1@gmail.tmt",
       "giverSection": {
@@ -1580,7 +1616,10 @@
       },
       "id": "00000000-0000-4000-8000-000000000913",
       "feedbackQuestion": {
-        "id": "00000000-0000-4000-8000-000000000802"
+        "id": "00000000-0000-4000-8000-000000000802",
+        "questionDetails": {
+          "questionType": "CONTRIB"
+        }
       },
       "giver": "student6InCourse1@gmail.tmt",
       "giverSection": {

--- a/src/test/resources/data/FeedbackContributionQuestionTestSql.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTestSql.json
@@ -797,6 +797,9 @@
       "course": {
         "id": "idOfTypicalCourse1"
       },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000301"
+      },
       "name": "student1 In Course1</td></div>'\"",
       "email": "student1InCourse1@gmail.tmt",
       "regKey": "A0FE6AD6372398CA2959FCA124F6814400585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94C981353713EFE3302B8F442DC212734B3"
@@ -811,6 +814,9 @@
       "course": {
         "id": "idOfTypicalCourse1"
       },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000301"
+      },
       "name": "student2 In Course1",
       "email": "student2InCourse1@gmail.tmt",
       "regKey": "6EDAE0630DC4C5772312F20768F1450F00585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE201722978445EABC65144592472620CCDD91AF0492"
@@ -821,6 +827,9 @@
       "courseId": "idOfTypicalCourse1",
       "course": {
         "id": "idOfTypicalCourse1"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000301"
       },
       "name": "student3 In Course1",
       "email": "student3InCourse1@gmail.tmt",
@@ -833,6 +842,9 @@
       "course": {
         "id": "idOfTypicalCourse1"
       },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000302"
+      },
       "name": "student4 In Course1",
       "email": "student4InCourse1@gmail.tmt",
       "regKey": "CBD0FE74AC7452D55EF332B427CB630300585D441AB0A0DEF7C7CF8757E59C028BB80CD76F31CCA858A0FE2017229784A172CB294E11BF031D4275F15279B68D"
@@ -843,6 +855,9 @@
       "courseId": "idOfTypicalCourse1",
       "course": {
         "id": "idOfTypicalCourse1"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000303"
       },
       "name": "student5 In Course1",
       "email": "student5InCourse1@gmail.tmt",
@@ -855,6 +870,9 @@
       "course": {
         "id": "idOfTypicalCourse1"
       },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000303"
+      },
       "name": "student6 In Course1",
       "email": "student6InCourse1@gmail.tmt",
       "regKey": "E456D2D37DF53B098610C58FF71A67AD00585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94C748EF9DE10D496A68AADE22ADF666D03"
@@ -866,6 +884,9 @@
       "course": {
         "id": "idOfTypicalCourse1"
       },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000304"
+      },
       "name": "student7 In Course1",
       "email": "student7InCourse1@gmail.tmt",
       "regKey": "A331C17E9E97668714303DF9ADF912A800585D441AB0A0DEF7C7CF8757E59C02DD4BA1616BDB1FEED0A4F7BE5F5BC94CBC61E006C4FAD4DE57B1C5704AFBBBBB"
@@ -876,6 +897,9 @@
       "courseId": "idOfTypicalCourse1",
       "course": {
         "id": "idOfTypicalCourse1"
+      },
+      "team": {
+        "id": "00000000-0000-4000-8000-000000000304"
       },
       "name": "student8 In Course1",
       "email": "student8InCourse1@gmail.tmt",
@@ -1339,6 +1363,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000901",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1354,6 +1381,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000902",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1369,6 +1399,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000903",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student1InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1384,6 +1417,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000904",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1399,6 +1435,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000905",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1414,6 +1453,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000906",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student2InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1429,6 +1471,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000907",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1444,6 +1489,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000908",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1459,6 +1507,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000909",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000801"
+      },
       "giver": "student3InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1474,6 +1525,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000910",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000802"
+      },
       "giver": "student5InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1489,6 +1543,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000911",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000802"
+      },
       "giver": "student5InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000202"
@@ -1504,6 +1561,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000912",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000802"
+      },
       "giver": "student6InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"
@@ -1519,6 +1579,9 @@
         "questionType": "CONTRIB"
       },
       "id": "00000000-0000-4000-8000-000000000913",
+      "feedbackQuestion": {
+        "id": "00000000-0000-4000-8000-000000000802"
+      },
       "giver": "student6InCourse1@gmail.tmt",
       "giverSection": {
         "id": "00000000-0000-4000-8000-000000000201"


### PR DESCRIPTION
Part of #12048

**Description**
The project is currently migrating from a legacy Datastore architecture to a PostgreSQL backend. As part of this migration, the test classes located in `src/test/java/teammates/common/datatransfer/questions/` are still exclusively testing the legacy Datastore `*Attributes` (e.g., `FeedbackQuestionAttributes`).

We need to introduce SQL-compatible tests for these classes to ensure both database implementations are supported on the `master` branch until the final clean-slate cutover.

**Proposed Solution**
- Duplicate the legacy test methods in the following files to support the new SQL entities (e.g., `FeedbackContributionQuestion`, `FeedbackRankRecipientsQuestion`, `FeedbackTextQuestion`):
  - `FeedbackContributionQuestionDetailsTest.java`
  - `FeedbackRankRecipientsQuestionDetailsTest.java`
  - `FeedbackTextQuestionDetailsTest.java`
- Generate a new SQL-compatible JSON test data file (`FeedbackContributionQuestionTestSql.json`) using the `ConvertDatastoreJsonToSqlJson` utility script to avoid manual object setup.
- Ensure both the legacy Datastore tests and the new SQL tests run and pass concurrently on the `master` branch.