### PR TITLE
feat/oidc: Update unit and integration tests to use accountId

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
@@ -76,7 +76,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
                 () -> accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(),
-                studentInCourse.getGoogleId()));
+                studentInCourse.getAccountId()));
         assertEquals("Student has already joined course", eaee.getMessage());
 
         ______TS("success: with encryption and new account to be created");
@@ -85,7 +85,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         Account accountCreated = accountsLogic.getAccountForAccountId(loggedInGoogleId);
 
         assertEquals(loggedInGoogleId, usersLogic.getStudentForEmail(
-                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId());
+                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getAccountId());
         assertNotNull(accountCreated);
 
         ______TS("success: student joined but account already exists");
@@ -97,7 +97,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         accountsLogic.joinCourseForStudent(student3YetToJoinCourse.getRegKey(), existingAccountId);
 
         assertEquals(existingAccountId, usersLogic.getStudentForEmail(
-                student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getGoogleId());
+                student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getAccountId());
 
         ______TS("failure: already joined");
 
@@ -142,7 +142,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         Instructor joinedInstructor = usersLogic.getInstructorForEmail(
                         instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail());
-        assertEquals(loggedInGoogleId, joinedInstructor.getGoogleId());
+        assertEquals(loggedInGoogleId, joinedInstructor.getAccountId());
 
         Account accountCreated = accountsLogic.getAccountForAccountId(loggedInGoogleId);
         assertNotNull(accountCreated);
@@ -153,11 +153,11 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         Account existingAccount = new Account(existingAccountId, "accountName", instructor3YetToJoinCourse.getEmail());
         accountsDb.createAccount(existingAccount);
 
-        accountsLogic.joinCourseForInstructor(key[1], existingAccount.getGoogleId());
+        accountsLogic.joinCourseForInstructor(key[1], existingAccount.getId());
 
         joinedInstructor = usersLogic.getInstructorForEmail(
                         instructor3YetToJoinCourse.getCourseId(), existingAccount.getEmail());
-        assertEquals(existingAccountId, joinedInstructor.getGoogleId());
+        assertEquals(existingAccountId, joinedInstructor.getAccountId());
 
         ______TS("failure: instructor already joined");
 
@@ -188,7 +188,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ednee = assertThrows(EntityDoesNotExistException.class,
                 () -> accountsLogic.joinCourseForInstructor(instructor2YetToJoinCourse.getRegKey(),
-                    instructor2YetToJoinCourse.getGoogleId()));
+                    instructor2YetToJoinCourse.getAccountId()));
         assertEquals("The course you are trying to join has been deleted by an instructor", ednee.getMessage());
     }
 

--- a/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/AccountsLogicIT.java
@@ -82,7 +82,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: with encryption and new account to be created");
 
         accountsLogic.joinCourseForStudent(student2YetToJoinCourse.getRegKey(), loggedInGoogleId);
-        Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
+        Account accountCreated = accountsLogic.getAccountForAccountId(loggedInGoogleId);
 
         assertEquals(loggedInGoogleId, usersLogic.getStudentForEmail(
                 student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId());
@@ -144,7 +144,7 @@ public class AccountsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
                         instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail());
         assertEquals(loggedInGoogleId, joinedInstructor.getGoogleId());
 
-        Account accountCreated = accountsLogic.getAccountForGoogleId(loggedInGoogleId);
+        Account accountCreated = accountsLogic.getAccountForAccountId(loggedInGoogleId);
         assertNotNull(accountCreated);
 
         ______TS("success: instructor joined but account already exists");

--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -82,7 +82,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         usersLogic.resetInstructorGoogleId(email, courseId, googleId);
 
         assertNull(instructor.getAccount());
-        assertEquals(anotherAccount, accountsLogic.getAccountForGoogleId(googleId));
+        assertEquals(anotherAccount, accountsLogic.getAccountForAccountId(googleId));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         usersLogic.resetStudentGoogleId(email, courseId, googleId);
 
         assertNull(student.getAccount());
-        assertEquals(anotherAccount, accountsLogic.getAccountForGoogleId(googleId));
+        assertEquals(anotherAccount, accountsLogic.getAccountForAccountId(googleId));
     }
 
     @Test

--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -54,7 +54,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         String email = instructor.getEmail();
         String courseId = instructor.getCourseId();
-        String googleId = instructor.getGoogleId();
+        String googleId = instructor.getAccountId();
 
         ______TS("success: reset instructor that does not exist");
         assertThrows(EntityDoesNotExistException.class,
@@ -94,7 +94,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         String email = student.getEmail();
         String courseId = student.getCourseId();
-        String googleId = student.getGoogleId();
+        String googleId = student.getAccountId();
 
         ______TS("success: reset student that does not exist");
         assertThrows(EntityDoesNotExistException.class,

--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -86,7 +86,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
     }
 
     @Test
-    public void testResetStudentGoogleId()
+    public void testResetStudentAccountId()
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         Student student = getTypicalStudent();
         student.setCourse(course);
@@ -98,11 +98,11 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("success: reset student that does not exist");
         assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetStudentGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetStudentAccountId(email, courseId, googleId));
 
         ______TS("success: reset student that exists");
         usersLogic.createStudent(student);
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+        usersLogic.resetStudentAccountId(email, courseId, googleId);
 
         assertNull(student.getAccount());
         assertEquals(0, accountsLogic.getAccountsForEmail(email).size());
@@ -119,7 +119,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         anotherUser.setAccount(anotherAccount);
 
         usersLogic.createInstructor(anotherUser);
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+        usersLogic.resetStudentAccountId(email, courseId, googleId);
 
         assertNull(student.getAccount());
         assertEquals(anotherAccount, accountsLogic.getAccountForAccountId(googleId));

--- a/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/UsersLogicIT.java
@@ -46,7 +46,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
     }
 
     @Test
-    public void testResetInstructorGoogleId()
+    public void testResetInstructorAccountId()
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         Instructor instructor = getTypicalInstructor();
         instructor.setCourse(course);
@@ -58,11 +58,11 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("success: reset instructor that does not exist");
         assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetInstructorGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetInstructorAccountId(email, courseId, googleId));
 
         ______TS("success: reset instructor that exists");
         usersLogic.createInstructor(instructor);
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
+        usersLogic.resetInstructorAccountId(email, courseId, googleId);
 
         assertNull(instructor.getAccount());
         assertEquals(0, accountsLogic.getAccountsForEmail(email).size());
@@ -79,7 +79,7 @@ public class UsersLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         anotherUser.setAccount(anotherAccount);
 
         usersLogic.createStudent(anotherUser);
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
+        usersLogic.resetInstructorAccountId(email, courseId, googleId);
 
         assertNull(instructor.getAccount());
         assertEquals(anotherAccount, accountsLogic.getAccountForAccountId(googleId));

--- a/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
@@ -31,10 +31,10 @@ public class AccountsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         Account firstAccount = getTypicalAccount();
 
         Account secondAccount = getTypicalAccount();
-        secondAccount.setGoogleId(firstAccount.getGoogleId() + "-2");
+        secondAccount.setGoogleId(firstAccount.getId() + "-2");
 
         Account thirdAccount = getTypicalAccount();
-        thirdAccount.setGoogleId(firstAccount.getGoogleId() + "-3");
+        thirdAccount.setGoogleId(firstAccount.getId() + "-3");
 
         String email = firstAccount.getEmail();
 

--- a/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
@@ -97,7 +97,7 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         ______TS("success: gets an instructor by googleId");
         actualInstructor = usersDb.getInstructorByGoogleId(instructor.getCourseId(),
-                instructor.getAccount().getGoogleId());
+                instructor.getAccount().getId());
         verifyEquals(instructor, actualInstructor);
 
         ______TS("success: gets an instructor by googleId that does not exist");
@@ -133,7 +133,7 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertNull(actualStudent);
 
         ______TS("success: gets a student by googleId");
-        actualStudent = usersDb.getStudentByGoogleId(student.getCourseId(), student.getAccount().getGoogleId());
+        actualStudent = usersDb.getStudentByGoogleId(student.getCourseId(), student.getAccount().getId());
         verifyEquals(student, actualStudent);
 
         ______TS("success: gets a student by googleId that does not exist");
@@ -167,15 +167,15 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         usersDb.createStudent(secondStudent);
         secondStudent.setAccount(userSharedAccount);
 
-        List<User> users = usersDb.getAllUsersByGoogleId(userSharedAccount.getGoogleId());
+        List<User> users = usersDb.getAllUsersByGoogleId(userSharedAccount.getId());
         assertEquals(4, users.size());
         assertTrue(List.of(firstInstructor, secondInstructor, firstStudent, secondStudent).containsAll(users));
 
-        List<Instructor> instructors = usersDb.getAllInstructorsByGoogleId(userSharedAccount.getGoogleId());
+        List<Instructor> instructors = usersDb.getAllInstructorsByGoogleId(userSharedAccount.getId());
         assertEquals(2, instructors.size());
         assertTrue(List.of(firstInstructor, secondInstructor).containsAll(instructors));
 
-        List<Student> students = usersDb.getAllStudentsByGoogleId(userSharedAccount.getGoogleId());
+        List<Student> students = usersDb.getAllStudentsByGoogleId(userSharedAccount.getId());
         assertEquals(2, students.size());
         assertTrue(List.of(firstStudent, secondStudent).containsAll(students));
 
@@ -279,7 +279,7 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
         List<Student> expectedStudents = List.of(student, student2);
 
-        List<Student> actualStudents = usersDb.getStudentsByGoogleId(student.getGoogleId());
+        List<Student> actualStudents = usersDb.getStudentsByGoogleId(student.getAccountId());
 
         assertEquals(expectedStudents.size(), actualStudents.size());
         assertTrue(expectedStudents.containsAll(actualStudents));

--- a/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
@@ -347,7 +347,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         ______TS("Students cannot access");
         Student student = createTypicalStudent(course, "inaccessibleforstudents@teammates.tmt");
 
-        loginAsStudent(student.getAccount().getGoogleId());
+        loginAsStudent(student.getAccount().getId());
         verifyCannotAccess(params);
 
     }
@@ -357,7 +357,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         ______TS("Instructors cannot access");
         Instructor instructor = createTypicalInstructor(course, "inaccessibleforinstructors@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
         verifyCannotAccess(params);
 
     }
@@ -373,7 +373,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         mockUserProvision.setMaintainer(false);
 
         // not checking for non-masquerade mode because admin may not be an instructor
-        verifyCanMasquerade(instructor.getAccount().getGoogleId(), submissionParams);
+        verifyCanMasquerade(instructor.getAccount().getId(), submissionParams);
         mockUserProvision.setInstructor(false);
     }
 
@@ -389,7 +389,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         mockUserProvision.setStudent(false);
         mockUserProvision.setMaintainer(false);
         // not checking for non-masquerade mode because admin may not be an instructor
-        verifyCanMasquerade(instructor.getAccount().getGoogleId(), submissionParams);
+        verifyCanMasquerade(instructor.getAccount().getId(), submissionParams);
         mockUserProvision.setInstructor(false);
     }
 
@@ -400,7 +400,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         Instructor instructor = createTypicalInstructor(course,
                 "inaccessiblewithoutmodifysessionprivilege@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
         verifyCannotAccess(submissionParams);
     }
 
@@ -411,7 +411,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         Instructor instructor = createTypicalInstructor(course,
                 "inaccessiblewithoutsubmitsessioninsectionsprivilege@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
         verifyCannotAccess(submissionParams);
     }
 
@@ -422,7 +422,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
 
         ______TS("without correct course privilege cannot access");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
         verifyCannotAccess(submissionParams);
 
         ______TS("only instructor with correct course privilege should pass");
@@ -448,11 +448,11 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         Instructor instructorOtherCourse = createTypicalInstructor(courseOther,
                 "accessibleforinstructorsofthesamecourse-otherinstructor@teammates.tmt");
 
-        loginAsInstructor(instructorSameCourse.getAccount().getGoogleId());
+        loginAsInstructor(instructorSameCourse.getAccount().getId());
         verifyCanAccess(submissionParams);
 
-        verifyCannotMasquerade(studentSameCourse.getAccount().getGoogleId(), submissionParams);
-        verifyCannotMasquerade(instructorOtherCourse.getAccount().getGoogleId(), submissionParams);
+        verifyCannotMasquerade(studentSameCourse.getAccount().getId(), submissionParams);
+        verifyCannotMasquerade(instructorOtherCourse.getAccount().getId(), submissionParams);
 
     }
 
@@ -469,18 +469,18 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
         Instructor instructorOtherCourse = createTypicalInstructor(courseOther,
                 "accessibleforinstructorsofothercourse-otherinstructor@teammates.tmt");
 
-        loginAsInstructor(instructorOtherCourse.getAccount().getGoogleId());
+        loginAsInstructor(instructorOtherCourse.getAccount().getId());
         verifyCanAccess(submissionParams);
 
-        verifyCannotMasquerade(studentSameCourse.getAccount().getGoogleId(), submissionParams);
-        verifyCannotMasquerade(instructorSameCourse.getAccount().getGoogleId(), submissionParams);
+        verifyCannotMasquerade(studentSameCourse.getAccount().getId(), submissionParams);
+        verifyCannotMasquerade(instructorSameCourse.getAccount().getId(), submissionParams);
     }
 
     void verifyAccessibleForStudentsOfTheSameCourse(Course course, String[] submissionParams)
             throws InvalidParametersException, EntityAlreadyExistsException {
         ______TS("course students can access");
         Student student = createTypicalStudent(course, "accessibleforstudentsofthesamecourse@teammates.tmt");
-        loginAsStudent(student.getAccount().getGoogleId());
+        loginAsStudent(student.getAccount().getId());
         verifyCanAccess(submissionParams);
     }
 
@@ -492,7 +492,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
                 "inaccessibleforstudentsofothercourse-other@teammates.tmt");
         assert !course.getId().equals(courseOther.getId());
 
-        loginAsStudent(otherStudent.getAccount().getGoogleId());
+        loginAsStudent(otherStudent.getAccount().getId());
         verifyCannotAccess(submissionParams);
     }
 
@@ -504,7 +504,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithSql
                 "inaccessibleforinstructorsofothercourses@teammates.tmt");
         assert !course.getId().equals(courseOther.getId());
 
-        loginAsInstructor(otherInstructor.getAccount().getGoogleId());
+        loginAsInstructor(otherInstructor.getAccount().getId());
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/it/java/teammates/it/ui/webapi/CreateAccountActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountActionIT.java
@@ -51,7 +51,7 @@ public class CreateAccountActionIT extends BaseActionIT<CreateAccountAction> {
     @Transactional
     protected void testExecute() throws InvalidParametersException, EntityAlreadyExistsException {
         Account instructor1 = typicalBundle.accounts.get("unregisteredInstructor1");
-        loginAsUnregistered(instructor1.getGoogleId());
+        loginAsUnregistered(instructor1.getId());
 
         AccountRequest accReq = typicalBundle.accountRequests.get("unregisteredInstructor1");
         String email = accReq.getEmail();
@@ -106,7 +106,7 @@ public class CreateAccountActionIT extends BaseActionIT<CreateAccountAction> {
         ______TS("Normal case with invalid timezone, timezone should default to UTC");
 
         Account instructor2 = typicalBundle.accounts.get("unregisteredInstructor2");
-        loginAsUnregistered(instructor2.getGoogleId());
+        loginAsUnregistered(instructor2.getId());
 
         accReq = typicalBundle.accountRequests.get("unregisteredInstructor2");
         email = accReq.getEmail();

--- a/src/it/java/teammates/it/ui/webapi/CreateFeedbackQuestionActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateFeedbackQuestionActionIT.java
@@ -48,7 +48,7 @@ public class CreateFeedbackQuestionActionIT extends BaseActionIT<CreateFeedbackQ
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
 
-        loginAsInstructor(instructor1OfCourse1.getAccount().getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccount().getId());
 
         ______TS("Not enough parameters");
 
@@ -131,7 +131,7 @@ public class CreateFeedbackQuestionActionIT extends BaseActionIT<CreateFeedbackQ
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, "abcRandomSession",
         };
 
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
         verifyEntityNotFoundAcl(submissionParams);
 
         ______TS("inaccessible without ModifySessionPrivilege");

--- a/src/it/java/teammates/it/ui/webapi/CreateFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateFeedbackResponseCommentActionIT.java
@@ -45,7 +45,7 @@ public class CreateFeedbackResponseCommentActionIT extends BaseActionIT<CreateFe
         ______TS("Successful case: student submission");
         Student student = typicalBundle.students.get("student1InCourse1");
         FeedbackResponse fr = typicalBundle.feedbackResponses.get("response1ForQ1InSession2");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, fr.getId().toString(),
@@ -79,7 +79,7 @@ public class CreateFeedbackResponseCommentActionIT extends BaseActionIT<CreateFe
 
         ______TS("students access own response to give comments");
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
         verifyCanAccess(submissionParamsStudentToStudents);
     }
 

--- a/src/it/java/teammates/it/ui/webapi/DeleteFeedbackQuestionActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteFeedbackQuestionActionIT.java
@@ -49,7 +49,7 @@ public class DeleteFeedbackQuestionActionIT extends BaseActionIT<DeleteFeedbackQ
                 logic.getFeedbackQuestion(fq1.getId());
         assertEquals(FeedbackQuestionType.TEXT, typicalQuestion.getQuestionDetailsCopy().getQuestionType());
 
-        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+        loginAsInstructor(instructor1ofCourse1.getAccountId());
 
         ______TS("Not enough parameters");
 
@@ -82,7 +82,7 @@ public class DeleteFeedbackQuestionActionIT extends BaseActionIT<DeleteFeedbackQ
 
         FeedbackQuestion typicalQuestion = logic.getFeedbackQuestion(fq1.getId());
 
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
 
         ______TS("inaccessible without ModifySessionPrivilege");
 

--- a/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteFeedbackResponseCommentActionIT.java
@@ -65,14 +65,14 @@ public class DeleteFeedbackResponseCommentActionIT extends BaseActionIT<DeleteFe
         Instructor instructorWhoGiveComment = typicalBundle.instructors.get("instructor1OfCourse1");
 
         assertEquals(instructorWhoGiveComment.getEmail(), frc.getGiver());
-        loginAsInstructor(instructorWhoGiveComment.getGoogleId());
+        loginAsInstructor(instructorWhoGiveComment.getAccountId());
         verifyCanAccess(submissionParams);
 
         ______TS("Different instructor of same course cannot delete comment");
 
         Instructor differentInstructorInSameCourse = typicalBundle.instructors.get("instructor2OfCourse1");
         assertNotEquals(differentInstructorInSameCourse.getEmail(), frc.getGiver());
-        loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
+        loginAsInstructor(differentInstructorInSameCourse.getAccountId());
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -47,7 +47,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         loginAsAdmin();
 
         Instructor instructor = typicalBundle.instructors.get("instructor2OfCourse1");
-        String instructorId = instructor.getGoogleId();
+        String instructorId = instructor.getAccountId();
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INSTRUCTOR_ID, instructorId,
@@ -67,7 +67,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     public void testExecute_deleteInstructorByEmail_shouldPass() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor instructor2OfCourse1 = typicalBundle.instructors.get("instructor2OfCourse1");
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor2OfCourse1.getEmail(),
@@ -91,7 +91,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         loginAsAdmin();
 
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse3");
-        String instructorId = instructor.getGoogleId();
+        String instructorId = instructor.getAccountId();
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INSTRUCTOR_ID, instructorId,
@@ -105,17 +105,17 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructor.getCourseId(), instructor.getEmail()));
-        assertNotNull(logic.getInstructorByAccountId(instructor.getCourseId(), instructor.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructor.getCourseId(), instructor.getAccountId()));
     }
 
     @Test
     protected void testExecute_instructorDeleteOwnRoleByGoogleId_shouldPass() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor instructor2OfCourse1 = typicalBundle.instructors.get("instructor2OfCourse1");
-        loginAsInstructor(instructor2OfCourse1.getGoogleId());
+        loginAsInstructor(instructor2OfCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructor2OfCourse1.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor2OfCourse1.getAccountId(),
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
         };
 
@@ -136,11 +136,11 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         Instructor instructorToDelete = typicalBundle.instructors.get("instructor1OfCourse3");
         String courseId = instructorToDelete.getCourseId();
 
-        loginAsInstructor(instructorToDelete.getGoogleId());
+        loginAsInstructor(instructorToDelete.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getAccountId(),
         };
 
         assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
@@ -150,7 +150,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructorToDelete.getCourseId(), instructorToDelete.getEmail()));
-        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getAccountId()));
     }
 
     @Test
@@ -162,18 +162,18 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getAccountId(),
         };
 
         assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
 
         InvalidOperationException ioe = verifyInvalidOperation(
-                addUserIdToParams(instructorToDelete.getGoogleId(), submissionParams));
+                addUserIdToParams(instructorToDelete.getAccountId(), submissionParams));
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructorToDelete.getCourseId(), instructorToDelete.getEmail()));
-        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getAccountId()));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getAccountId(),
         };
 
         loginAsAdmin();
@@ -191,7 +191,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         assertTrue(logic.getInstructorsByCourse(courseId).size() > 1);
 
         DeleteInstructorAction deleteInstructorAction =
-                getAction(addUserIdToParams(instructorToDelete.getGoogleId(), submissionParams));
+                getAction(addUserIdToParams(instructorToDelete.getAccountId(), submissionParams));
         JsonResult response = getJsonResult(deleteInstructorAction);
 
         MessageOutput messageOutput = (MessageOutput) response.getOutput();
@@ -203,7 +203,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     @Test
     protected void testExecute_notEnoughParameters_shouldFail() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        String instructorId = instructor1OfCourse1.getGoogleId();
+        String instructorId = instructor1OfCourse1.getAccountId();
 
         String[] onlyInstructorParameter = new String[] {
                 Const.ParamsNames.INSTRUCTOR_ID, instructorId,
@@ -234,7 +234,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         attemptToDeleteFakeInstructorByEmail();
 
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
 
         attemptToDeleteFakeInstructorByGoogleId();
         attemptToDeleteFakeInstructorByEmail();
@@ -279,7 +279,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         loginAsAdmin();
 
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        String instructorId = instructor1OfCourse1.getGoogleId();
+        String instructorId = instructor1OfCourse1.getAccountId();
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INSTRUCTOR_ID, instructorId,

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -105,7 +105,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructor.getCourseId(), instructor.getEmail()));
-        assertNotNull(logic.getInstructorByGoogleId(instructor.getCourseId(), instructor.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructor.getCourseId(), instructor.getGoogleId()));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructorToDelete.getCourseId(), instructorToDelete.getEmail()));
-        assertNotNull(logic.getInstructorByGoogleId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
     }
 
     @Test
@@ -173,7 +173,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
         assertNotNull(logic.getInstructorForEmail(instructorToDelete.getCourseId(), instructorToDelete.getEmail()));
-        assertNotNull(logic.getInstructorByGoogleId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
+        assertNotNull(logic.getInstructorByAccountId(instructorToDelete.getCourseId(), instructorToDelete.getGoogleId()));
     }
 
     @Test
@@ -248,7 +248,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
         };
 
-        assertNull(logic.getInstructorByGoogleId(instructor1OfCourse1.getCourseId(), "fake-googleId"));
+        assertNull(logic.getInstructorByAccountId(instructor1OfCourse1.getCourseId(), "fake-googleId"));
 
         DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
         JsonResult response = getJsonResult(deleteInstructorAction);

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -43,7 +43,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         String courseId = instructor.getCourseId();
 
         ______TS("Typical Success Case delete a student by email");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
@@ -58,24 +58,24 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         ______TS("Typical Success Case delete a student by id");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_ACCOUNT_ID, student2InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student2InCourse1.getAccountId(),
         };
 
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNull(logic.getStudentByAccountId(courseId, student2InCourse1.getGoogleId()));
+        assertNull(logic.getStudentByAccountId(courseId, student2InCourse1.getAccountId()));
 
         ______TS("Course does not exist, fails silently");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, "non-existent-course",
-                Const.ParamsNames.STUDENT_ACCOUNT_ID, student3InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student3InCourse1.getAccountId(),
         };
 
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNotNull(logic.getStudentByAccountId(student3InCourse1.getCourseId(), student3InCourse1.getGoogleId()));
+        assertNotNull(logic.getStudentByAccountId(student3InCourse1.getCourseId(), student3InCourse1.getAccountId()));
 
         ______TS("Student does not exist, fails silently");
         params = new String[] {
@@ -102,7 +102,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         verifyHttpParameterFailure(params);
 
         params = new String[] {
-                Const.ParamsNames.STUDENT_ACCOUNT_ID, student1InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student1InCourse1.getAccountId(),
         };
 
         verifyAccessibleForAdmin(params);

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -64,7 +64,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNull(logic.getStudentByGoogleId(courseId, student2InCourse1.getGoogleId()));
+        assertNull(logic.getStudentByAccountId(courseId, student2InCourse1.getGoogleId()));
 
         ______TS("Course does not exist, fails silently");
         params = new String[] {
@@ -75,7 +75,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNotNull(logic.getStudentByGoogleId(student3InCourse1.getCourseId(), student3InCourse1.getGoogleId()));
+        assertNotNull(logic.getStudentByAccountId(student3InCourse1.getCourseId(), student3InCourse1.getGoogleId()));
 
         ______TS("Student does not exist, fails silently");
         params = new String[] {

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -58,7 +58,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         ______TS("Typical Success Case delete a student by id");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_ID, student2InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student2InCourse1.getGoogleId(),
         };
 
         deleteStudentAction = getAction(params);
@@ -69,7 +69,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         ______TS("Course does not exist, fails silently");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, "non-existent-course",
-                Const.ParamsNames.STUDENT_ID, student3InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student3InCourse1.getGoogleId(),
         };
 
         deleteStudentAction = getAction(params);
@@ -80,7 +80,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         ______TS("Student does not exist, fails silently");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_ID, "non-existent-id",
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, "non-existent-id",
         };
 
         deleteStudentAction = getAction(params);
