### PR TITLE
[#13471] Revert "Notifications page: Add Mark All as Read button"

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
@@ -63,22 +63,6 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
 
         notificationsPage.verifyNotShownNotifications(notShownNotifications);
         notificationsPage.verifyShownNotifications(shownNotifications, readNotificationsIds);
-
-        ______TS("mark all notifications as read");
-        notificationsPage.markAllNotificationsAsRead();
-        notificationsPage.verifyStatusMessage("All notifications marked as read!");
-
-        teammates.test.ThreadHelper.waitFor(2000);
-
-        ______TS("notification banner is not visible");
-        assertFalse(notificationsPage.isBannerVisible());
-
-        AccountData updatedAccountFromDb = BACKDOOR.getAccountData(instructorAccount.getGoogleId());
-        Notification notification1 = testData.notifications.get("notification1");
-        Notification notification3 = testData.notifications.get("notification3");
-
-        assertTrue(updatedAccountFromDb.getReadNotifications().containsKey(notification1.getId().toString()));
-        assertTrue(updatedAccountFromDb.getReadNotifications().containsKey(notification3.getId().toString()));
     }
 
     private void testStudent() {
@@ -109,26 +93,10 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
 
         notificationsPage.verifyNotShownNotifications(notShownNotifications);
         notificationsPage.verifyShownNotifications(shownNotifications, readNotificationsIds);
-
-        ______TS("mark all notifications as read");
-        notificationsPage.markAllNotificationsAsRead();
-        notificationsPage.verifyStatusMessage("All notifications marked as read!");
-
-        teammates.test.ThreadHelper.waitFor(2000);
-
-        ______TS("notification banner is not visible");
-        assertFalse(notificationsPage.isBannerVisible());
-
-        AccountData updatedAccountFromDb = BACKDOOR.getAccountData(studentAccount.getGoogleId());
-        Notification notification1 = testData.notifications.get("notification1");
-        Notification notification2 = testData.notifications.get("notification2");
-
-        assertTrue(updatedAccountFromDb.getReadNotifications().containsKey(notification1.getId().toString()));
-        assertTrue(updatedAccountFromDb.getReadNotifications().containsKey(notification2.getId().toString()));
     }
 
     private void testNotificationBanner() {
-        Account studentAccount = testData.accounts.get("notif.studentBanner");
+        Account studentAccount = testData.accounts.get("notif.student");
         AppUrl studentHomePageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
         StudentHomePage homePage = loginToPage(studentHomePageUrl, StudentHomePage.class,
                 studentAccount.getGoogleId());

--- a/src/e2e/java/teammates/e2e/pageobjects/UserNotificationsPageSql.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/UserNotificationsPageSql.java
@@ -27,9 +27,6 @@ public class UserNotificationsPageSql extends AppPage {
     @FindBy(id = "notifications-timezone")
     private WebElement notificationsTimezone;
 
-    @FindBy(id = "mark-all-read")
-    private WebElement markAllAsReadButton;
-
     public UserNotificationsPageSql(Browser browser) {
         super(browser);
     }
@@ -97,11 +94,6 @@ public class UserNotificationsPageSql extends AppPage {
     public void markNotificationAsRead(Notification notification) {
         WebElement notificationTab = notificationTabs.findElement(By.id(notification.getId().toString()));
         click(notificationTab.findElement(By.className("btn-mark-as-read")));
-        waitForPageToLoad(true);
-    }
-
-    public void markAllNotificationsAsRead() {
-        click(markAllAsReadButton);
         waitForPageToLoad(true);
     }
 

--- a/src/e2e/resources/data/NotificationsE2ETestSql.json
+++ b/src/e2e/resources/data/NotificationsE2ETestSql.json
@@ -11,12 +11,6 @@
       "googleId": "tm.e2e.notif.student",
       "name": "Teammates Test Student",
       "email": "notif.student@gmail.tmt"
-    },
-    "notif.studentBanner": {
-      "id": "00000000-0000-4000-8000-000000000003",
-      "googleId": "tm.e2e.notif.studentBanner",
-      "name": "Teammates Test Student Banner",
-      "email": "notif.studentbanner@gmail.tmt"
     }
   },
   "accountRequests": {},
@@ -91,21 +85,6 @@
       "email": "notif.student@gmail.tmt",
       "name": "Amy Betsy</option></td></div>'\"",
       "comments": "This student's name is Amy Betsy</option></td></div>'\""
-    },
-    "notif.studentBanner": {
-      "id": "00000000-0000-4000-8000-000000000602",
-      "account": {
-        "id": "00000000-0000-4000-8000-000000000003"
-      },
-      "course": {
-        "id": "tm.e2e.notif.course1"
-      },
-      "team": {
-        "id": "00000000-0000-4000-8000-000000000301"
-      },
-      "email": "notif.studentbanner@gmail.tmt",
-      "name": "Banner Test Student",
-      "comments": ""
     }
   },
   "notifications": {
@@ -184,15 +163,6 @@
       "id": "00000000-0000-4000-8000-000000002101",
       "account": {
         "id": "00000000-0000-4000-8000-000000000002"
-      },
-      "notification": {
-        "id": "00000000-0000-4000-8000-000000001104"
-      }
-    },
-    "notification4Banner.student": {
-      "id": "00000000-0000-4000-8000-000000002102",
-      "account": {
-        "id": "00000000-0000-4000-8000-000000000003"
       },
       "notification": {
         "id": "00000000-0000-4000-8000-000000001104"

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -23,14 +22,41 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
     <p>
       All dates are displayed in UTC time.
     </p>
+  </div><div
+    class="row mb-3"
+  >
+    <div
+      class="col-12"
+    >
+      <div
+        class="float-end"
+      >
+        <strong
+          class="d-inline"
+        >
+           Sort By: 
+        </strong>
+        <div
+          class="btn-group"
+          data-toggle="buttons"
+        >
+          <button
+            class="btn btn-light"
+            id="sort-end-time"
+          >
+            End Time
+          </button>
+          <button
+            class="btn btn-light"
+            id="sort-start-time"
+          >
+            Start Time
+          </button>
+        </div>
+      </div>
+    </div>
   </div><tm-loading-retry>
     <div>
-      <div
-        class="alert alert-warning margin-top-30px"
-        role="alert"
-      >
-         There are no unread notifications. 
-      </div>
     </div>
     <div
       id="notification-tabs"
@@ -112,7 +138,6 @@ exports[`UserNotificationsListComponent should snap when it fails to load 1`] = 
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed={[Function Boolean]}
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -158,7 +183,6 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -176,15 +200,17 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-2"
+    class="row mb-3"
   >
     <div
-      class="col-12 d-flex justify-content-between align-items-center"
+      class="col-12"
     >
       <div
-        class="d-flex align-items-center gap-2"
+        class="float-end"
       >
-        <strong>
+        <strong
+          class="d-inline"
+        >
            Sort By: 
         </strong>
         <div
@@ -205,13 +231,6 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
           </button>
         </div>
       </div>
-      <button
-        class="btn btn-success"
-        id="mark-all-read"
-        type="button"
-      >
-         Mark All as Read 
-      </button>
     </div>
   </div><tm-loading-retry>
     <div>
@@ -344,7 +363,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -362,15 +380,17 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-2"
+    class="row mb-3"
   >
     <div
-      class="col-12 d-flex justify-content-between align-items-center"
+      class="col-12"
     >
       <div
-        class="d-flex align-items-center gap-2"
+        class="float-end"
       >
-        <strong>
+        <strong
+          class="d-inline"
+        >
            Sort By: 
         </strong>
         <div
@@ -392,13 +412,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
           </button>
         </div>
       </div>
-      <button
-        class="btn btn-success"
-        id="mark-all-read"
-        type="button"
-      >
-         Mark All as Read 
-      </button>
     </div>
   </div><tm-loading-retry>
     <div>
@@ -531,7 +544,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -549,15 +561,17 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-2"
+    class="row mb-3"
   >
     <div
-      class="col-12 d-flex justify-content-between align-items-center"
+      class="col-12"
     >
       <div
-        class="d-flex align-items-center gap-2"
+        class="float-end"
       >
-        <strong>
+        <strong
+          class="d-inline"
+        >
            Sort By: 
         </strong>
         <div
@@ -579,13 +593,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
           </button>
         </div>
       </div>
-      <button
-        class="btn btn-success"
-        id="mark-all-read"
-        type="button"
-      >
-         Mark All as Read 
-      </button>
     </div>
   </div><tm-loading-retry>
     <div>
@@ -718,7 +725,6 @@ exports[`UserNotificationsListComponent should snap with default fields when loa
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications={[Function Boolean]}
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -765,7 +771,6 @@ exports[`UserNotificationsListComponent should snap with no notifications 1`] = 
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -788,7 +793,7 @@ exports[`UserNotificationsListComponent should snap with no notifications 1`] = 
         class="alert alert-warning margin-top-30px"
         role="alert"
       >
-         There are no unread notifications. 
+         There are no active notifications. 
       </div>
     </div>
     <div

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -1,49 +1,56 @@
 <div id="notifications-timezone">
   <p>All dates are displayed in {{ timezone }} time.</p>
 </div>
-<div class="row mb-2" *ngIf="hasUnreadNotifications">
-  <div class="col-12 d-flex justify-content-between align-items-center">
-    <div class="d-flex align-items-center gap-2">
-      <strong> Sort By: </strong>
-      <div class="btn-group" data-toggle="buttons">
-        <button id="sort-end-time" class="btn btn-light" [disabled]="isSelectedForSorting(SortBy.NOTIFICATION_END_TIME)" (click)="sortNotificationsBy(SortBy.NOTIFICATION_END_TIME)">End Time</button>
-        <button id="sort-start-time" class="btn btn-light" [disabled]="isSelectedForSorting(SortBy.NOTIFICATION_START_TIME)" (click)="sortNotificationsBy(SortBy.NOTIFICATION_START_TIME)">Start Time</button>
+@if (notificationTabs.length > 0) {
+  <div class="row mb-3">
+    <div class="col-12">
+      <div class="float-end">
+        <strong class="d-inline"> Sort By: </strong>
+        <div class="btn-group" data-toggle="buttons">
+          <button id="sort-end-time" class="btn btn-light" [disabled]="isSelectedForSorting(SortBy.NOTIFICATION_END_TIME)" (click)="sortNotificationsBy(SortBy.NOTIFICATION_END_TIME)">End Time</button>
+          <button id="sort-start-time" class="btn btn-light" [disabled]="isSelectedForSorting(SortBy.NOTIFICATION_START_TIME)" (click)="sortNotificationsBy(SortBy.NOTIFICATION_START_TIME)">Start Time</button>
+        </div>
       </div>
     </div>
-    <button id="mark-all-read" class="btn btn-success" type="button" (click)="markAllNotificationsAsRead()">
-      Mark All as Read
-    </button>
   </div>
-</div>
+}
 
 <tm-loading-retry [shouldShowRetry]="hasLoadingFailed" [message]="'Failed to load notifications'" (retryEvent)="loadNotifications()">
   <div *tmIsLoading="isLoadingNotifications">
-    <div class="alert alert-warning margin-top-30px" role="alert" *ngIf="!hasUnreadNotifications && !isLoadingNotifications">
-      There are no unread notifications.
-    </div>
+    @if (notificationTabs.length === 0 && !isLoadingNotifications) {
+      <div class="alert alert-warning margin-top-30px" role="alert">
+        There are no active notifications.
+      </div>
+    }
   </div>
   <ng-container>
     <div id="notification-tabs">
-      <div *ngFor="let notificationTab of notificationTabs">
-        <div [id]="notificationTab.notification.notificationId" class="card">
-          <div class="card-header cursor-pointer mb-0" [ngClass]="notificationTab.notification.style | notificationStyleClass" (click)="toggleCard(notificationTab)">
-            <strong class="text-break">{{notificationTab.notification.title}} [{{notificationTab.startDate}} - {{notificationTab.endDate}}]</strong>
-            <div class="card-header-btn-toolbar">
-              <tm-panel-chevron [isExpanded]="notificationTab.hasTabExpanded"></tm-panel-chevron>
+      @for (notificationTab of notificationTabs; track notificationTab) {
+        <div>
+          <div [id]="notificationTab.notification.notificationId" class="card">
+            <div class="card-header cursor-pointer mb-0" [ngClass]="notificationTab.notification.style | notificationStyleClass" (click)="toggleCard(notificationTab)">
+              <strong class="text-break">{{notificationTab.notification.title}} [{{notificationTab.startDate}} - {{notificationTab.endDate}}]</strong>
+              <div class="card-header-btn-toolbar">
+                <tm-panel-chevron [isExpanded]="notificationTab.hasTabExpanded"></tm-panel-chevron>
+              </div>
             </div>
-          </div>
-          <div class="mb-0" *ngIf="notificationTab.hasTabExpanded" @collapseAnim>
-            <div [ngClass]="getBodyTextClass(notificationTab)">
-              <div class="notification-message" [innerHtml]="notificationTab.notification.message"></div>
-            </div>
-            <div class="d-flex flex-row-reverse me-4 mb-3" *ngIf="!notificationTab.isRead">
-              <button class="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
-                Mark as Read
-              </button>
-            </div>
+            @if (notificationTab.hasTabExpanded) {
+              <div class="mb-0" @collapseAnim>
+                <div [ngClass]="getBodyTextClass(notificationTab)">
+                  <div class="notification-message" [innerHtml]="notificationTab.notification.message"></div>
+                </div>
+                @if (!notificationTab.isRead) {
+                  <div class="d-flex flex-row-reverse me-4 mb-3">
+                    <button class="btn-mark-as-read" type="button" [ngClass]="getButtonClass(notificationTab)" (click)="markNotificationAsRead(notificationTab)">
+                      Mark as Read
+                    </button>
+                  </div>
+                }
+              </div>
+            }
           </div>
         </div>
-      </div>
+      }
     </div>
   </ng-container>
 </tm-loading-retry>

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -1,4 +1,4 @@
-import { NgIf, NgFor, NgClass } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import { forkJoin } from 'rxjs';
 import { finalize } from 'rxjs/operators';
@@ -39,14 +39,14 @@ export interface NotificationTab {
   imports: [
     LoadingRetryComponent,
     LoadingSpinnerDirective,
-    NgIf,
-    NgFor,
     NgClass,
     PanelChevronComponent,
     NotificationStyleClassPipe,
-  ],
+],
 })
 export class UserNotificationsListComponent implements OnInit {
+
+  // enum
   NotificationTargetUser: typeof NotificationTargetUser = NotificationTargetUser;
   SortBy: typeof SortBy = SortBy;
 
@@ -64,12 +64,10 @@ export class UserNotificationsListComponent implements OnInit {
 
   DATE_FORMAT: string = 'DD MMM YYYY';
 
-  constructor(
-    private notificationService: NotificationService,
-    private statusMessageService: StatusMessageService,
-    private timezoneService: TimezoneService,
-    private tableComparatorService: TableComparatorService,
-  ) {}
+  constructor(private notificationService: NotificationService,
+              private statusMessageService: StatusMessageService,
+              private timezoneService: TimezoneService,
+              private tableComparatorService: TableComparatorService) { }
 
   ngOnInit(): void {
     this.loadNotifications();
@@ -81,29 +79,16 @@ export class UserNotificationsListComponent implements OnInit {
 
     forkJoin({
       readNotifications: this.notificationService.getReadNotifications(),
-      notifications: this.notificationService.getAllNotificationsForTargetUser(
-        this.userType,
-      ),
+      notifications: this.notificationService.getAllNotificationsForTargetUser(this.userType),
     })
-      .pipe(
-        finalize(() => {
-          this.isLoadingNotifications = false;
-        }),
-      )
+      .pipe(finalize(() => { this.isLoadingNotifications = false; }))
       .subscribe({
-        next: ({
-          readNotifications,
-          notifications,
-        }: {
-          readNotifications: ReadNotifications,
-          notifications: Notifications,
+        next: ({ readNotifications, notifications }: {
+          readNotifications: ReadNotifications, notifications: Notifications,
         }) => {
-          const readNotificationsSet: Set<string> = new Set(
-            readNotifications.readNotifications,
-          );
+          const readNotificationsSet: Set<string> = new Set(readNotifications.readNotifications);
           this.notificationTabs = notifications.notifications.map(
-            (notification) =>
-              this.createNotificationTab(notification, readNotificationsSet),
+            (notification) => this.createNotificationTab(notification, readNotificationsSet),
           );
           this.sortNotificationsBy(this.notificationsSortBy);
         },
@@ -114,24 +99,17 @@ export class UserNotificationsListComponent implements OnInit {
       });
   }
 
-  private createNotificationTab(
-    notification: Notification,
-    readNotifications: Set<string>,
-  ): NotificationTab {
+  private createNotificationTab(notification: Notification, readNotifications: Set<string>): NotificationTab {
     const isRead: boolean = readNotifications.has(notification.notificationId);
     return {
       notification,
       hasTabExpanded: !isRead,
       isRead,
       startDate: this.timezoneService.formatToString(
-        notification.startTimestamp,
-        this.timezone,
-        this.DATE_FORMAT,
+        notification.startTimestamp, this.timezone, this.DATE_FORMAT,
       ),
       endDate: this.timezoneService.formatToString(
-        notification.endTimestamp,
-        this.timezone,
-        this.DATE_FORMAT,
+        notification.endTimestamp, this.timezone, this.DATE_FORMAT,
       ),
     };
   }
@@ -142,86 +120,18 @@ export class UserNotificationsListComponent implements OnInit {
 
   markNotificationAsRead(notificationTab: NotificationTab): void {
     const notification: Notification = notificationTab.notification;
-    this.notificationService
-      .markNotificationAsRead({
-        notificationId: notification.notificationId,
-        endTimestamp: notification.endTimestamp,
-      })
+    this.notificationService.markNotificationAsRead({
+      notificationId: notification.notificationId,
+      endTimestamp: notification.endTimestamp,
+    })
       .subscribe({
         next: () => {
           notificationTab.isRead = true;
-          this.statusMessageService.showSuccessToast(
-            'Notification marked as read.',
-          );
+          this.statusMessageService.showSuccessToast('Notification marked as read.');
           notificationTab.hasTabExpanded = false;
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
-        },
-      });
-  }
-
-  private hasMarkAllReadError = false;
-
-  get hasUnreadNotifications(): boolean {
-    return this.notificationTabs.some((tab) => !tab.isRead);
-  }
-
-  markAllNotificationsAsRead(): void {
-    const unreadTabs = this.notificationTabs.filter((tab) => !tab.isRead);
-
-    if (unreadTabs.length === 0) {
-      this.statusMessageService.showSuccessToast(
-        'All notifications are already read.',
-      );
-      return;
-    }
-
-    unreadTabs.forEach((tab) => {
-      tab.hasTabExpanded = false;
-      tab.isRead = true;
-    });
-
-    this.statusMessageService.showSuccessToast(
-      'All notifications marked as read!',
-    );
-    this.hasMarkAllReadError = false;
-
-    this.processMarkAsReadSequentially(unreadTabs, 0);
-  }
-
-  private processMarkAsReadSequentially(tabs: any[], index: number): void {
-    if (index >= tabs.length) {
-      return;
-    }
-
-    const tab = tabs[index];
-
-    this.notificationService
-      .markNotificationAsRead({
-        notificationId: tab.notification.notificationId,
-        endTimestamp: tab.notification.endTimestamp,
-      })
-      .subscribe({
-        next: () => {
-          setTimeout(
-            () => this.processMarkAsReadSequentially(tabs, index + 1),
-            600,
-          );
-        },
-        error: () => {
-          tab.isRead = false;
-
-          if (!this.hasMarkAllReadError) {
-            this.hasMarkAllReadError = true;
-            this.statusMessageService.showErrorToast(
-              'Some notifications could not be marked as read and may reappear on refresh.',
-            );
-          }
-          setTimeout(
-            () => this.processMarkAsReadSequentially(tabs, index + 1),
-            600,
-          );
         },
       });
   }
@@ -234,17 +144,26 @@ export class UserNotificationsListComponent implements OnInit {
     return `btn btn-${notificationTab.notification.style.toLowerCase()}`;
   }
 
+  /**
+   * Checks the option selected to sort notifications.
+   */
   isSelectedForSorting(by: SortBy): boolean {
     return this.notificationsSortBy === by;
   }
 
+  /**
+   * Sorts the notifications according to the selected option.
+   */
   sortNotificationsBy(by: SortBy): void {
     this.notificationsSortBy = by;
     this.notificationTabs.sort(this.sortTabsBy(by));
   }
 
-  sortTabsBy(by: SortBy): (a: NotificationTab, b: NotificationTab) => number {
-    return (a: NotificationTab, b: NotificationTab): number => {
+  /**
+   * Sorts the notification tabs in order.
+   */
+  sortTabsBy(by: SortBy): ((a: NotificationTab, b: NotificationTab) => number) {
+    return ((a: NotificationTab, b: NotificationTab): number => {
       let strA: string;
       let strB: string;
       let order: SortOrder;
@@ -265,6 +184,6 @@ export class UserNotificationsListComponent implements OnInit {
           order = SortOrder.ASC;
       }
       return this.tableComparatorService.compare(by, order, strA, strB);
-    };
+    });
   }
 }


### PR DESCRIPTION
This reverts commit 22fb32d7a2e424ed8ceee6b8d62d4171f4e5ad76.

<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13471

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

The commit has been reverted because it's not quite production ready yet. The biggest issue is that the mark notification as read endpoint is called sequentially every 600ms. This means 10 notifications will take >6s to be mark as read. 

Generally, the solution should be to batch the requests on the backend. An endpoint can be created for this. If that's not possible, then the requests should be handled in parallel, with reasonable limits on the number of concurrent requests. 
