### PR TITLE
[#13596] Saved text responses with trailing spaces are incorrectly displayed as unsaved

### DIFF
--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -76,6 +76,7 @@ export class RichTextEditorComponent implements OnInit {
       relative_urls: false,
       convert_urls: false,
       remove_linebreaks: false,
+      entity_encoding: 'raw',
       placeholder: this.placeholderText,
       plugins: [
         'advlist', 'autolink', 'autoresize', 'lists', 'link', 'image', 'charmap', 'anchor',


### PR DESCRIPTION
fixes #13596 

[#13596] Fix: prevent TinyMCE encoding issue causing false unsaved state

**Outline of Solution**

Trailing spaces in responses entered via TinyMCE were being encoded into named entities (e.g., &nbsp;). This caused a mismatch between saved and loaded content, leading to the tab being incorrectly marked as unsaved after a page refresh.

To resolve this, the `entity_encoding` option in TinyMCE was set to "raw". This ensures that literal characters are preserved instead of being converted into HTML entities.

With this change, the saved and loaded content remain consistent, preventing false unsaved state indications.