### PR TITLE
[#13721] Optimize ReadNotification actions

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
@@ -1,16 +1,10 @@
 package teammates.it.sqllogic.core;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.UUID;
-
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
-import teammates.common.datatransfer.NotificationStyle;
-import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -20,14 +14,11 @@ import teammates.common.util.StringHelper;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.AccountsLogic;
 import teammates.sqllogic.core.CoursesLogic;
-import teammates.sqllogic.core.NotificationsLogic;
 import teammates.sqllogic.core.UsersLogic;
 import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.Instructor;
-import teammates.storage.sqlentity.Notification;
-import teammates.storage.sqlentity.ReadNotification;
 import teammates.storage.sqlentity.Student;
 import teammates.test.AssertHelper;
 
@@ -37,7 +28,6 @@ import teammates.test.AssertHelper;
 public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     private AccountsLogic accountsLogic = AccountsLogic.inst();
-    private NotificationsLogic notificationsLogic = NotificationsLogic.inst();
     private UsersLogic usersLogic = UsersLogic.inst();
     private CoursesLogic coursesLogic = CoursesLogic.inst();
 
@@ -57,28 +47,6 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         persistDataBundle(typicalDataBundle);
         HibernateUtil.flushSession();
         HibernateUtil.clearSession();
-    }
-
-    @Test
-    public void testUpdateReadNotifications()
-            throws EntityAlreadyExistsException, InvalidParametersException, EntityDoesNotExistException {
-        ______TS("success: mark notification as read");
-        Account account = new Account("google-id", "name", "email@teammates.com");
-        Notification notification = new Notification(Instant.parse("2011-01-01T00:00:00Z"),
-                Instant.parse("2099-01-01T00:00:00Z"), NotificationStyle.DANGER, NotificationTargetUser.GENERAL,
-                "A deprecation note", "<p>Deprecation happens in three minutes</p>");
-        accountsDb.createAccount(account);
-        notificationsLogic.createNotification(notification);
-
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-        accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime());
-
-        Account actualAccount = accountsDb.getAccountByGoogleId(googleId);
-        List<ReadNotification> accountReadNotifications = actualAccount.getReadNotifications();
-        assertEquals(1, accountReadNotifications.size());
-        assertSame(actualAccount, accountReadNotifications.get(0).getAccount());
-        assertSame(notification, accountReadNotifications.get(0).getNotification());
     }
 
     @Test

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -859,13 +859,6 @@ public class Logic {
     }
 
     /**
-     * Get a list of IDs of the read notifications of the account.
-     */
-    public List<UUID> getReadNotificationsId(String id) {
-        return accountsLogic.getReadNotificationsId(id);
-    }
-
-    /**
      * Gets a list of notifications that have been read by the account with {@code accountId}.
      */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -859,7 +859,7 @@ public class Logic {
     }
 
     /**
-     * Create a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
+     * Creates a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
      */
     public ReadNotification createReadNotification(UUID accountId, UUID notificationId) {
         return notificationsLogic.createReadNotification(accountId, notificationId);

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -873,20 +873,6 @@ public class Logic {
     }
 
     /**
-     * Updates user read status for notification with ID {@code notificationId} and
-     * expiry time {@code endTime}.
-     *
-     * <p>
-     * Preconditions:
-     * </p>
-     * * All parameters are non-null. {@code endTime} must be after current moment.
-     */
-    public List<UUID> updateReadNotifications(String id, UUID notificationId, Instant endTime)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        return accountsLogic.updateReadNotifications(id, notificationId, endTime);
-    }
-
-    /**
      * Gets instructor associated with {@code id}.
      *
      * @param id Id of Instructor.

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -47,6 +47,7 @@ import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.FeedbackSessionLog;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.ReadNotification;
 import teammates.storage.sqlentity.Section;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.Team;
@@ -862,6 +863,10 @@ public class Logic {
      */
     public List<UUID> getReadNotificationsId(String id) {
         return accountsLogic.getReadNotificationsId(id);
+    }
+
+    public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
+        return notificationsLogic.getReadNotificationsByAccountId(accountId);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -865,6 +865,9 @@ public class Logic {
         return accountsLogic.getReadNotificationsId(id);
     }
 
