### PR TITLE
[#13752] Fix page scroll blocked when hovering over number input

### DIFF
--- a/src/web/app/components/wheel-disabler/wheel-disabler.directive.ts
+++ b/src/web/app/components/wheel-disabler/wheel-disabler.directive.ts
@@ -7,8 +7,8 @@ import { Directive, HostListener } from '@angular/core';
 export class WheelDisablerDirective {
 
   @HostListener('wheel', ['$event'])
-  onWheel(e: Event): void {
-    e.preventDefault();
+  onWheel(e: WheelEvent): void {
+    (e.target as HTMLElement).blur();
   }
 
 }


### PR DESCRIPTION
## Issue Number - #13752
## Problem
Page scrolling was disabled whenever the mouse cursor was over a `<input type="number">` element that used the `tmDisableWheel` directive. This was caused by `e.preventDefault()` in `WheelDisablerDirective`, which suppressed both the number value change and the browser's native scroll behavior.

## Fix
Replaced `e.preventDefault()` with `(e.target as HTMLElement).blur()` in `WheelDisablerDirective`. Blurring the input on wheel events prevents accidental value changes via scroll while allowing the wheel event to propagate and scroll the page normally.

## Files Changed
- `src/web/app/components/wheel-disabler/wheel-disabler.directive.ts`