@@ -102,7 +102,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         verifyHttpParameterFailure(params);
 
         params = new String[] {
-                Const.ParamsNames.STUDENT_ID, student1InCourse1.getGoogleId(),
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, student1InCourse1.getGoogleId(),
         };
 
         verifyAccessibleForAdmin(params);

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentsActionIT.java
@@ -44,7 +44,7 @@ public class DeleteStudentsActionIT extends BaseActionIT<DeleteStudentsAction> {
         int deleteLimit = 4;
 
         ______TS("Typical Success Case delete a limited number of students");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         List<Student> studentsToDelete = logic.getStudentsForCourse(courseId);
 

--- a/src/it/java/teammates/it/ui/webapi/EnrollStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/EnrollStudentsActionIT.java
@@ -66,7 +66,7 @@ public class EnrollStudentsActionIT extends BaseActionIT<EnrollStudentsAction> {
         Team team = logic.getTeamOrCreate(section, "Team 1");
         Student newStudent = new Student(course, "Test Student", "test@email.com", "Test Comment", team);
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,

--- a/src/it/java/teammates/it/ui/webapi/GetCoursesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetCoursesActionIT.java
@@ -46,7 +46,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
     @Test
     public void testGetCoursesAction_withNoParameter_shouldThrowHttpParameterException() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyHttpParameterFailure();
     }
 
@@ -54,7 +54,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
     public void testGetCoursesAction_withInvalidEntityType_shouldReturnBadResponse() {
         String[] params = new String[] { Const.ParamsNames.ENTITY_TYPE, "invalid_entity_type" };
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyHttpParameterFailure(params);
     }
 
@@ -62,7 +62,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
     public void testGetCoursesAction_withInstructorEntityTypeAndNoCourseStatus_shouldThrowParameterFailure() {
         String[] params = { Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR, };
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyHttpParameterFailure(params);
     }
 
@@ -74,7 +74,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
         };
 
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyHttpParameterFailure(params);
     }
 
@@ -85,7 +85,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
                 Const.ParamsNames.COURSE_STATUS, Const.CourseStatus.ACTIVE,
         };
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         CoursesData courses = getValidCourses(params);
         assertEquals(3, courses.getCourses().size());
@@ -105,7 +105,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
         };
 
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         CoursesData courses = getValidCourses(params);
         assertEquals(2, courses.getCourses().size());
@@ -119,7 +119,7 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
     public void testGetCoursesAction_withStudentEntityType_shouldReturnCorrectCourses() {
         String[] params = { Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT };
         Student student = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         CoursesData courses = getValidCourses(params);
         courses.getCourses().sort((c1, c2) -> c1.getCourseId().compareTo(c2.getCourseId()));
@@ -173,12 +173,12 @@ public class GetCoursesActionIT extends BaseActionIT<GetCoursesAction> {
         Student student = typicalBundle.students.get("student1InCourse1");
 
         ______TS("Login as instructor, only instructor entity type can access");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyCanAccess(instructorParams);
         verifyCannotAccess(studentParams);
 
         ______TS("Login as student, only student entity type can access");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
         verifyCanAccess(studentParams);
         verifyCannotAccess(instructorParams);
     }

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackResponseCommentActionIT.java
@@ -60,7 +60,7 @@ public class GetFeedbackResponseCommentActionIT extends BaseActionIT<GetFeedback
     protected void testAccessControl() throws Exception {
         ______TS("typical success case as student_submission");
         Student student1InCourse1 = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsStudent(student1InCourse1.getAccountId());
 
         FeedbackResponse fr = typicalBundle.feedbackResponses.get("response1ForQ1");
 

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionLogsActionIT.java
@@ -214,11 +214,11 @@ public class GetFeedbackSessionLogsActionIT extends BaseActionIT<GetFeedbackSess
         ______TS("Only instructors with modify student, session and instructor privilege can access");
         verifyCannotAccess(submissionParams);
 
-        loginAsInstructor(helper.getGoogleId());
+        loginAsInstructor(helper.getAccountId());
         verifyCannotAccess(submissionParams);
 
         ______TS("Only instructors of the same course can access");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyCanAccess(submissionParams);
     }
 

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -41,7 +41,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
     @Override
     protected void testExecute() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        String instructorId = instructor1OfCourse1.getGoogleId();
+        String instructorId = instructor1OfCourse1.getAccountId();
         Course course = typicalBundle.courses.get("course1");
         FeedbackSession fsa = typicalBundle.feedbackSessions.get("session1InCourse1");
 

--- a/src/it/java/teammates/it/ui/webapi/GetHasResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetHasResponsesActionIT.java
@@ -44,7 +44,7 @@ public class GetHasResponsesActionIT extends BaseActionIT<GetHasResponsesAction>
 
         FeedbackQuestion fq = typicalBundle.feedbackQuestions.get("qn1InSession1InCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getId().toString(),

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorActionIT.java
@@ -42,7 +42,7 @@ public class GetInstructorActionIT extends BaseActionIT<GetInstructorAction> {
         Course course = typicalBundle.courses.get("course1");
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
 
         ______TS("Typical Success Case with INSTRUCTOR_SUBMISSION");
         String[] params = {
@@ -96,7 +96,7 @@ public class GetInstructorActionIT extends BaseActionIT<GetInstructorAction> {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
         ______TS("only instructors of the same course with correct privilege can access");
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorActionIT.java
@@ -55,7 +55,7 @@ public class GetInstructorActionIT extends BaseActionIT<GetInstructorAction> {
 
         InstructorData response = (InstructorData) actionOutput.getOutput();
         assertEquals(instructor.getName(), response.getName());
-        assertNull(response.getGoogleId());
+        assertNull(response.getAccountId());
         assertNull(response.getKey());
 
         ______TS("Typical Success Case with FULL_DETAIL");

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorPrivilegeActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorPrivilegeActionIT.java
@@ -42,7 +42,7 @@ public class GetInstructorPrivilegeActionIT extends BaseActionIT<GetInstructorPr
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor otherInstructor = typicalBundle.instructors.get("instructor2OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         ______TS("Typical Success Case fetching privilege of self");
         String[] params = new String[] {
@@ -93,7 +93,7 @@ public class GetInstructorPrivilegeActionIT extends BaseActionIT<GetInstructorPr
         ______TS("Typical Success Case fetching privilege of another instructor by id");
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_ID, otherInstructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, otherInstructor.getAccountId(),
         };
 
         getInstructorPrivilegeAction = getAction(params);

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
@@ -43,7 +43,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     protected void testExecute() throws Exception {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         ______TS("Typical Success Case with FULL_DETAIL");
         String[] params = new String[] {
@@ -96,7 +96,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         Student student = typicalBundle.students.get("student1InCourse1");
 
         ______TS("Course not found, logged in as instructor, intent FULL_DETAIL");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, "does-not-exist-id",
@@ -106,7 +106,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         verifyEntityNotFoundAcl(params);
 
         ______TS("Course not found, logged in as student, intent undefined");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, "does-not-exist-id",
@@ -132,7 +132,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         verifyCannotAccess(params);
 
         ______TS("Unknown intent, logged in as instructor");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
@@ -150,7 +150,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         verifyOnlyInstructorsOfTheSameCourseCanAccess(instructor.getCourse(), params);
 
         ______TS("Intent undefined, should authenticate as student, access own course");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.COURSE_ID, student.getCourseId(),

--- a/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetInstructorsActionIT.java
@@ -74,7 +74,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
         assertEquals(3, instructors.size());
 
         for (InstructorData instructorData : instructors) {
-            assertNull(instructorData.getGoogleId());
+            assertNull(instructorData.getAccountId());
             assertNull(instructorData.getJoinState());
             assertNull(instructorData.getIsDisplayedToStudents());
             assertNull(instructorData.getRole());

--- a/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
@@ -127,8 +127,8 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         ______TS("Normal case: No logged in user for an unused regkey; should be valid/unused/allowed");
 
         try {
-            logic.resetStudentGoogleId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
-            logic.resetInstructorGoogleId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getGoogleId());
+            logic.resetStudentAcccountId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
+            logic.resetInstructorAccountId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getGoogleId());
         } catch (EntityDoesNotExistException e) {
             e.printStackTrace();
         }

--- a/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
@@ -127,7 +127,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         ______TS("Normal case: No logged in user for an unused regkey; should be valid/unused/allowed");
 
         try {
-            logic.resetStudentAcccountId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
+            logic.resetStudentAccountId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
             logic.resetInstructorAccountId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getGoogleId());
         } catch (EntityDoesNotExistException e) {
             e.printStackTrace();

--- a/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
@@ -77,7 +77,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Wrong logged in user for a used regkey; should be valid/used/disallowed");
 
-        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getGoogleId());
+        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,
@@ -94,7 +94,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Correct logged in user for a used regkey; should be valid/used/allowed");
 
-        loginAsStudent(student1.getGoogleId());
+        loginAsStudent(student1.getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, student1Key,
@@ -109,7 +109,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         assertTrue(output.isUsed());
         assertTrue(output.isAllowedAccess());
 
-        loginAsInstructor(instructor1.getGoogleId());
+        loginAsInstructor(instructor1.getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,
@@ -127,8 +127,8 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         ______TS("Normal case: No logged in user for an unused regkey; should be valid/unused/allowed");
 
         try {
-            logic.resetStudentAccountId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
-            logic.resetInstructorAccountId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getGoogleId());
+            logic.resetStudentAccountId(student1.getEmail(), student1.getCourseId(), student1.getAccountId());
+            logic.resetInstructorAccountId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getAccountId());
         } catch (EntityDoesNotExistException e) {
             e.printStackTrace();
         }
@@ -163,7 +163,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Any logged in user for an unused regkey; should be valid/unused/allowed");
 
-        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getGoogleId());
+        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getAccountId());
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,

--- a/src/it/java/teammates/it/ui/webapi/GetSessionResponseStatsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetSessionResponseStatsActionIT.java
@@ -39,7 +39,7 @@ public class GetSessionResponseStatsActionIT extends BaseActionIT<GetSessionResp
     @Test
     protected void testExecute() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         ______TS("typical: instructor accesses feedback stats of his/her course");
 

--- a/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
@@ -51,7 +51,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
     @Test
     protected void testExecute() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         ______TS("Typical: Instructor accesses results of their course");
 
@@ -134,7 +134,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
 
         ______TS("Typical: Student accesses results of their course");
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         submissionParams = new String[] {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, accessibleFeedbackSession.getName(),
@@ -157,7 +157,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
 
         ______TS("Typical: Student accesses results of their course by questionId");
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         FeedbackQuestion question = typicalBundle.feedbackQuestions.get("qn1InSession1InCourse1");
 
@@ -205,7 +205,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
         };
         Student student1InCourse1 = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsStudent(student1InCourse1.getAccountId());
         verifyCannotAccess(submissionParams);
 
         ______TS("Accessible for authenticated instructor when published");
@@ -317,7 +317,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
         };
 
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsStudent(student1InCourse1.getAccountId());
         verifyCanAccess(submissionParams);
     }
 
@@ -332,7 +332,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, unpublishedFeedbackSession.getName(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
         };
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsStudent(student1InCourse1.getAccountId());
         verifyCannotAccess(submissionParams);
     }
 
@@ -348,7 +348,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         };
 
         loginAsAdmin();
-        verifyCanMasquerade(student1InCourse1.getGoogleId(), submissionParams);
+        verifyCanMasquerade(student1InCourse1.getAccountId(), submissionParams);
     }
 
     @Test
@@ -364,7 +364,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
         };
 
-        loginAsStudent(studentInOtherCourse.getGoogleId());
+        loginAsStudent(studentInOtherCourse.getAccountId());
         verifyCannotAccess(submissionParams);
 
         // Malicious api call using course Id of the student to bypass the check

--- a/src/it/java/teammates/it/ui/webapi/GetStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetStudentActionIT.java
@@ -113,7 +113,7 @@ public class GetStudentActionIT extends BaseActionIT<GetStudentAction> {
 
         assertEquals(student.getName(), response.getName());
         assertEquals(student.getRegKey(), response.getKey());
-        assertEquals(student.getGoogleId(), response.getGoogleId());
+        assertEquals(student.getGoogleId(), response.getAccountId());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/GetStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetStudentActionIT.java
@@ -44,7 +44,7 @@ public class GetStudentActionIT extends BaseActionIT<GetStudentAction> {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
         ______TS("Typical Success Case logged in as instructor, Registered Student");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -58,7 +58,7 @@ public class GetStudentActionIT extends BaseActionIT<GetStudentAction> {
         assertEquals(student.getName(), response.getName());
 
         logoutUser();
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         ______TS("Typical Success Case logged in as student, Registered Student");
         params = new String[] {
@@ -113,7 +113,7 @@ public class GetStudentActionIT extends BaseActionIT<GetStudentAction> {
 
         assertEquals(student.getName(), response.getName());
         assertEquals(student.getRegKey(), response.getKey());
-        assertEquals(student.getGoogleId(), response.getAccountId());
+        assertEquals(student.getAccountId(), response.getAccountId());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class GetStudentActionIT extends BaseActionIT<GetStudentAction> {
                 Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
         };
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         verifyInaccessibleForInstructorsOfOtherCourses(course, params);
 

--- a/src/it/java/teammates/it/ui/webapi/GetStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetStudentsActionIT.java
@@ -45,7 +45,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
         Student student = typicalBundle.students.get("student1InCourse1");
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         ______TS("Typical Success Case with only course id, logged in as instructor");
         String[] params = new String[] {
@@ -67,7 +67,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
         assertEquals(student.getCourseId(), firstStudentInStudents.getCourseId());
 
         logoutUser();
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         ______TS("Typical Success Case with course id and team name, logged in as student");
         params = new String[] {
@@ -104,7 +104,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
                 Const.ParamsNames.COURSE_ID, course.getId(),
         };
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         verifyCanAccess(params);
 
@@ -115,7 +115,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
                 Const.ParamsNames.TEAM_NAME, student.getTeamName(),
         };
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
 
         verifyCanAccess(params);
 

--- a/src/it/java/teammates/it/ui/webapi/GetStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetStudentsActionIT.java
@@ -61,7 +61,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
 
         StudentData firstStudentInStudents = students.get(0);
 
-        assertNull(firstStudentInStudents.getGoogleId());
+        assertNull(firstStudentInStudents.getAccountId());
         assertNull(firstStudentInStudents.getKey());
         assertEquals(student.getName(), firstStudentInStudents.getName());
         assertEquals(student.getCourseId(), firstStudentInStudents.getCourseId());
@@ -86,7 +86,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
 
         StudentData actualOtherTeamMember = students.get(1);
 
-        assertNull(actualOtherTeamMember.getGoogleId());
+        assertNull(actualOtherTeamMember.getAccountId());
         assertNull(actualOtherTeamMember.getKey());
         assertEquals(expectedOtherTeamMember.getName(), actualOtherTeamMember.getName());
         assertEquals(expectedOtherTeamMember.getCourseId(), actualOtherTeamMember.getCourseId());

--- a/src/it/java/teammates/it/ui/webapi/RegenerateInstructorKeyActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/RegenerateInstructorKeyActionIT.java
@@ -117,7 +117,7 @@ public class RegenerateInstructorKeyActionIT extends BaseActionIT<RegenerateInst
         verifyOnlyAdminCanAccess(course, submissionParams);
 
         ______TS("Instructors cannot access");
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
 
         verifyInaccessibleForInstructors(course, submissionParams);
     }

--- a/src/it/java/teammates/it/ui/webapi/RegenerateStudentKeyActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/RegenerateStudentKeyActionIT.java
@@ -117,7 +117,7 @@ public class RegenerateStudentKeyActionIT extends BaseActionIT<RegenerateStudent
         verifyOnlyAdminCanAccess(course, submissionParams);
 
         ______TS("Students cannot access");
-        loginAsStudent(student.getAccount().getGoogleId());
+        loginAsStudent(student.getAccount().getId());
 
         verifyInaccessibleForStudents(course, submissionParams);
     }

--- a/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
@@ -57,7 +57,7 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
         assertEquals(response.getMessage(), "Account is successfully reset.");
         assertNotNull(student);
         assertNull(student.getAccount());
-        assertNull(student.getGoogleId());
+        assertNull(student.getAccountId());
 
         ______TS("Student Email param given but Student is non existent");
         String invalidEmail = "does-not-exist-email@teammates.tmt";
@@ -82,7 +82,7 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
         assertEquals(response.getMessage(), "Account is successfully reset.");
         assertNotNull(instructor);
         assertNull(instructor.getAccount());
-        assertNull(instructor.getGoogleId());
+        assertNull(instructor.getAccountId());
 
         ______TS("Instructor Email param given but Instructor is non existent");
         invalidParams = new String[] {

--- a/src/it/java/teammates/it/ui/webapi/SearchInstructorsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchInstructorsActionIT.java
@@ -93,7 +93,7 @@ public class SearchInstructorsActionIT extends BaseActionIT<SearchInstructorsAct
     @Test
     protected void testExecute_searchGoogleId_shouldSucceed() {
         loginAsAdmin();
-        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, instructor.getGoogleId() };
+        String[] submissionParams = new String[] { Const.ParamsNames.SEARCH_KEY, instructor.getAccountId() };
         SearchInstructorsAction action = getAction(submissionParams);
         JsonResult result = getJsonResult(action);
         InstructorsData response = (InstructorsData) result.getOutput();

--- a/src/it/java/teammates/it/ui/webapi/SearchStudentsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SearchStudentsActionIT.java
@@ -73,7 +73,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
         loginAsAdmin();
         verifyHttpParameterFailure(instructorParams);
 
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
         verifyHttpParameterFailure(adminParams);
     }
 
@@ -142,7 +142,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
 
     @Test
     public void execute_instructorSearchGoogleId_matchOnlyStudentsInCourse() {
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
         String[] googleIdParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "student1",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
@@ -156,7 +156,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
 
     @Test
         public void execute_searchWithoutSearchService_shouldSucceed() {
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccountId());
         String[] params = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "student1",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -66,7 +66,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private Instructor loginInstructor(String instructorId) {
         Instructor instructor = getInstructor(instructorId);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         HibernateUtil.flushSession();
         return instructor;
     }
@@ -87,7 +87,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private Student loginStudent(String studentId) {
         Student student = getStudent(studentId);
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student.getAccountId());
         HibernateUtil.flushSession();
         return student;
     }
@@ -502,7 +502,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         questionNumber = 2;
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.STUDENT_SUBMISSION);
 
-        verifyCanMasquerade(student.getGoogleId(), submissionParams);
+        verifyCanMasquerade(student.getAccountId(), submissionParams);
 
         ______TS("Typical success with instructor: instructor answers question with correct giver");
         loginInstructor("instructor1OfCourse1");
@@ -567,7 +567,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         questionNumber = 4;
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
 
-        verifyCanMasquerade(instructor.getGoogleId(), submissionParams);
+        verifyCanMasquerade(instructor.getAccountId(), submissionParams);
 
         ______TS("Failure with instructor: instructor logged in as student");
         loginStudent("student1InCourse1");
@@ -590,7 +590,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
 
         verifyCanAccess(submissionParams);
-        verifyCanMasquerade(instructor.getGoogleId(), submissionParams);
+        verifyCanMasquerade(instructor.getAccountId(), submissionParams);
 
         ______TS("Failure with instructor: instructor has no modify session comment privileges");
         loginInstructor("instructor1OfCourse1");
@@ -603,7 +603,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
 
         verifyCannotAccess(submissionParams);
-        verifyCannotMasquerade(instructor.getGoogleId(), submissionParams);
+        verifyCannotMasquerade(instructor.getAccountId(), submissionParams);
 
         // Reset privileges
         setSubmitSessionInSectionsInstructorPrivilege(session, instructor, true);

--- a/src/it/java/teammates/it/ui/webapi/UpdateFeedbackQuestionActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateFeedbackQuestionActionIT.java
@@ -51,7 +51,7 @@ public class UpdateFeedbackQuestionActionIT extends BaseActionIT<UpdateFeedbackQ
         FeedbackQuestion typicalQuestion = logic.getFeedbackQuestion(fq1.getId());
         assertEquals(FeedbackQuestionType.TEXT, typicalQuestion.getQuestionDetailsCopy().getQuestionType());
 
-        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+        loginAsInstructor(instructor1ofCourse1.getAccountId());
 
         ______TS("Not enough parameters");
 
@@ -118,7 +118,7 @@ public class UpdateFeedbackQuestionActionIT extends BaseActionIT<UpdateFeedbackQ
 
         ______TS("non-existent feedback question");
 
-        loginAsInstructor(instructor1OfCourse1.getAccount().getGoogleId());
+        loginAsInstructor(instructor1OfCourse1.getAccount().getId());
 
         verifyEntityNotFoundAcl(Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000");
 

--- a/src/it/java/teammates/it/ui/webapi/UpdateFeedbackResponseCommentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateFeedbackResponseCommentActionIT.java
@@ -43,7 +43,7 @@ public class UpdateFeedbackResponseCommentActionIT extends BaseActionIT<UpdateFe
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackResponseComment frc = typicalBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1");
         ______TS("Typical successful case for INSTRUCTOR_RESULT");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String [] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
@@ -74,7 +74,7 @@ public class UpdateFeedbackResponseCommentActionIT extends BaseActionIT<UpdateFe
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, frc.getId().toString(),
         };
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyCanAccess(submissionParams);
     }
 

--- a/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
@@ -67,7 +67,7 @@ public class UpdateInstructorActionIT extends BaseActionIT<UpdateInstructorActio
 
         InstructorData response = (InstructorData) actionOutput.getOutput();
 
-        Instructor editedInstructor = logic.getInstructorByGoogleId(courseId, instructorId);
+        Instructor editedInstructor = logic.getInstructorByAccountId(courseId, instructorId);
         assertEquals(newInstructorName, editedInstructor.getName());
         assertEquals(newInstructorName, response.getName());
         assertEquals(newInstructorEmail, editedInstructor.getEmail());
@@ -124,7 +124,7 @@ public class UpdateInstructorActionIT extends BaseActionIT<UpdateInstructorActio
 
         response = (InstructorData) actionOutput.getOutput();
 
-        editedInstructor = logic.getInstructorByGoogleId(courseId, instructorId);
+        editedInstructor = logic.getInstructorByAccountId(courseId, instructorId);
         assertEquals(newInstructorEmail, editedInstructor.getEmail());
         assertEquals(newInstructorEmail, response.getEmail());
         assertEquals(newInstructorName, editedInstructor.getName());

--- a/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
@@ -42,7 +42,7 @@ public class UpdateInstructorActionIT extends BaseActionIT<UpdateInstructorActio
     @Test
     protected void testExecute() {
         Instructor instructorToEdit = typicalBundle.instructors.get("instructor2OfCourse1");
-        String instructorId = instructorToEdit.getGoogleId();
+        String instructorId = instructorToEdit.getAccountId();
         String courseId = instructorToEdit.getCourseId();
         String instructorDisplayName = instructorToEdit.getDisplayName();
 
@@ -95,9 +95,9 @@ public class UpdateInstructorActionIT extends BaseActionIT<UpdateInstructorActio
 
         instructorToEdit = typicalBundle.instructors.get("instructor1OfCourse3");
 
-        loginAsInstructor(instructorToEdit.getGoogleId());
+        loginAsInstructor(instructorToEdit.getAccountId());
 
-        reqBody = new InstructorCreateRequest(instructorToEdit.getGoogleId(), instructorToEdit.getName(),
+        reqBody = new InstructorCreateRequest(instructorToEdit.getAccountId(), instructorToEdit.getName(),
                 instructorToEdit.getEmail(), Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
                 null, false);
 

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -58,7 +58,7 @@ public class AccountsLogicTest extends BaseTestCase {
             users.add(getTypicalStudent());
         }
 
-        when(usersLogic.getAllUsersByGoogleId(googleId)).thenReturn(users);
+        when(usersLogic.getAllUsersByAccountId(googleId)).thenReturn(users);
         when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
 
         accountsLogic.deleteAccountCascade(googleId);

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -38,7 +38,7 @@ public class AccountsLogicTest extends BaseTestCase {
     @Test
     public void testDeleteAccount_accountExists_success() {
         Account account = getTypicalAccount();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
@@ -50,7 +50,7 @@ public class AccountsLogicTest extends BaseTestCase {
     @Test
     public void testDeleteAccountCascade_googleIdExists_success() {
         Account account = getTypicalAccount();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
         List<User> users = new ArrayList<>();
 
         for (int i = 0; i < 2; ++i) {

--- a/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountsLogicTest.java
@@ -40,7 +40,7 @@ public class AccountsLogicTest extends BaseTestCase {
         Account account = getTypicalAccount();
         String googleId = account.getGoogleId();
 
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
         accountsLogic.deleteAccount(googleId);
 
@@ -59,7 +59,7 @@ public class AccountsLogicTest extends BaseTestCase {
         }
 
         when(usersLogic.getAllUsersByAccountId(googleId)).thenReturn(users);
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
         accountsLogic.deleteAccountCascade(googleId);
 

--- a/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
@@ -378,7 +378,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
         verify(coursesLogic, times(1)).deleteCourseCascade(course.getId());
         verify(notificationsLogic, times(1)).deleteNotification(notification.getId());
-        verify(accountsLogic, times(1)).deleteAccount(account.getGoogleId());
+        verify(accountsLogic, times(1)).deleteAccount(account.getId());
         verify(accountRequestsLogic, times(1)).deleteAccountRequest(accountRequest.getId());
     }
 
@@ -401,7 +401,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
         dataBundleLogic.removeDataBundle(dataBundle);
 
-        verify(accountsLogic, times(1)).deleteAccount(account.getGoogleId());
+        verify(accountsLogic, times(1)).deleteAccount(account.getId());
     }
 
     @Test

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -68,7 +68,7 @@ public class UsersLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException {
         String courseId = instructor.getCourseId();
         String email = instructor.getEmail();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(instructor);
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
@@ -89,7 +89,7 @@ public class UsersLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException {
         String courseId = instructor.getCourseId();
         String email = instructor.getEmail();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(null);
 
@@ -105,7 +105,7 @@ public class UsersLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException {
         String courseId = student.getCourseId();
         String email = student.getEmail();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(student);
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
@@ -122,7 +122,7 @@ public class UsersLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException {
         String courseId = student.getCourseId();
         String email = student.getEmail();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(null);
 

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -101,7 +101,7 @@ public class UsersLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testResetStudentGoogleId_studentExistsWithEmptyUsersListFromGoogleId_success()
+    public void testResetStudentGoogleId_studentExistsWithEmptyUsersListFromAccountId_success()
             throws EntityDoesNotExistException {
         String courseId = student.getCourseId();
         String email = student.getEmail();
@@ -111,14 +111,14 @@ public class UsersLogicTest extends BaseTestCase {
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
         when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+        usersLogic.resetStudentAccountId(email, courseId, googleId);
 
         assertNull(student.getAccount());
         verify(accountsLogic, times(1)).deleteAccountCascade(googleId);
     }
 
     @Test
-    public void testResetStudentGoogleId_entityDoesNotExists_throwsEntityDoesNotExistException()
+    public void testResetStudentAccountId_entityDoesNotExists_throwsEntityDoesNotExistException()
             throws EntityDoesNotExistException {
         String courseId = student.getCourseId();
         String email = student.getEmail();
@@ -127,7 +127,7 @@ public class UsersLogicTest extends BaseTestCase {
         when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(null);
 
         EntityDoesNotExistException exception = assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetStudentGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetStudentAccountId(email, courseId, googleId));
 
         assertEquals(ERROR_UPDATE_NON_EXISTENT
                 + "Student [courseId=" + courseId + ", email=" + email + "]", exception.getMessage());

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -64,7 +64,7 @@ public class UsersLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testResetInstructorGoogleId_instructorExistsWithEmptyUsersListFromGoogleId_success()
+    public void testResetInstructorGoogleId_instructorExistsWithEmptyUsersListFromAccountId_success()
             throws EntityDoesNotExistException {
         String courseId = instructor.getCourseId();
         String email = instructor.getEmail();
@@ -78,7 +78,7 @@ public class UsersLogicTest extends BaseTestCase {
         instructorsList.add(instructor);
         when(usersLogic.getInstructorsForCourse(courseId)).thenReturn(instructorsList);
 
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
+        usersLogic.resetInstructorAccountId(email, courseId, googleId);
 
         assertEquals(null, instructor.getAccount());
         verify(accountsLogic, times(1)).deleteAccountCascade(googleId);
@@ -94,7 +94,7 @@ public class UsersLogicTest extends BaseTestCase {
         when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(null);
 
         EntityDoesNotExistException exception = assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetInstructorGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetInstructorAccountId(email, courseId, googleId));
 
         assertEquals(ERROR_UPDATE_NON_EXISTENT
                 + "Instructor [courseId=" + courseId + ", email=" + email + "]", exception.getMessage());

--- a/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/UsersLogicTest.java
@@ -72,7 +72,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(instructor);
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
         List<Instructor> instructorsList = new ArrayList<>();
         instructorsList.add(instructor);
@@ -109,7 +109,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(student);
         when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(accountsLogic.getAccountForAccountId(googleId)).thenReturn(account);
 
         usersLogic.resetStudentGoogleId(email, courseId, googleId);
 

--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -730,9 +730,9 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructor);
 
         if (canMasquerade) {
-            verifyCanMasquerade(instructor.getGoogleId(), params);
+            verifyCanMasquerade(instructor.getAccountId(), params);
         } else {
-            verifyCannotMasquerade(instructor.getGoogleId(), params);
+            verifyCannotMasquerade(instructor.getAccountId(), params);
         }
 
         mockUserProvision.setInstructor(false);

--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -727,7 +727,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         mockUserProvision.setInstructor(true);
         mockUserProvision.setStudent(false);
         mockUserProvision.setMaintainer(false);
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructor);
 
         if (canMasquerade) {
             verifyCanMasquerade(instructor.getGoogleId(), params);
@@ -742,7 +742,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         Instructor sameCourseInstructor = getTypicalInstructor();
         sameCourseInstructor.setCourse(thisCourse);
 
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(sameCourseInstructor);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(sameCourseInstructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
         logoutUser();
@@ -754,7 +754,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
         otherCourseInstructor.setCourse(otherCourse);
 
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(otherCourseInstructor);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(otherCourseInstructor);
 
         logoutUser();
         loginAsInstructor(otherCourseInstructor.getId().toString());
@@ -773,7 +773,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         Instructor instructor = getTypicalInstructor();
         instructor.setAccount(new Account("instructor-googleId", instructor.getName(), instructor.getEmail()));
 
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
         instructor.setCourse(thisCourse);
@@ -805,7 +805,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             Course thisCourse, InstructorPrivileges instructorPrivileges, boolean canAccess, String... params) {
         Instructor instructor = getTypicalInstructor();
 
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
         instructor.setCourse(thisCourse);

--- a/src/test/java/teammates/sqlui/webapi/BinCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BinCourseActionTest.java
@@ -75,7 +75,7 @@ public class BinCourseActionTest extends BaseActionTest<BinCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -95,7 +95,7 @@ public class BinCourseActionTest extends BaseActionTest<BinCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/BinFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BinFeedbackSessionActionTest.java
@@ -58,7 +58,7 @@ public class BinFeedbackSessionActionTest extends BaseActionTest<BinFeedbackSess
 
     @Test
     void testExecute_typicalCase_success() throws Exception {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalFeedbackSession.getCourseId(),
@@ -84,7 +84,7 @@ public class BinFeedbackSessionActionTest extends BaseActionTest<BinFeedbackSess
 
     @Test
     void testExecute_invalidHttpParameters_throwsInvalidHttpParameterException() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyHttpParameterFailure();
         verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, typicalFeedbackSession.getCourseId());
@@ -93,7 +93,7 @@ public class BinFeedbackSessionActionTest extends BaseActionTest<BinFeedbackSess
 
     @Test
     void testAccessControl_nonExistentFeedbackSession_throwsEntityNotFoundException() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalFeedbackSession.getCourseId(),

--- a/src/test/java/teammates/sqlui/webapi/CreateCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateCourseActionTest.java
@@ -60,7 +60,7 @@ public class CreateCourseActionTest extends BaseActionTest<CreateCourseAction> {
         expectedCourse.setCreatedAt(Instant.parse("2022-01-01T00:00:00Z"));
 
         when(mockLogic.createCourse(course)).thenReturn(expectedCourse);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
         mockHibernateUtil.when(HibernateUtil::flushSession).thenAnswer(Answers.RETURNS_DEFAULTS);
 
         CourseCreateRequest request = new CourseCreateRequest();

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackQuestionActionTest.java
@@ -204,7 +204,7 @@ public class CreateFeedbackQuestionActionTest extends BaseActionTest<CreateFeedb
                 Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyEntityNotFoundAcl(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -149,7 +149,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Arrays.asList(CommentVisibilityType.INSTRUCTORS));
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenThrow(EntityAlreadyExistsException.class);
@@ -176,7 +176,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -208,7 +208,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -239,7 +239,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -270,7 +270,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -301,7 +301,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -332,7 +332,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -363,7 +363,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -395,7 +395,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -426,7 +426,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorSubmission();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -456,7 +456,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForStudentSubmission();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
@@ -474,7 +474,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Test
     void testAccessControl_typicalCaseForInstructorResult_canAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         loginAsInstructor(typicalInstructor.getGoogleId());
 
@@ -514,7 +514,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(contributionResponse.getId())).thenReturn(contributionResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -537,7 +537,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Test
     void testAccessControl_submitCommentForOthersResponse_cannotAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
 
         String[] params = new String[] {
@@ -562,7 +562,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
                 .thenReturn(instructorWithoutAccess);
 
         loginAsInstructor(instructorWithoutAccess.getGoogleId());
@@ -585,7 +585,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -634,7 +634,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
                 .thenReturn(instructorInSameCourse);
 
         verifyCanAccess(params);
@@ -643,7 +643,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Test
     void testAccessControl_adminToMasqueradeAsInstructor_canAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(any(String.class), any(String.class)))
+        when(mockLogic.getInstructorByAccountId(any(String.class), any(String.class)))
                 .thenReturn(typicalInstructor);
 
         loginAsAdmin();
@@ -669,7 +669,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         // mock the extended deadline to be 10 minutes ago with a 15 minute grace period
@@ -699,7 +699,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(feedbackSessionPastEndTime.getEndTime());
@@ -728,7 +728,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
 
         // mock the extended deadline to be 10 minutes in the future
@@ -759,7 +759,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(feedbackSessionPastEndTime.getEndTime());

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -149,12 +149,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Arrays.asList(CommentVisibilityType.INSTRUCTORS));
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenThrow(EntityAlreadyExistsException.class);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyInvalidOperation(typicalRequestBody, params);
     }
@@ -176,12 +176,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -208,12 +208,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -239,12 +239,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -270,12 +270,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -301,12 +301,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -332,12 +332,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -363,12 +363,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -395,12 +395,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorResult();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -426,12 +426,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForInstructorSubmission();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -456,12 +456,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseComment typicalComment = getTypicalCommentForStudentSubmission();
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.createFeedbackResponseComment(any(FeedbackResponseComment.class)))
                 .thenReturn(typicalComment);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         CreateFeedbackResponseCommentAction action = getAction(typicalRequestBody, params);
         JsonResult r = getJsonResult(action);
@@ -474,9 +474,9 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Test
     void testAccessControl_typicalCaseForInstructorResult_canAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -514,10 +514,10 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(contributionResponse.getId())).thenReturn(contributionResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyHttpParameterFailureAcl(params);
     }
@@ -537,7 +537,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Test
     void testAccessControl_submitCommentForOthersResponse_cannotAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
 
         String[] params = new String[] {
@@ -545,7 +545,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 typicalFeedbackResponse.getId().toString(),
         };
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -562,10 +562,10 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getAccountId()))
                 .thenReturn(instructorWithoutAccess);
 
-        loginAsInstructor(instructorWithoutAccess.getGoogleId());
+        loginAsInstructor(instructorWithoutAccess.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -585,10 +585,10 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -611,7 +611,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     void testAccessControl_studentAccessInstructorResponse_cannotAccess() {
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -626,7 +626,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         Instructor instructorInSameCourse = getTypicalInstructor();
         instructorInSameCourse.setEmail("instructor2@teammates.tmt");
 
-        loginAsInstructor(instructorInSameCourse.getGoogleId());
+        loginAsInstructor(instructorInSameCourse.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -634,7 +634,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         };
 
         when(mockLogic.getFeedbackResponse(typicalFeedbackResponse.getId())).thenReturn(typicalFeedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getAccountId()))
                 .thenReturn(instructorInSameCourse);
 
         verifyCanAccess(params);
@@ -653,7 +653,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 typicalFeedbackResponse.getId().toString(),
         };
 
-        verifyCanMasquerade(typicalInstructor.getGoogleId(), params);
+        verifyCanMasquerade(typicalInstructor.getAccountId(), params);
     }
 
     @Test
@@ -669,14 +669,14 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         // mock the extended deadline to be 10 minutes ago with a 15 minute grace period
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -699,12 +699,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(feedbackSessionPastEndTime.getEndTime());
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -728,14 +728,14 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
 
         // mock the extended deadline to be 10 minutes in the future
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,
@@ -759,12 +759,12 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 getTypicalFeedbackResponseDetails());
 
         when(mockLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(feedbackSessionPastEndTime.getEndTime());
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(), Const.ParamsNames.FEEDBACK_RESPONSE_ID,

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionActionTest.java
@@ -61,7 +61,7 @@ public class CreateFeedbackSessionActionTest extends BaseActionTest<CreateFeedba
         instructor = generateInstructor1InCourse(course);
         feedbackSession = generateSession1InCourse(course, instructor);
 
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.createFeedbackSession(isA(FeedbackSession.class))).thenReturn(feedbackSession);
     }

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionActionTest.java
@@ -61,14 +61,14 @@ public class CreateFeedbackSessionActionTest extends BaseActionTest<CreateFeedba
         instructor = generateInstructor1InCourse(course);
         feedbackSession = generateSession1InCourse(course, instructor);
 
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.createFeedbackSession(isA(FeedbackSession.class))).thenReturn(feedbackSession);
     }
 
     @Test
     protected void testExecute_insufficientParams_failure() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         verifyHttpParameterFailure();
     }
 
@@ -76,7 +76,7 @@ public class CreateFeedbackSessionActionTest extends BaseActionTest<CreateFeedba
     protected void testExecute_createFeedbackSession_success()
             throws InvalidParametersException, EntityAlreadyExistsException {
         try (MockedStatic<HibernateUtil> mockedHibernate = Mockito.mockStatic(HibernateUtil.class)) {
-            loginAsInstructor(instructor.getGoogleId());
+            loginAsInstructor(instructor.getAccountId());
             String[] params = {
                     Const.ParamsNames.COURSE_ID, course.getId(),
             };

--- a/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
@@ -72,7 +72,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForId(typicalInstructor.getAccountId())).thenReturn(inviterAccount);
+        when(mockLogic.getAccount(typicalInstructor.getAccountId())).thenReturn(inviterAccount);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, newInstructor, typicalCourse))
@@ -168,7 +168,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForId(Mockito.anyString())).thenReturn(inviterAccount);
+        when(mockLogic.getAccount(Mockito.anyString())).thenReturn(inviterAccount);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(

--- a/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
@@ -50,7 +50,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         typicalInstructor = getTypicalInstructor();
         typicalCourse = getTypicalCourse();
-        inviterAccount = new Account(typicalInstructor.getGoogleId(), "Inviter Name", "inviter@teammates.tmt");
+        inviterAccount = new Account(typicalInstructor.getAccountId(), "Inviter Name", "inviter@teammates.tmt");
     }
 
     @Test
@@ -66,19 +66,19 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
                 false, null, getEnum(newInstructorRole),
                 new InstructorPrivileges(newInstructorRole));
 
-        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getGoogleId(),
+        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getAccountId(),
                 newInstructorName, newInstructorEmail, newInstructorRole,
                 null, false);
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForId(typicalInstructor.getGoogleId())).thenReturn(inviterAccount);
+        when(mockLogic.getAccountForId(typicalInstructor.getAccountId())).thenReturn(inviterAccount);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, newInstructor, typicalCourse))
                 .thenReturn(mockEmail);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         CreateInstructorAction action = getAction(requestBody, params);
         JsonResult r = getJsonResult(action);