+    /**
+     * Gets a list of notifications that have been read by the account with {@code accountId}.
+     */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
         return notificationsLogic.getReadNotificationsByAccountId(accountId);
     }

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -859,6 +859,13 @@ public class Logic {
     }
 
     /**
+     * Create a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
+     */
+    public ReadNotification createReadNotification(UUID accountId, UUID notificationId) {
+        return notificationsLogic.createReadNotification(accountId, notificationId);
+    }
+
+    /**
      * Gets a list of notifications that have been read by the account with {@code accountId}.
      */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {

--- a/src/main/java/teammates/sqllogic/core/AccountsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountsLogic.java
@@ -156,15 +156,6 @@ public final class AccountsLogic {
     }
 
     /**
-     * Gets ids of read notifications in an account.
-     */
-    public List<UUID> getReadNotificationsId(String googleId) {
-        return accountsDb.getAccountByGoogleId(googleId).getReadNotifications().stream()
-                .map(n -> n.getNotification().getId())
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Joins the user as a student.
      */
     public Student joinCourseForStudent(String registrationKey, String googleId)

--- a/src/main/java/teammates/sqllogic/core/AccountsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountsLogic.java
@@ -1,9 +1,7 @@
 package teammates.sqllogic.core;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -12,8 +10,6 @@ import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.Instructor;
-import teammates.storage.sqlentity.Notification;
-import teammates.storage.sqlentity.ReadNotification;
 import teammates.storage.sqlentity.Student;
 import teammates.storage.sqlentity.User;
 
@@ -29,8 +25,6 @@ public final class AccountsLogic {
 
     private AccountsDb accountsDb;
 
-    private NotificationsLogic notificationsLogic;
-
     private UsersLogic usersLogic;
 
     private CoursesLogic coursesLogic;
@@ -39,10 +33,9 @@ public final class AccountsLogic {
         // prevent initialization
     }
 
-    void initLogicDependencies(AccountsDb accountsDb, NotificationsLogic notificationsLogic,
+    void initLogicDependencies(AccountsDb accountsDb,
             UsersLogic usersLogic, CoursesLogic coursesLogic) {
         this.accountsDb = accountsDb;
-        this.notificationsLogic = notificationsLogic;
         this.usersLogic = usersLogic;
         this.coursesLogic = coursesLogic;
     }
@@ -118,41 +111,6 @@ public final class AccountsLogic {
         }
 
         deleteAccount(googleId);
-    }
-
-    /**
-     * Updates the readNotifications of an account.
-     *
-     * @param googleId       google ID of the user who read the notification.
-     * @param notificationId ID of notification to be marked as read.
-     * @param endTime        the expiry time of the notification, i.e. notification
-     *                       will not be shown after this time.
-     * @return the account with updated read notifications.
-     * @throws InvalidParametersException  if the notification has expired.
-     * @throws EntityDoesNotExistException if account or notification does not
-     *                                     exist.
-     */
-    public List<UUID> updateReadNotifications(String googleId, UUID notificationId, Instant endTime)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = accountsDb.getAccountByGoogleId(googleId);
-        if (account == null) {
-            throw new EntityDoesNotExistException("Trying to update the read notifications of a non-existent account.");
-        }
-
-        Notification notification = notificationsLogic.getNotification(notificationId);
-        if (notification == null) {
-            throw new EntityDoesNotExistException("Trying to mark as read a notification that does not exist.");
-        }
-        if (endTime.isBefore(Instant.now())) {
-            throw new InvalidParametersException("Trying to mark an expired notification as read.");
-        }
-
-        ReadNotification readNotification = new ReadNotification(account, notification);
-        account.addReadNotification(readNotification);
-
-        return account.getReadNotifications().stream()
-                .map(n -> n.getNotification().getId())
-                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
 import teammates.common.util.JsonUtils;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
@@ -261,11 +261,9 @@ public final class DataBundleLogic {
      * Persists data in the given {@link DataBundle} to the database.
      *
      * @throws InvalidParametersException if invalid data is encountered.
-     * @throws EntityDoesNotExistException if an entity was not found.
-     *         (ReadNotification requires Account and Notification to be created)
      */
     public DataBundle persistDataBundle(DataBundle dataBundle)
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         if (dataBundle == null) {
             throw new InvalidParametersException("Null data bundle");
         }
@@ -339,8 +337,10 @@ public final class DataBundleLogic {
         fslLogic.createFeedbackSessionLogs(new ArrayList<>(sessionLogs));
 
         for (ReadNotification readNotification : readNotifications) {
-            accountsLogic.updateReadNotifications(readNotification.getAccount().getGoogleId(),
-                    readNotification.getNotification().getId(), readNotification.getNotification().getEndTime());
+            if (!readNotification.isValid()) {
+                throw new InvalidParametersException(readNotification.getInvalidityInfo());
+            }
+            HibernateUtil.persist(readNotification);
         }
 
         for (DeadlineExtension deadlineExtension : deadlineExtensions) {

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -43,7 +43,7 @@ public class LogicStarter implements ServletContextListener {
         UsersLogic usersLogic = UsersLogic.inst();
 
         accountRequestsLogic.initLogicDependencies(AccountRequestsDb.inst());
-        accountsLogic.initLogicDependencies(AccountsDb.inst(), notificationsLogic, usersLogic, coursesLogic);
+        accountsLogic.initLogicDependencies(AccountsDb.inst(), usersLogic, coursesLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic, usersLogic, accountsLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,
                 deadlineExtensionsLogic, fsLogic, fslLogic, fqLogic, frLogic, frcLogic,

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -129,6 +129,9 @@ public final class NotificationsLogic {
         return notificationsDb.getActiveNotificationsByTargetUser(targetUser);
     }
 
+    /**
+     * Gets a list of notifications that have been read by the account with {@code accountId}.
+     */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
         assert accountId != null;
         return notificationsDb.getReadNotificationsByAccountId(accountId);

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -11,7 +11,9 @@ import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlapi.NotificationsDb;
+import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
 
@@ -135,5 +137,20 @@ public final class NotificationsLogic {
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
         assert accountId != null;
         return notificationsDb.getReadNotificationsByAccountId(accountId);
+    }
+
+    /**
+     * Create a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
+     */
+    public ReadNotification createReadNotification(UUID accountId, UUID notificationId) {
+        assert accountId != null;
+        assert notificationId != null;
+
+        Account account = HibernateUtil.getReference(Account.class, accountId);
+        Notification notification = HibernateUtil.getReference(Notification.class, notificationId);
+
+        ReadNotification readNotification = new ReadNotification(account, notification);
+
+        return notificationsDb.createReadNotification(readNotification);
     }
 }

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -140,7 +140,7 @@ public final class NotificationsLogic {
     }
 
     /**
-     * Create a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
+     * Creates a read notification for the account with {@code accountId} and the notification with {@code notificationId}.
      */
     public ReadNotification createReadNotification(UUID accountId, UUID notificationId) {
         assert accountId != null;

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -13,6 +13,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.NotificationsDb;
 import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.ReadNotification;
 
 /**
  * Handles the logic related to notifications.
@@ -126,5 +127,10 @@ public final class NotificationsLogic {
     public List<Notification> getActiveNotificationsByTargetUser(NotificationTargetUser targetUser) {
         assert targetUser != null;
         return notificationsDb.getActiveNotificationsByTargetUser(targetUser);
+    }
+
+    public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
+        assert accountId != null;
+        return notificationsDb.getReadNotificationsByAccountId(accountId);
     }
 }

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -123,6 +123,14 @@ public final class NotificationsDb {
     }
 
     /**
+     * Creates a read notification.
+     */
+    public ReadNotification createReadNotification(ReadNotification readNotification) {
+        HibernateUtil.persist(readNotification);
+        return readNotification;
+    }
+
+    /**
      * Gets read notifications by account ID.
      *
      * @return a list of read notifications for the specified account ID.

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -17,6 +17,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.ReadNotification;
 
 /**
  * Handles CRUD operations for notifications.
@@ -121,4 +122,17 @@ public final class NotificationsDb {
         return HibernateUtil.merge(notification);
     }
 
+    /**
+     * Gets read notifications by account ID.
+     *
+     * @return a list of read notifications for the specified account ID.
+     */
+    public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<ReadNotification> cq = cb.createQuery(ReadNotification.class);
+        Root<ReadNotification> root = cq.from(ReadNotification.class);
+        cq.select(root).where(cb.equal(root.get("account").get("id"), accountId));
+        TypedQuery<ReadNotification> query = HibernateUtil.createQuery(cq);
+        return query.getResultList();
+    }
 }

--- a/src/main/java/teammates/storage/sqlentity/Account.java
+++ b/src/main/java/teammates/storage/sqlentity/Account.java
@@ -39,7 +39,7 @@ public class Account extends BaseEntity {
     @Column(nullable = false)
     private String email;
 
-    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<ReadNotification> readNotifications = new ArrayList<>();
 

--- a/src/main/java/teammates/ui/output/ReadNotificationData.java
+++ b/src/main/java/teammates/ui/output/ReadNotificationData.java
@@ -1,0 +1,32 @@
+package teammates.ui.output;
+
+import java.util.UUID;
+
+import teammates.storage.sqlentity.ReadNotification;
+
+/**
+ * Output format of a read notification.
+ */
+public class ReadNotificationData extends ApiOutput {
+    private final UUID readNotificationId;
+    private final UUID accountId;
+    private final UUID notificationId;
+
+    public ReadNotificationData(ReadNotification readNotification) {
+        this.readNotificationId = readNotification.getId();
+        this.accountId = readNotification.getAccount().getId();
+        this.notificationId = readNotification.getNotification().getId();
+    }
+
+    public UUID getReadNotificationId() {
+        return readNotificationId;
+    }
+
+    public UUID getAccountId() {
+        return accountId;
+    }
+
+    public UUID getNotificationId() {
+        return notificationId;
+    }
+}

--- a/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
+++ b/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
@@ -5,24 +5,17 @@ package teammates.ui.request;
  */
 public class MarkNotificationAsReadRequest extends BasicRequest {
     private String notificationId;
-    private long endTimestamp;
 
-    public MarkNotificationAsReadRequest(String notificationId, Long endTimestamp) {
+    public MarkNotificationAsReadRequest(String notificationId) {
         this.notificationId = notificationId;
-        this.endTimestamp = endTimestamp;
     }
 
     public String getNotificationId() {
         return this.notificationId;
     }
 
-    public Long getEndTimestamp() {
-        return this.endTimestamp;
-    }
-
     @Override
     public void validate() throws InvalidHttpRequestBodyException {
         assertTrue(notificationId != null, "Notification id should not be null.");
-        assertTrue(endTimestamp > 0L, "End timestamp should be more than zero");
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -1,12 +1,16 @@
 package teammates.ui.webapi;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.apache.http.HttpStatus;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
+import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Notification;
 import teammates.ui.output.NotificationsData;
 
@@ -73,11 +77,20 @@ public class GetNotificationsAction extends Action {
         }
 
         // Filter unread notifications
-        List<UUID> readNotifications = sqlLogic.getReadNotificationsId(userInfo.getId());
+        // TODO: This should be a single query to the database instead of fetching all notifications and filtering in memory
+        Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
+        if (account == null) {
+            // This should not happen as the user is authenticated
+            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+        Set<UUID> readNotifications = sqlLogic.getReadNotificationsByAccountId(account.getId())
+                .stream()
+                .map(n -> n.getNotification().getId())
+                .collect(Collectors.toSet());
         notifications = notifications
                 .stream()
                 .filter(n -> !readNotifications.contains(n.getId()))
-                .collect(Collectors.toList());
+                .toList();
 
         if (userInfo.isAdmin) {
             return new JsonResult(new NotificationsData(notifications));
@@ -90,6 +103,7 @@ public class GetNotificationsAction extends Action {
             }
             n.setShown();
         }
+
         return new JsonResult(new NotificationsData(notifications));
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -3,6 +3,9 @@ package teammates.ui.webapi;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.http.HttpStatus;
+
+import teammates.storage.sqlentity.Account;
 import teammates.ui.output.ReadNotificationsData;
 
 /**
@@ -21,8 +24,15 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     public ActionResult execute() {
+        Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
+        if (account == null) {
+            // This should not happen as the user is authenticated
+            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
         List<UUID> readNotifications =
-                sqlLogic.getReadNotificationsId(userInfo.getId());
+                sqlLogic.getReadNotificationsByAccountId(account.getId()).stream()
+                        .map(n -> n.getNotification().getId())
+                        .toList();
         ReadNotificationsData output = new ReadNotificationsData(readNotifications);
         return new JsonResult(output);
     }

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -2,6 +2,8 @@ package teammates.ui.webapi;
 
 import java.util.UUID;
 
+import org.apache.http.HttpStatus;
+
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.ReadNotification;
 import teammates.ui.output.ReadNotificationData;
@@ -30,6 +32,10 @@ public class MarkNotificationAsReadAction extends Action {
         UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
 
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
+        if (account == null) {
+            // This should not happen as the user is authenticated
+            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
         ReadNotification readNotification = sqlLogic.createReadNotification(account.getId(), notificationId);
         ReadNotificationData output = new ReadNotificationData(readNotification);
 

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -1,12 +1,10 @@
 package teammates.ui.webapi;
 
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
-import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
-import teammates.ui.output.ReadNotificationsData;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.ReadNotification;
+import teammates.ui.output.ReadNotificationData;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
@@ -30,17 +28,11 @@ public class MarkNotificationAsReadAction extends Action {
         MarkNotificationAsReadRequest readNotificationCreateRequest =
                 getAndValidateRequestBody(MarkNotificationAsReadRequest.class);
         UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
-        Instant endTime = Instant.ofEpochMilli(readNotificationCreateRequest.getEndTimestamp());
 
-        try {
-            List<UUID> readNotifications =
-                    sqlLogic.updateReadNotifications(userInfo.getId(), notificationId, endTime);
-            ReadNotificationsData output = new ReadNotificationsData(readNotifications);
-            return new JsonResult(output);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
-        } catch (InvalidParametersException e) {
-            throw new InvalidHttpRequestBodyException(e);
-        }
+        Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
+        ReadNotification readNotification = sqlLogic.createReadNotification(account.getId(), notificationId);
+        ReadNotificationData output = new ReadNotificationData(readNotification);
+
+        return new JsonResult(output);
     }
 }

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -5,20 +5,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.AccountsDb;
 import teammates.storage.sqlentity.Account;
-import teammates.storage.sqlentity.Notification;
-import teammates.storage.sqlentity.ReadNotification;
 import teammates.storage.sqlentity.User;
 import teammates.test.BaseTestCase;
 
@@ -31,8 +25,6 @@ public class AccountsLogicTest extends BaseTestCase {
 
     private AccountsDb accountsDb;
 
-    private NotificationsLogic notificationsLogic;
-
     private UsersLogic usersLogic;
 
     private CoursesLogic coursesLogic;
@@ -40,9 +32,8 @@ public class AccountsLogicTest extends BaseTestCase {
     @BeforeMethod
     public void setUpMethod() {
         accountsDb = mock(AccountsDb.class);
-        notificationsLogic = mock(NotificationsLogic.class);
         usersLogic = mock(UsersLogic.class);
-        accountsLogic.initLogicDependencies(accountsDb, notificationsLogic, usersLogic, coursesLogic);
+        accountsLogic.initLogicDependencies(accountsDb, usersLogic, coursesLogic);
     }
 
     @Test
@@ -77,95 +68,5 @@ public class AccountsLogicTest extends BaseTestCase {
             verify(usersLogic, times(1)).deleteUser(user);
         }
         verify(accountsDb, times(1)).deleteAccount(account);
-    }
-
-    @Test
-    public void testUpdateReadNotifications_shouldReturnCorrectReadNotificationId_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = getTypicalAccount();
-        Notification notification = getTypicalNotificationWithId();
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-        when(notificationsLogic.getNotification(notificationId)).thenReturn(notification);
-
-        List<UUID> readNotificationIds = accountsLogic.updateReadNotifications(googleId, notificationId,
-                notification.getEndTime());
-
-        verify(accountsDb, times(1)).getAccountByGoogleId(googleId);
-        verify(notificationsLogic, times(1)).getNotification(notificationId);
-
-        assertEquals(1, readNotificationIds.size());
-        assertEquals(notificationId, readNotificationIds.get(0));
-    }
-
-    @Test
-    public void testUpdateReadNotifications_shouldAddReadNotificationToAccount_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = getTypicalAccount();
-        Notification notification = getTypicalNotificationWithId();
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-        when(notificationsLogic.getNotification(notificationId)).thenReturn(notification);
-
-        accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime());
-
-        verify(accountsDb, times(1)).getAccountByGoogleId(googleId);
-        verify(notificationsLogic, times(1)).getNotification(notificationId);
-
-        List<ReadNotification> accountReadNotifications = account.getReadNotifications();
-        assertEquals(1, accountReadNotifications.size());
-        ReadNotification readNotification = accountReadNotifications.get(0);
-        assertSame(account, readNotification.getAccount());
-        assertSame(notification, readNotification.getNotification());
-    }
-
-    @Test
-    public void testUpdateReadNotifications_accountDoesNotExist_throwEntityDoesNotExistException() {
-        Account account = getTypicalAccount();
-        Notification notification = getTypicalNotificationWithId();
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(null);
-        when(notificationsLogic.getNotification(notificationId)).thenReturn(notification);
-
-        EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
-                () -> accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime()));
-        assertEquals("Trying to update the read notifications of a non-existent account.", ex.getMessage());
-    }
-
-    @Test
-    public void testUpdateReadNotifications_notificationDoesNotExist_throwEntityDoesNotExistException() {
-        Account account = getTypicalAccount();
-        Notification notification = getTypicalNotificationWithId();
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-        when(notificationsLogic.getNotification(notificationId)).thenReturn(null);
-
-        EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
-                () -> accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime()));
-        assertEquals("Trying to mark as read a notification that does not exist.", ex.getMessage());
-    }
-
-    @Test
-    public void testUpdateReadNotifications_markExpiredNotificationAsRead_throwInvalidParametersException() {
-        Account account = getTypicalAccount();
-        Notification notification = getTypicalNotificationWithId();
-        notification.setEndTime(Instant.parse("2012-01-01T00:00:00Z"));
-        String googleId = account.getGoogleId();
-        UUID notificationId = notification.getId();
-
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-        when(notificationsLogic.getNotification(notificationId)).thenReturn(notification);
-
-        InvalidParametersException ex = assertThrows(InvalidParametersException.class,
-                () -> accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime()));
-        assertEquals("Trying to mark an expired notification as read.", ex.getMessage());
     }
 }

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -168,39 +168,4 @@ public class AccountsLogicTest extends BaseTestCase {
                 () -> accountsLogic.updateReadNotifications(googleId, notificationId, notification.getEndTime()));
         assertEquals("Trying to mark an expired notification as read.", ex.getMessage());
     }
-
-    @Test
-    public void testGetReadNotificationsId_doesNotHaveReadNotifications_success() {
-        Account account = getTypicalAccount();
-        String googleId = account.getGoogleId();
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-
-        List<UUID> readNotifications = accountsLogic.getReadNotificationsId(googleId);
-
-        assertEquals(0, readNotifications.size());
-    }
-
-    @Test
-    public void testGetReadNotificationsId_hasReadNotifications_success() {
-        Account account = getTypicalAccount();
-        List<ReadNotification> readNotifications = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            Notification notification = getTypicalNotificationWithId();
-            ReadNotification readNotification = new ReadNotification(account, notification);
-            readNotifications.add(readNotification);
-        }
-        account.setReadNotifications(readNotifications);
-
-        String googleId = account.getGoogleId();
-        when(accountsDb.getAccountByGoogleId(googleId)).thenReturn(account);
-
-        List<UUID> actualReadNotifications = accountsLogic.getReadNotificationsId(googleId);
-
-        assertEquals(10, actualReadNotifications.size());
-
-        for (int i = 0; i < 10; i++) {
-            assertEquals(readNotifications.get(i).getNotification().getId(),
-                    actualReadNotifications.get(i));
-        }
-    }
 }

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -27,12 +27,11 @@ public class AccountsLogicTest extends BaseTestCase {
 
     private UsersLogic usersLogic;
 
-    private CoursesLogic coursesLogic;
-
     @BeforeMethod
     public void setUpMethod() {
         accountsDb = mock(AccountsDb.class);
         usersLogic = mock(UsersLogic.class);
+        CoursesLogic coursesLogic = mock(CoursesLogic.class);
         accountsLogic.initLogicDependencies(accountsDb, usersLogic, coursesLogic);
     }
 

--- a/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
@@ -1,13 +1,15 @@
 package teammates.sqllogic.core;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -15,6 +17,7 @@ import teammates.common.datatransfer.DataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
 import teammates.storage.sqlentity.Course;
@@ -34,6 +37,8 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     private final DataBundleLogic dataBundleLogic = DataBundleLogic.inst();
 
+    private MockedStatic<HibernateUtil> mockHibernateUtil;
+
     private AccountsLogic accountsLogic;
     private AccountRequestsLogic accountRequestsLogic;
     private CoursesLogic coursesLogic;
@@ -43,6 +48,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @BeforeMethod
     public void setUpMethod() {
+        mockHibernateUtil = mockStatic(HibernateUtil.class);
         accountsLogic = mock(AccountsLogic.class);
         accountRequestsLogic = mock(AccountRequestsLogic.class);
         coursesLogic = mock(CoursesLogic.class);
@@ -60,6 +66,11 @@ public class DataBundleLogicTest extends BaseTestCase {
                 fsLogic, fslLogic, fqLogic, frLogic, frcLogic, notificationsLogic, usersLogic);
     }
 
+    @AfterMethod
+    public void tearDown() {
+        mockHibernateUtil.close();
+    }
+
     @Test
     public void testPersistDataBundle_nullBundle_throwsException() {
         InvalidParametersException ex = assertThrows(InvalidParametersException.class,
@@ -69,7 +80,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_emptyBundle_success()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle emptyBundle = new DataBundle();
 
         DataBundle result = dataBundleLogic.persistDataBundle(emptyBundle);
@@ -83,7 +94,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withCourse_createsCourse()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Course course = getTypicalCourse();
         dataBundle.courses.put("course1", course);
@@ -102,7 +113,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withAccount_createsAccount()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Account account = getTypicalAccount();
         dataBundle.accounts.put("account1", account);
@@ -118,7 +129,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withNotification_createsNotification()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Notification notification = getTypicalNotificationWithId();
         dataBundle.notifications.put("notification1", notification);
@@ -137,7 +148,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withAccountRequest_createsAccountRequest()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         AccountRequest accountRequest = getTypicalAccountRequest();
         dataBundle.accountRequests.put("accountRequest1", accountRequest);
@@ -155,7 +166,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withMultipleEntities_createsAllEntities()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
 
         Course course = getTypicalCourse();
@@ -197,7 +208,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withSectionsAndTeams_createsHierarchy()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Course course = getTypicalCourse();
         Section section = new Section(course, "Section 1");
@@ -232,7 +243,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withStudentsAndInstructors_createsUsers()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Course course = getTypicalCourse();
         Section section = new Section(course, "Section 1");
@@ -273,7 +284,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withFeedbackSession_createsSession()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
@@ -295,7 +306,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_withReadNotifications_updatesReadNotifications()
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         DataBundle dataBundle = new DataBundle();
         Account account = getTypicalAccount();
         Notification notification = getTypicalNotificationWithId();
@@ -320,8 +331,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(account, result.accounts.get("account1"));
         assertEquals(notification, result.notifications.get("notification1"));
         assertEquals(readNotification, result.readNotifications.get("readNotification1"));
-        verify(accountsLogic, times(1)).updateReadNotifications(
-                eq(account.getGoogleId()), eq(notification.getId()), eq(notification.getEndTime()));
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(readNotification), times(1));
     }
 
     @Test

--- a/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Account;

--- a/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
@@ -1,5 +1,6 @@
 package teammates.sqllogic.core;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -194,5 +195,20 @@ public class NotificationsLogicTest extends BaseTestCase {
         assertSame(notification1, readNotifications.get(0).getNotification());
         assertSame(account, readNotifications.get(1).getAccount());
         assertSame(notification2, readNotifications.get(1).getNotification());
+    }
+
+    @Test
+    public void testCreateReadNotification_success() {
+        Account account = getTypicalAccount();
+        Notification notification = getTypicalNotificationWithId();
+
+        when(HibernateUtil.getReference(Account.class, account.getId())).thenReturn(account);
+        when(HibernateUtil.getReference(Notification.class, notification.getId())).thenReturn(notification);
+        when(notificationsDb.createReadNotification(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReadNotification result = notificationsLogic.createReadNotification(account.getId(), notification.getId());
+        verify(notificationsDb, times(1)).createReadNotification(any());
+        assertEquals(account.getId(), result.getAccount().getId());
+        assertEquals(notification.getId(), result.getNotification().getId());
     }
 }

--- a/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/NotificationsLogicTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import org.mockito.MockedStatic;
@@ -22,7 +23,9 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlapi.NotificationsDb;
+import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.ReadNotification;
 import teammates.test.BaseTestCase;
 
 /**
@@ -170,5 +173,26 @@ public class NotificationsLogicTest extends BaseTestCase {
                         "<p>Deprecation happens in three seconds</p>"));
 
         assertEquals("Trying to update non-existent Entity: " + Notification.class, ex.getMessage());
+    }
+
+    @Test
+    public void testGetReadNotificationsByAccountId_success() {
+        Account account = getTypicalAccount();
+        Notification notification1 = getTypicalNotificationWithId();
+        Notification notification2 = getTypicalNotificationWithId();
+
+        when(notificationsDb.getReadNotificationsByAccountId(account.getId())).thenReturn(List.of(
+                new ReadNotification(account, notification1),
+                new ReadNotification(account, notification2)
+        ));
+
+        List<ReadNotification> readNotifications = notificationsLogic.getReadNotificationsByAccountId(account.getId());
+        verify(notificationsDb, times(1)).getReadNotificationsByAccountId(account.getId());
+
+        assertEquals(2, readNotifications.size());
+        assertSame(account, readNotifications.get(0).getAccount());
+        assertSame(notification1, readNotifications.get(0).getNotification());
+        assertSame(account, readNotifications.get(1).getAccount());
+        assertSame(notification2, readNotifications.get(1).getNotification());
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.NotificationTargetUser;
@@ -22,7 +23,7 @@ import teammates.ui.webapi.JsonResult;
  * SUT: {@link GetNotificationsAction}.
  */
 public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsAction> {
-    private static final String GOOGLE_ID = "user-googleId";
+    private static final String GOOGLE_ID = "google-id";
     private static final int READ_NOTIFICATION_COUNT = 5;
     private static final int UNREAD_NOTIFICATION_COUNT = 10;
 
@@ -34,6 +35,11 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     @Override
     String getRequestMethod() {
         return GET;
+    }
+
+    @BeforeMethod
+    public void setUpMethod() {
+        when(mockLogic.getAccountForGoogleId(GOOGLE_ID)).thenReturn(getTypicalAccount());
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
@@ -5,13 +5,12 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
-import teammates.storage.sqlentity.Instructor;
-import teammates.storage.sqlentity.Notification;
+import teammates.storage.sqlentity.Account;
+import teammates.storage.sqlentity.ReadNotification;
 import teammates.ui.output.ReadNotificationsData;
 import teammates.ui.webapi.GetReadNotificationsAction;
 import teammates.ui.webapi.JsonResult;
@@ -35,16 +34,16 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
 
     @Test
     protected void testExecute_getReadNotificationsAsInstructor_shouldSucceed() {
-        Instructor instructor = getTypicalInstructor();
-        List<Notification> testNotifications = new ArrayList<>();
+        Account account = getTypicalAccount();
+        List<ReadNotification> testReadNotifications = new ArrayList<>();
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(account.getGoogleId());
         for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
-            testNotifications.add(getTypicalNotificationWithId());
+            testReadNotifications.add(new ReadNotification(account, getTypicalNotificationWithId()));
         }
 
-        List<UUID> testNotificationIds = testNotifications.stream().map(Notification::getId).collect(Collectors.toList());
-        when(mockLogic.getReadNotificationsId(instructor.getGoogleId())).thenReturn(testNotificationIds);
+        when(mockLogic.getAccountForGoogleId(account.getGoogleId())).thenReturn(account);
+        when(mockLogic.getReadNotificationsByAccountId(account.getId())).thenReturn(testReadNotifications);
 
         GetReadNotificationsAction action = getAction();
         JsonResult jsonResult = getJsonResult(action);
@@ -53,8 +52,9 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
 
         List<UUID> readNotificationsData = output.getReadNotifications();
 
-        readNotificationsData.forEach(notificationId ->
-                assertTrue(testNotificationIds.contains(notificationId)));
         assertEquals(READ_NOTIFICATION_COUNT, readNotificationsData.size());
+        readNotificationsData.forEach(notificationId ->
+                assertTrue(testReadNotifications.stream()
+                        .anyMatch(readNotification -> readNotification.getNotification().getId().equals(notificationId))));
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -1,24 +1,16 @@
 package teammates.sqlui.webapi;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.UUID;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
-import teammates.storage.sqlentity.Instructor;
+import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Notification;
-import teammates.ui.output.ReadNotificationsData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.storage.sqlentity.ReadNotification;
+import teammates.ui.output.ReadNotificationData;
 import teammates.ui.request.MarkNotificationAsReadRequest;
-import teammates.ui.webapi.EntityNotFoundException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.MarkNotificationAsReadAction;
 
@@ -26,8 +18,7 @@ import teammates.ui.webapi.MarkNotificationAsReadAction;
  * SUT: {@link MarkNotificationAsReadAction}.
  */
 public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotificationAsReadAction> {
-    Instructor instructor;
-    String instructorId;
+    Account account;
     Notification testNotification;
 
     @Override
@@ -42,82 +33,39 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
 
     @BeforeMethod
     void setUp() {
-        instructor = getTypicalInstructor();
-        instructorId = instructor.getGoogleId();
+        account = getTypicalAccount();
         testNotification = getTypicalNotificationWithId();
-        loginAsInstructor(instructorId);
+        loginAsInstructor(account.getGoogleId());
     }
 
     @Test
-    protected void testExecute_markNotificationAsRead_shouldSucceed() throws Exception {
-        when(mockLogic.updateReadNotifications(
-                instructorId,
-                testNotification.getId(),
-                testNotification.getEndTime()
-        )).thenReturn(List.of(testNotification.getId()));
+    protected void testExecute_markNotificationAsRead_shouldSucceed() {
+        ReadNotification readNotification = new ReadNotification(account, testNotification);
+        when(mockLogic.createReadNotification(
+                account.getId(),
+                testNotification.getId()
+        )).thenReturn(readNotification);
+        when(mockLogic.getAccountForGoogleId(account.getGoogleId())).thenReturn(account);
 
         MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
-                testNotification.getId().toString(), testNotification.getEndTime().toEpochMilli());
+                testNotification.getId().toString());
 
         MarkNotificationAsReadAction action = getAction(reqBody);
         JsonResult actionOutput = getJsonResult(action);
 
-        ReadNotificationsData response = (ReadNotificationsData) actionOutput.getOutput();
-        List<UUID> readNotifications = response.getReadNotifications();
-
-        assertTrue(readNotifications.contains(testNotification.getId()));
+        ReadNotificationData response = (ReadNotificationData) actionOutput.getOutput();
+        assertEquals(testNotification.getId(), response.getNotificationId());
+        assertEquals(account.getId(), response.getAccountId());
+        assertEquals(readNotification.getId(), response.getReadNotificationId());
     }
 
     @Test
     protected void testExecute_markInvalidNotificationAsRead_shouldThrowIllegalArgumentError() {
         MarkNotificationAsReadRequest reqBody =
-                new MarkNotificationAsReadRequest("invalid id", testNotification.getEndTime().toEpochMilli());
+                new MarkNotificationAsReadRequest("invalid id");
 
         MarkNotificationAsReadAction action = getAction(reqBody);
 
-        assertThrows(IllegalArgumentException.class, () -> action.execute());
-    }
-
-    @Test
-    protected void testExecute_markNonExistentNotificationAsRead_shouldFail() throws Exception {
-        UUID nonExistentNotificationId = UUID.randomUUID();
-
-        MarkNotificationAsReadRequest reqBody =
-                new MarkNotificationAsReadRequest(
-                        nonExistentNotificationId.toString(),
-                        testNotification.getEndTime().toEpochMilli());
-
-        when(mockLogic.updateReadNotifications(
-                any(),
-                eq(nonExistentNotificationId),
-                eq(testNotification.getEndTime()))).thenThrow(new EntityDoesNotExistException(""));
-
-        MarkNotificationAsReadAction action = getAction(reqBody);
-
-        assertThrows(EntityNotFoundException.class, () -> action.execute());
-    }
-
-    @Test
-    protected void testExecute_notificationEndTimeIsZero_shouldFail() {
-        MarkNotificationAsReadRequest reqBody =
-                new MarkNotificationAsReadRequest(testNotification.getId().toString(), 0L);
-        verifyHttpRequestBodyFailure(reqBody);
-    }
-
-    @Test
-    protected void testExecute_markExpiredNotificationAsRead_shouldFail() throws Exception {
-        when(mockLogic.updateReadNotifications(
-                instructorId,
-                testNotification.getId(),
-                testNotification.getEndTime()
-        )).thenThrow(new InvalidParametersException("Trying to mark an expired notification as read."));
-
-        MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
-                testNotification.getId().toString(),
-                testNotification.getEndTime().toEpochMilli());
-
-        MarkNotificationAsReadAction action = getAction(reqBody);
-
-        assertThrows(InvalidHttpRequestBodyException.class, () -> action.execute());
+        assertThrows(IllegalArgumentException.class, action::execute);
     }
 }

--- a/src/web/app/components/notification-banner/notification-banner.component.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.ts
@@ -57,7 +57,6 @@ export class NotificationBannerComponent implements OnInit, OnChanges {
   markNotificationAsRead(notification: Notification): void {
     this.notificationService.markNotificationAsRead({
       notificationId: notification.notificationId,
-      endTimestamp: notification.endTimestamp,
     })
       .subscribe({
         next: () => {

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -122,7 +122,6 @@ export class UserNotificationsListComponent implements OnInit {
     const notification: Notification = notificationTab.notification;
     this.notificationService.markNotificationAsRead({
       notificationId: notification.notificationId,
-      endTimestamp: notification.endTimestamp,
     })
       .subscribe({
         next: () => {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Refactor ReadNotification related functionality.

Key changes:

1. ReadNotification related functionality is moved from AccountsLogic to NotificationsLogic. This belongs to the notification domain not the accounts one. On the frontend, it is already correctly placed in notification service.
2. Removed redundant end time validity check when creating read notifications.
3. When creating a ReadNotification, we now pass in accountId and notificationId and create the ReadNotification entity directly. We no longer perform explicit existence checks for the account or notification; instead, we rely on Hibernate/database foreign key constraints to raise an exception if either referenced entity does not exist.
4. Changed the cascade type for read notifications on Account from CascadeType.ALL to CascadeType.REMOVE.
5. ReadNotificationData has been added. I plan to update ReadNotificationsData to use it in the near future. Currently, ReadNotificationsData returns only a list of notification IDs rather than ReadNotification objects. Returning the full entity is cleaner and more RESTful.
