### PR TITLE
[#13696] FIX Revert "Notifications page: Add Mark All as Read button"

### DIFF
--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -112,7 +111,6 @@ exports[`UserNotificationsListComponent should snap when it fails to load 1`] = 
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed={[Function Boolean]}
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -158,7 +156,6 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -344,7 +341,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -531,7 +527,6 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -718,7 +713,6 @@ exports[`UserNotificationsListComponent should snap with default fields when loa
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications={[Function Boolean]}
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}
@@ -765,7 +759,6 @@ exports[`UserNotificationsListComponent should snap with no notifications 1`] = 
   NotificationTargetUser={[Function Object]}
   SortBy={[Function Object]}
   hasLoadingFailed="false"
-  hasMarkAllReadError="false"
   isLoadingNotifications="false"
   notificationService={[Function NotificationService]}
   notificationTabs={[Function Array]}

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -161,8 +161,6 @@ export class UserNotificationsListComponent implements OnInit {
       });
   }
 
-  private hasMarkAllReadError = false;
-
   get hasUnreadNotifications(): boolean {
     return this.notificationTabs.some((tab) => !tab.isRead);
   }
@@ -177,53 +175,31 @@ export class UserNotificationsListComponent implements OnInit {
       return;
     }
 
+    const requests = unreadTabs.map((tab) =>
+      this.notificationService.markNotificationAsRead({
+        notificationId: tab.notification.notificationId,
+        endTimestamp: tab.notification.endTimestamp,
+      }),
+    );
+
     unreadTabs.forEach((tab) => {
       tab.hasTabExpanded = false;
       tab.isRead = true;
     });
 
-    this.statusMessageService.showSuccessToast(
-      'All notifications marked as read!',
-    );
-    this.hasMarkAllReadError = false;
-
-    this.processMarkAsReadSequentially(unreadTabs, 0);
-  }
-
-  private processMarkAsReadSequentially(tabs: any[], index: number): void {
-    if (index >= tabs.length) {
-      return;
-    }
-
-    const tab = tabs[index];
-
-    this.notificationService
-      .markNotificationAsRead({
-        notificationId: tab.notification.notificationId,
-        endTimestamp: tab.notification.endTimestamp,
-      })
-      .subscribe({
-        next: () => {
-          setTimeout(
-            () => this.processMarkAsReadSequentially(tabs, index + 1),
-            600,
-          );
-        },
-        error: () => {
-          tab.isRead = false;
-
-          if (!this.hasMarkAllReadError) {
-            this.hasMarkAllReadError = true;
-            this.statusMessageService.showErrorToast(
-              'Some notifications could not be marked as read and may reappear on refresh.',
-            );
-          }
-          setTimeout(
-            () => this.processMarkAsReadSequentially(tabs, index + 1),
-            600,
-          );
-        },
-      });
+    forkJoin(requests).subscribe({
+      next: () => {
+        this.statusMessageService.showSuccessToast(
+          'All notifications marked as read!',
+        );
+      },
+      error: (resp: ErrorMessageOutput) => {
+        this.statusMessageService.showErrorToast(
+          'Some notifications could not be marked as read. Please refresh.',
+        );
+        console.error('Batch mark-as-read failed:', resp);
+      },
+    });
   }
 
   getBodyTextClass(notificationTab: NotificationTab): string {


### PR DESCRIPTION
Fixes #13696 which is a part of #13471

**Outline of Solution**

The sequential 600ms API calls have now been replaced with parallel execution using RxJS forkJoin, making the process instant for users with many notifications.