@@ -103,14 +103,14 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         String existingInstructorEmail = "valid@teammates.tmt";
         String existingInstructorRole = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
 
-        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getGoogleId(),
+        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getAccountId(),
                 existingInstructorName, existingInstructorEmail, existingInstructorRole,
                 null, false);
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenThrow(EntityAlreadyExistsException.class);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         InvalidOperationException ioe = verifyInvalidOperation(requestBody, params);
         assertEquals("An instructor with the same email address already exists in the course.",
@@ -132,14 +132,14 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         String invalidInstructorEmail = "newInvalidInstructor.email.tmt";
         String newInstructorRole = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
 
-        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getGoogleId(),
+        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getAccountId(),
                 newInstructorName, invalidInstructorEmail, newInstructorRole,
                 null, false);
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenThrow(InvalidParametersException.class);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyHttpRequestBodyFailure(requestBody, params);
 
@@ -162,7 +162,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
                 false, null, getEnum(newInstructorRole),
                 new InstructorPrivileges(newInstructorRole));
 
-        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getGoogleId(),
+        InstructorCreateRequest requestBody = new InstructorCreateRequest(typicalInstructor.getAccountId(),
                 newInstructorName, newInstructorEmail, newInstructorRole,
                 null, false);
 

--- a/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateInstructorActionTest.java
@@ -72,7 +72,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForGoogleId(typicalInstructor.getGoogleId())).thenReturn(inviterAccount);
+        when(mockLogic.getAccountForId(typicalInstructor.getGoogleId())).thenReturn(inviterAccount);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, newInstructor, typicalCourse))
@@ -168,7 +168,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForGoogleId(Mockito.anyString())).thenReturn(inviterAccount);
+        when(mockLogic.getAccountForId(Mockito.anyString())).thenReturn(inviterAccount);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(

--- a/src/test/java/teammates/sqlui/webapi/DeleteAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteAccountActionTest.java
@@ -50,7 +50,7 @@ public class DeleteAccountActionTest extends BaseActionTest<DeleteAccountAction>
                 false, "", null, new InstructorPrivileges());
         instructor.setAccount(stubAccount);
         String[] params = {
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
         DeleteAccountAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();

--- a/src/test/java/teammates/sqlui/webapi/DeleteCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteCourseActionTest.java
@@ -92,7 +92,7 @@ public class DeleteCourseActionTest extends BaseActionTest<DeleteCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -112,7 +112,7 @@ public class DeleteCourseActionTest extends BaseActionTest<DeleteCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/DeleteFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteFeedbackResponseCommentActionTest.java
@@ -128,7 +128,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
                 .thenReturn(instructorWithoutAccess);
 
         loginAsInstructor(instructorWithoutAccess.getGoogleId());
@@ -164,7 +164,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(any(String.class), any(String.class))).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(any(String.class), any(String.class))).thenReturn(null);
 
         loginAsUnregistered("unreg.user");
 
@@ -199,7 +199,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -223,7 +223,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
                 .thenReturn(instructorInSameCourse);
 
         verifyCanAccess(params);
@@ -240,7 +240,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(any(String.class), any(String.class)))
+        when(mockLogic.getInstructorByAccountId(any(String.class), any(String.class)))
                 .thenReturn(typicalInstructor);
 
         loginAsAdmin();
@@ -267,7 +267,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -286,7 +286,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, typicalInstructor))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -310,7 +310,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
                 .thenReturn(differentInstructorInSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentInstructorInSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -333,7 +333,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, typicalStudent))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -359,7 +359,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
                 .thenReturn(differentStudentFromSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -407,7 +407,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentInDifferentTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInDifferentTeam.getGoogleId()))
                 .thenReturn(differentStudentInDifferentTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentInDifferentTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -436,7 +436,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentInSameTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInSameTeam.getGoogleId()))
                 .thenReturn(differentStudentInSameTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentInSameTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -466,7 +466,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
                 .thenReturn(instructorWithPrivilege);
 
         loginAsInstructor(instructorWithPrivilege.getGoogleId());
@@ -492,7 +492,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -518,7 +518,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -540,7 +540,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
@@ -564,7 +564,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
@@ -589,7 +589,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
@@ -614,7 +614,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));

--- a/src/test/java/teammates/sqlui/webapi/DeleteFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteFeedbackResponseCommentActionTest.java
@@ -82,7 +82,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         DeleteFeedbackResponseCommentAction action = getAction(params);
         JsonResult r = getJsonResult(action);
@@ -103,7 +103,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
         when(mockLogic.getFeedbackResponseComment(nonExistentCommentId))
                 .thenReturn(null);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         DeleteFeedbackResponseCommentAction action = getAction(params);
         JsonResult r = getJsonResult(action);
@@ -128,10 +128,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutAccess.getAccountId()))
                 .thenReturn(instructorWithoutAccess);
 
-        loginAsInstructor(instructorWithoutAccess.getGoogleId());
+        loginAsInstructor(instructorWithoutAccess.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -183,7 +183,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -199,10 +199,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -219,11 +219,11 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
         };
 
-        loginAsInstructor(instructorInSameCourse.getGoogleId());
+        loginAsInstructor(instructorInSameCourse.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorInSameCourse.getAccountId()))
                 .thenReturn(instructorInSameCourse);
 
         verifyCanAccess(params);
@@ -245,7 +245,7 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         loginAsAdmin();
 
-        verifyCanMasquerade(typicalInstructor.getGoogleId(), params);
+        verifyCanMasquerade(typicalInstructor.getAccountId(), params);
     }
 
     @Test
@@ -267,10 +267,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -286,12 +286,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, typicalInstructor))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -310,12 +310,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getAccountId()))
                 .thenReturn(differentInstructorInSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentInstructorInSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
+        loginAsInstructor(differentInstructorInSameCourse.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -333,12 +333,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, typicalStudent))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -359,12 +359,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getAccountId()))
                 .thenReturn(differentStudentFromSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentFromSameCourse.getGoogleId());
+        loginAsStudent(differentStudentFromSameCourse.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -407,12 +407,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInDifferentTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInDifferentTeam.getAccountId()))
                 .thenReturn(differentStudentInDifferentTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentInDifferentTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentInDifferentTeam.getGoogleId());
+        loginAsStudent(differentStudentInDifferentTeam.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -436,12 +436,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInSameTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentInSameTeam.getAccountId()))
                 .thenReturn(differentStudentInSameTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentInSameTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentInSameTeam.getGoogleId());
+        loginAsStudent(differentStudentInSameTeam.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -466,10 +466,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getAccountId()))
                 .thenReturn(instructorWithPrivilege);
 
-        loginAsInstructor(instructorWithPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithPrivilege.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -492,10 +492,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -518,10 +518,10 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -540,12 +540,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -564,12 +564,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -589,12 +589,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(10)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -614,12 +614,12 @@ public class DeleteFeedbackResponseCommentActionTest extends BaseActionTest<Dele
 
         when(mockLogic.getFeedbackResponseComment(typicalFeedbackResponseComment.getId()))
                 .thenReturn(typicalFeedbackResponseComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteInstructorActionTest.java
@@ -69,8 +69,8 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor2.getGoogleId())).thenReturn(instructor2);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor2.getAccountId())).thenReturn(instructor2);
         when(mockLogic.getStudentByAccountId(course.getId(), studentId)).thenReturn(student);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor2.getEmail())).thenReturn(instructor2);
@@ -82,13 +82,13 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     void testExecute_deleteInstructorByGoogleId_success() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor2.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor2.getAccountId(),
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor2.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor2.getAccountId());
         verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor2.getEmail());
         verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
@@ -117,7 +117,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         assertEquals(mockLogic.getInstructorsByCourse(course.getId()).size(), 1);
@@ -126,7 +126,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getAccountId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
@@ -136,14 +136,14 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         InvalidOperationException ioe = verifyInvalidOperation(params);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getAccountId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
@@ -153,30 +153,30 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         InvalidOperationException ioe = verifyInvalidOperation(params);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getAccountId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
     @Test
     void testExecute_instructorDeleteOwnRoleByGoogleId_success() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getAccountId());
         verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor.getEmail());
         verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
@@ -224,13 +224,13 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, nonExistentCourseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByAccountId(nonExistentCourseId, instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(nonExistentCourseId, instructor.getAccountId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
@@ -243,7 +243,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     @Test
     void testExecute_missingCourseIdWithInstructorId_throwsInvalidHttpParameterException() {
         String[] params = {
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         verifyHttpParameterFailure(params);
@@ -271,7 +271,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, instructor.getAccountId(),
         };
 
         verifyOnlyInstructorsOfTheSameCourseCanAccess(course, params);

--- a/src/test/java/teammates/sqlui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteInstructorActionTest.java
@@ -69,9 +69,9 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor2.getGoogleId())).thenReturn(instructor2);
-        when(mockLogic.getStudentByGoogleId(course.getId(), studentId)).thenReturn(student);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor2.getGoogleId())).thenReturn(instructor2);
+        when(mockLogic.getStudentByAccountId(course.getId(), studentId)).thenReturn(student);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor2.getEmail())).thenReturn(instructor2);
         when(mockLogic.getInstructorsByCourse(course.getId())).thenReturn(List.of(instructor, instructor2));
@@ -88,7 +88,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor2.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor2.getGoogleId());
         verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor2.getEmail());
         verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
@@ -126,7 +126,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
@@ -143,7 +143,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
@@ -160,7 +160,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
     }
 
@@ -176,7 +176,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructor.getGoogleId());
         verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor.getEmail());
         verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
@@ -184,7 +184,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
     @Test
     void testExecute_deleteNonExistentInstructorByGoogleId_failSilently() {
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "fake-googleId")).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "fake-googleId")).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -194,7 +194,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), "fake-googleId");
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), "fake-googleId");
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
@@ -230,7 +230,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(nonExistentCourseId, instructor.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(nonExistentCourseId, instructor.getGoogleId());
         verify(mockLogic, never()).deleteInstructorCascade(any(), any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -75,7 +75,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void testExecute_deleteStudentById_success() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, studentId,
         };
 
         DeleteStudentAction action = getAction(params);
@@ -92,7 +92,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "RANDOM_COURSE",
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, studentId,
         };
 
         DeleteStudentAction action = getAction(params);
@@ -109,7 +109,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, "RANDOM_STUDENT",
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, "RANDOM_STUDENT",
         };
 
         DeleteStudentAction action = getAction(params);
@@ -156,7 +156,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     @Test
     void testExecute_missingCourseIdWithStudentId_throwsInvalidHttpParameterException() {
         String[] params = {
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, studentId,
         };
 
         verifyHttpParameterFailure(params);
@@ -175,7 +175,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.STUDENT_ACCOUNT_ID, studentId,
         };
 
         verifyAdminsCanAccess(params);

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentActionTest.java
@@ -51,9 +51,9 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getStudentByGoogleId(course.getId(), studentId)).thenReturn(student);
+        when(mockLogic.getStudentByAccountId(course.getId(), studentId)).thenReturn(student);
         when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorId)).thenReturn(instructor);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
+        verify(mockLogic, never()).getStudentByAccountId(any(), any());
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
@@ -81,7 +81,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), studentId);
+        verify(mockLogic, times(1)).getStudentByAccountId(course.getId(), studentId);
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
@@ -98,14 +98,14 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getStudentByGoogleId("RANDOM_COURSE", studentId);
+        verify(mockLogic, times(1)).getStudentByAccountId("RANDOM_COURSE", studentId);
         verify(mockLogic, never()).deleteStudentCascade(any(), any());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
     void testExecute_nonExistentStudentId_failSilently() {
-        when(mockLogic.getStudentByGoogleId(course.getId(), "RANDOM_STUDENT")).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(course.getId(), "RANDOM_STUDENT")).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -115,7 +115,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), "RANDOM_STUDENT");
+        verify(mockLogic, times(1)).getStudentByAccountId(course.getId(), "RANDOM_STUDENT");
         verify(mockLogic, never()).deleteStudentCascade(any(), any());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
