### PR TITLE
[#13718] Replace InstructorCommentsComponent inheritance with composition

### DIFF
--- a/src/web/app/pages-instructor/instructor-comments-handler.ts
+++ b/src/web/app/pages-instructor/instructor-comments-handler.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { FeedbackResponseCommentService } from '../../services/feedback-response-comment.service';
 import { StatusMessageService } from '../../services/status-message.service';
 import { TableComparatorService } from '../../services/table-comparator.service';
@@ -10,9 +11,13 @@ import { CommentToCommentRowModelPipe } from '../components/comment-box/comment-
 import { ErrorMessageOutput } from '../error-message-output';
 
 /**
- * Base class for instructor comment CRUD operations.
+ * Reusable handler for instructor comment CRUD operations.
+ *
+ * This handler is intended to be provided at component level so each consumer
+ * gets an isolated comment state.
  */
-export abstract class InstructorCommentsComponent {
+@Injectable()
+export class InstructorCommentsHandler {
 
   currInstructorName?: string;
 
@@ -20,11 +25,11 @@ export abstract class InstructorCommentsComponent {
   // from responseID to comment table model
   instructorCommentTableModel: Record<string, CommentTableModel> = {};
 
-  protected constructor(
-        protected commentToCommentRowModel: CommentToCommentRowModelPipe,
-        protected commentService: FeedbackResponseCommentService,
-        protected statusMessageService: StatusMessageService,
-        protected tableComparatorService: TableComparatorService) { }
+  constructor(
+        private commentToCommentRowModel: CommentToCommentRowModelPipe,
+        private commentService: FeedbackResponseCommentService,
+        private statusMessageService: StatusMessageService,
+        private tableComparatorService: TableComparatorService) { }
 
   /**
    * Deletes an instructor comment.
@@ -84,7 +89,7 @@ export abstract class InstructorCommentsComponent {
   /**
    * Saves an instructor comment.
    */
-  saveNewComment(responseId: string, timezone: string): void {
+  addComment(responseId: string, timezone: string): void {
     const commentTableModel: CommentTableModel = this.instructorCommentTableModel[responseId];
     const commentRowToAdd: CommentRowModel = commentTableModel.newCommentRow;
 
@@ -119,6 +124,11 @@ export abstract class InstructorCommentsComponent {
             this.statusMessageService.showErrorToast(resp.error.message);
           },
         });
+  }
+
+  // Kept for compatibility with existing saveNewComment bindings.
+  saveNewComment(responseId: string, timezone: string): void {
+    this.addComment(responseId, timezone);
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -86,40 +86,40 @@
       <tm-instructor-session-result-question-view [questions]="questionsModel"
         [section]="section" [sectionType]="sectionType" [session] = "session"
         [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-        [(instructorCommentTableModel)]="instructorCommentTableModel"
-        (saveNewCommentEvent)="saveNewComment($event, session.timeZone)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event, session.timeZone)"
+        [(instructorCommentTableModel)]="comments.instructorCommentTableModel"
+        (saveNewCommentEvent)="comments.saveNewComment($event, session.timeZone)" (deleteCommentEvent)="comments.deleteComment($event)" (updateCommentEvent)="comments.updateComment($event, session.timeZone)"
       (toggleAndLoadTab)="toggleQuestionTab($event)" (loadTab)="loadQuestionTab($event)" (downloadQuestionResult)="downloadQuestionResultHandler($event)"></tm-instructor-session-result-question-view>
     }
     @if (viewType === InstructorSessionResultViewType.GRQ) {
       <tm-instructor-session-result-grq-view [responses]="sectionsModel" [isExpandAll]="isExpandAll"
         [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
         [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-        [(instructorCommentTableModel)]="instructorCommentTableModel"
-        (saveNewCommentEvent)="saveNewComment($event, session.timeZone)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event, session.timeZone)"
+        [(instructorCommentTableModel)]="comments.instructorCommentTableModel"
+        (saveNewCommentEvent)="comments.saveNewComment($event, session.timeZone)" (deleteCommentEvent)="comments.deleteComment($event)" (updateCommentEvent)="comments.updateComment($event, session.timeZone)"
       (toggleAndLoadTab)="toggleSectionTab($event)" (loadTab)="loadSectionTab($event)"></tm-instructor-session-result-grq-view>
     }
     @if (viewType === InstructorSessionResultViewType.RGQ) {
       <tm-instructor-session-result-rgq-view [responses]="sectionsModel" [isExpandAll]="isExpandAll"
         [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
         [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-        [(instructorCommentTableModel)]="instructorCommentTableModel"
-        (saveNewCommentEvent)="saveNewComment($event, session.timeZone)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event, session.timeZone)"
+        [(instructorCommentTableModel)]="comments.instructorCommentTableModel"
+        (saveNewCommentEvent)="comments.saveNewComment($event, session.timeZone)" (deleteCommentEvent)="comments.deleteComment($event)" (updateCommentEvent)="comments.updateComment($event, session.timeZone)"
       (toggleAndLoadTab)="toggleSectionTab($event)" (loadTab)="loadSectionTab($event)"></tm-instructor-session-result-rgq-view>
     }
     @if (viewType === InstructorSessionResultViewType.GQR) {
       <tm-instructor-session-result-gqr-view [responses]="sectionsModel" [isExpandAll]="isExpandAll"
         [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
         [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-        [(instructorCommentTableModel)]="instructorCommentTableModel"
-        (saveNewCommentEvent)="saveNewComment($event, session.timeZone)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event, session.timeZone)"
+        [(instructorCommentTableModel)]="comments.instructorCommentTableModel"
+        (saveNewCommentEvent)="comments.saveNewComment($event, session.timeZone)" (deleteCommentEvent)="comments.deleteComment($event)" (updateCommentEvent)="comments.updateComment($event, session.timeZone)"
       (toggleAndLoadTab)="toggleSectionTab($event)" (loadTab)="loadSectionTab($event)"></tm-instructor-session-result-gqr-view>
     }
     @if (viewType === InstructorSessionResultViewType.RQG) {
       <tm-instructor-session-result-rqg-view [responses]="sectionsModel" [isExpandAll]="isExpandAll"
         [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
         [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-        [(instructorCommentTableModel)]="instructorCommentTableModel"
-        (saveNewCommentEvent)="saveNewComment($event, session.timeZone)" (deleteCommentEvent)="deleteComment($event)" (updateCommentEvent)="updateComment($event, session.timeZone)"
+        [(instructorCommentTableModel)]="comments.instructorCommentTableModel"
+        (saveNewCommentEvent)="comments.saveNewComment($event, session.timeZone)" (deleteCommentEvent)="comments.deleteComment($event)" (updateCommentEvent)="comments.updateComment($event, session.timeZone)"
       (toggleAndLoadTab)="toggleSectionTab($event)" (loadTab)="loadSectionTab($event)"></tm-instructor-session-result-rqg-view>
     }
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -13,7 +13,6 @@ import { InstructorSessionResultSectionType } from './instructor-session-result-
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 import { CourseService } from '../../../services/course.service';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
-import { FeedbackResponseCommentService } from '../../../services/feedback-response-comment.service';
 import { FeedbackSessionActionsService } from '../../../services/feedback-session-actions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { FileSaveService } from '../../../services/file-save.service';
@@ -22,11 +21,9 @@ import { NavigationService } from '../../../services/navigation.service';
 import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
-import { TableComparatorService } from '../../../services/table-comparator.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
   CourseSectionNames,
-  FeedbackResponseComment,
   FeedbackQuestions,
   FeedbackSession,
   FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
@@ -40,10 +37,7 @@ import {
   Students,
 } from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
-import { SortBy, SortOrder } from '../../../types/sort-properties';
 import { AjaxLoadingComponent } from '../../components/ajax-loading/ajax-loading.component';
-import { CommentRowModel } from '../../components/comment-box/comment-row/comment-row.component';
-import { CommentTableModel } from '../../components/comment-box/comment-table/comment-table.model';
 import { CommentToCommentRowModelPipe } from '../../components/comment-box/comment-to-comment-row-model.pipe';
 import { CommentsToCommentTableModelPipe } from '../../components/comment-box/comments-to-comment-table-model.pipe';
 import { LoadingRetryComponent } from '../../components/loading-retry/loading-retry.component';
@@ -59,6 +53,7 @@ import { SimpleModalType } from '../../components/simple-modal/simple-modal-type
 import { TeammatesRouterDirective } from '../../components/teammates-router/teammates-router.directive';
 import { ViewResultsPanelComponent } from '../../components/view-results-panel/view-results-panel.component';
 import { ErrorMessageOutput } from '../../error-message-output';
+import { InstructorCommentsHandler } from '../instructor-comments-handler';
 import { SectionTabModel, QuestionTabModel } from './instructor-session-tab.model';
 
 const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
@@ -86,6 +81,7 @@ const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
     PreviewSessionResultPanelComponent,
 ],
   providers: [
+    InstructorCommentsHandler,
     CommentsToCommentTableModelPipe,
     CommentToCommentRowModelPipe,
   ],
@@ -133,12 +129,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
   allInstructorsInCourse: Instructor[] = [];
   emailOfInstructorToPreview: string = '';
 
-  currInstructorName?: string;
-
-  // this is a separate model for instructor comments
-  // from responseID to comment table model
-  instructorCommentTableModel: Record<string, CommentTableModel> = {};
-
   FeedbackSessionPublishStatus: typeof FeedbackSessionPublishStatus = FeedbackSessionPublishStatus;
   isExpandAll: boolean = false;
 
@@ -174,124 +164,10 @@ export class InstructorSessionResultPageComponent implements OnInit {
               private timezoneService: TimezoneService,
               private simpleModalService: SimpleModalService,
               private commentsToCommentTableModel: CommentsToCommentTableModelPipe,
+              public comments: InstructorCommentsHandler,
               private navigationService: NavigationService,
-              private statusMessageService: StatusMessageService,
-              private commentService: FeedbackResponseCommentService,
-              private commentToCommentRowModel: CommentToCommentRowModelPipe,
-              private tableComparatorService: TableComparatorService) {
+              private statusMessageService: StatusMessageService) {
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
-  }
-
-  /**
-   * Deletes an instructor comment.
-   */
-  deleteComment(data: { responseId: string, index: number }): void {
-    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[data.responseId];
-    const commentToDelete: FeedbackResponseComment =
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.instructorCommentTableModel[data.responseId].commentRows[data.index].originalComment!;
-
-    this.commentService.deleteComment(commentToDelete.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
-        .subscribe({
-          next: () => {
-            commentTableModel.commentRows.splice(data.index, 1);
-            this.instructorCommentTableModel[data.responseId] = {
-              ...commentTableModel,
-            };
-          },
-          error: (resp: ErrorMessageOutput) => {
-            this.statusMessageService.showErrorToast(resp.error.message);
-          },
-        });
-  }
-
-  /**
-   * Updates an instructor comment.
-   */
-  updateComment(data: { responseId: string, index: number }, timezone: string): void {
-    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[data.responseId];
-    const commentRowToUpdate: CommentRowModel = commentTableModel.commentRows[data.index];
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const commentToUpdate: FeedbackResponseComment = commentRowToUpdate.originalComment!;
-
-    this.commentService.updateComment({
-      commentText: commentRowToUpdate.commentEditFormModel.commentText,
-      showCommentTo: commentRowToUpdate.commentEditFormModel.showCommentTo,
-      showGiverNameTo: commentRowToUpdate.commentEditFormModel.showGiverNameTo,
-    }, commentToUpdate.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
-        .subscribe({
-          next: (commentResponse: FeedbackResponseComment) => {
-            commentTableModel.commentRows[data.index] = this.commentToCommentRowModel.transform({
-              ...commentResponse,
-              commentGiverName: commentRowToUpdate.commentGiverName,
-              // the current instructor will become the last editor
-              lastEditorName: this.currInstructorName,
-            }, timezone);
-            this.instructorCommentTableModel[data.responseId] = {
-              ...commentTableModel,
-            };
-          },
-          error: (resp: ErrorMessageOutput) => {
-            this.statusMessageService.showErrorToast(resp.error.message);
-          },
-        });
-  }
-
-  /**
-   * Saves an instructor comment.
-   */
-  addComment(responseId: string, timezone: string): void {
-    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[responseId];
-    const commentRowToAdd: CommentRowModel = commentTableModel.newCommentRow;
-
-    this.commentService.createComment({
-      commentText: commentRowToAdd.commentEditFormModel.commentText,
-      showCommentTo: commentRowToAdd.commentEditFormModel.showCommentTo,
-      showGiverNameTo: commentRowToAdd.commentEditFormModel.showGiverNameTo,
-    }, responseId, Intent.INSTRUCTOR_RESULT)
-        .subscribe({
-          next: (commentResponse: FeedbackResponseComment) => {
-            commentTableModel.commentRows.push(this.commentToCommentRowModel.transform({
-              ...commentResponse,
-              // the giver and editor name will be the current login instructor
-              commentGiverName: this.currInstructorName,
-              lastEditorName: this.currInstructorName,
-            }, timezone));
-            this.instructorCommentTableModel[responseId] = {
-              ...commentTableModel,
-              newCommentRow: {
-                commentEditFormModel: {
-                  commentText: '',
-                  isUsingCustomVisibilities: false,
-                  showCommentTo: [],
-                  showGiverNameTo: [],
-                },
-                isEditing: false,
-              },
-              isAddingNewComment: false,
-            };
-          },
-          error: (resp: ErrorMessageOutput) => {
-            this.statusMessageService.showErrorToast(resp.error.message);
-          },
-        });
-  }
-
-  // Kept for compatibility with existing template bindings.
-  saveNewComment(responseId: string, timezone: string): void {
-    this.addComment(responseId, timezone);
-  }
-
-  /**
-   * Sorts instructor's comments according to creation date.
-   */
-  sortComments(commentTable: CommentTableModel): void {
-    commentTable.commentRows.sort((a: CommentRowModel, b: CommentRowModel) => {
-      return this.tableComparatorService.compare(
-          SortBy.COMMENTS_CREATION_DATE,
-          SortOrder.ASC,
-          String(a.originalComment?.createdAt), String(b.originalComment?.createdAt));
-    });
   }
 
   ngOnInit(): void {
@@ -440,7 +316,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
           courseId,
           intent: Intent.FULL_DETAIL,
         }).subscribe((instructor: Instructor) => {
-          this.currInstructorName = instructor.name;
+          this.comments.currInstructorName = instructor.name;
         });
       },
       error: (resp: ErrorMessageOutput) => {
@@ -598,9 +474,9 @@ export class InstructorSessionResultPageComponent implements OnInit {
    */
   preprocessComments(responses: ResponseOutput[]): void {
     responses.forEach((response: ResponseOutput) => {
-      this.instructorCommentTableModel[response.responseId] =
+      this.comments.instructorCommentTableModel[response.responseId] =
          this.commentsToCommentTableModel.transform(response.instructorComments, false, this.session.timeZone);
-      this.sortComments(this.instructorCommentTableModel[response.responseId]);
+      this.comments.sortComments(this.comments.instructorCommentTableModel[response.responseId]);
       // clear the original comments for safe as instructorCommentTableModel will become the single point of truth
       response.instructorComments = [];
     });

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -26,6 +26,7 @@ import { TableComparatorService } from '../../../services/table-comparator.servi
 import { TimezoneService } from '../../../services/timezone.service';
 import {
   CourseSectionNames,
+  FeedbackResponseComment,
   FeedbackQuestions,
   FeedbackSession,
   FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
@@ -39,7 +40,10 @@ import {
   Students,
 } from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
+import { SortBy, SortOrder } from '../../../types/sort-properties';
 import { AjaxLoadingComponent } from '../../components/ajax-loading/ajax-loading.component';
+import { CommentRowModel } from '../../components/comment-box/comment-row/comment-row.component';
+import { CommentTableModel } from '../../components/comment-box/comment-table/comment-table.model';
 import { CommentToCommentRowModelPipe } from '../../components/comment-box/comment-to-comment-row-model.pipe';
 import { CommentsToCommentTableModelPipe } from '../../components/comment-box/comments-to-comment-table-model.pipe';
 import { LoadingRetryComponent } from '../../components/loading-retry/loading-retry.component';
@@ -55,7 +59,6 @@ import { SimpleModalType } from '../../components/simple-modal/simple-modal-type
 import { TeammatesRouterDirective } from '../../components/teammates-router/teammates-router.directive';
 import { ViewResultsPanelComponent } from '../../components/view-results-panel/view-results-panel.component';
 import { ErrorMessageOutput } from '../../error-message-output';
-import { InstructorCommentsComponent } from '../instructor-comments.component';
 import { SectionTabModel, QuestionTabModel } from './instructor-session-tab.model';
 
 const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
@@ -87,7 +90,7 @@ const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
     CommentToCommentRowModelPipe,
   ],
 })
-export class InstructorSessionResultPageComponent extends InstructorCommentsComponent implements OnInit {
+export class InstructorSessionResultPageComponent implements OnInit {
 
   // enum
   InstructorSessionResultSectionType: typeof InstructorSessionResultSectionType = InstructorSessionResultSectionType;
@@ -130,6 +133,12 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
   allInstructorsInCourse: Instructor[] = [];
   emailOfInstructorToPreview: string = '';
 
+  currInstructorName?: string;
+
+  // this is a separate model for instructor comments
+  // from responseID to comment table model
+  instructorCommentTableModel: Record<string, CommentTableModel> = {};
+
   FeedbackSessionPublishStatus: typeof FeedbackSessionPublishStatus = FeedbackSessionPublishStatus;
   isExpandAll: boolean = false;
 
@@ -166,12 +175,123 @@ export class InstructorSessionResultPageComponent extends InstructorCommentsComp
               private simpleModalService: SimpleModalService,
               private commentsToCommentTableModel: CommentsToCommentTableModelPipe,
               private navigationService: NavigationService,
-              statusMessageService: StatusMessageService,
-              commentService: FeedbackResponseCommentService,
-              commentToCommentRowModel: CommentToCommentRowModelPipe,
-              tableComparatorService: TableComparatorService) {
-    super(commentToCommentRowModel, commentService, statusMessageService, tableComparatorService);
+              private statusMessageService: StatusMessageService,
+              private commentService: FeedbackResponseCommentService,
+              private commentToCommentRowModel: CommentToCommentRowModelPipe,
+              private tableComparatorService: TableComparatorService) {
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
+  }
+
+  /**
+   * Deletes an instructor comment.
+   */
+  deleteComment(data: { responseId: string, index: number }): void {
+    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[data.responseId];
+    const commentToDelete: FeedbackResponseComment =
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.instructorCommentTableModel[data.responseId].commentRows[data.index].originalComment!;
+
+    this.commentService.deleteComment(commentToDelete.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
+        .subscribe({
+          next: () => {
+            commentTableModel.commentRows.splice(data.index, 1);
+            this.instructorCommentTableModel[data.responseId] = {
+              ...commentTableModel,
+            };
+          },
+          error: (resp: ErrorMessageOutput) => {
+            this.statusMessageService.showErrorToast(resp.error.message);
+          },
+        });
+  }
+
+  /**
+   * Updates an instructor comment.
+   */
+  updateComment(data: { responseId: string, index: number }, timezone: string): void {
+    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[data.responseId];
+    const commentRowToUpdate: CommentRowModel = commentTableModel.commentRows[data.index];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const commentToUpdate: FeedbackResponseComment = commentRowToUpdate.originalComment!;
+
+    this.commentService.updateComment({
+      commentText: commentRowToUpdate.commentEditFormModel.commentText,
+      showCommentTo: commentRowToUpdate.commentEditFormModel.showCommentTo,
+      showGiverNameTo: commentRowToUpdate.commentEditFormModel.showGiverNameTo,
+    }, commentToUpdate.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
+        .subscribe({
+          next: (commentResponse: FeedbackResponseComment) => {
+            commentTableModel.commentRows[data.index] = this.commentToCommentRowModel.transform({
+              ...commentResponse,
+              commentGiverName: commentRowToUpdate.commentGiverName,
+              // the current instructor will become the last editor
+              lastEditorName: this.currInstructorName,
+            }, timezone);
+            this.instructorCommentTableModel[data.responseId] = {
+              ...commentTableModel,
+            };
+          },
+          error: (resp: ErrorMessageOutput) => {
+            this.statusMessageService.showErrorToast(resp.error.message);
+          },
+        });
+  }
+
+  /**
+   * Saves an instructor comment.
+   */
+  addComment(responseId: string, timezone: string): void {
+    const commentTableModel: CommentTableModel = this.instructorCommentTableModel[responseId];
+    const commentRowToAdd: CommentRowModel = commentTableModel.newCommentRow;
+
+    this.commentService.createComment({
+      commentText: commentRowToAdd.commentEditFormModel.commentText,
+      showCommentTo: commentRowToAdd.commentEditFormModel.showCommentTo,
+      showGiverNameTo: commentRowToAdd.commentEditFormModel.showGiverNameTo,
+    }, responseId, Intent.INSTRUCTOR_RESULT)
+        .subscribe({
+          next: (commentResponse: FeedbackResponseComment) => {
+            commentTableModel.commentRows.push(this.commentToCommentRowModel.transform({
+              ...commentResponse,
+              // the giver and editor name will be the current login instructor
+              commentGiverName: this.currInstructorName,
+              lastEditorName: this.currInstructorName,
+            }, timezone));
+            this.instructorCommentTableModel[responseId] = {
+              ...commentTableModel,
+              newCommentRow: {
+                commentEditFormModel: {
+                  commentText: '',
+                  isUsingCustomVisibilities: false,
+                  showCommentTo: [],
+                  showGiverNameTo: [],
+                },
+                isEditing: false,
+              },
+              isAddingNewComment: false,
+            };
+          },
+          error: (resp: ErrorMessageOutput) => {
+            this.statusMessageService.showErrorToast(resp.error.message);
+          },
+        });
+  }
+
+  // Kept for compatibility with existing template bindings.
+  saveNewComment(responseId: string, timezone: string): void {
+    this.addComment(responseId, timezone);
+  }
+
+  /**
+   * Sorts instructor's comments according to creation date.
+   */
+  sortComments(commentTable: CommentTableModel): void {
+    commentTable.commentRows.sort((a: CommentRowModel, b: CommentRowModel) => {
+      return this.tableComparatorService.compare(
+          SortBy.COMMENTS_CREATION_DATE,
+          SortOrder.ASC,
+          String(a.originalComment?.createdAt), String(b.originalComment?.createdAt));
+    });
   }
 
   ngOnInit(): void {

--- a/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
@@ -2,14 +2,11 @@
 
 exports[`InstructorStudentRecordsPageComponent should snap when student results are still loading 1`] = `
 <tm-instructor-student-records-page
-  commentService={[Function FeedbackResponseCommentService]}
-  commentToCommentRowModel={[Function CommentToCommentRowModelPipe]}
+  comments={[Function InstructorCommentsHandler]}
   commentsToCommentTableModel={[Function CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
-  instructorCommentTableModel={[Function Object]}
   instructorService={[Function InstructorService]}
   isStudentResultsLoading={[Function Boolean]}
   route={[Function Object]}
@@ -54,14 +51,11 @@ exports[`InstructorStudentRecordsPageComponent should snap when student results 
 
 exports[`InstructorStudentRecordsPageComponent should snap with default fields 1`] = `
 <tm-instructor-student-records-page
-  commentService={[Function FeedbackResponseCommentService]}
-  commentToCommentRowModel={[Function CommentToCommentRowModelPipe]}
+  comments={[Function InstructorCommentsHandler]}
   commentsToCommentTableModel={[Function CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
-  instructorCommentTableModel={[Function Object]}
   instructorService={[Function InstructorService]}
   isStudentResultsLoading={[Function Boolean]}
   route={[Function Object]}
@@ -106,14 +100,11 @@ exports[`InstructorStudentRecordsPageComponent should snap with default fields 1
 
 exports[`InstructorStudentRecordsPageComponent should snap with populated fields 1`] = `
 <tm-instructor-student-records-page
-  commentService={[Function FeedbackResponseCommentService]}
-  commentToCommentRowModel={[Function CommentToCommentRowModelPipe]}
+  comments={[Function InstructorCommentsHandler]}
   commentsToCommentTableModel={[Function CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
-  instructorCommentTableModel={[Function Object]}
   instructorService={[Function InstructorService]}
   isStudentResultsLoading="false"
   route={[Function Object]}

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
@@ -18,10 +18,10 @@
               <tm-grq-rgq-view-responses
                 [session]="session.feedbackSession"
                 [responses]="session.responsesReceivedByStudent" [groupByTeam]="false"
-                [isGrq]="false" [instructorCommentTableModel]="instructorCommentTableModel"
-                (saveNewCommentEvent)="saveNewComment($event, session.feedbackSession.timeZone)"
-                (deleteCommentEvent)="deleteComment($event)"
-                (updateCommentEvent)="updateComment($event, session.feedbackSession.timeZone)"
+                [isGrq]="false" [instructorCommentTableModel]="comments.instructorCommentTableModel"
+                (saveNewCommentEvent)="comments.saveNewComment($event, session.feedbackSession.timeZone)"
+                (deleteCommentEvent)="comments.deleteComment($event)"
+                (updateCommentEvent)="comments.updateComment($event, session.feedbackSession.timeZone)"
                 [isExpandAll]="true">
               </tm-grq-rgq-view-responses>
             }
@@ -34,10 +34,10 @@
               <tm-grq-rgq-view-responses
                 [session]="session.feedbackSession"
                 [responses]="session.responsesGivenByStudent" [groupByTeam]="false"
-                [isGrq]="true" [instructorCommentTableModel]="instructorCommentTableModel"
-                (saveNewCommentEvent)="saveNewComment($event, session.feedbackSession.timeZone)"
-                (deleteCommentEvent)="deleteComment($event)"
-                (updateCommentEvent)="updateComment($event, session.feedbackSession.timeZone)"
+                [isGrq]="true" [instructorCommentTableModel]="comments.instructorCommentTableModel"
+                (saveNewCommentEvent)="comments.saveNewComment($event, session.feedbackSession.timeZone)"
+                (deleteCommentEvent)="comments.deleteComment($event)"
+                (updateCommentEvent)="comments.updateComment($event, session.feedbackSession.timeZone)"
                 [isExpandAll]="true"
               ></tm-grq-rgq-view-responses>
             }

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest, Observable } from 'rxjs';
 import { finalize, map, mergeMap, tap } from 'rxjs/operators';
-import { FeedbackResponseCommentService } from '../../../services/feedback-response-comment.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { StatusMessageService } from '../../../services/status-message.service';
@@ -30,7 +29,7 @@ import {
 import { collapseAnim } from '../../components/teammates-common/collapse-anim';
 import { areEmailsEqual } from '../../components/teammates-common/email-utils';
 import { ErrorMessageOutput } from '../../error-message-output';
-import { InstructorCommentsComponent } from '../instructor-comments.component';
+import { InstructorCommentsHandler } from '../instructor-comments-handler';
 
 interface SessionTab {
   isCollapsed: boolean;
@@ -54,11 +53,12 @@ interface SessionTab {
     GrqRgqViewResponsesComponent,
 ],
   providers: [
+    InstructorCommentsHandler,
     CommentsToCommentTableModelPipe,
     CommentToCommentRowModelPipe,
   ],
 })
-export class InstructorStudentRecordsPageComponent extends InstructorCommentsComponent implements OnInit {
+export class InstructorStudentRecordsPageComponent implements OnInit {
 
   courseId: string = '';
   studentName: string = '';
@@ -74,12 +74,9 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
               private studentService: StudentService,
               private instructorService: InstructorService,
               private commentsToCommentTableModel: CommentsToCommentTableModelPipe,
-              tableComparatorService: TableComparatorService,
-              statusMessageService: StatusMessageService,
-              commentService: FeedbackResponseCommentService,
-              commentToCommentRowModel: CommentToCommentRowModelPipe) {
-    super(commentToCommentRowModel, commentService, statusMessageService, tableComparatorService);
-  }
+              public comments: InstructorCommentsHandler,
+              private tableComparatorService: TableComparatorService,
+              private statusMessageService: StatusMessageService) {}
 
   ngOnInit(): void {
     this.route.queryParams.subscribe({
@@ -104,7 +101,7 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
       courseId,
       intent: Intent.FULL_DETAIL,
     }).subscribe((instructor: Instructor) => {
-      this.currInstructorName = instructor.name;
+      this.comments.currInstructorName = instructor.name;
     });
   }
 
@@ -224,9 +221,9 @@ export class InstructorStudentRecordsPageComponent extends InstructorCommentsCom
    */
   preprocessComments(responses: ResponseOutput[], timezone: string): void {
     responses.forEach((response: ResponseOutput) => {
-      this.instructorCommentTableModel[response.responseId] =
+      this.comments.instructorCommentTableModel[response.responseId] =
           this.commentsToCommentTableModel.transform(response.instructorComments, false, timezone);
-      this.sortComments(this.instructorCommentTableModel[response.responseId]);
+      this.comments.sortComments(this.comments.instructorCommentTableModel[response.responseId]);
       // clear the original comments for safe as instructorCommentTableModel will become the single point of truth
       response.instructorComments = [];
     });


### PR DESCRIPTION
Part of #13718

Description
This PR refactors the instructor comment CRUD logic by replacing the inheritance-based model with a composition pattern. Previously, instructor pages inherited state and methods from an abstract base class, creating tight coupling. This logic has now been encapsulated into a reusable, injectable handler.

**Changes**

- Created instructor-comments-handler.ts: Encapsulates all instructor comment properties (instructorCommentTableModel, currInstructorName) and CRUD operations (addComment, deleteComment, sortComments).

- Refactored Components: Removed extends InstructorCommentsComponent from:
- - InstructorSessionResultPageComponent
- - InstructorStudentRecordsPageComponent

Dependency Injection: Injected the new handler as a public comments property at the component level to ensure isolated state per page instance.

Template Migration: Updated .html templates for both pages to bind events and data directly to the new comments handler (e.g., comments.addComment()).

Cleanup: Deleted the now-obsolete abstract base class src/web/app/pages-instructor/instructor-comments.component.ts.

Verification Results
Manual Verification: Confirmed that adding, editing, and deleting instructor comments works correctly on both the Session Results and Student Records pages.

Unit Testing:
Ran npm run test with a final exit code of 0.
Resolved regression failures in instructor-student-records-page.component.spec.ts.snap by updating snapshots to match the new compositional structure.