### PR TITLE
[#13635] Sanitize default admin email templates for open-source

### DIFF
--- a/src/main/resources/newInstructorAccountWelcome.html
+++ b/src/main/resources/newInstructorAccountWelcome.html
@@ -1,7 +1,7 @@
 <p>Hi ${userName},</p>
 
 <p>
-  Damith here, from the TEAMMATES team. I'm a faculty member at National University of Singapore.
+  The TEAMMATES Admin Team here.
   Thanks for your interest in using TEAMMATES. We have created an account for you.
 </p>
 
@@ -28,11 +28,9 @@
 
 <p>Happy teaching!</p>
 
-<p>-Damith (for TEAMMATES team)</p>
+<p>-[Administrator Name] (for TEAMMATES team)</p>
 <p>
-  Damith C. Rajapakse (Dr) ; Associate Professor, School of Computing,
-  National University of Singapore ; COM2-2-57, 13 Computing Drive, Singapore 117417 ;
-  65-6516 4359 (Office) ; 65-6779 4580 (Fax) ;
-  damith@comp.nus.edu.sg (email) ;
-  http://www.comp.nus.edu.sg/~damithch (Home page)
+  [Administrator Name] ; [Institution Name] ;
+  [Administrator Phone Number] (Office) ; [Administrator Phone Number] (Fax) ;
+  admin@institution.edu (email)
 </p>

--- a/src/test/resources/emails/instructorNewAccountEmail.html
+++ b/src/test/resources/emails/instructorNewAccountEmail.html
@@ -1,7 +1,7 @@
 <p>Hi Instr,</p>
 
 <p>
-  Damith here, from the TEAMMATES team. I'm a faculty member at National University of Singapore.
+  The TEAMMATES Admin Team here.
   Thanks for your interest in using TEAMMATES. We have created an account for you.
 </p>
 
@@ -28,11 +28,9 @@
 
 <p>Happy teaching!</p>
 
-<p>-Damith (for TEAMMATES team)</p>
+<p>-[Administrator Name] (for TEAMMATES team)</p>
 <p>
-  Damith C. Rajapakse (Dr) ; Associate Professor, School of Computing,
-  National University of Singapore ; COM2-2-57, 13 Computing Drive, Singapore 117417 ;
-  65-6516 4359 (Office) ; 65-6779 4580 (Fax) ;
-  damith@comp.nus.edu.sg (email) ;
-  http://www.comp.nus.edu.sg/~damithch (Home page)
+  [Administrator Name] ; [Institution Name] ;
+  [Administrator Phone Number] (Office) ; [Administrator Phone Number] (Fax) ;
+  admin@institution.edu (email)
 </p>

--- a/src/test/resources/emails/instructorNewAccountEmailTestingSanitization.html
+++ b/src/test/resources/emails/instructorNewAccountEmailTestingSanitization.html
@@ -1,7 +1,7 @@
 <p>Hi Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt;,</p>
 
 <p>
-  Damith here, from the TEAMMATES team. I'm a faculty member at National University of Singapore.
+  The TEAMMATES Admin Team here.
   Thanks for your interest in using TEAMMATES. We have created an account for you.
 </p>
 
@@ -28,11 +28,9 @@
 
 <p>Happy teaching!</p>
 
-<p>-Damith (for TEAMMATES team)</p>
+<p>-[Administrator Name] (for TEAMMATES team)</p>
 <p>
-  Damith C. Rajapakse (Dr) ; Associate Professor, School of Computing,
-  National University of Singapore ; COM2-2-57, 13 Computing Drive, Singapore 117417 ;
-  65-6516 4359 (Office) ; 65-6779 4580 (Fax) ;
-  damith@comp.nus.edu.sg (email) ;
-  http://www.comp.nus.edu.sg/~damithch (Home page)
+  [Administrator Name] ; [Institution Name] ;
+  [Administrator Phone Number] (Office) ; [Administrator Phone Number] (Fax) ;
+  admin@institution.edu (email)
 </p>


### PR DESCRIPTION
Part of #13635 

### Description
This PR sanitizes the default `NEW_INSTRUCTOR_ACCOUNT_WELCOME` email templates to make them open-source friendly for organizations outside of NUS.

### Key Changes
- Removed hardcoded personal information (e.g., "Damith", specific phone numbers/emails).
- Removed hardcoded institutional information (e.g., "National University of Singapore").
- Replaced the above with clear, generic placeholders (e.g., `[Administrator Name]`, `[Institution Name]`, `[Administrator Phone Number]`).
- Updated corresponding test HTML fixtures to match the new sanitized baseline to ensure CI tests pass.

### Testing Done
- [x] Verified local test suites pass with the updated placeholder strings.