@@ -132,7 +132,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
+        verify(mockLogic, never()).getStudentByAccountId(any(), any());
         verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), "RANDOM_EMAIL");
         verify(mockLogic, times(1)).deleteStudentCascade(any(), any());
         verify(mockLogic, never()).deleteStudentCascade(course.getId(), student.getEmail());

--- a/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/DeleteStudentsActionTest.java
@@ -49,7 +49,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorId)).thenReturn(instructor);
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/EnrollStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/EnrollStudentsActionTest.java
@@ -72,7 +72,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
                         && Objects.equals(argument.getSection(), newStudent.getSection())))).thenReturn(newStudent);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
 
         StudentsEnrollRequest req = prepareRequest(newStudent);
         String[] params = new String[] {
@@ -98,7 +98,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(existingStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
         when(mockLogic.updateStudentCascade(
@@ -133,7 +133,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), "email.com")).thenReturn(existingStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), "email.com")).thenReturn(null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
         when(mockLogic.updateStudentCascade(
@@ -169,7 +169,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
 
@@ -201,7 +201,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>(List.of(newStudent)));
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(newStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
 
@@ -243,7 +243,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     public void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, new InstructorPrivileges());
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(instructor.getGoogleId());
         String[] params = new String[] {
@@ -260,7 +260,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, instructorPrivileges);
         loginAsInstructor(instructor.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/EnrollStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/EnrollStudentsActionTest.java
@@ -59,7 +59,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         Instructor instructor = getTypicalInstructor();
         // Ensure instructor has the required permissions
         instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         Student newStudent = new Student(course, "name", "email.com", "", team);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>());
@@ -72,7 +72,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
                         && Objects.equals(argument.getSection(), newStudent.getSection())))).thenReturn(newStudent);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
 
         StudentsEnrollRequest req = prepareRequest(newStudent);
         String[] params = new String[] {
@@ -91,14 +91,14 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         Instructor instructor = getTypicalInstructor();
         // Ensure instructor has the required permissions
         instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         Student newStudent = new Student(course, "name", "email.com", "", team);
         Student existingStudent = new Student(course, "oldName", "email.com", "", team);
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>(List.of(existingStudent)));
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(existingStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
         when(mockLogic.updateStudentCascade(
@@ -123,7 +123,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     public void testExecute_studentAlreadyEnrolled_caseInsensitiveEmail() throws Exception {
         Instructor instructor = getTypicalInstructor();
         instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         Student existingStudent = new Student(course, "oldName", "email.com", "", team);
         Student requestStudent = new Student(course, "name", "Email.Com", "", team);
@@ -133,7 +133,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), "email.com")).thenReturn(existingStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), "email.com")).thenReturn(null);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
         when(mockLogic.updateStudentCascade(
@@ -163,13 +163,13 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         Instructor instructor = getTypicalInstructor();
         // Ensure instructor has the required permissions
         instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         Student newStudent = new Student(course, "name", "email.com", "", team);
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>());
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
 
@@ -192,7 +192,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         Instructor instructor = getTypicalInstructor();
         // Ensure instructor has the required permissions
         instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         doThrow(new InvalidParametersException("")).when(mockLogic).updateStudentCascade(any(Student.class));
 
@@ -201,7 +201,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>(List.of(newStudent)));
         when(mockLogic.getStudentForEmail(course.getId(), newStudent.getEmail())).thenReturn(newStudent);
         when(mockLogic.getInstructorForEmail(course.getId(), newStudent.getEmail())).thenReturn(null);
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getTeamOrCreate(section, "team")).thenReturn(team);
         when(mockLogic.getSectionOrCreate(course.getId(), "section")).thenReturn(section);
 
@@ -221,7 +221,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     @Test
     public void testExecute_invalidCourseId_invalidHttpRequestBodyException() {
         Instructor instructor = getTypicalInstructor();
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, null,
         };
@@ -243,9 +243,9 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     public void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, new InstructorPrivileges());
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, course.getId(),
         };
@@ -259,8 +259,8 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
                 false, "", null, instructorPrivileges);
-        loginAsInstructor(instructor.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        loginAsInstructor(instructor.getAccountId());
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/GetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetAccountActionTest.java
@@ -32,7 +32,7 @@ public class GetAccountActionTest extends BaseActionTest<GetAccountAction> {
     void testExecute_validParams_success() {
         loginAsAdmin();
         Account account = new Account(googleId, "name", "email");
-        when(mockLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(mockLogic.getAccountForId(googleId)).thenReturn(account);
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_ID, googleId,
         };
@@ -44,13 +44,13 @@ public class GetAccountActionTest extends BaseActionTest<GetAccountAction> {
     @Test
     void testExecute_accountDoesNotExist_throwsEntityNotFoundException() {
         loginAsAdmin();
-        when(mockLogic.getAccountForGoogleId(googleId)).thenReturn(null);
+        when(mockLogic.getAccountForId(googleId)).thenReturn(null);
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_ID, googleId,
         };
         EntityNotFoundException e = verifyEntityNotFound(params);
         assertEquals("Account does not exist.", e.getMessage());
-        verify(mockLogic, times(1)).getAccountForGoogleId(googleId);
+        verify(mockLogic, times(1)).getAccountForId(googleId);
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetAccountActionTest.java
@@ -32,7 +32,7 @@ public class GetAccountActionTest extends BaseActionTest<GetAccountAction> {
     void testExecute_validParams_success() {
         loginAsAdmin();
         Account account = new Account(googleId, "name", "email");
-        when(mockLogic.getAccountForId(googleId)).thenReturn(account);
+        when(mockLogic.getAccount(googleId)).thenReturn(account);
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_ID, googleId,
         };
@@ -44,13 +44,13 @@ public class GetAccountActionTest extends BaseActionTest<GetAccountAction> {
     @Test
     void testExecute_accountDoesNotExist_throwsEntityNotFoundException() {
         loginAsAdmin();
-        when(mockLogic.getAccountForId(googleId)).thenReturn(null);
+        when(mockLogic.getAccount(googleId)).thenReturn(null);
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_ID, googleId,
         };
         EntityNotFoundException e = verifyEntityNotFound(params);
         assertEquals("Account does not exist.", e.getMessage());
-        verify(mockLogic, times(1)).getAccountForId(googleId);
+        verify(mockLogic, times(1)).getAccount(googleId);
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetAccountsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetAccountsActionTest.java
@@ -34,7 +34,7 @@ public class GetAccountsActionTest extends BaseActionTest<GetAccountsAction> {
         for (int i = 0; i < accountDataList.size(); i++) {
             AccountData accountData = accountDataList.get(i);
             Account account = accounts.get(i);
-            assertEquals(accountData.getGoogleId(), account.getGoogleId());
+            assertEquals(accountData.getGoogleId(), account.getId());
             assertEquals(accountData.getEmail(), account.getEmail());
             assertEquals(accountData.getName(), account.getName());
         }

--- a/src/test/java/teammates/sqlui/webapi/GetCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetCourseActionTest.java
@@ -50,7 +50,7 @@ public class GetCourseActionTest extends BaseActionTest<GetCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -85,7 +85,7 @@ public class GetCourseActionTest extends BaseActionTest<GetCourseAction> {
         Student student = new Student(course, "name", "studen_email@tm.tmt", "student comments");
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getStudentByGoogleId(course.getId(), googleId)).thenReturn(student);
+        when(mockLogic.getStudentByAccountId(course.getId(), googleId)).thenReturn(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/GetCoursesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetCoursesActionTest.java
@@ -53,7 +53,7 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
     @Test
     void testExecute_withInstructorAndActiveCourses_success() {
         loginAsInstructor(stubInstructor.getGoogleId());
-        when(mockLogic.getInstructorsForGoogleId(stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructorList);
         when(mockLogic.getCoursesForInstructors(argThat(
                 argument -> Objects.equals(argument.get(0).getGoogleId(),
@@ -72,7 +72,7 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
     @Test
     void testExecute_withInstructorAndSoftDeletedCourses_success() {
         loginAsInstructor(stubInstructor.getGoogleId());
-        when(mockLogic.getInstructorsForGoogleId(stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructorList);
         when(mockLogic.getSoftDeletedCoursesForInstructors(argThat(
                 argument -> Objects.equals(argument.get(0).getGoogleId(),

--- a/src/test/java/teammates/sqlui/webapi/GetCoursesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetCoursesActionTest.java
@@ -52,12 +52,12 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
 
     @Test
     void testExecute_withInstructorAndActiveCourses_success() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-        when(mockLogic.getInstructorsForAccountId(stubInstructor.getGoogleId()))
+        loginAsInstructor(stubInstructor.getAccountId());
+        when(mockLogic.getInstructorsForAccountId(stubInstructor.getAccountId()))
                 .thenReturn(stubInstructorList);
         when(mockLogic.getCoursesForInstructors(argThat(
-                argument -> Objects.equals(argument.get(0).getGoogleId(),
-                        stubInstructor.getGoogleId()))))
+                argument -> Objects.equals(argument.get(0).getAccountId(),
+                        stubInstructor.getAccountId()))))
                 .thenReturn(stubCourseList);
         String[] params = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
@@ -71,12 +71,12 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
 
     @Test
     void testExecute_withInstructorAndSoftDeletedCourses_success() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-        when(mockLogic.getInstructorsForAccountId(stubInstructor.getGoogleId()))
+        loginAsInstructor(stubInstructor.getAccountId());
+        when(mockLogic.getInstructorsForAccountId(stubInstructor.getAccountId()))
                 .thenReturn(stubInstructorList);
         when(mockLogic.getSoftDeletedCoursesForInstructors(argThat(
-                argument -> Objects.equals(argument.get(0).getGoogleId(),
-                        stubInstructor.getGoogleId()))))
+                argument -> Objects.equals(argument.get(0).getAccountId(),
+                        stubInstructor.getAccountId()))))
                 .thenReturn(stubCourseList);
         String[] params = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
@@ -90,7 +90,7 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
 
     @Test
     void testExecute_withInstructorAndInvalidCourseStatus_throwsException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
                 Const.ParamsNames.COURSE_STATUS, "invalid",
@@ -183,7 +183,7 @@ public class GetCoursesActionTest extends BaseActionTest<GetCoursesAction> {
 
     @Test
     void testSpecificAccessControl_loginUserAndEntityMismatch_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackQuestionRecipientsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackQuestionRecipientsActionTest.java
@@ -76,7 +76,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getRecipientsOfQuestion(
                 argThat(arg -> arg.getId().equals(typicalFeedbackQuestion.getId())),
@@ -103,7 +103,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getRecipientsOfQuestion(
                 argThat(arg -> arg.getId().equals(typicalFeedbackQuestion.getId())),
@@ -179,7 +179,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         selfRecipients.put("self", new FeedbackQuestionRecipient(typicalStudent.getName(), typicalStudent.getEmail()));
 
         when(mockLogic.getFeedbackQuestion(selfQuestion.getId())).thenReturn(selfQuestion);
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getRecipientsOfQuestion(any(), any(), any())).thenReturn(selfRecipients);
 
@@ -245,7 +245,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         ______TS("Student accessing own feedback - can access");
         loginAsStudent(typicalStudent.getGoogleId());
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         verifyCanAccess(params);
 
@@ -270,7 +270,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         ______TS("Instructor accessing own feedback - can access");

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackQuestionRecipientsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackQuestionRecipientsActionTest.java
@@ -76,15 +76,15 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getRecipientsOfQuestion(
                 argThat(arg -> arg.getId().equals(typicalFeedbackQuestion.getId())),
                 argThat(arg -> arg == null),
-                argThat(arg -> arg.getGoogleId().equals(typicalStudent.getGoogleId()))))
+                argThat(arg -> arg.getAccountId().equals(typicalStudent.getAccountId()))))
                 .thenReturn(typicalRecipients);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         GetFeedbackQuestionRecipientsAction action = getAction(params);
         JsonResult result = action.execute();
@@ -103,15 +103,15 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getRecipientsOfQuestion(
                 argThat(arg -> arg.getId().equals(typicalFeedbackQuestion.getId())),
-                argThat(arg -> arg.getGoogleId().equals(typicalInstructor.getGoogleId())),
+                argThat(arg -> arg.getAccountId().equals(typicalInstructor.getAccountId())),
                 argThat(arg -> arg == null)))
                 .thenReturn(typicalRecipients);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         GetFeedbackQuestionRecipientsAction action = getAction(params);
         JsonResult result = action.execute();
@@ -132,7 +132,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyHttpParameterFailure(params);
     }
@@ -146,7 +146,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId()))
                 .thenReturn(typicalFeedbackQuestion);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyHttpParameterFailure(params);
     }
@@ -160,7 +160,7 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
 
         when(mockLogic.getFeedbackQuestion(any(UUID.class))).thenReturn(null);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyEntityNotFound(params);
     }
@@ -179,11 +179,11 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         selfRecipients.put("self", new FeedbackQuestionRecipient(typicalStudent.getName(), typicalStudent.getEmail()));
 
         when(mockLogic.getFeedbackQuestion(selfQuestion.getId())).thenReturn(selfQuestion);
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getRecipientsOfQuestion(any(), any(), any())).thenReturn(selfRecipients);
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         GetFeedbackQuestionRecipientsAction action = getAction(selfParams);
         JsonResult result = action.execute();
@@ -244,8 +244,8 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
                 .thenReturn(typicalFeedbackSession);
 
         ______TS("Student accessing own feedback - can access");
-        loginAsStudent(typicalStudent.getGoogleId());
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        loginAsStudent(typicalStudent.getAccountId());
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         verifyCanAccess(params);
 
@@ -270,12 +270,12 @@ public class GetFeedbackQuestionRecipientsActionTest extends BaseActionTest<GetF
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalInstructor.getCourseId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         ______TS("Instructor accessing own feedback - can access");
         typicalFeedbackQuestion.setGiverType(FeedbackParticipantType.INSTRUCTORS);
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
         verifyCanAccess(params);
 
         ______TS("Instructor preview as student - can access");

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackResponseCommentActionTest.java
@@ -94,7 +94,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testExecute_notEnoughParameters_shouldFail() {
-        loginAsInstructor(instructorOfCourse1.getGoogleId());
+        loginAsInstructor(instructorOfCourse1.getAccountId());
 
         verifyHttpParameterFailure();
         verifyHttpParameterFailure(Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString());
@@ -102,7 +102,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     protected void testExecute_invalidIntent_shouldFail() {
-        loginAsInstructor(instructorOfCourse1.getGoogleId());
+        loginAsInstructor(instructorOfCourse1.getAccountId());
 
         when(mockLogic.getFeedbackResponse(any())).thenReturn(responseForQ1);
 
@@ -112,7 +112,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         };
         verifyHttpParameterFailure(submissionParams);
 
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ1.getId().toString(),
@@ -122,7 +122,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testExecute_studentSubmissionTypicalSuccessCase_shouldPass() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -140,7 +140,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testExecute_instructorSubmissionTypicalSuccessCase_shouldPass() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -158,7 +158,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testExecute_commnetDoesNotExist_shouldFail() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -175,7 +175,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testExecute_responseDoesNotExist_shouldThrowException() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -191,7 +191,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testAccessControl() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ1.getId().toString(),
@@ -203,7 +203,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         verifyCanAccess(submissionParams);
 
-        loginAsInstructor(instructorOfCourse1.getGoogleId());
+        loginAsInstructor(instructorOfCourse1.getAccountId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ2.getId().toString(),
@@ -217,7 +217,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testAccessControl_invalidIntent_shouldFail() {
-        loginAsStudent(studentInCourse1.getGoogleId());
+        loginAsStudent(studentInCourse1.getAccountId());
         String[] studentInvalidIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ1.getId().toString(),
@@ -228,7 +228,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         verifyHttpParameterFailureAcl(studentInvalidIntentParams);
 
-        loginAsInstructor(instructorOfCourse1.getGoogleId());
+        loginAsInstructor(instructorOfCourse1.getAccountId());
         String[] instructorInvalidIntentParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ1.getId().toString(),
@@ -239,7 +239,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
     @Test
     void testAccessControl_responseDoesNotExist_shouldFail() {
-        loginAsInstructor(instructorOfCourse1.getGoogleId());
+        loginAsInstructor(instructorOfCourse1.getAccountId());
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -254,7 +254,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
     void testAccessControl_accessAcrossCourses_shouldFail() {
 
         // instructor access other instructor's response from different course
-        loginAsInstructor(instructorOfCourse2.getGoogleId());
+        loginAsInstructor(instructorOfCourse2.getAccountId());
         String[] submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ2.getId().toString(),
@@ -267,7 +267,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         verifyCannotAccess(submissionParams);
 
         // students access other students' response from different course
-        loginAsStudent(studentInCourse2.getGoogleId());
+        loginAsStudent(studentInCourse2.getAccountId());
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, responseForQ1.getId().toString(),

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackResponseCommentActionTest.java
@@ -199,7 +199,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
 
         when(mockLogic.getFeedbackSession(any(), any())).thenReturn(feedbackSessionInCourse1);
         when(mockLogic.getFeedbackResponse(any())).thenReturn(responseForQ1);
-        when(mockLogic.getStudentByGoogleId(any(), any())).thenReturn(studentInCourse1);
+        when(mockLogic.getStudentByAccountId(any(), any())).thenReturn(studentInCourse1);
 
         verifyCanAccess(submissionParams);
 
@@ -210,7 +210,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         };
         when(mockLogic.getFeedbackSession(any(), any())).thenReturn(feedbackSessionInCourse1);
         when(mockLogic.getFeedbackResponse(any())).thenReturn(responseForQ2);
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructorOfCourse1);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructorOfCourse1);
 
         verifyCanAccess(submissionParams);
     }
@@ -262,7 +262,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         };
         when(mockLogic.getFeedbackSession(any(), any())).thenReturn(feedbackSessionInCourse1);
         when(mockLogic.getFeedbackResponse(any())).thenReturn(responseForQ2);
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructorOfCourse2);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(instructorOfCourse2);
 
         verifyCannotAccess(submissionParams);
 
@@ -275,7 +275,7 @@ public class GetFeedbackResponseCommentActionTest extends BaseActionTest<GetFeed
         };
         when(mockLogic.getFeedbackSession(any(), any())).thenReturn(feedbackSessionInCourse1);
         when(mockLogic.getFeedbackResponse(any())).thenReturn(responseForQ1);
-        when(mockLogic.getStudentByGoogleId(any(), any())).thenReturn(studentInCourse2);
+        when(mockLogic.getStudentByAccountId(any(), any())).thenReturn(studentInCourse2);
 
         verifyCannotAccess(submissionParams);
     }

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackResponsesActionTest.java
@@ -133,7 +133,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         switch (type) {
         case STUDENT:
             if (isBasicParams) {
-                when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+                when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
             } else {
                 when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
             }
@@ -141,14 +141,14 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
             if (isCommentInResponse) {
                 when(mockLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(
                         argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                        argThat(student -> student.getGoogleId().equals(stubStudent.getGoogleId())
+                        argThat(student -> student.getAccountId().equals(stubStudent.getAccountId())
                                 && student.getName().equals(stubStudent.getName())
                                 && student.getCourse().equals(stubStudent.getCourse()))))
                         .thenReturn(stubFeedbackResponsesNonNullComments);
             } else {
                 when(mockLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(
                         argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                        argThat(student -> student.getGoogleId().equals(stubStudent.getGoogleId())
+                        argThat(student -> student.getAccountId().equals(stubStudent.getAccountId())
                                 && student.getName().equals(stubStudent.getName())
                                 && student.getCourse().equals(stubStudent.getCourse()))))
                         .thenReturn(stubFeedbackResponsesNullComments);
@@ -156,7 +156,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
             break;
         case INSTRUCTOR:
             if (isBasicParams) {
-                when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+                when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                         .thenReturn(stubInstructor);
             } else {
                 when(mockLogic.getInstructorForEmail(stubCourse.getId(), stubInstructor.getEmail()))
@@ -166,14 +166,14 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
             if (isCommentInResponse) {
                 when(mockLogic.getFeedbackResponsesFromInstructorForQuestion(
                         argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                        argThat(instructor -> instructor.getGoogleId().equals(stubInstructor.getGoogleId())
+                        argThat(instructor -> instructor.getAccountId().equals(stubInstructor.getAccountId())
                                 && instructor.getName().equals(stubInstructor.getName())
                                 && instructor.getCourse().equals(stubInstructor.getCourse()))))
                         .thenReturn(stubFeedbackResponsesNonNullComments);
             } else {
                 when(mockLogic.getFeedbackResponsesFromInstructorForQuestion(
                         argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                        argThat(instructor -> instructor.getGoogleId().equals(stubInstructor.getGoogleId())
+                        argThat(instructor -> instructor.getAccountId().equals(stubInstructor.getAccountId())
                                 && instructor.getName().equals(stubInstructor.getName())
                                 && instructor.getCourse().equals(stubInstructor.getCourse()))))
                         .thenReturn(stubFeedbackResponsesNullComments);
@@ -186,7 +186,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_insufficientParams_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params1 = {};
         verifyHttpParameterFailure(params1);
 
@@ -205,7 +205,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_invalidIntent_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
@@ -219,7 +219,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_studentSubmissionNoPreviewAsNoModeratedPersonNullComments_successfullyGetResponses() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -235,7 +235,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_studentSubmissionNoPreviewAsNoModeratedPersonNonNullComments_successfullyGetResponses() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -251,7 +251,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_instructorSubmissionNoPreviewAsNoModeratedPersonNullComments_successfullyGetResponses() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -267,7 +267,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_instructorSubmissionNoPreviewAsNoModeratedPersonNonNullComments_successfullyGetResponses() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -283,17 +283,17 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_instructorSubmissionNoResponses_emptyResponseData() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
 
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackResponsesFromInstructorForQuestion(
                 argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                argThat(instructor -> instructor.getGoogleId().equals(stubInstructor.getGoogleId())
+                argThat(instructor -> instructor.getAccountId().equals(stubInstructor.getAccountId())
                         && instructor.getName().equals(stubInstructor.getName())
                         && instructor.getCourse().equals(stubInstructor.getCourse())))).thenReturn(List.of());
         GetFeedbackResponsesAction action = getAction(params);
@@ -303,17 +303,17 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_studentSubmissionNoResponses_emptyResponseData() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(
                 argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
-                argThat(student -> student.getGoogleId().equals(stubStudent.getGoogleId())
+                argThat(student -> student.getAccountId().equals(stubStudent.getAccountId())
                         && student.getName().equals(stubStudent.getName())
                         && student.getCourse().equals(stubStudent.getCourse())))).thenReturn(List.of());
         GetFeedbackResponsesAction action = getAction(params);
@@ -323,7 +323,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_instructorSubmissionNoPreviewAsModeratedPersonNonNullComments_successfullyGetResponses() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -350,7 +350,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testExecute_idCannotBeConvertedToUuid_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params1 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "random-invalid-id",
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
@@ -361,7 +361,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         assertEquals("Expected UUID value for questionid parameter, but found: [random-invalid-id]", ihpe.getMessage());
 
         logoutUser();
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params2 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "random-invalid-id",
@@ -418,12 +418,12 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_notAnswerableForStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
 
         String[] params = {
@@ -453,13 +453,13 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_notAnswerableForInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId()))
                 .thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(stubInstructor);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
@@ -488,7 +488,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_invalidIntent_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
@@ -523,12 +523,12 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_studentSubmissionAsInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -543,11 +543,11 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_instructorSubmissionAsStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
@@ -560,7 +560,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_invalidQuestion_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(null);
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
@@ -573,11 +573,11 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_typicalInstructorAccess_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -596,12 +596,12 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 .getEnum(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
         Instructor stubInstructorWithoutPrivileges = new Instructor(stubCourse, "instructor-1-name", "valid1@teammates.tmt",
                 false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, customRole, customInstructorPrivileges);
-        loginAsInstructor(stubInstructorWithoutPrivileges.getGoogleId());
+        loginAsInstructor(stubInstructorWithoutPrivileges.getAccountId());
 
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPrivileges.getAccountId()))
                 .thenReturn(stubInstructorWithoutPrivileges);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
@@ -633,12 +633,12 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_typicalStudentAccess_canAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -651,7 +651,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_previewAs_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         FeedbackQuestion questionAnswerableToInstructor = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
@@ -687,7 +687,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_questionModeratedInstructorSubmission_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         FeedbackQuestion questionThatCanBeModerated = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         questionThatCanBeModerated.setShowGiverNameTo(List.of(FeedbackParticipantType.INSTRUCTORS));
         questionThatCanBeModerated.setShowRecipientNameTo(List.of(FeedbackParticipantType.INSTRUCTORS));
@@ -696,7 +696,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         when(mockLogic.getInstructorForEmail(stubCourse.getId(), stubInstructor.getEmail())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(stubInstructor);
 
         String[] params1 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionThatCanBeModerated.getId().toString(),
@@ -708,7 +708,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_questionModeratedStudentSubmission_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
@@ -719,7 +719,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(null);
 
         String[] params1 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
@@ -747,7 +747,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_questionCannotBeModeratedInstructorSubmission_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         FeedbackQuestion questionThatCannotBeModerated = stubFeedbackQuestion;
 
         when(mockLogic.getFeedbackQuestion(questionThatCannotBeModerated.getId())).thenReturn(questionThatCannotBeModerated);
@@ -766,7 +766,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_accessAcrossCourses_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         Course anotherCourse = getTypicalCourse();
         anotherCourse.setId("another-course-id");
         anotherCourse.setName("another-course-name");
@@ -776,7 +776,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         anotherFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
         when(mockLogic.getFeedbackQuestion(anotherFeedbackQuestion.getId())).thenReturn(anotherFeedbackQuestion);
-        when(mockLogic.getStudentByAccountId(anotherCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(anotherCourse.getId(), stubStudent.getAccountId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(anotherFeedbackSession.getName(), anotherFeedbackSession.getCourseId()))
                 .thenReturn(anotherFeedbackSession);
 
@@ -791,7 +791,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_idCannotBeConvertedToUuid_throwsInvalidHttpParameterException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "random-invalid-id",
@@ -804,9 +804,9 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_entityDoesNotBelongInCourse_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -819,12 +819,12 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         assertEquals("Trying to access system using a non-existent instructor entity", uae1.getMessage());
 
         logoutUser();
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(null);
 
         String[] params2 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
@@ -899,7 +899,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_instructorWithOnlyModifySessionCommentPrivileges_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         Instructor instructorWithLimitedPrivileges =
                 getInstructorWithLimitedPrivileges(Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         instructorWithLimitedPrivileges.setAccount(getTypicalAccount());
@@ -914,7 +914,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 .thenReturn(instructorWithLimitedPrivileges);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), instructorWithLimitedPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), instructorWithLimitedPrivileges.getAccountId()))
                 .thenReturn(instructorWithLimitedPrivileges);
 
         String[] params = {
@@ -927,7 +927,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_instructorWithOnlySubmitSectionPrivileges_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         Instructor instructorWithLimitedPrivileges =
                 getInstructorWithLimitedPrivileges(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         instructorWithLimitedPrivileges.setAccount(getTypicalAccount());
@@ -935,7 +935,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackResponsesActionTest.java
@@ -133,7 +133,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         switch (type) {
         case STUDENT:
             if (isBasicParams) {
-                when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+                when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
             } else {
                 when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
             }
@@ -156,7 +156,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
             break;
         case INSTRUCTOR:
             if (isBasicParams) {
-                when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+                when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                         .thenReturn(stubInstructor);
             } else {
                 when(mockLogic.getInstructorForEmail(stubCourse.getId(), stubInstructor.getEmail()))
@@ -290,7 +290,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
 
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackResponsesFromInstructorForQuestion(
                 argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
                 argThat(instructor -> instructor.getGoogleId().equals(stubInstructor.getGoogleId())
@@ -310,7 +310,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
 
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackResponsesFromStudentOrTeamForQuestion(
                 argThat(argument -> argument.getId().equals(stubFeedbackQuestion.getId())),
                 argThat(student -> student.getGoogleId().equals(stubStudent.getGoogleId())
@@ -423,7 +423,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
 
         String[] params = {
@@ -459,7 +459,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 .thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId()))
                 .thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
@@ -528,7 +528,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -547,7 +547,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
@@ -577,7 +577,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -601,7 +601,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithoutPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPrivileges.getGoogleId()))
                 .thenReturn(stubInstructorWithoutPrivileges);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
@@ -638,7 +638,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -696,7 +696,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         when(mockLogic.getInstructorForEmail(stubCourse.getId(), stubInstructor.getEmail())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
 
         String[] params1 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionThatCanBeModerated.getId().toString(),
@@ -719,7 +719,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
 
         String[] params1 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
@@ -776,7 +776,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         anotherFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
         when(mockLogic.getFeedbackQuestion(anotherFeedbackQuestion.getId())).thenReturn(anotherFeedbackQuestion);
-        when(mockLogic.getStudentByGoogleId(anotherCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(anotherCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(anotherFeedbackSession.getName(), anotherFeedbackSession.getCourseId()))
                 .thenReturn(anotherFeedbackSession);
 
@@ -806,7 +806,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
     void testSpecificAccessControl_entityDoesNotBelongInCourse_cannotAccess() {
         loginAsInstructor(stubInstructor.getGoogleId());
         when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 
@@ -824,7 +824,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
 
         String[] params2 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
@@ -857,7 +857,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         UnauthorizedAccessException uae1 = assertThrows(UnauthorizedAccessException.class, action1::checkAccessControl);
         assertEquals("User is not logged in", uae1.getMessage());
 
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), null)).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), null)).thenReturn(null);
         String[] params2 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionThatCanBeModerated.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -865,14 +865,14 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         GetFeedbackResponsesAction action2 = getAction(params2);
         UnauthorizedAccessException uae2 = assertThrows(UnauthorizedAccessException.class, action2::checkAccessControl);
         assertEquals("Trying to access system using a non-existent instructor entity", uae2.getMessage());
-        verify(mockLogic, never()).getInstructorByGoogleId(stubCourse.getId(), null);
+        verify(mockLogic, never()).getInstructorByAccountId(stubCourse.getId(), null);
 
         // Student
         FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         questionAnswerableToStudent.setGiverType(FeedbackParticipantType.STUDENTS);
         when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), null)).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), null)).thenReturn(null);
 
         String[] params3 = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
@@ -914,7 +914,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 .thenReturn(instructorWithLimitedPrivileges);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), instructorWithLimitedPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), instructorWithLimitedPrivileges.getGoogleId()))
                 .thenReturn(instructorWithLimitedPrivileges);
 
         String[] params = {
@@ -935,7 +935,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         FeedbackQuestion questionAnswerableToInstructor = stubFeedbackQuestion;
         when(mockLogic.getFeedbackQuestion(questionAnswerableToInstructor.getId()))
                 .thenReturn(questionAnswerableToInstructor);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
 

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
@@ -46,7 +46,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         feedbackSession1 = generateSession1InCourse(course1);
 
         when(mockLogic.getFeedbackSession(feedbackSession1.getName(), course1.getId())).thenReturn(feedbackSession1);
-        when(mockLogic.getStudentByGoogleId(course1.getId(), student1.getAccount().getGoogleId())).thenReturn(student1);
+        when(mockLogic.getStudentByAccountId(course1.getId(), student1.getAccount().getGoogleId())).thenReturn(student1);
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionActionTest.java
@@ -46,12 +46,12 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
         feedbackSession1 = generateSession1InCourse(course1);
 
         when(mockLogic.getFeedbackSession(feedbackSession1.getName(), course1.getId())).thenReturn(feedbackSession1);
-        when(mockLogic.getStudentByAccountId(course1.getId(), student1.getAccount().getGoogleId())).thenReturn(student1);
+        when(mockLogic.getStudentByAccountId(course1.getId(), student1.getAccount().getId())).thenReturn(student1);
     }
 
     @Test
     protected void textExecute_studentSubmissionNoExtensionAndBeforeEndTime_statusOpen() {
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -119,7 +119,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionNoExtensionAfterEndTimeWithinGracePeriod_statusGracePeriod() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -159,7 +159,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionNoExtensionAfterEndTimeBeyondGracePeriod_statusClosed() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -199,7 +199,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionWithExtensionBeforeEndTime_statusOpen() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -240,7 +240,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionWithExtensionAfterEndTimeBeforeExtendedDeadline_statusOpen() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -281,7 +281,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionWithExtensionAfterExtendedDeadlineWithinGracePeriod_statusGracePeriod() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();
@@ -322,7 +322,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
     @Test
     protected void textExecute_studentSubmissionWithExtensionAfterExtendedDeadlineBeyondGracePeriod_statusClosed() {
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String courseId = feedbackSession1.getCourse().getId();
         String feedbackSessionName = feedbackSession1.getName();

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionDeadlineExtensionsActionTest.java
@@ -72,22 +72,22 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
 
     @Test
     void testExecute_noParameters_shouldFail() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
         verifyHttpParameterFailure();
     }
 
     @Test
     void testExecute_sessionNotFound_throwsEntityNotFoundException() {
         when(mockLogic.getFeedbackSession(FEEDBACK_SESSION_NAME, COURSE_ID)).thenReturn(null);
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyEntityNotFoundAcl(getTypicalParams());
     }
 
     @Test
     void testExecute_noDeadlineExtensions_returnsEmptyMaps() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
+        loginAsInstructor(typicalInstructor.getAccountId());
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
@@ -106,8 +106,8 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
         typicalFeedbackSession.setDeadlineExtensions(List.of(studentDeadline));
 
         when(mockLogic.getStudentsForCourse(COURSE_ID)).thenReturn(List.of(typicalStudent));
-        loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
+        loginAsInstructor(typicalInstructor.getAccountId());
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
@@ -128,8 +128,8 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
         typicalFeedbackSession.setDeadlineExtensions(List.of(instructorDeadline));
 
         when(mockLogic.getInstructorsByCourse(COURSE_ID)).thenReturn(List.of(typicalInstructor));
-        loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
+        loginAsInstructor(typicalInstructor.getAccountId());
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionDeadlineExtensionsActionTest.java
@@ -87,7 +87,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
     @Test
     void testExecute_noDeadlineExtensions_returnsEmptyMaps() {
         loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
@@ -107,7 +107,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
 
         when(mockLogic.getStudentsForCourse(COURSE_ID)).thenReturn(List.of(typicalStudent));
         loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
@@ -129,7 +129,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
 
         when(mockLogic.getInstructorsByCourse(COURSE_ID)).thenReturn(List.of(typicalInstructor));
         loginAsInstructor(typicalInstructor.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionLogsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionLogsActionTest.java
@@ -287,7 +287,7 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -307,7 +307,7 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
@@ -167,10 +167,10 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
@@ -114,7 +114,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
 
         loginAsUnregistered(googleId);
@@ -132,7 +132,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
 
         loginAsStudent(googleId);
@@ -150,7 +150,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
 
         loginAsInstructor(googleId);
@@ -167,7 +167,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         loginAsInstructor(typicalInstructor.getGoogleId());

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionsActionTest.java
@@ -53,8 +53,8 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         sessionsInCourse1.add(generateSession1InCourse(course1, "feedbacksession-2"));
 
         when(mockLogic.getFeedbackSessionsForCourse(course1.getId())).thenReturn(sessionsInCourse1);
-        when(mockLogic.getStudentsByGoogleId(student1.getAccount().getGoogleId())).thenReturn(List.of(student1));
-        when(mockLogic.getInstructorByGoogleId(
+        when(mockLogic.getStudentsByAccountId(student1.getAccount().getGoogleId())).thenReturn(List.of(student1));
+        when(mockLogic.getInstructorByAccountId(
                 instructor1.getAccount().getGoogleId(), course1.getId())).thenReturn(instructor1);
         for (FeedbackSession session : sessionsInCourse1) {
             when(mockLogic.getDeadlineForUser(session, student1)).thenReturn(session.getEndTime());
@@ -117,7 +117,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
 
         Instant extendedDeadline = Instant.parse("2028-01-01T00:00:00Z");
 
-        when(mockLogic.getInstructorsForGoogleId(instructor.getAccount().getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getGoogleId()))
                 .thenReturn(List.of(instructor));
         when(mockLogic.getFeedbackSessionsForInstructors(List.of(instructor)))
                 .thenReturn(List.of(closedSession));
@@ -148,7 +148,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         Instructor instructor = generateInstructor1InCourse(course);
         FeedbackSession closedSession = generateClosedFeedbackSessionInCourse(course, "closed-session");
 
-        when(mockLogic.getInstructorsForGoogleId(instructor.getAccount().getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getGoogleId()))
                 .thenReturn(List.of(instructor));
         when(mockLogic.getFeedbackSessionsForInstructors(List.of(instructor)))
                 .thenReturn(List.of(closedSession));

--- a/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetFeedbackSessionsActionTest.java
@@ -53,9 +53,9 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         sessionsInCourse1.add(generateSession1InCourse(course1, "feedbacksession-2"));
 
         when(mockLogic.getFeedbackSessionsForCourse(course1.getId())).thenReturn(sessionsInCourse1);
-        when(mockLogic.getStudentsByAccountId(student1.getAccount().getGoogleId())).thenReturn(List.of(student1));
+        when(mockLogic.getStudentsByAccountId(student1.getAccount().getId())).thenReturn(List.of(student1));
         when(mockLogic.getInstructorByAccountId(
-                instructor1.getAccount().getGoogleId(), course1.getId())).thenReturn(instructor1);
+                instructor1.getAccount().getId(), course1.getId())).thenReturn(instructor1);
         for (FeedbackSession session : sessionsInCourse1) {
             when(mockLogic.getDeadlineForUser(session, student1)).thenReturn(session.getEndTime());
         }
@@ -63,7 +63,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
 
     @Test
     protected void textExecute() {
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String[] submissionParam = {
                 Const.ParamsNames.IS_IN_RECYCLE_BIN, "false",
@@ -92,7 +92,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         when(mockLogic.getDeadlineForUser(closedSession, student1))
                 .thenReturn(extendedDeadline);
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String[] submissionParams = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
@@ -117,14 +117,14 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
 
         Instant extendedDeadline = Instant.parse("2028-01-01T00:00:00Z");
 
-        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getId()))
                 .thenReturn(List.of(instructor));
         when(mockLogic.getFeedbackSessionsForInstructors(List.of(instructor)))
                 .thenReturn(List.of(closedSession));
         when(mockLogic.getDeadlineForUser(closedSession, instructor))
                 .thenReturn(extendedDeadline);
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
 
         String[] submissionParams = {
                 Const.ParamsNames.IS_IN_RECYCLE_BIN, "false",
@@ -148,14 +148,14 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         Instructor instructor = generateInstructor1InCourse(course);
         FeedbackSession closedSession = generateClosedFeedbackSessionInCourse(course, "closed-session");
 
-        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getGoogleId()))
+        when(mockLogic.getInstructorsForAccountId(instructor.getAccount().getId()))
                 .thenReturn(List.of(instructor));
         when(mockLogic.getFeedbackSessionsForInstructors(List.of(instructor)))
                 .thenReturn(List.of(closedSession));
         when(mockLogic.getDeadlineForUser(closedSession, instructor))
                 .thenReturn(closedSession.getEndTime());
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor.getAccount().getId());
 
         String[] submissionParams = {
                 Const.ParamsNames.IS_IN_RECYCLE_BIN, "false",
@@ -182,7 +182,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
         when(mockLogic.getDeadlineForUser(closedSession, student1))
                 .thenReturn(closedSession.getEndTime());
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1.getAccount().getId());
 
         String[] submissionParams = {
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,

--- a/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
@@ -70,7 +70,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_instructorWithNonExistentCourse_throwsEntityNotFoundException() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, "non-existent course",
@@ -83,7 +83,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_instructorWithNonExistentFeedbackQuestion_throwsEntityNotFoundException() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000",
@@ -96,7 +96,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_instructorGetRespondentsInCourse_success() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalInstructor.getCourseId(),
@@ -120,7 +120,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_instructorGetRespondentsForQuestion_success() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalFeedbackQuestion.getId().toString(),
@@ -145,7 +145,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_instructorWithQuestionIdAndCourseId_preferQuestionId() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalFeedbackQuestion.getId().toString(),
@@ -177,7 +177,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_studentWithNonExistentFeedbackSession_throwsEntityNotFoundException() {
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalStudent.getCourseId(),
@@ -194,7 +194,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_studentGetHasRespondedForSession_success() {
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalStudent.getCourseId(),
@@ -204,7 +204,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalStudent.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
 
         // mock that the student has responded
@@ -221,7 +221,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verify(mockLogic, times(1))
                 .getFeedbackSession(typicalFeedbackSession.getName(), typicalStudent.getCourseId());
         verify(mockLogic, times(1))
-                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId());
         verify(mockLogic, times(1))
                 .isFeedbackSessionAttemptedByStudent(
                         typicalFeedbackSession, typicalStudent.getEmail(), typicalStudent.getTeamName());
@@ -229,7 +229,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
     @Test
     void testExecute_studentGetHasRespondedForSessionWithoutFeedbackSessionNameParam_success() {
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
         List<FeedbackSession> feedbackSessions = getTypicalFeedbackSessions(typicalCourse);
 
         String[] params = new String[] {
@@ -238,7 +238,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         };
 
         when(mockLogic.getFeedbackSessionsForCourse(typicalCourse.getId())).thenReturn(feedbackSessions);
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
 
         // mock that student has responded to all feedback sessions
@@ -264,7 +264,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(1)).getFeedbackSessionsForCourse(typicalCourse.getId());
         verify(mockLogic, times(1))
-                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId());
         for (FeedbackSession feedbackSession : feedbackSessions) {
             if ("invisible session".equals(feedbackSession.getName())) {
                 // invisible session is skipped
@@ -308,13 +308,13 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         ______TS("Students cannot access");
 
-        loginAsStudent(getTypicalStudent().getGoogleId());
+        loginAsStudent(getTypicalStudent().getAccountId());
 
         verifyCannotAccess(paramsWithCourse);
         verifyCannotAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByAccountId(typicalCourse.getId(), getTypicalStudent().getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), getTypicalStudent().getAccountId());
 
         // check that getCourse and getFeedbackQuestion are run once per test for logged in users
         verify(mockLogic, times(2)).getCourse(typicalCourse.getId());
@@ -341,13 +341,13 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.DEFAULT_TIME_ZONE, "teammates");
         instructorOfOtherCourse.setCourse(otherCourse);
 
-        loginAsInstructor(instructorOfOtherCourse.getGoogleId());
+        loginAsInstructor(instructorOfOtherCourse.getAccountId());
 
         verifyCannotAccess(paramsWithCourse);
         verifyCannotAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByAccountId(typicalCourse.getId(), instructorOfOtherCourse.getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), instructorOfOtherCourse.getAccountId());
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
@@ -366,23 +366,23 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(paramsWithCourse);
         verifyCanAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId());
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
 
     @Test
     void testAccessControl_studentOfSameCourse_canAccessStudentGetHasResponded() {
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalStudent.getCourseId(),
@@ -390,7 +390,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };
 
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalFeedbackSession.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
@@ -398,14 +398,14 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCanAccess(params);
 
         verify(mockLogic, times(1))
-                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId());
         verify(mockLogic, times(1))
                 .getFeedbackSession(typicalFeedbackSession.getName(), typicalFeedbackSession.getCourseId());
     }
 
     @Test
     void testAccessControl_studentOfSameCourse_canAccessStudentGetHasRespondedWithoutFsParam() {
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
         List<FeedbackSession> feedbackSessions = getTypicalFeedbackSessions(typicalCourse);
 
         String[] params = new String[] {
@@ -413,7 +413,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };
 
-        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getFeedbackSessionsForCourse(typicalCourse.getId())).thenReturn(feedbackSessions);
 
@@ -421,18 +421,18 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(1)).getFeedbackSessionsForCourse(typicalCourse.getId());
         verify(mockLogic, times(3))
