### PR TITLE
[#13469] Fix broken styling on Style column in Admin Notifications page

### DIFF
--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/__snapshots__/notifications-table.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/__snapshots__/notifications-table.component.spec.ts.snap
@@ -167,9 +167,13 @@ exports[`NotificationsTableComponent should snap like in notification page with 
               INSTRUCTOR
             </td>
             <td
-              class="text-break alert alert-success"
+              class="text-break p-0"
             >
-              Success (green)
+              <div
+                class="mb-0 h-100 d-flex align-items-center alert alert-success"
+              >
+                Success (green)
+              </div>
             </td>
             <td
               class="text-break"
@@ -233,9 +237,13 @@ exports[`NotificationsTableComponent should snap like in notification page with 
               GENERAL
             </td>
             <td
-              class="text-break alert alert-danger"
+              class="text-break p-0"
             >
-              Danger (red)
+              <div
+                class="mb-0 h-100 d-flex align-items-center alert alert-danger"
+              >
+                Danger (red)
+              </div>
             </td>
             <td
               class="text-break"
@@ -441,9 +449,13 @@ exports[`NotificationsTableComponent should snap like in notification page with 
               INSTRUCTOR
             </td>
             <td
-              class="text-break alert alert-success"
+              class="text-break p-0"
             >
-              Success (green)
+              <div
+                class="mb-0 h-100 d-flex align-items-center alert alert-success"
+              >
+                Success (green)
+              </div>
             </td>
             <td
               class="text-break"
@@ -507,9 +519,13 @@ exports[`NotificationsTableComponent should snap like in notification page with 
               GENERAL
             </td>
             <td
-              class="text-break alert alert-danger"
+              class="text-break p-0"
             >
-              Danger (red)
+              <div
+                class="mb-0 h-100 d-flex align-items-center alert alert-danger"
+              >
+                Danger (red)
+              </div>
             </td>
             <td
               class="text-break"

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
@@ -97,7 +97,7 @@
             <td class="text-break"><span class="ngb-tooltip-class" ngbTooltip="{{ notificationsTableRowModel.notification.startTimestamp | formatDateDetail: guessTimezone }}">{{ notificationsTableRowModel.notification.startTimestamp | formatDateBrief: guessTimezone }}</span></td>
             <td class="text-break"><span class="ngb-tooltip-class" ngbTooltip="{{ notificationsTableRowModel.notification.endTimestamp | formatDateDetail: guessTimezone }}">{{ notificationsTableRowModel.notification.endTimestamp | formatDateBrief: guessTimezone }}</span></td>
             <td class="text-break">{{ notificationsTableRowModel.notification.targetUser }}</td>
-            <td class="text-break" [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">{{ notificationsTableRowModel.notification.style | notificationStyleDescription }}</td>
+            <td class="text-break p-0"><div class="mb-0 h-100 d-flex align-items-center" [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">{{ notificationsTableRowModel.notification.style | notificationStyleDescription }}</div></td>
             <td class="text-break"><span class="ngb-tooltip-class" ngbTooltip="{{ notificationsTableRowModel.notification.createdAt | formatDateDetail: guessTimezone }}">{{ notificationsTableRowModel.notification.createdAt | formatDateBrief: guessTimezone }}</span></td>
             <td class="actions-cell">
               <div class="d-flex">


### PR DESCRIPTION
Fixes #13469

**Outline of Solution**

While looking at the admin notifications page, I noticed the Style column had lost its colored background. After digging into the issue history and the reviewer feedback on PR #13535, I traced the root cause to Bootstrap `alert alert-*` classes being applied directly on a `<td>` element. When Bootstrap 5.3 shipped, it changed how alert styles behave on table cells, which broke the colored preview that used to work under Bootstrap 4.x/5.2.

The fix wraps the style cell content in a `<div>` element that carries the `alert alert-*` classes, while the `<td>` gets `p-0` to remove padding so the inner div fills the cell naturally. This is the approach the reviewer on #13535 recommended — using an actual alert element rather than applying alert classes to a table cell.

Snapshot tests have been updated accordingly.