### PR TITLE
[#13635] Migrate NEW_INSTRUCTOR_ACCOUNT_WELCOME to dynamic DB template (POC)

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -204,6 +204,8 @@ public final class Const {
         public static final String NOTIFICATION_IS_FETCHING_ALL = "isfetchingall";
         public static final String NOTFICATION_END_TIME = "endtime";
         public static final String CONTINUE_URL = "continueurl";
+
+        public static final String TEMPLATE_KEY = "templatekey";
     }
 
     /**
@@ -384,6 +386,8 @@ public final class Const {
         public static final String SESSION_LINKS_RECOVERY = URI_PREFIX + "/sessionlinksrecovery";
         public static final String EMAIL = URI_PREFIX + "/email";
         public static final String LOGIN_EMAIL = URI_PREFIX + "/email/login";
+        public static final String EMAIL_TEMPLATE = URI_PREFIX + "/email/template";
+        public static final String EMAIL_TEMPLATES = URI_PREFIX + "/email/templates";
         public static final String SESSION_LOGS = URI_PREFIX + "/logs/session";
         public static final String LOGS = URI_PREFIX + "/logs/query";
         public static final String ACTION_CLASS = URI_PREFIX + "/actionclass";

--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -17,6 +17,7 @@ import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
+import teammates.storage.sqlentity.EmailTemplate;
 import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
@@ -60,6 +61,7 @@ public final class HibernateUtil {
 
     private static final List<Class<? extends BaseEntity>> ANNOTATED_CLASSES = List.of(
             AccountRequest.class,
+            EmailTemplate.class,
             Course.class,
             FeedbackSession.class,
             Account.class,

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -28,6 +28,7 @@ import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
 import teammates.sqllogic.core.DataBundleLogic;
 import teammates.sqllogic.core.DeadlineExtensionsLogic;
+import teammates.sqllogic.core.EmailTemplatesLogic;
 import teammates.sqllogic.core.FeedbackQuestionsLogic;
 import teammates.sqllogic.core.FeedbackResponseCommentsLogic;
 import teammates.sqllogic.core.FeedbackResponsesLogic;
@@ -40,6 +41,7 @@ import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
+import teammates.storage.sqlentity.EmailTemplate;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackResponse;
 import teammates.storage.sqlentity.FeedbackResponseComment;
@@ -78,6 +80,7 @@ public class Logic {
     final UsersLogic usersLogic = UsersLogic.inst();
     final NotificationsLogic notificationsLogic = NotificationsLogic.inst();
     final DataBundleLogic dataBundleLogic = DataBundleLogic.inst();
+    final EmailTemplatesLogic emailTemplatesLogic = EmailTemplatesLogic.inst();
 
     Logic() {
         // prevent initialization
@@ -1277,6 +1280,31 @@ public class Logic {
 
     public List<Notification> getAllNotifications() {
         return notificationsLogic.getAllNotifications();
+    }
+
+    /**
+     * Gets the custom email template for {@code templateKey},
+     * or {@code null} if no custom template has been saved.
+     */
+    public EmailTemplate getEmailTemplate(String templateKey) {
+        return emailTemplatesLogic.getEmailTemplate(templateKey);
+    }
+
+    /**
+     * Creates or updates the email template for the given key.
+     *
+     * @return the persisted email template.
+     * @throws InvalidParametersException if the template is not valid.
+     */
+    public EmailTemplate upsertEmailTemplate(EmailTemplate emailTemplate) throws InvalidParametersException {
+        return emailTemplatesLogic.upsertEmailTemplate(emailTemplate);
+    }
+
+    /**
+     * Deletes a custom email template, reverting to the static file fallback.
+     */
+    public void deleteEmailTemplate(EmailTemplate emailTemplate) {
+        emailTemplatesLogic.deleteEmailTemplate(emailTemplate);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
+++ b/src/main/java/teammates/sqllogic/api/SqlEmailGenerator.java
@@ -22,10 +22,12 @@ import teammates.common.util.Templates.EmailTemplates;
 import teammates.common.util.TimeHelper;
 import teammates.sqllogic.core.CoursesLogic;
 import teammates.sqllogic.core.DeadlineExtensionsLogic;
+import teammates.sqllogic.core.EmailTemplatesLogic;
 import teammates.sqllogic.core.FeedbackSessionsLogic;
 import teammates.sqllogic.core.UsersLogic;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
+import teammates.storage.sqlentity.EmailTemplate;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -866,18 +868,41 @@ public final class SqlEmailGenerator {
 
     /**
      * Generates the new instructor account join email for the given {@code instructor}.
+     *
+     * <p>The email body and subject are sourced from the admin-configured template in the
+     * database if one exists. If no custom template has been saved (or it has been reverted),
+     * the method falls back to the static HTML file and the default subject defined in
+     * {@link EmailType#NEW_INSTRUCTOR_ACCOUNT}.
      */
     public EmailWrapper generateNewInstructorAccountJoinEmail(
             String instructorEmail, String instructorName, String joinUrl) {
 
-        String emailBody = Templates.populateTemplate(EmailTemplates.NEW_INSTRUCTOR_ACCOUNT_WELCOME,
-                "${userName}", SanitizationHelper.sanitizeForHtml(instructorName),
+        String sanitizedName = SanitizationHelper.sanitizeForHtml(instructorName);
+
+        EmailTemplate dbTemplate =
+                EmailTemplatesLogic.inst().getEmailTemplate("NEW_INSTRUCTOR_ACCOUNT_WELCOME");
+
+        String bodySource;
+        String emailSubject;
+
+        if (dbTemplate != null) {
+            bodySource = dbTemplate.getBody();
+            emailSubject = Templates.populateTemplate(dbTemplate.getSubject(),
+                    "${userName}", sanitizedName,
+                    "${joinUrl}", joinUrl);
+        } else {
+            bodySource = EmailTemplates.NEW_INSTRUCTOR_ACCOUNT_WELCOME;
+            emailSubject = String.format(EmailType.NEW_INSTRUCTOR_ACCOUNT.getSubject(), sanitizedName);
+        }
+
+        String emailBody = Templates.populateTemplate(bodySource,
+                "${userName}", sanitizedName,
                 "${joinUrl}", joinUrl);
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(instructorEmail);
         email.setBcc(Config.SUPPORT_EMAIL);
         email.setType(EmailType.NEW_INSTRUCTOR_ACCOUNT);
-        email.setSubjectFromType(SanitizationHelper.sanitizeForHtml(instructorName));
+        email.setSubject(emailSubject);
         email.setContent(emailBody);
         return email;
     }

--- a/src/main/java/teammates/sqllogic/core/EmailTemplatesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/EmailTemplatesLogic.java
@@ -1,0 +1,58 @@
+package teammates.sqllogic.core;
+
+import teammates.common.exception.InvalidParametersException;
+import teammates.storage.sqlapi.EmailTemplatesDb;
+import teammates.storage.sqlentity.EmailTemplate;
+
+/**
+ * Handles the logic related to email templates.
+ */
+public final class EmailTemplatesLogic {
+
+    private static final EmailTemplatesLogic instance = new EmailTemplatesLogic();
+
+    private EmailTemplatesDb emailTemplatesDb;
+
+    private EmailTemplatesLogic() {
+        // prevent initialization
+    }
+
+    public static EmailTemplatesLogic inst() {
+        return instance;
+    }
+
+    /**
+     * Initialise dependencies for {@code EmailTemplatesLogic} object.
+     */
+    public void initLogicDependencies(EmailTemplatesDb emailTemplatesDb) {
+        this.emailTemplatesDb = emailTemplatesDb;
+    }
+
+    /**
+     * Gets the email template associated with {@code templateKey},
+     * or {@code null} if no custom template has been saved for that key.
+     */
+    public EmailTemplate getEmailTemplate(String templateKey) {
+        assert templateKey != null;
+        return emailTemplatesDb.getEmailTemplate(templateKey);
+    }
+
+    /**
+     * Creates or updates the email template for the given key.
+     *
+     * @return the persisted email template.
+     * @throws InvalidParametersException if the template is not valid.
+     */
+    public EmailTemplate upsertEmailTemplate(EmailTemplate emailTemplate) throws InvalidParametersException {
+        assert emailTemplate != null;
+        return emailTemplatesDb.upsertEmailTemplate(emailTemplate);
+    }
+
+    /**
+     * Deletes a custom email template, reverting to the static file fallback.
+     * Does nothing if {@code emailTemplate} is {@code null}.
+     */
+    public void deleteEmailTemplate(EmailTemplate emailTemplate) {
+        emailTemplatesDb.deleteEmailTemplate(emailTemplate);
+    }
+}

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -13,6 +13,7 @@ import teammates.storage.sqlapi.FeedbackResponseCommentsDb;
 import teammates.storage.sqlapi.FeedbackResponsesDb;
 import teammates.storage.sqlapi.FeedbackSessionLogsDb;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
+import teammates.storage.sqlapi.EmailTemplatesDb;
 import teammates.storage.sqlapi.NotificationsDb;
 import teammates.storage.sqlapi.UsageStatisticsDb;
 import teammates.storage.sqlapi.UsersDb;
@@ -38,11 +39,13 @@ public class LogicStarter implements ServletContextListener {
         FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
         FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
         FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();
+        EmailTemplatesLogic emailTemplatesLogic = EmailTemplatesLogic.inst();
         NotificationsLogic notificationsLogic = NotificationsLogic.inst();
         UsageStatisticsLogic usageStatisticsLogic = UsageStatisticsLogic.inst();
         UsersLogic usersLogic = UsersLogic.inst();
 
         accountRequestsLogic.initLogicDependencies(AccountRequestsDb.inst());
+        emailTemplatesLogic.initLogicDependencies(EmailTemplatesDb.inst());
         accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic, coursesLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic, usersLogic, accountsLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,

--- a/src/main/java/teammates/storage/sqlapi/EmailTemplatesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/EmailTemplatesDb.java
@@ -1,0 +1,78 @@
+package teammates.storage.sqlapi;
+
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
+import teammates.storage.sqlentity.EmailTemplate;
+
+/**
+ * Generates CRUD operations for EmailTemplate.
+ *
+ * @see EmailTemplate
+ */
+public final class EmailTemplatesDb {
+    private static final EmailTemplatesDb instance = new EmailTemplatesDb();
+
+    private EmailTemplatesDb() {
+        // prevent instantiation
+    }
+
+    public static EmailTemplatesDb inst() {
+        return instance;
+    }
+
+    /**
+     * Gets an EmailTemplate by its {@code templateKey} from the database,
+     * or {@code null} if no template with that key exists.
+     */
+    public EmailTemplate getEmailTemplate(String templateKey) {
+        assert templateKey != null;
+
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<EmailTemplate> cr = cb.createQuery(EmailTemplate.class);
+        Root<EmailTemplate> root = cr.from(EmailTemplate.class);
+        cr.select(root).where(cb.equal(root.get("templateKey"), templateKey));
+
+        TypedQuery<EmailTemplate> query = HibernateUtil.createQuery(cr);
+        return query.getResultStream().findFirst().orElse(null);
+    }
+
+    /**
+     * Creates or updates an EmailTemplate in the database.
+     *
+     * <p>If a template with the same {@code templateKey} already exists, its
+     * subject and body are updated. Otherwise a new template is persisted.
+     */
+    public EmailTemplate upsertEmailTemplate(EmailTemplate emailTemplate) throws InvalidParametersException {
+        assert emailTemplate != null;
+
+        if (!emailTemplate.isValid()) {
+            throw new InvalidParametersException(emailTemplate.getInvalidityInfo());
+        }
+
+        EmailTemplate existingTemplate = getEmailTemplate(emailTemplate.getTemplateKey());
+        if (existingTemplate == null) {
+            HibernateUtil.persist(emailTemplate);
+            return emailTemplate;
+        }
+
+        existingTemplate.setSubject(emailTemplate.getSubject());
+        existingTemplate.setBody(emailTemplate.getBody());
+        HibernateUtil.merge(existingTemplate);
+        return existingTemplate;
+    }
+
+    /**
+     * Deletes an EmailTemplate, reverting to the static file fallback.
+     * Does nothing if {@code emailTemplate} is {@code null}.
+     */
+    public void deleteEmailTemplate(EmailTemplate emailTemplate) {
+        if (emailTemplate != null) {
+            HibernateUtil.remove(emailTemplate);
+        }
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/EmailTemplate.java
+++ b/src/main/java/teammates/storage/sqlentity/EmailTemplate.java
@@ -1,0 +1,132 @@
+package teammates.storage.sqlentity;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entity for email templates configurable by an admin.
+ */
+@Entity
+@Table(name = "EmailTemplates",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "Unique template key", columnNames = "templateKey"),
+        })
+public class EmailTemplate extends BaseEntity {
+    @Id
+    private UUID id;
+
+    private String templateKey;
+
+    private String subject;
+
+    @Column(columnDefinition = "TEXT")
+    private String body;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    protected EmailTemplate() {
+        // required by Hibernate
+    }
+
+    public EmailTemplate(String templateKey, String subject, String body) {
+        this.setId(UUID.randomUUID());
+        this.setTemplateKey(templateKey);
+        this.setSubject(subject);
+        this.setBody(body);
+        this.setCreatedAt(Instant.now());
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        List<String> errors = new ArrayList<>();
+
+        if (templateKey == null || templateKey.isBlank()) {
+            addNonEmptyError("Template key cannot be empty.", errors);
+        }
+        if (subject == null || subject.isBlank()) {
+            addNonEmptyError("Email template subject cannot be empty.", errors);
+        }
+        if (body == null || body.isBlank()) {
+            addNonEmptyError("Email template body cannot be empty.", errors);
+        }
+
+        return errors;
+    }
+
+    public UUID getId() {
+        return this.id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTemplateKey() {
+        return this.templateKey;
+    }
+
+    public void setTemplateKey(String templateKey) {
+        this.templateKey = templateKey;
+    }
+
+    public String getSubject() {
+        return this.subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return this.body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Instant getUpdatedAt() {
+        return this.updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        } else if (this == other) {
+            return true;
+        } else if (this.getClass() == other.getClass()) {
+            EmailTemplate otherEmailTemplate = (EmailTemplate) other;
+            return Objects.equals(this.getId(), otherEmailTemplate.getId());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getId().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "EmailTemplate [id=" + id + ", templateKey=" + templateKey + ", subject=" + subject
+                + ", createdAt=" + getCreatedAt() + ", updatedAt=" + updatedAt + "]";
+    }
+}

--- a/src/main/java/teammates/ui/output/EmailTemplateData.java
+++ b/src/main/java/teammates/ui/output/EmailTemplateData.java
@@ -1,0 +1,63 @@
+package teammates.ui.output;
+
+import jakarta.annotation.Nullable;
+
+import teammates.storage.sqlentity.EmailTemplate;
+
+/**
+ * Output format for a single email template.
+ */
+public class EmailTemplateData extends ApiOutput {
+    private final String templateKey;
+    private final String subject;
+    private final String body;
+    private final boolean isCustomized;
+
+    @Nullable
+    private final Long updatedAt;
+
+    /**
+     * Constructs output from a DB-backed custom template.
+     */
+    public EmailTemplateData(EmailTemplate emailTemplate) {
+        this.templateKey = emailTemplate.getTemplateKey();
+        this.subject = emailTemplate.getSubject();
+        this.body = emailTemplate.getBody();
+        this.isCustomized = true;
+        this.updatedAt = emailTemplate.getUpdatedAt() != null
+                ? emailTemplate.getUpdatedAt().toEpochMilli()
+                : null;
+    }
+
+    /**
+     * Constructs output for a static fallback (no custom template in DB).
+     */
+    public EmailTemplateData(String templateKey, String defaultSubject, String defaultBody) {
+        this.templateKey = templateKey;
+        this.subject = defaultSubject;
+        this.body = defaultBody;
+        this.isCustomized = false;
+        this.updatedAt = null;
+    }
+
+    public String getTemplateKey() {
+        return templateKey;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public boolean getIsCustomized() {
+        return isCustomized;
+    }
+
+    @Nullable
+    public Long getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/teammates/ui/output/EmailTemplatesData.java
+++ b/src/main/java/teammates/ui/output/EmailTemplatesData.java
@@ -1,0 +1,18 @@
+package teammates.ui.output;
+
+import java.util.List;
+
+/**
+ * Output format for the list of configurable email template keys.
+ */
+public class EmailTemplatesData extends ApiOutput {
+    private final List<String> templateKeys;
+
+    public EmailTemplatesData(List<String> templateKeys) {
+        this.templateKeys = templateKeys;
+    }
+
+    public List<String> getTemplateKeys() {
+        return templateKeys;
+    }
+}

--- a/src/main/java/teammates/ui/request/EmailTemplateUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/EmailTemplateUpdateRequest.java
@@ -1,0 +1,43 @@
+package teammates.ui.request;
+
+/**
+ * The request body for creating or updating an email template.
+ */
+public class EmailTemplateUpdateRequest extends BasicRequest {
+    private String templateKey;
+    private String subject;
+    private String body;
+    private boolean resetToDefault;
+
+    public EmailTemplateUpdateRequest(String templateKey, String subject, String body, boolean resetToDefault) {
+        this.templateKey = templateKey;
+        this.subject = subject;
+        this.body = body;
+        this.resetToDefault = resetToDefault;
+    }
+
+    @Override
+    public void validate() throws InvalidHttpRequestBodyException {
+        assertTrue(templateKey != null && !templateKey.isBlank(), "templateKey cannot be null or empty");
+        if (!resetToDefault) {
+            assertTrue(subject != null && !subject.isBlank(), "subject cannot be null or empty");
+            assertTrue(body != null && !body.isBlank(), "body cannot be null or empty");
+        }
+    }
+
+    public String getTemplateKey() {
+        return this.templateKey;
+    }
+
+    public String getSubject() {
+        return this.subject;
+    }
+
+    public String getBody() {
+        return this.body;
+    }
+
+    public boolean isResetToDefault() {
+        return this.resetToDefault;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -99,6 +99,11 @@ public final class ActionFactory {
         map(ResourceURIs.SEARCH_ACCOUNT_REQUESTS, GET, SearchAccountRequestsAction.class);
         map(ResourceURIs.EMAIL, GET, GenerateEmailAction.class);
 
+        // EMAIL TEMPLATE APIs
+        map(ResourceURIs.EMAIL_TEMPLATE, GET, GetEmailTemplateAction.class);
+        map(ResourceURIs.EMAIL_TEMPLATE, PUT, UpdateEmailTemplateAction.class);
+        map(ResourceURIs.EMAIL_TEMPLATES, GET, GetEmailTemplatesAction.class);
+
         map(ResourceURIs.SESSIONS_ONGOING, GET, GetOngoingSessionsAction.class);
         map(ResourceURIs.SESSION_STATS, GET, GetSessionResponseStatsAction.class);
         map(ResourceURIs.SESSION, GET, GetFeedbackSessionAction.class);

--- a/src/main/java/teammates/ui/webapi/GetEmailTemplateAction.java
+++ b/src/main/java/teammates/ui/webapi/GetEmailTemplateAction.java
@@ -1,0 +1,54 @@
+package teammates.ui.webapi;
+
+import java.util.Map;
+
+import teammates.common.util.Const;
+import teammates.common.util.Templates;
+import teammates.storage.sqlentity.EmailTemplate;
+import teammates.ui.output.EmailTemplateData;
+
+/**
+ * Gets an email template by its key.
+ *
+ * <p>If a custom template has been saved to the database, that is returned.
+ * Otherwise the response contains the static file content so the frontend
+ * can pre-populate the editor with the current default.
+ */
+public class GetEmailTemplateAction extends AdminOnlyAction {
+
+    /**
+     * Fallback subjects used when the template has not been customised.
+     * These mirror the subjects hardcoded in {@code SqlEmailGenerator}.
+     */
+    private static final Map<String, String> DEFAULT_SUBJECTS = Map.of(
+            "NEW_INSTRUCTOR_ACCOUNT_WELCOME", "Welcome to TEAMMATES!"
+    );
+
+    /**
+     * Fallback bodies used when the template has not been customised.
+     * Each value is the content of the corresponding static HTML resource file.
+     */
+    private static final Map<String, String> DEFAULT_BODIES = Map.of(
+            "NEW_INSTRUCTOR_ACCOUNT_WELCOME", Templates.EmailTemplates.NEW_INSTRUCTOR_ACCOUNT_WELCOME
+    );
+
+    @Override
+    public JsonResult execute() {
+        String templateKey = getNonNullRequestParamValue(Const.ParamsNames.TEMPLATE_KEY);
+
+        if (!GetEmailTemplatesAction.CONFIGURABLE_TEMPLATE_KEYS.contains(templateKey)) {
+            throw new EntityNotFoundException("Email template with key '" + templateKey + "' does not exist.");
+        }
+
+        EmailTemplate emailTemplate = sqlLogic.getEmailTemplate(templateKey);
+
+        if (emailTemplate != null) {
+            return new JsonResult(new EmailTemplateData(emailTemplate));
+        }
+
+        // Fall back to the static file so the frontend can show the current default.
+        String defaultSubject = DEFAULT_SUBJECTS.get(templateKey);
+        String defaultBody = DEFAULT_BODIES.get(templateKey);
+        return new JsonResult(new EmailTemplateData(templateKey, defaultSubject, defaultBody));
+    }
+}

--- a/src/main/java/teammates/ui/webapi/GetEmailTemplatesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetEmailTemplatesAction.java
@@ -1,0 +1,23 @@
+package teammates.ui.webapi;
+
+import java.util.List;
+
+import teammates.ui.output.EmailTemplatesData;
+
+/**
+ * Gets the list of email template keys that are configurable by an admin.
+ */
+public class GetEmailTemplatesAction extends AdminOnlyAction {
+
+    /**
+     * The set of template keys that admins are permitted to customise.
+     * Add new keys here as more templates are migrated to the database.
+     */
+    static final List<String> CONFIGURABLE_TEMPLATE_KEYS =
+            List.of("NEW_INSTRUCTOR_ACCOUNT_WELCOME");
+
+    @Override
+    public JsonResult execute() {
+        return new JsonResult(new EmailTemplatesData(CONFIGURABLE_TEMPLATE_KEYS));
+    }
+}

--- a/src/main/java/teammates/ui/webapi/UpdateEmailTemplateAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateEmailTemplateAction.java
@@ -1,0 +1,66 @@
+package teammates.ui.webapi;
+
+import java.util.Map;
+
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Templates;
+import teammates.storage.sqlentity.EmailTemplate;
+import teammates.ui.output.EmailTemplateData;
+import teammates.ui.request.EmailTemplateUpdateRequest;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+
+/**
+ * Updates (or resets) a configurable email template.
+ *
+ * <p>When {@code resetToDefault} is {@code true} in the request body,
+ * the custom DB record is deleted and the static file fallback resumes.
+ * Otherwise the template is created or updated in the database.
+ */
+public class UpdateEmailTemplateAction extends AdminOnlyAction {
+
+    /**
+     * Fallback subjects, kept in sync with {@code GetEmailTemplateAction}
+     * to provide a consistent response when resetting to default.
+     */
+    private static final Map<String, String> DEFAULT_SUBJECTS = Map.of(
+            "NEW_INSTRUCTOR_ACCOUNT_WELCOME", "Welcome to TEAMMATES!"
+    );
+
+    private static final Map<String, String> DEFAULT_BODIES = Map.of(
+            "NEW_INSTRUCTOR_ACCOUNT_WELCOME", Templates.EmailTemplates.NEW_INSTRUCTOR_ACCOUNT_WELCOME
+    );
+
+    @Override
+    public JsonResult execute() throws InvalidHttpRequestBodyException {
+        EmailTemplateUpdateRequest updateRequest = getAndValidateRequestBody(EmailTemplateUpdateRequest.class);
+
+        String templateKey = updateRequest.getTemplateKey();
+
+        if (!GetEmailTemplatesAction.CONFIGURABLE_TEMPLATE_KEYS.contains(templateKey)) {
+            throw new EntityNotFoundException("Email template with key '" + templateKey + "' does not exist.");
+        }
+
+        if (updateRequest.isResetToDefault()) {
+            EmailTemplate existing = sqlLogic.getEmailTemplate(templateKey);
+            if (existing != null) {
+                sqlLogic.deleteEmailTemplate(existing);
+            }
+            String defaultSubject = DEFAULT_SUBJECTS.get(templateKey);
+            String defaultBody = DEFAULT_BODIES.get(templateKey);
+            return new JsonResult(new EmailTemplateData(templateKey, defaultSubject, defaultBody));
+        }
+
+        EmailTemplate emailTemplate = new EmailTemplate(
+                templateKey,
+                updateRequest.getSubject(),
+                updateRequest.getBody());
+
+        try {
+            emailTemplate = sqlLogic.upsertEmailTemplate(emailTemplate);
+        } catch (InvalidParametersException e) {
+            throw new InvalidHttpRequestBodyException(e);
+        }
+
+        return new JsonResult(new EmailTemplateData(emailTemplate));
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-email-templates.xml
+++ b/src/main/resources/db/changelog/db.changelog-email-templates.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="teammates (generated)" id="1773792000000-1">
+        <createTable tableName="email_templates">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="email_templates_pkey" />
+            </column>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE" />
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" />
+            <column name="template_key" type="VARCHAR(100)">
+                <constraints nullable="false" unique="true"
+                    uniqueConstraintName="email_templates_template_key_key" />
+            </column>
+            <column name="subject" type="VARCHAR(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="body" type="TEXT">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-root.xml
+++ b/src/main/resources/db/changelog/db.changelog-root.xml
@@ -8,4 +8,5 @@
     <include file="src/main/resources/db/changelog/db.changelog-v9.0.0-beta.5.xml" />
     <include file="src/main/resources/db/changelog/db.changelog-v9.0.0-beta.7.xml" />
     <include file="src/main/resources/db/changelog/db.changelog-add-gin.xml"/>
+    <include file="src/main/resources/db/changelog/db.changelog-email-templates.xml"/>
 </databaseChangeLog>

--- a/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.html
+++ b/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.html
@@ -1,0 +1,109 @@
+<h1>Email Templates</h1>
+<p>
+  Customise the emails that TEAMMATES sends to users.
+  Changes take effect immediately for all future emails.
+  If no custom template is saved, the system uses the built-in default.
+</p>
+
+<tm-loading-retry [shouldShowRetry]="hasKeysLoadingFailed" [message]="'Failed to load template list'"
+  (retryEvent)="loadTemplateKeys()">
+
+  <div *tmIsLoading="isKeysLoading">
+
+    @if (templateKeys.length > 0) {
+
+      <!-- Template selector -->
+      <div class="card margin-top-20px">
+        <div class="card-body">
+          <div class="form-group">
+            <label for="template-selector"><strong>Select Template to Edit</strong></label>
+            <select id="template-selector" class="form-control"
+              [(ngModel)]="selectedKey"
+              (ngModelChange)="onTemplateKeyChange()"
+              [disabled]="isTemplateLoading || isSaving">
+              @for (key of templateKeys; track key) {
+                <option [value]="key">{{ key }}</option>
+              }
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <!-- Editor card -->
+      <div class="card margin-top-20px">
+        <div class="card-body">
+          <div *tmIsLoading="isTemplateLoading">
+
+            <!-- Variables hint -->
+            <div class="alert alert-info" role="alert">
+              <strong>&#128161; Available Variables:</strong>
+              You can use <code>{{ '${userName}' }}</code> and <code>{{ '${joinUrl}' }}</code> in your
+              message. The system will automatically replace these when sending the email.
+            </div>
+
+            <!-- Subject input -->
+            <div class="form-group">
+              <label for="template-subject"><strong>Subject</strong></label>
+              <input id="template-subject"
+                type="text"
+                class="form-control"
+                [(ngModel)]="model.subject"
+                placeholder="Email subject line"
+                [disabled]="isSaving">
+            </div>
+
+            <!-- Editor and live preview side-by-side -->
+            <div class="row margin-top-20px">
+              <div class="col-md-6">
+                <label><strong>HTML Body</strong></label>
+                <textarea id="template-body"
+                  class="form-control template-body-editor"
+                  [(ngModel)]="model.body"
+                  placeholder="Enter the HTML body for the email..."
+                  [disabled]="isSaving">
+                </textarea>
+              </div>
+
+              <div class="col-md-6">
+                <label><strong>Live Preview</strong></label>
+                <div class="template-preview-panel" [innerHTML]="sanitizedPreview"></div>
+              </div>
+            </div>
+
+            <!-- Customisation status badge -->
+            <div class="margin-top-10px">
+              @if (model.isCustomized) {
+                <span class="badge badge-success">&#10003; Custom Template Active</span>
+              } @else {
+                <span class="badge badge-secondary">Using Default Template</span>
+              }
+            </div>
+
+            <!-- Action buttons -->
+            <div class="d-flex justify-content-end margin-top-20px">
+              @if (model.isCustomized) {
+                <button class="btn btn-outline-danger margin-right-5px"
+                  (click)="revertToDefault()"
+                  [disabled]="isSaving">
+                  <i class="fas fa-undo"></i> Revert to Default
+                </button>
+              }
+              <button class="btn btn-primary"
+                (click)="saveTemplate()"
+                [disabled]="isSaving">
+                @if (isSaving) {
+                  <i class="fas fa-spinner fa-spin"></i> Saving...
+                } @else {
+                  <i class="fas fa-save"></i> Save Template
+                }
+              </button>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+    }
+
+  </div>
+</tm-loading-retry>

--- a/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.scss
+++ b/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.scss
@@ -1,0 +1,15 @@
+.template-body-editor {
+  height: 420px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 12px;
+  resize: vertical;
+}
+
+.template-preview-panel {
+  height: 420px;
+  overflow-y: auto;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  padding: 12px;
+  background-color: #fff;
+}

--- a/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.ts
+++ b/src/web/app/pages-admin/admin-email-templates-page/admin-email-templates-page.component.ts
@@ -1,0 +1,171 @@
+import { Component, OnInit } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { finalize } from 'rxjs/operators';
+import { EmailTemplateService } from '../../../services/email-template.service';
+import { StatusMessageService } from '../../../services/status-message.service';
+import { EmailTemplate, EmailTemplates } from '../../../types/api-output';
+import { EmailTemplateUpdateRequest } from '../../../types/api-request';
+import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
+import { LoadingRetryComponent } from '../../components/loading-retry/loading-retry.component';
+import { ErrorMessageOutput } from '../../error-message-output';
+
+interface EmailTemplateModel {
+  subject: string;
+  body: string;
+  isCustomized: boolean;
+}
+
+/**
+ * Admin page for viewing and editing configurable email templates.
+ */
+@Component({
+  selector: 'tm-admin-email-templates-page',
+  templateUrl: './admin-email-templates-page.component.html',
+  styleUrls: ['./admin-email-templates-page.component.scss'],
+  imports: [
+    FormsModule,
+    LoadingSpinnerDirective,
+    LoadingRetryComponent,
+  ],
+})
+export class AdminEmailTemplatesPageComponent implements OnInit {
+
+  templateKeys: string[] = [];
+  selectedKey: string = '';
+
+  isKeysLoading: boolean = false;
+  hasKeysLoadingFailed: boolean = false;
+  isTemplateLoading: boolean = false;
+  isSaving: boolean = false;
+
+  model: EmailTemplateModel = {
+    subject: '',
+    body: '',
+    isCustomized: false,
+  };
+
+  constructor(
+    private emailTemplateService: EmailTemplateService,
+    private statusMessageService: StatusMessageService,
+    private sanitizer: DomSanitizer,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadTemplateKeys();
+  }
+
+  /**
+   * Returns a trusted HTML string for the live preview panel.
+   * DomSanitizer is used so that inline <style> blocks — common in
+   * HTML email templates — are rendered faithfully in the preview.
+   */
+  get sanitizedPreview(): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(this.model.body);
+  }
+
+  /**
+   * Loads the list of configurable template keys, then auto-loads the first one.
+   */
+  loadTemplateKeys(): void {
+    this.isKeysLoading = true;
+    this.hasKeysLoadingFailed = false;
+    this.emailTemplateService.getEmailTemplates()
+      .pipe(finalize(() => { this.isKeysLoading = false; }))
+      .subscribe({
+        next: (data: EmailTemplates) => {
+          this.templateKeys = data.templateKeys;
+          if (this.templateKeys.length > 0) {
+            this.selectedKey = this.templateKeys[0];
+            this.loadTemplate(this.selectedKey);
+          }
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.hasKeysLoadingFailed = true;
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+  }
+
+  /**
+   * Called when the admin selects a different template from the dropdown.
+   */
+  onTemplateKeyChange(): void {
+    this.loadTemplate(this.selectedKey);
+  }
+
+  /**
+   * Fetches the template body and subject for the given key.
+   * Falls back to the static default if no custom version exists.
+   */
+  loadTemplate(templateKey: string): void {
+    this.isTemplateLoading = true;
+    this.emailTemplateService.getEmailTemplate(templateKey)
+      .pipe(finalize(() => { this.isTemplateLoading = false; }))
+      .subscribe({
+        next: (template: EmailTemplate) => {
+          this.model = {
+            subject: template.subject,
+            body: template.body,
+            isCustomized: template.isCustomized,
+          };
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+  }
+
+  /**
+   * Persists the current subject and body to the database.
+   */
+  saveTemplate(): void {
+    this.isSaving = true;
+    const request: EmailTemplateUpdateRequest = {
+      templateKey: this.selectedKey,
+      subject: this.model.subject,
+      body: this.model.body,
+      resetToDefault: false,
+    };
+    this.emailTemplateService.updateEmailTemplate(request)
+      .pipe(finalize(() => { this.isSaving = false; }))
+      .subscribe({
+        next: (template: EmailTemplate) => {
+          this.model.isCustomized = template.isCustomized;
+          this.statusMessageService.showSuccessToast('Email template saved successfully.');
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+  }
+
+  /**
+   * Deletes the custom DB record for the current template,
+   * then reloads the static default into the editor.
+   */
+  revertToDefault(): void {
+    this.isSaving = true;
+    const request: EmailTemplateUpdateRequest = {
+      templateKey: this.selectedKey,
+      subject: '',
+      body: '',
+      resetToDefault: true,
+    };
+    this.emailTemplateService.updateEmailTemplate(request)
+      .pipe(finalize(() => { this.isSaving = false; }))
+      .subscribe({
+        next: (template: EmailTemplate) => {
+          this.model = {
+            subject: template.subject,
+            body: template.body,
+            isCustomized: template.isCustomized,
+          };
+          this.statusMessageService.showSuccessToast('Email template reverted to default.');
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+  }
+}

--- a/src/web/app/pages-admin/admin-page.component.ts
+++ b/src/web/app/pages-admin/admin-page.component.ts
@@ -38,6 +38,10 @@ export class AdminPageComponent implements OnInit {
       display: 'Notifications',
     },
     {
+      url: '/web/admin/email-templates',
+      display: 'Email Templates',
+    },
+    {
       url: '/web/admin/logs',
       display: 'Logs',
     },

--- a/src/web/app/pages-admin/admin.routes.ts
+++ b/src/web/app/pages-admin/admin.routes.ts
@@ -45,6 +45,14 @@ const routes: Routes = [
       .then((m) => m.AdminNotificationsPageComponent),
   },
   {
+    path: 'email-templates',
+    loadComponent: () => import('./admin-email-templates-page/admin-email-templates-page.component')
+      .then((m) => m.AdminEmailTemplatesPageComponent),
+    data: {
+      pageTitle: 'Email Templates',
+    },
+  },
+  {
     path: 'logs',
     data: {
       isAdmin: true,

--- a/src/web/services/email-template.service.ts
+++ b/src/web/services/email-template.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpRequestService } from './http-request.service';
+import { ResourceEndpoints } from '../types/api-const';
+import { EmailTemplate, EmailTemplates } from '../types/api-output';
+import { EmailTemplateUpdateRequest } from '../types/api-request';
+
+/**
+ * Handles email template related logic injection.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class EmailTemplateService {
+
+  constructor(private httpRequestService: HttpRequestService) {}
+
+  /**
+   * Retrieves the list of configurable email template keys.
+   */
+  getEmailTemplates(): Observable<EmailTemplates> {
+    return this.httpRequestService.get(ResourceEndpoints.EMAIL_TEMPLATES);
+  }
+
+  /**
+   * Retrieves a single email template by key.
+   * Returns the custom DB-backed template if one exists, or the static default otherwise.
+   */
+  getEmailTemplate(templateKey: string): Observable<EmailTemplate> {
+    const paramMap: Record<string, string> = {
+      templatekey: templateKey,
+    };
+    return this.httpRequestService.get(ResourceEndpoints.EMAIL_TEMPLATE, paramMap);
+  }
+
+  /**
+   * Saves a custom email template, or resets it to the static default
+   * when {@code request.resetToDefault} is {@code true}.
+   */
+  updateEmailTemplate(request: EmailTemplateUpdateRequest): Observable<EmailTemplate> {
+    return this.httpRequestService.put(ResourceEndpoints.EMAIL_TEMPLATE, {}, request);
+  }
+}


### PR DESCRIPTION
Part of #13635 

### Description
This PR introduces the infrastructure to decouple TEAMMATES from hardcoded, static email templates. It allows administrators to dynamically edit email templates directly from the Admin UI, starting with the `NEW_INSTRUCTOR_ACCOUNT_WELCOME` email as a Proof of Concept (POC).

### Key Architectural Changes
1. **Storage Layer:** Created an `email_templates` table in PostgreSQL (via Liquibase), along with the `EmailTemplate` entity and `EmailTemplatesDb` DAO. It uses a unique constraint on the `templateKey`.
2. **API & Logic Layer:** Added REST endpoints (`GetEmailTemplatesAction`, `GetEmailTemplateAction`, `UpdateEmailTemplateAction`) routed through a new `EmailTemplatesLogic` singleton to safely fetch, upsert, and revert templates.
3. **Frontend:** Created a new standalone Angular component (`admin-email-templates-page`). It features a template editor with a live HTML preview (using `DomSanitizer.bypassSecurityTrustHtml` to safely render email `<style>` tags).
4. **Email Generation:** Updated `SqlEmailGenerator` to attempt fetching the template from the DB first. If no custom template exists, it safely falls back to the original static `.html` file. The subject line is also parsed dynamically to support variables like `${userName}`.

### Why just one email?
This PR serves as a "Vertical Slice" to establish and review the Database, API, and UI architecture safely. Once this pattern is approved, the remaining ~30 static emails can easily be migrated to this new system in follow-up PRs without ballooning the scope of this initial review.

### Screenshots / UI Preview

default format
<img width="1901" height="962" alt="image" src="https://github.com/user-attachments/assets/08bec03c-34a7-49eb-bb83-5199a509025c" />

revert to default option when you customise your message
<img width="1912" height="966" alt="image" src="https://github.com/user-attachments/assets/18c95c10-2a54-4db4-900f-7dd296b4f6c5" />


### Testing Done
- [x] Verified Liquibase migrations run successfully on local startup.
- [x] Verified template saves/updates correctly in PostgreSQL.
- [x] Verified "Revert to Default" successfully deletes the DB row and reloads the static fallback.
- [x] Triggered a real Account Request approval and verified via server logs that the email constructed utilizes the custom Subject and Body from the database, properly injecting `${userName}` and `${joinUrl}`.
- [x] Passed local `checkstyleMain` and `npm run lint`.