-                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getAccountId());
     }
 
     @Test
     void testAccessControl_notEnoughParameters_throwsInvalidHttpParameterException() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
         verifyHttpParameterFailure();
     }
 
     @Test
     void testAccessControl_wrongEntityType_cannotAccess() {
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, typicalInstructor.getCourseId(),

--- a/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
@@ -204,7 +204,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalStudent.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
 
         // mock that the student has responded
@@ -221,7 +221,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verify(mockLogic, times(1))
                 .getFeedbackSession(typicalFeedbackSession.getName(), typicalStudent.getCourseId());
         verify(mockLogic, times(1))
-                .getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
         verify(mockLogic, times(1))
                 .isFeedbackSessionAttemptedByStudent(
                         typicalFeedbackSession, typicalStudent.getEmail(), typicalStudent.getTeamName());
@@ -238,7 +238,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         };
 
         when(mockLogic.getFeedbackSessionsForCourse(typicalCourse.getId())).thenReturn(feedbackSessions);
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
 
         // mock that student has responded to all feedback sessions
@@ -264,7 +264,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(1)).getFeedbackSessionsForCourse(typicalCourse.getId());
         verify(mockLogic, times(1))
-                .getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
         for (FeedbackSession feedbackSession : feedbackSessions) {
             if ("invisible session".equals(feedbackSession.getName())) {
                 // invisible session is skipped
@@ -304,7 +304,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCannotAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByGoogleId(typicalCourse.getId(), "unregistered user");
+                .getInstructorByAccountId(typicalCourse.getId(), "unregistered user");
 
         ______TS("Students cannot access");
 
@@ -314,7 +314,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCannotAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByGoogleId(typicalCourse.getId(), getTypicalStudent().getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), getTypicalStudent().getGoogleId());
 
         // check that getCourse and getFeedbackQuestion are run once per test for logged in users
         verify(mockLogic, times(2)).getCourse(typicalCourse.getId());
@@ -347,7 +347,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCannotAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByGoogleId(typicalCourse.getId(), instructorOfOtherCourse.getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), instructorOfOtherCourse.getGoogleId());
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
@@ -366,7 +366,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -375,7 +375,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCanAccess(paramsWithFeedbackQuestion);
 
         verify(mockLogic, times(2))
-                .getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId());
+                .getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId());
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
@@ -390,7 +390,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };
 
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalFeedbackSession.getCourseId()))
                 .thenReturn(typicalFeedbackSession);
@@ -398,7 +398,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCanAccess(params);
 
         verify(mockLogic, times(1))
-                .getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
         verify(mockLogic, times(1))
                 .getFeedbackSession(typicalFeedbackSession.getName(), typicalFeedbackSession.getCourseId());
     }
@@ -413,7 +413,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };
 
-        when(mockLogic.getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getFeedbackSessionsForCourse(typicalCourse.getId())).thenReturn(feedbackSessions);
 
@@ -421,7 +421,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(1)).getFeedbackSessionsForCourse(typicalCourse.getId());
         verify(mockLogic, times(3))
-                .getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
+                .getStudentByAccountId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorActionTest.java
@@ -65,7 +65,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testExecute_unknownIntent_throwsInvalidHttpParameterException() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.toString(),
@@ -76,7 +76,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testExecute_instructorSubmission_success() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -105,7 +105,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testExecute_instructorResult_success() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_RESULT.toString(),
@@ -134,7 +134,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testExecute_fullDetail_success() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
@@ -150,7 +150,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
         Account account = new Account("google-id", "name", "email@tm.tmt");
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
         instructor.setAccount(account);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
@@ -179,7 +179,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testSpecificAccessControl_loggedInAsInstuctor_canAccess() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -191,7 +191,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testSpecificAccessControl_loggedInAsInstuctorFromAnotherCourse_cannotAccess() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "different-course",
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
@@ -203,7 +203,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     @Test
     void testSpecificAccessControl_loggedInAsInstuctorFullDetail_canAccess() {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "different-course",
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
@@ -216,7 +216,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
     void testSpecificAccessControl_notLoggedInFullDetail_cannotAccess() {
         logoutUser();
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null, null);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "user-id")).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), "user-id")).thenReturn(instructor);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "different-course",
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorActionTest.java
@@ -159,7 +159,7 @@ public class GetInstructorActionTest extends BaseActionTest<GetInstructorAction>
         GetInstructorAction getInstructorAction = getAction(params);
         InstructorData actionOutput = (InstructorData) getJsonResult(getInstructorAction).getOutput();
         InstructorData expected = new InstructorData(instructor);
-        expected.setGoogleId("google-id");
+        expected.setAccountId("google-id");
         assertEquals(JsonUtils.toJson(expected), JsonUtils.toJson(actionOutput));
     }
 

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
@@ -123,7 +123,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
 
     @Test
     void testExecute_fetchPrivilegeOfNonExistInstructor_shouldFail() {
-        loginAsInstructor(testInstructor1OfCourse1.getGoogleId());
+        loginAsInstructor(testInstructor1OfCourse1.getAccountId());
 
         // course id is used for instructor identify verification here.
         String[] invalidInstructorParams = {
@@ -137,7 +137,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
 
     @Test
     void testExecute_fetchPrivilegeOfAnotherInstructorByEmail_shouldSucceed() {
-        loginAsInstructor(testInstructor2OfCourse1.getGoogleId());
+        loginAsInstructor(testInstructor2OfCourse1.getAccountId());
 
         // course id is used for instructor identify verification here.
         String[] anotherInstructorParams = {
@@ -156,16 +156,16 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
 
     @Test
     protected void testExecute_fetchPrivilegeOfAnotherInstructor_shouldSucceed() {
-        loginAsInstructor(testInstructor2OfCourse1.getGoogleId());
+        loginAsInstructor(testInstructor2OfCourse1.getAccountId());
 
         // course id is used for instructor identify verification here.
         String[] anotherInstructorParams = {
                 Const.ParamsNames.COURSE_ID, testInstructor2OfCourse1.getCourseId(),
-                Const.ParamsNames.INSTRUCTOR_ID, testInstructor1OfCourse1.getGoogleId(),
+                Const.ParamsNames.INSTRUCTOR_ID, testInstructor1OfCourse1.getAccountId(),
         };
 
         when(mockLogic.getInstructorByAccountId(testInstructor2OfCourse1.getCourseId(),
-                testInstructor1OfCourse1.getGoogleId())).thenReturn(testInstructor1OfCourse1);
+                testInstructor1OfCourse1.getAccountId())).thenReturn(testInstructor1OfCourse1);
 
         GetInstructorPrivilegeAction a = getAction(anotherInstructorParams);
         InstructorPrivilegeData response = (InstructorPrivilegeData) getJsonResult(a).getOutput();
@@ -176,21 +176,21 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
 
     @Test
     protected void testExecute_notEnoughParameters_shouldFail() {
-        loginAsInstructor(testInstructor1OfCourse1.getGoogleId());
+        loginAsInstructor(testInstructor1OfCourse1.getAccountId());
 
         verifyHttpParameterFailure();
     }
 
     @Test
     protected void testExecute_fetchPrivilegeOfSelf_shouldSucceed() {
-        loginAsInstructor(testInstructor1OfCourse1.getGoogleId());
+        loginAsInstructor(testInstructor1OfCourse1.getAccountId());
 
         String[] courseIdParam = {
                 Const.ParamsNames.COURSE_ID, testInstructor1OfCourse1.getCourseId(),
         };
 
         when(mockLogic.getInstructorByAccountId(testInstructor1OfCourse1.getCourseId(),
-                testInstructor1OfCourse1.getGoogleId())).thenReturn(testInstructor1OfCourse1);
+                testInstructor1OfCourse1.getAccountId())).thenReturn(testInstructor1OfCourse1);
 
         GetInstructorPrivilegeAction a = getAction(courseIdParam);
         InstructorPrivilegeData response = (InstructorPrivilegeData) getJsonResult(a).getOutput();

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
@@ -101,7 +101,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
     void testAccessControl_instructorsOfDifferentCourses_cannotAccess() {
         loginAsInstructor(Const.ParamsNames.INSTRUCTOR_ID);
 
-        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(any(), any())).thenReturn(null);
 
         String[] submissionParams = { Const.ParamsNames.COURSE_ID, "course_id" };
         verifyCannotAccess(submissionParams);
@@ -164,7 +164,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
                 Const.ParamsNames.INSTRUCTOR_ID, testInstructor1OfCourse1.getGoogleId(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(testInstructor2OfCourse1.getCourseId(),
+        when(mockLogic.getInstructorByAccountId(testInstructor2OfCourse1.getCourseId(),
                 testInstructor1OfCourse1.getGoogleId())).thenReturn(testInstructor1OfCourse1);
 
         GetInstructorPrivilegeAction a = getAction(anotherInstructorParams);
@@ -189,7 +189,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
                 Const.ParamsNames.COURSE_ID, testInstructor1OfCourse1.getCourseId(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(testInstructor1OfCourse1.getCourseId(),
+        when(mockLogic.getInstructorByAccountId(testInstructor1OfCourse1.getCourseId(),
                 testInstructor1OfCourse1.getGoogleId())).thenReturn(testInstructor1OfCourse1);
 
         GetInstructorPrivilegeAction a = getAction(courseIdParam);

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorPrivilegeActionTest.java
@@ -91,7 +91,7 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
 
     @Test
     void testAccessControl_students_cannotAccess() {
-        loginAsStudent(Const.ParamsNames.STUDENT_ID);
+        loginAsStudent(Const.ParamsNames.STUDENT_ACCOUNT_ID);
 
         String[] submissionParams = { Const.ParamsNames.COURSE_ID, "course_id" };
         verifyCannotAccess(submissionParams);

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
@@ -81,17 +81,17 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         expectedInstructorsData.getInstructors().get(0).setKey(stubInstructorWithPermission.getRegKey());
         expectedInstructorsData.getInstructors().get(1).setKey(stubInstructorWithoutPermission.getRegKey());
         expectedInstructorsData.getInstructors().get(2).setKey(stubInstructorWithOnlyModifyInstructorPrivilege.getRegKey());
-        expectedInstructorsData.getInstructors().get(0).setAccountId(stubInstructorWithPermission.getGoogleId());
-        expectedInstructorsData.getInstructors().get(1).setAccountId(stubInstructorWithoutPermission.getGoogleId());
+        expectedInstructorsData.getInstructors().get(0).setAccountId(stubInstructorWithPermission.getAccountId());
+        expectedInstructorsData.getInstructors().get(1).setAccountId(stubInstructorWithoutPermission.getAccountId());
         expectedInstructorsData.getInstructors().get(2).setAccountId(stubInstructorWithOnlyModifyInstructorPrivilege
-                .getGoogleId());
+                .getAccountId());
 
         reset(mockLogic);
     }
 
     @Test
     void testExecute_invalidParams_throwsInvalidHttpParameterException() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         String[] params1 = {};
         verifyHttpParameterFailure(params1);
 
@@ -154,44 +154,44 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
     @Test
     void testExecute_fullDetailIntentInstructorWithPrivileges_shouldReturnFullDataWithoutKey() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getAccountId()))
                 .thenReturn(stubInstructorWithPermission);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, true);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
-        verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getAccountId());
     }
 
     @Test
     void testExecute_fullDetailIntentInstructorWithNoPrivileges_shouldReturnPartialData() {
-        loginAsInstructor(stubInstructorWithoutPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithoutPermission.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPermission.getAccountId()))
                 .thenReturn(stubInstructorWithoutPermission);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, false);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
         verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(),
