### PR TITLE
[#13721] Remove unused readNotifications field from AccountData

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
@@ -143,10 +143,10 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         };
 
         Set<String> readNotificationIds = Stream.of(
-                testData.notifications.get("notification1"),
-                testData.notifications.get("notification2"),
-                testData.notifications.get("notification4") // notification 4 is already read when test starts
-        ).map(notification -> notification.getId().toString()).collect(Collectors.toSet());
+                firstNotificationId,
+                secondNotificationId,
+                testData.notifications.get("notification4").getId().toString() // notification 4 is already read when test starts
+        ).collect(Collectors.toSet());
 
         notificationsPage.verifyShownNotifications(shownNotifications, readNotificationIds);
     }

--- a/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
@@ -14,7 +14,6 @@ import teammates.e2e.pageobjects.StudentHomePage;
 import teammates.e2e.pageobjects.StudentNotificationsPage;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.Notification;
-import teammates.ui.output.AccountData;
 
 /**
  * SUT: {@link Const.WebPageURIs#STUDENT_NOTIFICATIONS_PAGE}.
@@ -131,9 +130,25 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         } else {
             assertFalse(homePage.isBannerVisible());
         }
-        AccountData accountFromDb = BACKDOOR.getAccountData(studentAccount.getGoogleId());
-        assertTrue(accountFromDb.getReadNotifications().containsKey(firstNotificationId));
-        assertTrue(accountFromDb.getReadNotifications().containsKey(secondNotificationId));
+
+        ______TS("verify that the notifications marked as read are reflected in the notifications page");
+        AppUrl studentNotificationsPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_NOTIFICATIONS_PAGE);
+        StudentNotificationsPage notificationsPage = loginToPage(studentNotificationsPageUrl, StudentNotificationsPage.class,
+                studentAccount.getGoogleId());
+
+        Notification[] shownNotifications = {
+                testData.notifications.get("notification1"),
+                testData.notifications.get("notification2"),
+                testData.notifications.get("notification4"),
+        };
+
+        Set<String> readNotificationIds = Stream.of(
+                testData.notifications.get("notification1"),
+                testData.notifications.get("notification2"),
+                testData.notifications.get("notification4") // notification 4 is already read when test starts
+        ).map(notification -> notification.getId().toString()).collect(Collectors.toSet());
+
+        notificationsPage.verifyShownNotifications(shownNotifications, readNotificationIds);
     }
 
     @AfterClass

--- a/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
@@ -145,7 +145,8 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         Set<String> readNotificationIds = Stream.of(
                 firstNotificationId,
                 secondNotificationId,
-                testData.notifications.get("notification4").getId().toString() // notification 4 is already read when test starts
+                // notification 4 is already read when test starts
+                testData.notifications.get("notification4").getId().toString()
         ).collect(Collectors.toSet());
 
         notificationsPage.verifyShownNotifications(shownNotifications, readNotificationIds);

--- a/src/main/java/teammates/ui/output/AccountData.java
+++ b/src/main/java/teammates/ui/output/AccountData.java
@@ -1,8 +1,6 @@
 package teammates.ui.output;
 
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import teammates.storage.sqlentity.Account;
 
@@ -15,19 +13,12 @@ public class AccountData extends ApiOutput {
     private final String googleId;
     private final String name;
     private final String email;
-    private final Map<String, Long> readNotifications;
 
     public AccountData(Account account) {
         this.accountId = account.getId();
         this.googleId = account.getGoogleId();
         this.name = account.getName();
         this.email = account.getEmail();
-        this.readNotifications = account.getReadNotifications()
-                .stream()
-                .collect(Collectors.toMap(
-                        readNotification -> readNotification.getNotification().getId().toString(),
-                        readNotification ->
-                                readNotification.getNotification().getEndTime().toEpochMilli()));
     }
 
     public UUID getAccountId() {
@@ -44,10 +35,6 @@ public class AccountData extends ApiOutput {
 
     public String getName() {
         return name;
-    }
-
-    public Map<String, Long> getReadNotifications() {
-        return this.readNotifications;
     }
 
 }

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
@@ -31,7 +31,6 @@ export class AdminAccountsPageComponent implements OnInit {
     googleId: '',
     name: '',
     email: '',
-    readNotifications: {},
   };
 
   isLoadingAccountInfo: boolean = false;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

- Remove unused readNotifications field from AccountData. Since readNotifications is no longer part of AccountsData this practice is no longer justified.
- Update the Notifications E2E test to assert notification behavior by checking the UI state instead of calling the API. This should be the standard going forward, as asserting behaviour through the UI makes tests less coupled to implementation details and directly verifies that the functionality works as expected.