-                stubInstructorWithoutPermission.getGoogleId());
+                stubInstructorWithoutPermission.getAccountId());
     }
 
     @Test
     void testExecute_fullDetailIntentInstructorWithModifyPrivilegesOnly_shouldReturnFullDataWithoutKey() {
-        loginAsInstructor(stubInstructorWithOnlyModifyInstructorPrivilege.getGoogleId());
+        loginAsInstructor(stubInstructorWithOnlyModifyInstructorPrivilege.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
@@ -199,13 +199,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
         when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithOnlyModifyInstructorPrivilege
-                .getGoogleId())).thenReturn(stubInstructorWithOnlyModifyInstructorPrivilege);
+                .getAccountId())).thenReturn(stubInstructorWithOnlyModifyInstructorPrivilege);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, true);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
         verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(),
-                stubInstructorWithOnlyModifyInstructorPrivilege.getGoogleId());
+                stubInstructorWithOnlyModifyInstructorPrivilege.getAccountId());
     }
 
     private void verifyInstructorsData(InstructorsData expectedInstructorsData, InstructorsData actualInstructorsData,
@@ -256,7 +256,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
     @Test
     void testSpecificAccessControl_missingParams_throwsInvalidHttpParameterException() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         String[] params1 = {};
         verifyHttpParameterFailureAcl(params1);
 
@@ -273,7 +273,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
     @Test
     void testSpecificAccessControl_invalidCourseParams_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         when(mockLogic.getCourse("invalid-course-id")).thenReturn(null);
         String[] params1 = {
                 Const.ParamsNames.COURSE_ID, "invalid-course-id",
@@ -295,7 +295,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
     @Test
     void testSpecificAccessControl_unknownIntent_throwsInvalidHttpParameterException() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
@@ -324,13 +324,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
     @Test
     void testSpecificAccessControl_fullDetailIntentInstructorLoginSameCourse_canAccess() {
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getAccountId()))
                 .thenReturn(stubInstructorWithPermission);
         verifyCanAccess(params);
     }
@@ -346,12 +346,12 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         Student stubStudent = getTypicalStudent();
         stubStudent.setAccount(getTypicalAccount());
 
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
         verifyCanAccess(params);
     }
 
@@ -364,12 +364,12 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         anotherStudent.setAccount(getTypicalAccount());
         anotherStudent.getCourse().setId("course");
 
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         when(mockLogic.getCourse("course")).thenReturn(anotherStudent.getCourse());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course",
         };
-        when(mockLogic.getStudentByAccountId("course", stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId("course", stubStudent.getAccountId())).thenReturn(null);
         verifyCannotAccess(params);
     }
 
@@ -378,13 +378,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         Instructor anotherInstructor = getTypicalInstructor();
         anotherInstructor.getCourse().setId("course");
 
-        loginAsInstructor(stubInstructorWithPermission.getGoogleId());
+        loginAsInstructor(stubInstructorWithPermission.getAccountId());
         when(mockLogic.getCourse("course")).thenReturn(anotherInstructor.getCourse());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course",
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
-        when(mockLogic.getInstructorByAccountId("course", stubInstructorWithPermission.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId("course", stubInstructorWithPermission.getAccountId())).thenReturn(null);
         verifyCannotAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
@@ -81,9 +81,9 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         expectedInstructorsData.getInstructors().get(0).setKey(stubInstructorWithPermission.getRegKey());
         expectedInstructorsData.getInstructors().get(1).setKey(stubInstructorWithoutPermission.getRegKey());
         expectedInstructorsData.getInstructors().get(2).setKey(stubInstructorWithOnlyModifyInstructorPrivilege.getRegKey());
-        expectedInstructorsData.getInstructors().get(0).setGoogleId(stubInstructorWithPermission.getGoogleId());
-        expectedInstructorsData.getInstructors().get(1).setGoogleId(stubInstructorWithoutPermission.getGoogleId());
-        expectedInstructorsData.getInstructors().get(2).setGoogleId(stubInstructorWithOnlyModifyInstructorPrivilege
+        expectedInstructorsData.getInstructors().get(0).setAccountId(stubInstructorWithPermission.getGoogleId());
+        expectedInstructorsData.getInstructors().get(1).setAccountId(stubInstructorWithoutPermission.getGoogleId());
+        expectedInstructorsData.getInstructors().get(2).setAccountId(stubInstructorWithOnlyModifyInstructorPrivilege
                 .getGoogleId());
 
         reset(mockLogic);
@@ -215,7 +215,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         assertEquals(expectedInstructors.size(), actualInstructors.size());
         for (int i = 0; i < expectedInstructors.size(); i++) {
             if (isNullIntent) {
-                assertNull(actualInstructors.get(i).getGoogleId());
+                assertNull(actualInstructors.get(i).getAccountId());
                 assertNull(actualInstructors.get(i).getJoinState());
                 assertNull(actualInstructors.get(i).getIsDisplayedToStudents());
                 assertNull(actualInstructors.get(i).getRole());
@@ -237,10 +237,10 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
                 }
 
                 if (isGoogleIdSetForFullDetail) {
-                    assertNotNull(actualInstructors.get(i).getGoogleId());
-                    assertEquals(expectedInstructors.get(i).getGoogleId(), actualInstructors.get(i).getGoogleId());
+                    assertNotNull(actualInstructors.get(i).getAccountId());
+                    assertEquals(expectedInstructors.get(i).getAccountId(), actualInstructors.get(i).getAccountId());
                 } else {
-                    assertNull(actualInstructors.get(i).getGoogleId());
+                    assertNull(actualInstructors.get(i).getAccountId());
                 }
                 assertEquals(expectedInstructors.get(i).getName(), actualInstructors.get(i).getName());
                 assertEquals(expectedInstructors.get(i).getEmail(), actualInstructors.get(i).getEmail());

--- a/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetInstructorsActionTest.java
@@ -161,13 +161,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         };
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
                 .thenReturn(stubInstructorWithPermission);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, true);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
-        verify(mockLogic, times(1)).getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId());
+        verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId());
     }
 
     @Test
@@ -179,13 +179,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         };
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithoutPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithoutPermission.getGoogleId()))
                 .thenReturn(stubInstructorWithoutPermission);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, false);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
-        verify(mockLogic, times(1)).getInstructorByGoogleId(stubCourse.getId(),
+        verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(),
                 stubInstructorWithoutPermission.getGoogleId());
     }
 
@@ -198,13 +198,13 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         };
 
         when(mockLogic.getInstructorsByCourse(stubCourse.getId())).thenReturn(stubInstructors);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithOnlyModifyInstructorPrivilege
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithOnlyModifyInstructorPrivilege
                 .getGoogleId())).thenReturn(stubInstructorWithOnlyModifyInstructorPrivilege);
         GetInstructorsAction action = getAction(params);
         InstructorsData actualInstructorsData = (InstructorsData) getJsonResult(action).getOutput();
         verifyInstructorsData(expectedInstructorsData, actualInstructorsData, false, false, true);
         verify(mockLogic, times(1)).getInstructorsByCourse(stubCourse.getId());
-        verify(mockLogic, times(1)).getInstructorByGoogleId(stubCourse.getId(),
+        verify(mockLogic, times(1)).getInstructorByAccountId(stubCourse.getId(),
                 stubInstructorWithOnlyModifyInstructorPrivilege.getGoogleId());
     }
 
@@ -311,14 +311,14 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         String[] params1 = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), "unregistered")).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), "unregistered")).thenReturn(null);
         verifyCannotAccess(params1);
 
         String[] params2 = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), "unregistered")).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), "unregistered")).thenReturn(null);
         verifyCannotAccess(params2);
     }
 
@@ -330,7 +330,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithPermission.getGoogleId()))
                 .thenReturn(stubInstructorWithPermission);
         verifyCanAccess(params);
     }
@@ -351,7 +351,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
         verifyCanAccess(params);
     }
 
@@ -369,7 +369,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course",
         };
-        when(mockLogic.getStudentByGoogleId("course", stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId("course", stubStudent.getGoogleId())).thenReturn(null);
         verifyCannotAccess(params);
     }
 
@@ -384,7 +384,7 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
                 Const.ParamsNames.COURSE_ID, "course",
                 Const.ParamsNames.INTENT, "FULL_DETAIL",
         };
-        when(mockLogic.getInstructorByGoogleId("course", stubInstructorWithPermission.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId("course", stubInstructorWithPermission.getGoogleId())).thenReturn(null);
         verifyCannotAccess(params);
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
@@ -39,7 +39,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
     @BeforeMethod
     public void setUpMethod() {
-        when(mockLogic.getAccountForId(GOOGLE_ID)).thenReturn(getTypicalAccount());
+        when(mockLogic.getAccount(GOOGLE_ID)).thenReturn(getTypicalAccount());
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
@@ -39,7 +39,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
     @BeforeMethod
     public void setUpMethod() {
-        when(mockLogic.getAccountForGoogleId(GOOGLE_ID)).thenReturn(getTypicalAccount());
+        when(mockLogic.getAccountForId(GOOGLE_ID)).thenReturn(getTypicalAccount());
     }
 
     @Test

--- a/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetOngoingSessionsActionTest.java
@@ -212,11 +212,11 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         assertEquals(1, response.getTotalAwaitingSessions());
         assertEquals(3L, response.getTotalInstitutes());
         Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
-        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(c1Fs2, instructor2.getGoogleId());
+        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(c1Fs2, instructor2.getAccountId());
         expectedSessions.put("NUS", Collections.singletonList(expectedOngoingC1Fs2));
-        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(c2Fs1, instructor3.getGoogleId());
+        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(c2Fs1, instructor3.getAccountId());
         expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
-        OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getGoogleId());
+        OngoingSession expectedOngoingC3Fs1 = new OngoingSession(c3Fs1, instructor4.getAccountId());
         expectedSessions.put("UCL", Collections.singletonList(expectedOngoingC3Fs1));
         Map<String, List<OngoingSession>> actualSessions = response.getSessions();
         assertEqualSessions(expectedSessions, actualSessions);
@@ -279,9 +279,9 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
         assertEquals(1, response.getTotalAwaitingSessions());
         assertEquals(2L, response.getTotalInstitutes());
         Map<String, List<OngoingSession>> expectedSessions = new HashMap<>();
-        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(sqlC1Fs2, instructor2.getGoogleId());
+        OngoingSession expectedOngoingC1Fs2 = new OngoingSession(sqlC1Fs2, instructor2.getAccountId());
         expectedSessions.put("NUS", Collections.singletonList(expectedOngoingC1Fs2));
-        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(sqlC2Fs1, instructor3.getGoogleId());
+        OngoingSession expectedOngoingC2Fs1 = new OngoingSession(sqlC2Fs1, instructor3.getAccountId());
         expectedSessions.put("MIT", Collections.singletonList(expectedOngoingC2Fs1));
         Map<String, List<OngoingSession>> actualSessions = response.getSessions();
         assertEqualSessions(expectedSessions, actualSessions);

--- a/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
@@ -37,12 +37,12 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
         Account account = getTypicalAccount();
         List<ReadNotification> testReadNotifications = new ArrayList<>();
 
-        loginAsInstructor(account.getGoogleId());
+        loginAsInstructor(account.getId());
         for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
             testReadNotifications.add(new ReadNotification(account, getTypicalNotificationWithId()));
         }
 
-        when(mockLogic.getAccountForId(account.getGoogleId())).thenReturn(account);
+        when(mockLogic.getAccountForId(account.getId())).thenReturn(account);
         when(mockLogic.getReadNotificationsByAccountId(account.getId())).thenReturn(testReadNotifications);
 
         GetReadNotificationsAction action = getAction();

--- a/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
@@ -42,7 +42,7 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
             testReadNotifications.add(new ReadNotification(account, getTypicalNotificationWithId()));
         }
 
-        when(mockLogic.getAccountForGoogleId(account.getGoogleId())).thenReturn(account);
+        when(mockLogic.getAccountForId(account.getGoogleId())).thenReturn(account);
         when(mockLogic.getReadNotificationsByAccountId(account.getId())).thenReturn(testReadNotifications);
 
         GetReadNotificationsAction action = getAction();

--- a/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetReadNotificationsActionTest.java
@@ -42,7 +42,7 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
             testReadNotifications.add(new ReadNotification(account, getTypicalNotificationWithId()));
         }
 
-        when(mockLogic.getAccountForId(account.getId())).thenReturn(account);
+        when(mockLogic.getAccount(account.getId())).thenReturn(account);
         when(mockLogic.getReadNotificationsByAccountId(account.getId())).thenReturn(testReadNotifications);
 
         GetReadNotificationsAction action = getAction();

--- a/src/test/java/teammates/sqlui/webapi/GetRegkeyValidityActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetRegkeyValidityActionTest.java
@@ -60,13 +60,13 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         String[] params3 = {};
         verifyHttpParameterFailure(params3);
 
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
+        loginAsStudent(stubStudentWithAccount.getAccountId());
         verifyHttpParameterFailure(params1);
         verifyHttpParameterFailure(params2);
         verifyHttpParameterFailure(params3);
 
         logoutUser();
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
+        loginAsInstructor(stubInstructorWithAccount.getAccountId());
         verifyHttpParameterFailure(params1);
         verifyHttpParameterFailure(params2);
         verifyHttpParameterFailure(params3);
@@ -132,7 +132,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
     @Test
     void testExecute_studentIntentLoggedInUsedKey_validUsedAllowedKey() {
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
+        loginAsStudent(stubStudentWithAccount.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.REGKEY, stubRegkey,
@@ -164,7 +164,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
     @Test
     void testExecute_instructorIntentLoggedInUsedKey_validUsedAllowedKey() {
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
+        loginAsInstructor(stubInstructorWithAccount.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.REGKEY, stubRegkey,
@@ -320,7 +320,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
     @Test
     void testExecute_studentIntentLoggedInUnusedKey_validUnusedAllowed() {
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
+        loginAsStudent(stubStudentWithAccount.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.REGKEY, stubRegkey,
@@ -352,7 +352,7 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
 
     @Test
     void testExecute_instructorIntentLoggedInUnusedKey_validUnusedAllowed() {
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
+        loginAsInstructor(stubInstructorWithAccount.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.REGKEY, stubRegkey,
@@ -463,11 +463,11 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         verifyCanAccess();
 
         logoutUser();
-        loginAsStudent(stubStudentWithAccount.getGoogleId());
+        loginAsStudent(stubStudentWithAccount.getAccountId());
         verifyCanAccess();
 
         logoutUser();
-        loginAsInstructor(stubInstructorWithAccount.getGoogleId());
+        loginAsInstructor(stubInstructorWithAccount.getAccountId());
         verifyCanAccess();
 
         logoutUser();
@@ -475,11 +475,11 @@ public class GetRegkeyValidityActionTest extends BaseActionTest<GetRegkeyValidit
         verifyCanAccess();
 
         logoutUser();
-        loginAsUnregistered(stubStudentWithAccount.getGoogleId());
+        loginAsUnregistered(stubStudentWithAccount.getAccountId());
         verifyCanAccess();
 
         logoutUser();
-        loginAsStudentInstructor(stubStudentWithAccount.getGoogleId());
+        loginAsStudentInstructor(stubStudentWithAccount.getAccountId());
         verifyCanAccess();
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
@@ -173,7 +173,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
@@ -188,7 +188,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, "non-existent-course",
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), "non-existent-course"))
                 .thenReturn(null);
@@ -203,7 +203,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, "non-existent-feedback-session",
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession("non-existent-feedback-session", stubCourse.getId()))
                 .thenReturn(null);
@@ -218,7 +218,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), "invalid-id"))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), "invalid-id"))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
@@ -233,7 +233,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
@@ -243,7 +243,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
         anotherInstructor.setAccount(getTypicalAccount());
         anotherInstructor.setCourse(
                 new Course("another-course", "Another Course", Const.DEFAULT_TIME_ZONE, "teammates"));
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(anotherInstructor);
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetSessionResponseStatsActionTest.java
@@ -80,7 +80,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testExecute_instructorAccessOwnStats_getStats() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
@@ -101,7 +101,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testExecute_nonExistentFeedbackSession_throwsEntityDoesNotExistException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, "nonexistentFeedbackSession",
@@ -113,7 +113,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testExecute_nonExistentCourse_throwsEntityDoesNotExistException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
@@ -167,13 +167,13 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testSpecificAccessControl_instructorValidParamsOwnCourse_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
@@ -182,13 +182,13 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testSpecificAccessControl_instructorNonExistentCourse_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, "non-existent-course",
         };
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), "non-existent-course"))
                 .thenReturn(null);
@@ -197,13 +197,13 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testSpecificAccessControl_instructorNonExistentFeedbackSession_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, "non-existent-feedback-session",
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession("non-existent-feedback-session", stubCourse.getId()))
                 .thenReturn(null);
@@ -227,13 +227,13 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
 
     @Test
     void testSpecificAccessControl_instructorAccessNotOwnCourse_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, stubFeedbackSession.getName(),
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubCourse.getId()))
                 .thenReturn(stubFeedbackSession);
@@ -243,7 +243,7 @@ public class GetSessionResponseStatsActionTest extends BaseActionTest<GetSession
         anotherInstructor.setAccount(getTypicalAccount());
         anotherInstructor.setCourse(
                 new Course("another-course", "Another Course", Const.DEFAULT_TIME_ZONE, "teammates"));
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(anotherInstructor);
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/GetSessionResultsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetSessionResultsActionTest.java
@@ -83,7 +83,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
         // Specific mocked methods
         switch (intent) {
         case FULL_DETAIL:
-            when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
+            when(mockLogic.getInstructorByAccountId(session.getCourseId(), googleId)).thenReturn(instructorStub);
             when(mockLogic.getSessionResultsForCourse(argThat(
                     argument -> Objects.equals(argument.getName(), session.getName())),
                     eq(course.getId()), eq(instructorStub.getEmail()), isNull(), isNull(),
@@ -91,7 +91,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
             break;
         case INSTRUCTOR_RESULT:
             when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
-            when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
+            when(mockLogic.getInstructorByAccountId(session.getCourseId(), googleId)).thenReturn(instructorStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
                     eq(course.getId()), eq(instructorStub.getEmail()),
@@ -99,7 +99,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
             break;
         case STUDENT_RESULT:
             Student studentStub = getTypicalStudent();
-            when(mockLogic.getStudentByGoogleId(session.getCourseId(), googleId)).thenReturn(studentStub);
+            when(mockLogic.getStudentByAccountId(session.getCourseId(), googleId)).thenReturn(studentStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
                     eq(course.getId()), eq(studentStub.getEmail()),
@@ -200,7 +200,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
         when(mockLogic.getInstructorForEmail(course.getId(), instructorStub.getEmail())).thenReturn(instructorStub);
-        when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
+        when(mockLogic.getInstructorByAccountId(session.getCourseId(), googleId)).thenReturn(instructorStub);
         when(mockLogic.getSessionResultsForCourse(argThat(
                         argument -> Objects.equals(argument.getName(), session.getName())),
                 eq(course.getId()), eq(instructorStub.getEmail()), eq(questionStub.getId()), eq("sectionName"),
@@ -229,7 +229,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
         when(mockLogic.getInstructorForEmail(course.getId(), instructorStub.getEmail())).thenReturn(instructorStub);
-        when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
+        when(mockLogic.getInstructorByAccountId(session.getCourseId(), googleId)).thenReturn(instructorStub);
         when(mockLogic.getSessionResultsForUser(argThat(
                         argument -> Objects.equals(argument.getName(), session.getName())),
                 eq(course.getId()), eq(instructorStub.getEmail()),
@@ -256,7 +256,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
         when(mockLogic.getStudentForEmail(course.getId(), studentStub.getEmail())).thenReturn(studentStub);
-        when(mockLogic.getStudentByGoogleId(session.getCourseId(), googleId)).thenReturn(studentStub);
+        when(mockLogic.getStudentByAccountId(session.getCourseId(), googleId)).thenReturn(studentStub);
         when(mockLogic.getSessionResultsForUser(argThat(
                         argument -> Objects.equals(argument.getName(), session.getName())),
                 eq(course.getId()), eq(studentStub.getEmail()),
@@ -349,7 +349,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
     }
@@ -384,7 +384,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId())).thenReturn(session);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
     }
@@ -407,7 +407,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         Student sameCourseStudent = getTypicalStudent();
         sameCourseStudent.setCourse(course);
-        when(mockLogic.getStudentByGoogleId(eq(session.getCourseId()), any()))
+        when(mockLogic.getStudentByAccountId(eq(session.getCourseId()), any()))
                 .thenReturn(sameCourseStudent);
 
         verifyStudentsOfTheSameCourseCanAccess(course, buildParams(STUDENT_RESULT));
@@ -472,7 +472,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId()))
                 .thenReturn(session);
-        when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId))
+        when(mockLogic.getInstructorByAccountId(session.getCourseId(), googleId))
                 .thenReturn(instructor);
 
         verifyHttpParameterFailureAcl(buildParams(Intent.INSTRUCTOR_SUBMISSION));
@@ -502,7 +502,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
                 .thenReturn(session);
         when(mockLogic.getStudentForEmail(student.getCourseId(), student.getEmail()))
                 .thenReturn(student);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId))
                 .thenReturn(getTypicalInstructor());
 
         String[] params1 = buildParamsWithPreview(
@@ -525,11 +525,11 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         String[] params = buildParams(STUDENT_RESULT);
 
-        when(mockLogic.getStudentByGoogleId(course.getId(), googleId))
+        when(mockLogic.getStudentByAccountId(course.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId()))
                 .thenReturn(session);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId))
                 .thenReturn(getTypicalInstructor());
 
         verifyCannotAccess(params);
@@ -545,7 +545,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
 
         when(mockLogic.getFeedbackSession(session.getName(), session.getCourseId()))
                 .thenReturn(session);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId))
                 .thenReturn(instructor);
 
         verifyCannotAccess(params);

--- a/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
@@ -101,12 +101,12 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
     @Test
     void testExecute_validParamsRegisteredStudentLoggedIn_success() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
 
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
         stubStudentData.setInstitute(stubStudent.getCourse().getInstitute());
         GetStudentAction action = getAction(params);
         StudentData studentData = (StudentData) getJsonResult(action).getOutput();
@@ -136,7 +136,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         when(mockLogic.getStudentForEmail("random-course", stubStudent.getEmail())).thenReturn(null);
         verifyEntityNotFound(params);
 
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         verifyEntityNotFound(params);
     }
 
@@ -158,7 +158,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         };
         verifyHttpParameterFailure(params);
 
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         verifyHttpParameterFailure(params);
     }
 
@@ -176,7 +176,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
         stubStudentData = new StudentData(stubStudent);
         stubStudentData.setKey(stubStudent.getRegKey());
-        stubStudentData.setAccountId(stubStudent.getAccount().getGoogleId());
+        stubStudentData.setAccountId(stubStudent.getAccount().getId());
 
         GetStudentAction action = getAction(params);
         StudentData studentData = (StudentData) getJsonResult(action).getOutput();
@@ -215,7 +215,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
     @Test
     void testExecute_validParamsInstructor_success() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
@@ -229,7 +229,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
     @Test
     void testExecute_invalidCourseIdParamsInstructor_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "random-course",
                 Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
@@ -241,7 +241,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
     @Test
     void testExecute_invalidStudentEmailParamsInstructor_throwsEntityNotFoundException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params = {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.STUDENT_EMAIL, "invalid_email",
@@ -253,7 +253,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
     @Test
     void testExecute_incompleteParamsInstructor_throwsInvalidHttpParameterException() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         String[] params1 = {
                 Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
         };

--- a/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
@@ -176,7 +176,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         when(mockLogic.getStudentForEmail(stubCourse.getId(), stubStudent.getEmail())).thenReturn(stubStudent);
         stubStudentData = new StudentData(stubStudent);
         stubStudentData.setKey(stubStudent.getRegKey());
-        stubStudentData.setGoogleId(stubStudent.getAccount().getGoogleId());
+        stubStudentData.setAccountId(stubStudent.getAccount().getGoogleId());
 
         GetStudentAction action = getAction(params);
         StudentData studentData = (StudentData) getJsonResult(action).getOutput();
@@ -269,7 +269,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
 
         switch (reqEntity) {
         case STUDENT:
-            assertNull(actualStudentData.getGoogleId());
+            assertNull(actualStudentData.getAccountId());
             assertNull(actualStudentData.getKey());
             assertNull(actualStudentData.getComments());
             assertNull(actualStudentData.getJoinState());
@@ -277,7 +277,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
             assertEquals(expectedStudentData.getInstitute(), actualStudentData.getInstitute());
             break;
         case INSTRUCTOR:
-            assertNull(actualStudentData.getGoogleId());
+            assertNull(actualStudentData.getAccountId());
             assertNull(actualStudentData.getKey());
 
             assertNotNull(actualStudentData.getComments());
@@ -286,13 +286,13 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
             assertEquals(expectedStudentData.getJoinState(), actualStudentData.getJoinState());
             break;
         case ADMIN:
-            assertNotNull(actualStudentData.getGoogleId());
+            assertNotNull(actualStudentData.getAccountId());
             assertNotNull(actualStudentData.getKey());
             assertNotNull(actualStudentData.getComments());
             assertNotNull(actualStudentData.getJoinState());
 
             assertEquals(expectedStudentData.getKey(), actualStudentData.getKey());
-            assertEquals(expectedStudentData.getGoogleId(), actualStudentData.getGoogleId());
+            assertEquals(expectedStudentData.getAccountId(), actualStudentData.getAccountId());
             assertEquals(expectedStudentData.getComments(), actualStudentData.getComments());
             assertEquals(expectedStudentData.getJoinState(), actualStudentData.getJoinState());
             break;

--- a/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentActionTest.java
@@ -106,7 +106,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
                 Const.ParamsNames.COURSE_ID, stubCourse.getId(),
         };
 
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
         stubStudentData.setInstitute(stubStudent.getCourse().getInstitute());
         GetStudentAction action = getAction(params);
         StudentData studentData = (StudentData) getJsonResult(action).getOutput();
@@ -313,7 +313,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
             student.setAccount(acc);
             student.setCourse(course);
             return student;
-        }).when(mockLogic).getStudentByGoogleId(eq(course.getId()), anyString());
+        }).when(mockLogic).getStudentByAccountId(eq(course.getId()), anyString());
     }
 
     private void stubSelfLookupAsOtherCourse(Course requestedCourse, Course otherCourse, Student student) {
@@ -325,7 +325,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
             student.setAccount(acc);
             student.setCourse(otherCourse);
             return student;
-        }).when(mockLogic).getStudentByGoogleId(eq(requestedCourse.getId()), anyString());
+        }).when(mockLogic).getStudentByAccountId(eq(requestedCourse.getId()), anyString());
     }
 
     private String[] regKeyParams(String key) {

--- a/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
@@ -148,8 +148,8 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
      void testExecute_instructorWithPermission_success() {
-        loginAsInstructor(stubInstructorWithAllPrivileges.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithAllPrivileges.getGoogleId()))
+        loginAsInstructor(stubInstructorWithAllPrivileges.getAccountId());
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithAllPrivileges.getAccountId()))
                 .thenReturn(stubInstructorWithAllPrivileges);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -166,9 +166,9 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testExecute_instructorWithSameSectionPrivilegesAsStudents_success() {
-        loginAsInstructor(stubInstructorWithOnlyViewSectionPrivileges.getGoogleId());
+        loginAsInstructor(stubInstructorWithOnlyViewSectionPrivileges.getAccountId());
         when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithOnlyViewSectionPrivileges
-                .getGoogleId())).thenReturn(stubInstructorWithOnlyViewSectionPrivileges);
+                .getAccountId())).thenReturn(stubInstructorWithOnlyViewSectionPrivileges);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
         String[] params = {
@@ -196,8 +196,8 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testExecute_instructorWithOnlyViewSectionCourseLevelPrivilege_success() {
-        loginAsInstructor(stubInstructorWithCourseLevelPrivilege.getGoogleId());
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithCourseLevelPrivilege.getGoogleId()))
+        loginAsInstructor(stubInstructorWithCourseLevelPrivilege.getAccountId());
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithCourseLevelPrivilege.getAccountId()))
                 .thenReturn(stubInstructorWithCourseLevelPrivilege);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -214,9 +214,9 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testExecute_instructorWithDifferentSectionPrivilegesAsStudents_emptyList() {
-        loginAsInstructor(stubInstructorWithOnlyViewPrivilegesForDifferentSection.getGoogleId());
+        loginAsInstructor(stubInstructorWithOnlyViewPrivilegesForDifferentSection.getAccountId());
         when(mockLogic.getInstructorByAccountId(stubCourse.getId(),
-                stubInstructorWithOnlyViewPrivilegesForDifferentSection.getGoogleId()))
+                stubInstructorWithOnlyViewPrivilegesForDifferentSection.getAccountId()))
                 .thenReturn(stubInstructorWithOnlyViewPrivilegesForDifferentSection);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -234,7 +234,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testExecute_student_success() {
-        loginAsStudent(stubStudentOne.getGoogleId());
+        loginAsStudent(stubStudentOne.getAccountId());
         when(mockLogic.getStudentsByTeamName(stubStudentOne.getTeam().getName(),
                 stubStudentOne.getCourse().getId())).thenReturn(stubStudentListSectionOneTeamOne);
 
@@ -261,7 +261,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
             assertEquals(expectedStudents.get(i).getSectionName(), actualStudentsData.getStudents().get(i).getSectionName());
             assertEquals(expectedStudents.get(i).getEmail(), actualStudentsData.getStudents().get(i).getEmail());
             assertEquals(expectedStudents.get(i).getName(), actualStudentsData.getStudents().get(i).getName());
-            assertEquals(expectedStudents.get(i).getGoogleId(), actualStudentsData.getStudents().get(i).getAccountId());
+            assertEquals(expectedStudents.get(i).getAccountId(), actualStudentsData.getStudents().get(i).getAccountId());
             assertNull(actualStudentsData.getStudents().get(i).getKey());
             if (type == Type.INSTRUCTOR) {
                 assertEquals(expectedStudents.get(i).getComments(), actualStudentsData.getStudents().get(i).getComments());
@@ -401,10 +401,10 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_invalidCourse_cannotAccess() {
-        loginAsInstructor(stubInstructorWithAllPrivileges.getGoogleId());
+        loginAsInstructor(stubInstructorWithAllPrivileges.getAccountId());
         when(mockLogic.getInstructorByAccountId(
                 "invalid-course-id",
-                stubInstructorWithAllPrivileges.getGoogleId()))
+                stubInstructorWithAllPrivileges.getAccountId()))
                 .thenReturn(stubInstructorWithAllPrivileges);
         when(mockLogic.getCourse("invalid-course-id")).thenReturn(null);
         verifyCannotAccess(

--- a/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
@@ -261,7 +261,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
             assertEquals(expectedStudents.get(i).getSectionName(), actualStudentsData.getStudents().get(i).getSectionName());
             assertEquals(expectedStudents.get(i).getEmail(), actualStudentsData.getStudents().get(i).getEmail());
             assertEquals(expectedStudents.get(i).getName(), actualStudentsData.getStudents().get(i).getName());
-            assertEquals(expectedStudents.get(i).getGoogleId(), actualStudentsData.getStudents().get(i).getGoogleId());
+            assertEquals(expectedStudents.get(i).getGoogleId(), actualStudentsData.getStudents().get(i).getAccountId());
             assertNull(actualStudentsData.getStudents().get(i).getKey());
             if (type == Type.INSTRUCTOR) {
                 assertEquals(expectedStudents.get(i).getComments(), actualStudentsData.getStudents().get(i).getComments());

--- a/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetStudentsActionTest.java
@@ -149,7 +149,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
      void testExecute_instructorWithPermission_success() {
         loginAsInstructor(stubInstructorWithAllPrivileges.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithAllPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithAllPrivileges.getGoogleId()))
                 .thenReturn(stubInstructorWithAllPrivileges);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -167,7 +167,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
     void testExecute_instructorWithSameSectionPrivilegesAsStudents_success() {
         loginAsInstructor(stubInstructorWithOnlyViewSectionPrivileges.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithOnlyViewSectionPrivileges
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithOnlyViewSectionPrivileges
                 .getGoogleId())).thenReturn(stubInstructorWithOnlyViewSectionPrivileges);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -197,7 +197,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
     void testExecute_instructorWithOnlyViewSectionCourseLevelPrivilege_success() {
         loginAsInstructor(stubInstructorWithCourseLevelPrivilege.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructorWithCourseLevelPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructorWithCourseLevelPrivilege.getGoogleId()))
                 .thenReturn(stubInstructorWithCourseLevelPrivilege);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
 
@@ -215,7 +215,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
     void testExecute_instructorWithDifferentSectionPrivilegesAsStudents_emptyList() {
         loginAsInstructor(stubInstructorWithOnlyViewPrivilegesForDifferentSection.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(),
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(),
                 stubInstructorWithOnlyViewPrivilegesForDifferentSection.getGoogleId()))
                 .thenReturn(stubInstructorWithOnlyViewPrivilegesForDifferentSection);
         when(mockLogic.getStudentsForCourse(stubCourse.getId())).thenReturn(stubStudentListAll);
@@ -291,7 +291,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_studentSameTeam_canAccess() {
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), "student-googleId"))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), "student-googleId"))
                 .thenReturn(stubStudentOne);
 
         verifyStudentsCanAccess(
@@ -302,7 +302,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_studentOtherTeam_cannotAccess() {
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), "student-googleId"))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), "student-googleId"))
                 .thenReturn(stubStudentOne);
         verifyStudentsCannotAccess(
                 Const.ParamsNames.COURSE_ID, stubStudentOne.getCourse().getId(),
@@ -312,7 +312,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_studentOtherCourse_cannotAccess() {
-        when(mockLogic.getStudentByGoogleId("another-course-id", "student-googleId"))
+        when(mockLogic.getStudentByAccountId("another-course-id", "student-googleId"))
                 .thenReturn(null);
         verifyStudentsCannotAccess(
                 Const.ParamsNames.COURSE_ID, "another-course-id",
@@ -343,7 +343,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_unregisteredValidStudent_onlyLoggedInCanAccess() {
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), "unregistered-googleId"))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), "unregistered-googleId"))
                 .thenReturn(stubStudentOne);
 
         String[] params = {
@@ -355,7 +355,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_unregisteredInvalidStudent_cannotAccess() {
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), "unregistered-googleId"))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), "unregistered-googleId"))
                 .thenReturn(null);
 
         String[] params = {
@@ -368,7 +368,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_unregisteredValidInstructor_onlyLoggedInCanAccess() {
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), "unregistered-googleId"))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), "unregistered-googleId"))
                 .thenReturn(stubInstructorWithAllPrivileges);
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
 
@@ -380,7 +380,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
 
     @Test
     void testGetStudents_unregisteredInvalidInstructor_cannotAccess() {
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), "unregistered-googleId"))
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), "unregistered-googleId"))
                 .thenReturn(null);
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
 
@@ -402,7 +402,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
     void testGetStudents_invalidCourse_cannotAccess() {
         loginAsInstructor(stubInstructorWithAllPrivileges.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(
+        when(mockLogic.getInstructorByAccountId(
                 "invalid-course-id",
                 stubInstructorWithAllPrivileges.getGoogleId()))
                 .thenReturn(stubInstructorWithAllPrivileges);

--- a/src/test/java/teammates/sqlui/webapi/GetTimeZonesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetTimeZonesActionTest.java
@@ -42,7 +42,7 @@ public class GetTimeZonesActionTest extends BaseActionTest<GetTimeZonesAction> {
 
     @Test
     void testAccessControl_student_cannotAccess() {
-        loginAsStudent(Const.ParamsNames.STUDENT_ID);
+        loginAsStudent(Const.ParamsNames.STUDENT_ACCOUNT_ID);
         verifyCannotAccess();
     }
 

--- a/src/test/java/teammates/sqlui/webapi/GetUsageStatisticsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetUsageStatisticsActionTest.java
@@ -49,7 +49,7 @@ public class GetUsageStatisticsActionTest extends BaseActionTest<GetUsageStatist
     @Test
     void testAccessControl_student_cannotAccess() {
         logoutUser();
-        loginAsStudent(Const.ParamsNames.STUDENT_ID);
+        loginAsStudent(Const.ParamsNames.STUDENT_ACCOUNT_ID);
         verifyCannotAccess();
     }
 

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -45,7 +45,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
                 account.getId(),
                 testNotification.getId()
         )).thenReturn(readNotification);
-        when(mockLogic.getAccountForId(account.getId())).thenReturn(account);
+        when(mockLogic.getAccount(account.getId())).thenReturn(account);
 
         MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
                 testNotification.getId().toString());

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -45,7 +45,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
                 account.getId(),
                 testNotification.getId()
         )).thenReturn(readNotification);
-        when(mockLogic.getAccountForGoogleId(account.getGoogleId())).thenReturn(account);
+        when(mockLogic.getAccountForId(account.getGoogleId())).thenReturn(account);
 
         MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
                 testNotification.getId().toString());

--- a/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/MarkNotificationAsReadActionTest.java
@@ -35,7 +35,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
     void setUp() {
         account = getTypicalAccount();
         testNotification = getTypicalNotificationWithId();
-        loginAsInstructor(account.getGoogleId());
+        loginAsInstructor(account.getId());
     }
 
     @Test
@@ -45,7 +45,7 @@ public class MarkNotificationAsReadActionTest extends BaseActionTest<MarkNotific
                 account.getId(),
                 testNotification.getId()
         )).thenReturn(readNotification);
-        when(mockLogic.getAccountForId(account.getGoogleId())).thenReturn(account);
+        when(mockLogic.getAccountForId(account.getId())).thenReturn(account);
 
         MarkNotificationAsReadRequest reqBody = new MarkNotificationAsReadRequest(
                 testNotification.getId().toString());

--- a/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
@@ -181,7 +181,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -199,7 +199,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -217,7 +217,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -237,7 +237,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -254,7 +254,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);

--- a/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
@@ -237,12 +237,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -254,12 +254,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
@@ -57,7 +57,7 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
 
         loginAsInstructor(instructor.getGoogleId());
 
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
@@ -55,9 +55,9 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
         instructor = generateInstructor1InCourse(course);
         student = generateStudent1InCourse(course);
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
@@ -57,9 +57,9 @@ public class RemindFeedbackSessionSubmissionActionTest
         instructor = generateInstructor1InCourse(course);
         student = generateStudent1InCourse(course);
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
     }
 

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
@@ -59,7 +59,7 @@ public class RemindFeedbackSessionSubmissionActionTest
 
         loginAsInstructor(instructor.getGoogleId());
 
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
     }
 

--- a/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
@@ -173,7 +173,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(1))
-                .resetStudentAcccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
     }
 
     @Test
@@ -195,7 +195,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(0))
-                .resetStudentAcccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
     }
 
     @Test
@@ -231,7 +231,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         };
         when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
                 .thenReturn(stubStudent);
-        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentAcccountId(stubStudent.getEmail(),
+        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentAccountId(stubStudent.getEmail(),
                 stubStudent.getCourseId(), stubStudent.getGoogleId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());

--- a/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
@@ -151,7 +151,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(1)).resetInstructorAccountId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+                stubInstructor.getCourseId(), stubInstructor.getAccountId());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(1))
-                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getAccountId());
     }
 
     @Test
@@ -195,7 +195,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(0))
-                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getAccountId());
     }
 
     @Test
@@ -217,7 +217,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(0)).resetInstructorAccountId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+                stubInstructor.getCourseId(), stubInstructor.getAccountId());
     }
 
     @Test
@@ -232,7 +232,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
                 .thenReturn(stubStudent);
         doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentAccountId(stubStudent.getEmail(),
-                stubStudent.getCourseId(), stubStudent.getGoogleId());
+                stubStudent.getCourseId(), stubStudent.getAccountId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
 
@@ -250,7 +250,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), stubInstructor.getEmail()))
                 .thenReturn(stubInstructor);
         doThrow(EntityDoesNotExistException.class).when(mockLogic).resetInstructorAccountId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+                stubInstructor.getCourseId(), stubInstructor.getAccountId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
     }

--- a/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/ResetAccountActionTest.java
@@ -150,7 +150,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(1)).resetInstructorGoogleId(stubInstructor.getEmail(),
+        verify(mockLogic, times(1)).resetInstructorAccountId(stubInstructor.getEmail(),
                 stubInstructor.getCourseId(), stubInstructor.getGoogleId());
     }
 
@@ -173,7 +173,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(1))
-                .resetStudentGoogleId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAcccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
     }
 
     @Test
@@ -195,7 +195,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
         verify(mockLogic, times(0))
-                .resetStudentGoogleId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+                .resetStudentAcccountId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
     }
 
     @Test
@@ -216,7 +216,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(0)).resetInstructorGoogleId(stubInstructor.getEmail(),
+        verify(mockLogic, times(0)).resetInstructorAccountId(stubInstructor.getEmail(),
                 stubInstructor.getCourseId(), stubInstructor.getGoogleId());
     }
 
@@ -231,7 +231,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         };
         when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
                 .thenReturn(stubStudent);
-        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentGoogleId(stubStudent.getEmail(),
+        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentAcccountId(stubStudent.getEmail(),
                 stubStudent.getCourseId(), stubStudent.getGoogleId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
@@ -249,7 +249,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         };
         when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), stubInstructor.getEmail()))
                 .thenReturn(stubInstructor);
-        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetInstructorGoogleId(stubInstructor.getEmail(),
+        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetInstructorAccountId(stubInstructor.getEmail(),
                 stubInstructor.getCourseId(), stubInstructor.getGoogleId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());

--- a/src/test/java/teammates/sqlui/webapi/RestoreCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RestoreCourseActionTest.java
@@ -70,7 +70,7 @@ public class RestoreCourseActionTest extends BaseActionTest<RestoreCourseAction>
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -90,7 +90,7 @@ public class RestoreCourseActionTest extends BaseActionTest<RestoreCourseAction>
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/RestoreFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RestoreFeedbackSessionActionTest.java
@@ -60,7 +60,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         doNothing().when(mockLogic).restoreFeedbackSessionFromRecycleBin(FEEDBACK_SESSION_NAME, COURSE_ID);
         when(mockLogic.getFeedbackSession(FEEDBACK_SESSION_NAME, COURSE_ID))
                 .thenReturn(stubFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(COURSE_ID, GOOGLE_ID)).thenReturn(stubInstructor);
+        when(mockLogic.getInstructorByAccountId(COURSE_ID, GOOGLE_ID)).thenReturn(stubInstructor);
 
         loginAsInstructor(GOOGLE_ID);
 

--- a/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
@@ -82,7 +82,7 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
             Instructor instructor = instructors.get(i);
             InstructorData instructorData = instructorsData.getInstructors().get(i);
 
-            assertEquals(instructor.getGoogleId(), instructorData.getGoogleId());
+            assertEquals(instructor.getGoogleId(), instructorData.getAccountId());
             assertEquals(instructor.getCourseId(), instructorData.getCourseId());
             assertEquals(instructor.getEmail(), instructorData.getEmail());
             assertEquals(instructor.isDisplayedToStudents(), instructorData.getIsDisplayedToStudents());

--- a/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchInstructorsActionTest.java
@@ -82,7 +82,7 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
             Instructor instructor = instructors.get(i);
             InstructorData instructorData = instructorsData.getInstructors().get(i);
 
-            assertEquals(instructor.getGoogleId(), instructorData.getAccountId());
+            assertEquals(instructor.getAccountId(), instructorData.getAccountId());
             assertEquals(instructor.getCourseId(), instructorData.getCourseId());
             assertEquals(instructor.getEmail(), instructorData.getEmail());
             assertEquals(instructor.isDisplayedToStudents(), instructorData.getIsDisplayedToStudents());

--- a/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
@@ -87,7 +87,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
             assertEquals(student.getSectionName(), studentData.getSectionName());
 
             if (isAdmin) {
-                assertEquals(student.getGoogleId(), studentData.getAccountId());
+                assertEquals(student.getAccountId(), studentData.getAccountId());
                 assertEquals(student.getRegKey(), studentData.getKey());
                 assertEquals(student.getCourse().getInstitute(), studentData.getInstitute());
             } else {

--- a/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
@@ -87,11 +87,11 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
             assertEquals(student.getSectionName(), studentData.getSectionName());
 
             if (isAdmin) {
-                assertEquals(student.getGoogleId(), studentData.getGoogleId());
+                assertEquals(student.getGoogleId(), studentData.getAccountId());
                 assertEquals(student.getRegKey(), studentData.getKey());
                 assertEquals(student.getCourse().getInstitute(), studentData.getInstitute());
             } else {
-                assertNull(studentData.getGoogleId());
+                assertNull(studentData.getAccountId());
                 assertNull(studentData.getKey());
                 assertNull(studentData.getInstitute());
             }

--- a/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SearchStudentsActionTest.java
@@ -103,7 +103,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsInstructor(instructorId);
         List<Instructor> instructors = setupInstructors();
 
-        when(mockLogic.getInstructorsForGoogleId(instructorId)).thenReturn(instructors);
+        when(mockLogic.getInstructorsForAccountId(instructorId)).thenReturn(instructors);
         when(mockLogic.searchStudents(searchKey, instructors)).thenReturn(students);
 
         String[] params = {
@@ -114,7 +114,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         SearchStudentsAction action = getAction(params);
         StudentsData studentsData = (StudentsData) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorsForGoogleId(instructorId);
+        verify(mockLogic, times(1)).getInstructorsForAccountId(instructorId);
         verify(mockLogic, times(1)).searchStudents(searchKey, instructors);
         verify(mockLogic, never()).searchStudentsInWholeSystem(any());
         verify(mockLogic, never()).getCourseInstitute(any());
@@ -128,7 +128,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         loginAsInstructor(instructorId);
         List<Instructor> instructors = setupInstructors();
 
-        when(mockLogic.getInstructorsForGoogleId(instructorId)).thenReturn(instructors);
+        when(mockLogic.getInstructorsForAccountId(instructorId)).thenReturn(instructors);
         when(mockLogic.searchStudents(searchKey, instructors)).thenReturn(List.of());
 
         String[] params = {
@@ -139,7 +139,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         SearchStudentsAction action = getAction(params);
         StudentsData studentsData = (StudentsData) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorsForGoogleId(instructorId);
+        verify(mockLogic, times(1)).getInstructorsForAccountId(instructorId);
         verify(mockLogic, times(1)).searchStudents(searchKey, instructors);
         verify(mockLogic, never()).searchStudentsInWholeSystem(any());
         verify(mockLogic, never()).getCourseInstitute(any());
@@ -165,7 +165,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         SearchStudentsAction action = getAction(params);
         StudentsData studentsData = (StudentsData) getJsonResult(action).getOutput();
 
-        verify(mockLogic, never()).getInstructorsForGoogleId(any());
+        verify(mockLogic, never()).getInstructorsForAccountId(any());
         verify(mockLogic, never()).searchStudents(any(), any());
         verify(mockLogic, times(1)).searchStudentsInWholeSystem(searchKey);
         verify(mockLogic, times(students.size())).getCourseInstitute(argThat(courseId ->
@@ -190,7 +190,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         SearchStudentsAction action = getAction(params);
         StudentsData studentsData = (StudentsData) getJsonResult(action).getOutput();
 
-        verify(mockLogic, never()).getInstructorsForGoogleId(any());
+        verify(mockLogic, never()).getInstructorsForAccountId(any());
         verify(mockLogic, never()).searchStudents(any(), any());
         verify(mockLogic, times(1)).searchStudentsInWholeSystem(searchKey);
         verify(mockLogic, never()).getCourseInstitute(any());
@@ -238,7 +238,7 @@ public class SearchStudentsActionTest extends BaseActionTest<SearchStudentsActio
         SearchStudentsAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action, 500).getOutput();
 
-        verify(mockLogic, never()).getInstructorsForGoogleId(any());
+        verify(mockLogic, never()).getInstructorsForAccountId(any());
         verify(mockLogic, never()).searchStudents(any(), any());
         verify(mockLogic, times(1)).searchStudentsInWholeSystem(searchKey);
         verify(mockLogic, never()).getCourseInstitute(any());

--- a/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
@@ -85,7 +85,7 @@ public class SendJoinReminderEmailActionTest
         Account inviterAccount = mock(Account.class);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
-        when(mockLogic.getAccountForGoogleId(instructorGoogleId)).thenReturn(inviterAccount);
+        when(mockLogic.getAccountForId(instructorGoogleId)).thenReturn(inviterAccount);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, instructor, course))
                 .thenReturn(mock(EmailWrapper.class));
 
@@ -136,7 +136,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(canModifyStudentPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
     }
@@ -154,7 +154,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(cannotModifyStudentPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCannotAccess(params);
     }
@@ -171,7 +171,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(canModifyStudentPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
     }
@@ -188,7 +188,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(cannotModifyStudentPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCannotAccess(params);
     }
@@ -206,7 +206,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(canModifyInstructorPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
     }
@@ -224,7 +224,7 @@ public class SendJoinReminderEmailActionTest
         instructor.setPrivileges(cannotModifyInstructorPrivileges);
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SendJoinReminderEmailActionTest.java
@@ -85,7 +85,7 @@ public class SendJoinReminderEmailActionTest
         Account inviterAccount = mock(Account.class);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
-        when(mockLogic.getAccountForId(instructorGoogleId)).thenReturn(inviterAccount);
+        when(mockLogic.getAccount(instructorGoogleId)).thenReturn(inviterAccount);
         when(mockSqlEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, instructor, course))
                 .thenReturn(mock(EmailWrapper.class));
 

--- a/src/test/java/teammates/sqlui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -102,8 +102,8 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 any(FeedbackQuestion.class), anyString(), anyString(), anyString());
 
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(stubStudent);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
@@ -114,7 +114,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_insufficientParams_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params1 = {};
         verifyHttpParameterFailure(params1);
@@ -127,7 +127,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_invalidIntent_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] paramsStudentResult = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -150,7 +150,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_noRequestBody_throwsInvalidHttpRequestBodyException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -162,7 +162,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_nullRecipient_throwsInvalidOperationException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -187,7 +187,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_emptyRecipient_throwsInvalidOperationException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -212,7 +212,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_invalidRecipient_throwsInvalidOperationException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -237,7 +237,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_studentSubmissionNoExistingResponses_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -289,7 +289,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_instructorSubmissionNoExistingResponses_success() throws Exception {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -341,7 +341,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_withExistingResponses_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -404,7 +404,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_teamGiverType_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.TEAMS);
 
         String[] params = {
@@ -445,7 +445,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_questionSpecificValidationFails_throwsInvalidHttpRequestBodyException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -478,7 +478,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_tooManyRecipients_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         spyFeedbackQuestion.setNumOfEntitiesToGiveFeedbackTo(1);
 
         String[] params = {
@@ -520,7 +520,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_multipleRecipients_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -562,7 +562,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_teamBasedRecipients_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         spyFeedbackQuestion.setRecipientType(FeedbackParticipantType.TEAMS);
 
         String[] params = {
@@ -602,7 +602,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_idCannotBeConvertedToUuid_throwsInvalidHttpParameterException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, "invalid-uuid",
@@ -624,7 +624,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testExecute_maxPossibleRecipients_success() throws Exception {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         spyFeedbackQuestion.setNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS);
 
         String[] params = {
@@ -666,7 +666,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_questionDoesNotExist_throwsEntityNotFoundException() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
 
         when(mockLogic.getFeedbackQuestion(spyFeedbackQuestion.getId())).thenReturn(null);
 
@@ -682,7 +682,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_notAnswerableForStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
         String[] params = {
@@ -701,7 +701,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_notAnswerableForInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
@@ -719,7 +719,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_instructorWithoutSubmitPrivilege_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().plus(Duration.ofDays(1)));
@@ -741,10 +741,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_studentEntityDoesNotExist_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
-        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getAccountId())).thenReturn(null);
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);
 
@@ -758,9 +758,9 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_instructorEntityDoesNotExist_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
-        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getAccountId())).thenReturn(null);
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.INSTRUCTORS);
 
@@ -774,7 +774,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_sessionNotOpen_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
         stubFeedbackSession.setStartTime(Instant.now().plusSeconds(86400));
         stubFeedbackSession.setEndTime(Instant.now().plusSeconds(172800));
@@ -794,7 +794,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_sessionClosed_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minusSeconds(172800));
         stubFeedbackSession.setStartTime(Instant.now().minusSeconds(86400));
         stubFeedbackSession.setEndTime(Instant.now().minusSeconds(3600));
@@ -814,7 +814,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_submissionWithinGracePeriod_canAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().minus(Duration.ofMinutes(10)));
@@ -835,7 +835,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_submissionAfterDeadlineExtension_canAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().minus(Duration.ofMinutes(10)));
@@ -856,7 +856,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_previewMode_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.INSTRUCTORS);
 
@@ -871,7 +871,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_typicalStudentAccess_canAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().plus(Duration.ofDays(1)));
@@ -891,7 +891,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_typicalInstructorAccess_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().plus(Duration.ofDays(1)));
@@ -911,7 +911,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
 
     @Test
     void testSpecificAccessControl_instructorWithModeratorPrivilege_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
+        loginAsInstructor(stubInstructor.getAccountId());
         spyFeedbackQuestion.setShowGiverNameTo(List.of(FeedbackParticipantType.INSTRUCTORS));
         spyFeedbackQuestion.setShowRecipientNameTo(List.of(FeedbackParticipantType.INSTRUCTORS));
         spyFeedbackQuestion.setShowResponsesTo(List.of(FeedbackParticipantType.INSTRUCTORS));
@@ -945,15 +945,15 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         String[] params = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.USER_ID, stubStudent.getGoogleId(),
+                Const.ParamsNames.USER_ID, stubStudent.getAccountId(),
         };
 
-        verifyCanMasquerade(stubStudent.getGoogleId(), params);
+        verifyCanMasquerade(stubStudent.getAccountId(), params);
     }
 
     @Test
     void testSpecificAccessControl_studentModerationAttempt_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
+        loginAsStudent(stubStudent.getAccountId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);

--- a/src/test/java/teammates/sqlui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -102,8 +102,8 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 any(FeedbackQuestion.class), anyString(), anyString(), anyString());
 
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId()))
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
@@ -744,7 +744,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
 
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
+        when(mockLogic.getStudentByAccountId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.STUDENTS);
 
@@ -760,7 +760,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     void testSpecificAccessControl_instructorEntityDoesNotExist_cannotAccess() {
         loginAsInstructor(stubInstructor.getGoogleId());
 
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
 
         spyFeedbackQuestion.setGiverType(FeedbackParticipantType.INSTRUCTORS);
 

--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -174,12 +174,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByAccountId(courseId, typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(courseId, typicalInstructor.getAccountId()))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), courseId))
                 .thenReturn(null);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyEntityNotFoundAcl(params);
     }
@@ -192,12 +192,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
         };
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(feedbackSessionName, typicalCourse.getId()))
                 .thenReturn(null);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyEntityNotFoundAcl(params);
     }
@@ -276,12 +276,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -293,12 +293,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -174,7 +174,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(courseId, typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(courseId, typicalInstructor.getGoogleId()))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), courseId))
                 .thenReturn(null);
@@ -192,7 +192,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(feedbackSessionName, typicalCourse.getId()))
                 .thenReturn(null);
@@ -220,7 +220,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -238,7 +238,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -256,7 +256,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -276,7 +276,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);
@@ -293,7 +293,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
         };
 
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
                 .thenReturn(typicalFeedbackSession);

--- a/src/test/java/teammates/sqlui/webapi/UpdateCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateCourseActionTest.java
@@ -114,7 +114,7 @@ public class UpdateCourseActionTest extends BaseActionTest<UpdateCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -134,7 +134,7 @@ public class UpdateCourseActionTest extends BaseActionTest<UpdateCourseAction> {
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackQuestionActionTest.java
@@ -213,14 +213,14 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId())).thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         String[] submissionParams = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalFeedbackQuestion.getId().toString(),
         };
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
         verifyCanAccess(submissionParams);
     }
 
@@ -233,14 +233,14 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId())).thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(instructorWithoutAccess);
 
         String[] submissionParams = {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalFeedbackQuestion.getId().toString(),
         };
 
-        loginAsInstructor(instructorWithoutAccess.getGoogleId());
+        loginAsInstructor(instructorWithoutAccess.getAccountId());
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackQuestionActionTest.java
@@ -213,7 +213,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId())).thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         String[] submissionParams = {
@@ -233,7 +233,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),
                 typicalFeedbackQuestion.getCourseId())).thenReturn(typicalFeedbackSession);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(instructorWithoutAccess);
 
         String[] submissionParams = {

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackResponseCommentActionTest.java
@@ -85,10 +85,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         FeedbackResponseCommentUpdateRequest updateRequest = getTypicalRequestBody();
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -112,10 +112,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         FeedbackResponseCommentUpdateRequest updateRequest = getTypicalRequestBody();
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -139,10 +139,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         FeedbackResponseCommentUpdateRequest updateRequest = getTypicalRequestBody();
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -169,10 +169,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         FeedbackResponseCommentUpdateRequest updateRequest = new FeedbackResponseCommentUpdateRequest(
                 "updated comment", new ArrayList<>(), new ArrayList<>());
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -199,10 +199,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         FeedbackResponseCommentUpdateRequest updateRequest = new FeedbackResponseCommentUpdateRequest(
                 "updated comment", Arrays.asList(CommentVisibilityType.STUDENTS), new ArrayList<>());
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -243,10 +243,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         FeedbackResponseCommentUpdateRequest updateRequest = getTypicalRequestBody();
 
-        loginAsInstructor(differentInstructor.getGoogleId());
+        loginAsInstructor(differentInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructor.getAccountId()))
                 .thenReturn(differentInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -273,10 +273,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         FeedbackResponseCommentUpdateRequest updateRequest = getTypicalRequestBody();
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -300,10 +300,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         FeedbackResponseCommentUpdateRequest updateRequest = new FeedbackResponseCommentUpdateRequest(
                 "", new ArrayList<>(), new ArrayList<>());
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
 
         verifyHttpRequestBodyFailure(updateRequest, params);
@@ -337,10 +337,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivileges.getAccountId()))
                 .thenReturn(instructorWithPrivileges);
 
-        loginAsInstructor(instructorWithPrivileges.getGoogleId());
+        loginAsInstructor(instructorWithPrivileges.getAccountId());
         verifyCanAccess(params);
     }
 
@@ -358,10 +358,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivileges.getAccountId()))
                 .thenReturn(instructorWithoutPrivileges);
 
-        loginAsInstructor(instructorWithoutPrivileges.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivileges.getAccountId());
         verifyCannotAccess(params);
     }
 
@@ -379,7 +379,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 .thenReturn(typicalInstructor);
 
         loginAsAdmin();
-        verifyCanMasquerade(typicalInstructor.getGoogleId(), params);
+        verifyCanMasquerade(typicalInstructor.getAccountId(), params);
     }
 
     @Test
@@ -410,12 +410,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getAccountId()))
                 .thenReturn(differentStudentFromSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentFromSameCourse.getGoogleId());
+        loginAsStudent(differentStudentFromSameCourse.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -436,12 +436,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromDifferentTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromDifferentTeam.getAccountId()))
                 .thenReturn(differentStudentFromDifferentTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromDifferentTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentFromDifferentTeam.getGoogleId());
+        loginAsStudent(differentStudentFromDifferentTeam.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -462,12 +462,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameTeam.getAccountId()))
                 .thenReturn(differentStudentFromSameTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsStudent(differentStudentFromSameTeam.getGoogleId());
+        loginAsStudent(differentStudentFromSameTeam.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -485,12 +485,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getAccountId()))
                 .thenReturn(differentInstructorInSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentInstructorInSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
 
-        loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
+        loginAsInstructor(differentInstructorInSameCourse.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -524,10 +524,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getAccountId()))
                 .thenReturn(instructorWithPrivilege);
 
-        loginAsInstructor(instructorWithPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithPrivilege.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -549,10 +549,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -574,10 +574,10 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutPrivilege);
 
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -595,12 +595,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofMinutes(10)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -619,12 +619,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId()))
                 .thenReturn(typicalComment);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getAccountId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
 
-        loginAsInstructor(typicalInstructor.getGoogleId());
+        loginAsInstructor(typicalInstructor.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -643,12 +643,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofMinutes(10)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCanAccess(params);
     }
@@ -667,12 +667,12 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getAccountId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
 
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackResponseCommentActionTest.java
@@ -88,7 +88,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -115,7 +115,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsStudent(typicalStudent.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -142,7 +142,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -172,7 +172,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -202,7 +202,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -246,7 +246,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(differentInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), differentInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructor.getGoogleId()))
                 .thenReturn(differentInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -276,7 +276,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateFeedbackResponseComment(any(UUID.class), any(FeedbackResponseCommentUpdateRequest.class),
                 any(String.class))).thenReturn(updatedComment);
@@ -303,7 +303,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
         verifyHttpRequestBodyFailure(updateRequest, params);
@@ -337,7 +337,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivileges.getGoogleId()))
                 .thenReturn(instructorWithPrivileges);
 
         loginAsInstructor(instructorWithPrivileges.getGoogleId());
@@ -358,7 +358,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivileges.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivileges.getGoogleId()))
                 .thenReturn(instructorWithoutPrivileges);
 
         loginAsInstructor(instructorWithoutPrivileges.getGoogleId());
@@ -375,7 +375,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(any(String.class), any(String.class)))
+        when(mockLogic.getInstructorByAccountId(any(String.class), any(String.class)))
                 .thenReturn(typicalInstructor);
 
         loginAsAdmin();
@@ -410,7 +410,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameCourse.getGoogleId()))
                 .thenReturn(differentStudentFromSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -436,7 +436,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentFromDifferentTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromDifferentTeam.getGoogleId()))
                 .thenReturn(differentStudentFromDifferentTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromDifferentTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -462,7 +462,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), differentStudentFromSameTeam.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), differentStudentFromSameTeam.getGoogleId()))
                 .thenReturn(differentStudentFromSameTeam);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentStudentFromSameTeam))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -485,7 +485,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), differentInstructorInSameCourse.getGoogleId()))
                 .thenReturn(differentInstructorInSameCourse);
         when(mockLogic.getDeadlineForUser(typicalFeedbackSession, differentInstructorInSameCourse))
                 .thenReturn(Instant.now().plus(Duration.ofMinutes(15)));
@@ -524,7 +524,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
                 .thenReturn(instructorWithPrivilege);
 
         loginAsInstructor(instructorWithPrivilege.getGoogleId());
@@ -549,7 +549,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -574,7 +574,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutPrivilege);
 
         loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
@@ -595,7 +595,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofMinutes(10)));
@@ -619,7 +619,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId()))
                 .thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalInstructor))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));
@@ -643,7 +643,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofMinutes(10)));
@@ -667,7 +667,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
         };
 
         when(mockLogic.getFeedbackResponseComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getStudentByGoogleId(typicalCourse.getId(), typicalStudent.getGoogleId()))
+        when(mockLogic.getStudentByAccountId(typicalCourse.getId(), typicalStudent.getGoogleId()))
                 .thenReturn(typicalStudent);
         when(mockLogic.getDeadlineForUser(feedbackSessionPastEndTime, typicalStudent))
                 .thenReturn(Instant.now().minus(Duration.ofHours(1)));

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionActionTest.java
@@ -60,7 +60,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         instructor = generateInstructor1InCourse(course);
         feedbackSession = generateSession1InCourse(course, instructor);
 
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getFeedbackSession(feedbackSession.getName(), course.getId())).thenReturn(feedbackSession);
     }

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionActionTest.java
@@ -60,14 +60,14 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         instructor = generateInstructor1InCourse(course);
         feedbackSession = generateSession1InCourse(course, instructor);
 
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getFeedbackSession(feedbackSession.getName(), course.getId())).thenReturn(feedbackSession);
     }
 
     @Test
     void testExecute_typicalCase_success() throws Exception {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest(feedbackSession);
         String[] params = {
@@ -88,7 +88,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     @Test
     void testExecute_missingParams_throwsInvalidHttpParameterException() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest(feedbackSession);
 
@@ -100,7 +100,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     @Test
     void testExecute_invalidStartTime_throwsInvalidHttpRequestBodyException() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest(feedbackSession);
         // Start time more than 2 hours in the past triggers validation failure
@@ -117,7 +117,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     @Test
     void testExecute_invalidEndTime_throwsInvalidHttpRequestBodyException() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest(feedbackSession);
         // End time more than 1 hour in the past triggers validation failure
@@ -134,7 +134,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     @Test
     void testExecute_sessionVisibleTimeTooEarly_throwsInvalidHttpRequestBodyException() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         // Typical request sets start time to 2 days from now; visibility must be at most 30 days before that
         FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest(feedbackSession);
@@ -152,7 +152,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     @Test
     void testAccessControl_nonExistentFeedbackSession_throwsEntityNotFoundException() {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionDeadlineExtensionsActionTest.java
@@ -63,7 +63,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
         course = generateCourse1();
         instructor = generateInstructor1InCourse(course);
 
-        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getAccountId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>());
         when(mockLogic.getInstructorsByCourse(course.getId())).thenReturn(new ArrayList<>(List.of(instructor)));
@@ -75,7 +75,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
     @Test
     void testExecute_updateDeadlineExtensionEndTime_success()
             throws InvalidParametersException, EntityDoesNotExistException {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         FeedbackSession originalFeedbackSession = generateSession1InCourse(course, instructor);
 
         String[] param = new String[] {
@@ -102,7 +102,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
     @Test
     void testExecute_createDeadlineExtensionEndTime_success()
             throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor.getAccountId());
         FeedbackSession originalFeedbackSession = generateSession1InCourse(course, instructor);
 
         String[] param = new String[] {

--- a/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateFeedbackSessionDeadlineExtensionsActionTest.java
@@ -63,7 +63,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
         course = generateCourse1();
         instructor = generateInstructor1InCourse(course);
 
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getStudentsForCourse(course.getId())).thenReturn(new ArrayList<>());
         when(mockLogic.getInstructorsByCourse(course.getId())).thenReturn(new ArrayList<>(List.of(instructor)));

--- a/src/test/java/teammates/sqlui/webapi/UpdateInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateInstructorActionTest.java
@@ -250,7 +250,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         };
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
-        when(mockLogic.getInstructorByGoogleId(differentCourse.getId(), instructorFromDifferentCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(differentCourse.getId(), instructorFromDifferentCourse.getGoogleId()))
                 .thenReturn(instructorFromDifferentCourse);
 
         loginAsInstructor(instructorFromDifferentCourse.getGoogleId());
@@ -270,7 +270,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         };
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutCorrectPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutCorrectPrivilege.getGoogleId()))
                 .thenReturn(instructorWithoutCorrectPrivilege);
 
         loginAsInstructor(instructorWithoutCorrectPrivilege.getGoogleId());

--- a/src/test/java/teammates/sqlui/webapi/UpdateInstructorActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateInstructorActionTest.java
@@ -48,7 +48,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
 
     @Test
     void testExecute_typicalCase_success() throws Exception {
-        String instructorToUpdateId = typicalInstructorToUpdate.getGoogleId();
+        String instructorToUpdateId = typicalInstructorToUpdate.getAccountId();
         String instructorToUpdateDisplayName = typicalInstructorToUpdate.getDisplayName();
 
         loginAsInstructor(instructorToUpdateId);
@@ -85,7 +85,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
 
     @Test
     void testExecute_invalidEmail_throwsInvalidHttpRequestBodyException() throws Exception {
-        String instructorToUpdateId = typicalInstructorToUpdate.getGoogleId();
+        String instructorToUpdateId = typicalInstructorToUpdate.getAccountId();
         String instructorToUpdateDisplayName = typicalInstructorToUpdate.getDisplayName();
 
         loginAsInstructor(instructorToUpdateId);
@@ -111,7 +111,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
 
     @Test
     void testExecute_noInstructorDisplayed_throwsInvalidOperationException() throws Exception {
-        String instructorToUpdateId = typicalInstructorToUpdate.getGoogleId();
+        String instructorToUpdateId = typicalInstructorToUpdate.getAccountId();
 
         loginAsInstructor(instructorToUpdateId);
 
@@ -136,7 +136,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
 
     @Test
     void testExecute_adminToMasqueradeAsInstructor_success() throws Exception {
-        String instructorToUpdateId = typicalInstructorToUpdate.getGoogleId();
+        String instructorToUpdateId = typicalInstructorToUpdate.getAccountId();
         String instructorToUpdateDisplayName = typicalInstructorToUpdate.getDisplayName();
 
         loginAsAdmin();
@@ -183,7 +183,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
 
     @Test
     void testExecute_nullInstructorEmail_throwsInvalidHttpRequestBodyException() throws Exception {
-        String instructorToUpdateId = typicalInstructorToUpdate.getGoogleId();
+        String instructorToUpdateId = typicalInstructorToUpdate.getAccountId();
         String instructorToUpdateDisplayName = typicalInstructorToUpdate.getDisplayName();
 
         loginAsInstructor(instructorToUpdateId);
@@ -233,7 +233,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
                 Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
         };
 
-        loginAsStudent(typicalStudent.getGoogleId());
+        loginAsStudent(typicalStudent.getAccountId());
         verifyCannotAccess(params);
     }
 
@@ -250,10 +250,10 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         };
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
-        when(mockLogic.getInstructorByAccountId(differentCourse.getId(), instructorFromDifferentCourse.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(differentCourse.getId(), instructorFromDifferentCourse.getAccountId()))
                 .thenReturn(instructorFromDifferentCourse);
 
-        loginAsInstructor(instructorFromDifferentCourse.getGoogleId());
+        loginAsInstructor(instructorFromDifferentCourse.getAccountId());
 
         verifyCannotAccess(params);
     }
@@ -270,10 +270,10 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         };
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
-        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutCorrectPrivilege.getGoogleId()))
+        when(mockLogic.getInstructorByAccountId(typicalCourse.getId(), instructorWithoutCorrectPrivilege.getAccountId()))
                 .thenReturn(instructorWithoutCorrectPrivilege);
 
-        loginAsInstructor(instructorWithoutCorrectPrivilege.getGoogleId());
+        loginAsInstructor(instructorWithoutCorrectPrivilege.getAccountId());
 
         verifyCannotAccess(params);
     }

--- a/src/test/java/teammates/sqlui/webapi/UpdateInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateInstructorPrivilegeActionTest.java
@@ -61,7 +61,7 @@ public class UpdateInstructorPrivilegeActionTest extends BaseActionTest<UpdateIn
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
         when(mockLogic.getInstructorForEmail(course.getId(), instructorEmail)).thenReturn(instructor);
         when(mockLogic.getInstructorForEmail(course.getId(), helperEmail)).thenReturn(helper);
     }
@@ -318,7 +318,7 @@ public class UpdateInstructorPrivilegeActionTest extends BaseActionTest<UpdateIn
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), googleId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), googleId)).thenReturn(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
@@ -332,7 +332,7 @@ public class UpdateInstructorPrivilegeActionTest extends BaseActionTest<UpdateIn
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course-id",
         };
-        when(mockLogic.getInstructorByGoogleId("course-id", googleId)).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId("course-id", googleId)).thenReturn(null);
 
         loginAsStudent(googleId);
         verifyCannotAccess(params);

--- a/src/test/java/teammates/sqlui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateNotificationActionTest.java
@@ -81,7 +81,7 @@ public class UpdateNotificationActionTest extends BaseActionTest<UpdateNotificat
     @Test
     void testAccessControl_student_cannotAccess() {
         logoutUser();
-        loginAsStudent(Const.ParamsNames.STUDENT_ID);
+        loginAsStudent(Const.ParamsNames.STUDENT_ACCOUNT_ID);
         verifyCannotAccess();
     }
 

--- a/src/test/java/teammates/sqlui/webapi/UpdateStudentActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateStudentActionTest.java
@@ -509,7 +509,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
     @Test
     void testSpecificAccessControl_nonExistentInstructorId_cannotAccess() {
         String nonExistentInstructorId = "RANDOM_ID";
-        when(mockLogic.getInstructorByGoogleId(course.getId(), nonExistentInstructorId)).thenReturn(null);
+        when(mockLogic.getInstructorByAccountId(course.getId(), nonExistentInstructorId)).thenReturn(null);
         loginAsInstructor(nonExistentInstructorId);
 
         String[] params = {
@@ -518,7 +518,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         };
 
         verifyCannotAccess(params);
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), nonExistentInstructorId);
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), nonExistentInstructorId);
         verify(mockLogic, times(1)).getCourse(course.getId());
         verifyNoMoreInteractions(mockLogic, mockSqlEmailGenerator);
     }
@@ -528,7 +528,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         String instructorId = "instructor-googleId";
         // Instructor with co-owner role can modify student
         Instructor instructor = getTypicalInstructor();
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorId)).thenReturn(instructor);
         loginAsInstructor(instructorId);
 
         String[] params = {
@@ -537,7 +537,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         };
 
         verifyCanAccess(params);
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructorId);
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructorId);
         verify(mockLogic, times(1)).getCourse(course.getId());
         verifyNoMoreInteractions(mockLogic, mockSqlEmailGenerator);
     }
@@ -550,7 +550,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         InstructorPrivileges instructorPrivileges =
                 new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
         instructor.setPrivileges(instructorPrivileges);
-        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);
+        when(mockLogic.getInstructorByAccountId(course.getId(), instructorId)).thenReturn(instructor);
         loginAsInstructor(instructorId);
 
         String[] params = {
@@ -559,7 +559,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         };
 
         verifyCannotAccess(params);
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructorId);
+        verify(mockLogic, times(1)).getInstructorByAccountId(course.getId(), instructorId);
         verify(mockLogic, times(1)).getCourse(course.getId());
         verifyNoMoreInteractions(mockLogic, mockSqlEmailGenerator);
     }

--- a/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
@@ -53,7 +53,7 @@ public class AccountsDbTest extends BaseTestCase {
     @Test
     public void testGetAccountByGoogleId_accountExists_success() {
         Account account = getTypicalAccount();
-        String googleId = account.getGoogleId();
+        String googleId = account.getId();
 
         mockHibernateUtil
                 .when(() -> HibernateUtil.getBySimpleNaturalId(Account.class, googleId))


### PR DESCRIPTION
Part of #13678

NOTE: This change is only renaming changes in the unit tests and integration tests. Ignore incompatiblity with the actual logic, db, and DTO layer API

- Waiting for Auth/UserInfo/UserProvision layer to be updated