### PR TITLE
[#13752] Fix scroll blocked on number inputs by migrating answer forms to inputmode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+## vexp context tools <!-- vexp v2.0.12 -->
+
+**MANDATORY: use `run_pipeline` — do NOT grep, glob, or read files manually.**
+vexp returns pre-indexed, graph-ranked context in a single call.
+
+### Workflow
+1. `run_pipeline` with your task description — ALWAYS FIRST (replaces all other tools)
+2. Make targeted changes based on the context returned
+3. `run_pipeline` again only if you need more context
+
+### Available MCP tools
+- `run_pipeline` — **PRIMARY TOOL**. Runs capsule + impact + memory in 1 call.
+  Auto-detects intent. Includes file content. Example: `run_pipeline({ "task": "fix auth bug" })`
+- `get_skeleton` — compact file structure
+- `index_status` — indexing status
+- `expand_vexp_ref` — expand V-REF placeholders in v2 output
+
+### Agentic search
+- Do NOT use built-in file search, grep, or codebase indexing — always call `run_pipeline` first
+- If you spawn sub-agents or background tasks, pass them the context from `run_pipeline`
+  rather than letting them search the codebase independently
+
+### Smart Features
+Intent auto-detection, hybrid ranking, session memory, auto-expanding budget.
+
+### Multi-Repo
+`run_pipeline` auto-queries all indexed repos. Use `repos: ["alias"]` to scope. Run `index_status` to see aliases.
+<!-- /vexp -->

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.bak
 *.db
 *.exe
-
+.claude
 # Node.js
 node_modules/
 npm-debug.log

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.html
@@ -5,13 +5,12 @@
         <strong>{{ option }}</strong>
       </div>
       <div class="col-md-7 col-xs-12 text-md-start">
-        <input type="number" class="form-control"
+        <input type="text" inputmode="numeric" class="form-control"
           [ngModel]="i < responseDetails.answers.length ? responseDetails.answers[i] : ''"
           (ngModelChange)="triggerResponse(i, $event)"
+          (keypress)="onIntegerInput($event)"
           [disabled]="isDisabled"
-          [attr.aria-label]="getAriaLabelForOption(option)"
-          min="0" step="1"
-          tmDisableWheel>
+          [attr.aria-label]="getAriaLabelForOption(option)">
       </div>
     </div>
   }

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
@@ -10,8 +10,6 @@ import {
   DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS,
   DEFAULT_CONSTSUM_RESPONSE_DETAILS,
 } from '../../../../types/default-question-structs';
-import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.directive';
-
 /**
  * The constsum question options submission form for a recipient.
  */
@@ -19,10 +17,7 @@ import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.dire
   selector: 'tm-constsum-options-question-edit-answer-form',
   templateUrl: './constsum-options-question-edit-answer-form.component.html',
   styleUrls: ['./constsum-options-question-edit-answer-form.component.scss'],
-  imports: [
-    FormsModule,
-    WheelDisablerDirective,
-],
+  imports: [FormsModule],
 })
 export class ConstsumOptionsQuestionEditAnswerFormComponent
     extends QuestionEditAnswerFormComponent<FeedbackConstantSumQuestionDetails, FeedbackConstantSumResponseDetails> {
@@ -43,7 +38,7 @@ export class ConstsumOptionsQuestionEditAnswerFormComponent
   /**
    * Assigns a point to the option specified by index.
    */
-  triggerResponse(index: number, event: number): void {
+  triggerResponse(index: number, event: string | number): void {
     let newAnswers: number[] = this.responseDetails.answers.slice();
 
     if (newAnswers.length !== this.questionDetails.constSumOptions.length) {
@@ -51,7 +46,8 @@ export class ConstsumOptionsQuestionEditAnswerFormComponent
       newAnswers = Array(this.questionDetails.constSumOptions.length).fill(0);
     }
 
-    newAnswers[index] = event ? Math.ceil(event) : 0;
+    const numericValue = typeof event === 'string' ? parseInt(event, 10) : event;
+    newAnswers[index] = (numericValue != null && !Number.isNaN(numericValue)) ? Math.ceil(numericValue) : 0;
     this.triggerResponseDetailsChange('answers', newAnswers);
   }
 

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.html
@@ -1,11 +1,10 @@
 <div>
   <div class="form-group">
-      <input type="number" class="form-control"
+      <input type="text" inputmode="numeric" class="form-control"
              [ngModel]="responseDetails.answers.length === 1 ? responseDetails.answers[0] : ''"
              (ngModelChange)="triggerResponse($event)"
+             (keypress)="onIntegerInput($event)"
              [disabled]="isDisabled"
-             min="0" step="1"
-             tmDisableWheel
              [attr.aria-label]="getAriaLabel()">
   </div>
 </div>

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.ts
@@ -6,8 +6,6 @@ import {
   DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS,
   DEFAULT_CONSTSUM_RESPONSE_DETAILS,
 } from '../../../../types/default-question-structs';
-import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.directive';
-
 /**
  * The constsum question recipients submission form for a recipient.
  */
@@ -15,7 +13,7 @@ import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.dire
   selector: 'tm-constsum-recipients-question-edit-answer-form',
   templateUrl: './constsum-recipients-question-edit-answer-form.component.html',
   styleUrls: ['./constsum-recipients-question-edit-answer-form.component.scss'],
-  imports: [FormsModule, WheelDisablerDirective],
+  imports: [FormsModule],
 })
 export class ConstsumRecipientsQuestionEditAnswerFormComponent
     extends QuestionEditAnswerFormComponent<FeedbackConstantSumQuestionDetails, FeedbackConstantSumResponseDetails> {
@@ -29,7 +27,7 @@ export class ConstsumRecipientsQuestionEditAnswerFormComponent
   /**
    * Assigns a point to the recipient.
    */
-  triggerResponse(event: number): void {
+  triggerResponse(event: string | number): void {
 
     let newAnswers: number[] = this.responseDetails.answers.slice();
     // index 0 will the answer
@@ -37,10 +35,11 @@ export class ConstsumRecipientsQuestionEditAnswerFormComponent
       // initialize answers array on the fly
       newAnswers = [0];
     }
-    if (event == null) {
+    if (event == null || event === '') {
       newAnswers = [];
     } else {
-      newAnswers[0] = Math.ceil(event);
+      const numericValue = typeof event === 'string' ? parseInt(event, 10) : event;
+      newAnswers[0] = Number.isNaN(numericValue) ? 0 : Math.ceil(numericValue);
     }
 
     this.triggerResponseDetailsChange('answers', newAnswers);

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.html
@@ -1,7 +1,10 @@
 <div class="row text-start">
   <div class="col-md-3 col-xs-5">
-    <input type="number" class="form-control" [min]="questionDetails.minScale" [max]="questionDetails.maxScale" [step]="questionDetails.step" tmDisableWheel
-      [ngModel]="responseDetails.answer === NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED ? '' : responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled" [attr.aria-label]="getAriaLabel()">
+    <input type="text" inputmode="decimal" class="form-control"
+      [ngModel]="responseDetails.answer === NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED ? '' : responseDetails.answer"
+      (ngModelChange)="onAnswerChange($event)"
+      (keypress)="onFloatInput($event)"
+      [disabled]="isDisabled" [attr.aria-label]="getAriaLabel()">
   </div>
   <div id="possible-values" class="col-md-9 col-xs-6 text-secondary">
     Possible values: {{ possibleValues }}

--- a/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/num-scale-question-edit-answer-form.component.ts
@@ -11,8 +11,6 @@ import {
   DEFAULT_NUMSCALE_RESPONSE_DETAILS,
 } from '../../../../types/default-question-structs';
 import { NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED } from '../../../../types/feedback-response-details';
-import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.directive';
-
 /**
  * The numerical scale question submission form for a recipient.
  */
@@ -20,10 +18,7 @@ import { WheelDisablerDirective } from '../../wheel-disabler/wheel-disabler.dire
   selector: 'tm-num-scale-question-edit-answer-form',
   templateUrl: './num-scale-question-edit-answer-form.component.html',
   styleUrls: ['./num-scale-question-edit-answer-form.component.scss'],
-  imports: [
-    FormsModule,
-    WheelDisablerDirective,
-],
+  imports: [FormsModule],
 })
 export class NumScaleQuestionEditAnswerFormComponent
     extends QuestionEditAnswerFormComponent<FeedbackNumericalScaleQuestionDetails,
@@ -33,6 +28,14 @@ export class NumScaleQuestionEditAnswerFormComponent
 
   constructor() {
     super(DEFAULT_NUMSCALE_QUESTION_DETAILS(), DEFAULT_NUMSCALE_RESPONSE_DETAILS());
+  }
+
+  onAnswerChange(value: string): void {
+    const parsed = parseFloat(value);
+    this.triggerResponseDetailsChange(
+      'answer',
+      Number.isNaN(parsed) ? NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED : parsed,
+    );
   }
 
   get numberOfPossibleValues(): number {

--- a/src/web/app/components/question-types/question-edit-answer-form/question-edit-answer-form.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/question-edit-answer-form.ts
@@ -29,6 +29,27 @@ export abstract class QuestionEditAnswerFormComponent<
     this.responseDetails = responseDetails;
   }
 
+  onIntegerInput(event: KeyboardEvent): void {
+    const { key } = event;
+    if (key !== 'Backspace' && !/[0-9]/.test(key)) {
+      event.preventDefault();
+    }
+  }
+
+  onFloatInput(event: KeyboardEvent): void {
+    const { key } = event;
+    const isBackspace = key === 'Backspace';
+    const isDecimal = key === '.';
+    const isDigit = /[0-9]/.test(key);
+    if (!isBackspace && !isDigit && !isDecimal) {
+      event.preventDefault();
+      return;
+    }
+    if (isDecimal && (event.target as HTMLInputElement)?.value?.includes('.')) {
+      event.preventDefault();
+    }
+  }
+
   getAriaLabel(): string {
     if (this.recipient === '' || this.recipient === '%GENERAL%' || this.recipient === 'Myself') {
       return 'Response';

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.html
@@ -6,7 +6,7 @@
   </div>
   <div class="col-sm-4">
     <span class="ngb-tooltip-class" ngbTooltip="Value to be increased/decreased each step">Increment:</span>
-    <input id="increment-value" type="number" (keypress)="onFloatInput($event)" class="form-control" [ngModel]="model.step" (ngModelChange)="triggerModelChange('step', $event)" [disabled]="!isEditable" (input) = "restrictFloatInputLength($event, 'step')"
+    <input id="increment-value" type="number" (keypress)="onFloatInput($event)" (paste)="onPasteDecimal($event)" class="form-control" [ngModel]="model.step" (ngModelChange)="triggerModelChange('step', $event)" [disabled]="!isEditable" (input) = "restrictFloatInputLength($event, 'step')"
       step="any" min="0" max="999999999" aria-label="Increment Value Input">
   </div>
   <div class="col-sm-4">

--- a/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/num-scale-question-edit-details-form.component.spec.ts
@@ -56,14 +56,26 @@ describe('NumScaleQuestionEditDetailsFormComponent', () => {
     expect(eventSpy).toHaveBeenCalled();
   });
 
-  it('should allow decimal point inputs in onFloatInput', () => {
-    const event = new KeyboardEvent('keypress', {
-      key: '.',
-    });
+  it('should allow decimal point inputs in onFloatInput when no decimal exists', () => {
+    const inputElement = fixture.debugElement.query(By.css('#increment-value')).nativeElement as HTMLInputElement;
+    inputElement.value = '3';
+    const event = new KeyboardEvent('keypress', { key: '.' });
+    Object.defineProperty(event, 'target', { value: inputElement });
 
     const eventSpy = jest.spyOn(event, 'preventDefault');
     component.onFloatInput(event);
     expect(eventSpy).not.toHaveBeenCalled();
+  });
+
+  it('should prevent second decimal point input in onFloatInput when decimal already exists', () => {
+    const inputElement = fixture.debugElement.query(By.css('#increment-value')).nativeElement as HTMLInputElement;
+    inputElement.value = '3.14';
+    const event = new KeyboardEvent('keypress', { key: '.' });
+    Object.defineProperty(event, 'target', { value: inputElement });
+
+    const eventSpy = jest.spyOn(event, 'preventDefault');
+    component.onFloatInput(event);
+    expect(eventSpy).toHaveBeenCalled();
   });
 
   it('should allow digit inputs in onFloatInput', () => {

--- a/src/web/app/components/question-types/question-edit-details-form/question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/question-edit-details-form.component.ts
@@ -57,6 +57,10 @@ export abstract class QuestionEditDetailsFormComponent<D extends FeedbackQuestio
     const isDigit = /[0-9]/.test(key);
     if (!isBackspace && !isDigit && !isDecimal) {
       event.preventDefault();
+      return;
+    }
+    if (isDecimal && (event.target as HTMLInputElement)?.value?.includes('.')) {
+      event.preventDefault();
     }
   }
 
@@ -66,8 +70,20 @@ export abstract class QuestionEditDetailsFormComponent<D extends FeedbackQuestio
       return;
     }
     const pastedText = clipboardData.getData('text');
-    const isDigit = /^\d+$/.test(pastedText);
-    if (!isDigit) {
+    const isInteger = /^\d+$/.test(pastedText);
+    if (!isInteger) {
+      event.preventDefault();
+    }
+  }
+
+  onPasteDecimal(event: ClipboardEvent): void {
+    const { clipboardData } = event;
+    if (clipboardData == null) {
+      return;
+    }
+    const pastedText = clipboardData.getData('text');
+    const isDecimalNumber = /^\d+(\.\d+)?$/.test(pastedText);
+    if (!isDecimalNumber) {
       event.preventDefault();
     }
   }

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -2134,11 +2134,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           <input
                             aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
-                            max="10"
-                            min="1"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
+                            inputmode="decimal"
+                            type="text"
                           />
                         </div>
                         <div
@@ -2367,10 +2364,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           <input
                             aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
-                            min="0"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
+                            inputmode="numeric"
+                            type="text"
                           />
                         </div>
                       </div>
@@ -5181,11 +5176,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           <input
                             aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
-                            max="10"
-                            min="1"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
+                            inputmode="decimal"
+                            type="text"
                           />
                         </div>
                         <div
@@ -5416,10 +5408,8 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                           <input
                             aria-label="Response for Barry Harris"
                             class="form-control ng-untouched ng-pristine ng-valid"
-                            min="0"
-                            step="1"
-                            tmdisablewheel=""
-                            type="number"
+                            inputmode="numeric"
+                            type="text"
                           />
                         </div>
                       </div>


### PR DESCRIPTION
## Fixes #13752 

## Problem
Page scrolling was completely blocked whenever the cursor hovered over a
`<input type="number">` element using the `tmDisableWheel` directive, because
`e.preventDefault()` on the wheel event suppresses both the value change and
native scroll propagation.

## Approach
Rather than patching the directive, the three answer-form number inputs
(numerical scale, constsum options, constsum recipients) are migrated to
`type="text" inputmode="numeric|decimal"` — the approach now recommended by
the GOV.UK Design System and MDN. This eliminates the need for `tmDisableWheel`
on these inputs entirely.

## Changes

### Core fix
- `num-scale`, `constsum-options`, `constsum-recipients` answer forms: switched
  to `type="text" inputmode="decimal|numeric"`, removed `tmDisableWheel`

### Regressions fixed post-migration
- Removed now-unused `WheelDisablerDirective` from all three component `imports`
- Added `onIntegerInput` / `onFloatInput` to `QuestionEditAnswerFormComponent`
  base class and wired via `(keypress)` — restores character filtering lost when
  leaving `type="number"`
- Fixed string→number coercion: `ngModel` on `type="text"` emits strings; each
  component's change handler now parses to number, with correct fallback to
  `NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED` on empty input for num-scale, and
  answer-array clearing on empty input for constsum recipients

### Pre-existing bugs fixed
- `onFloatInput` previously allowed multiple decimal points (e.g. `"1.2.3"`);
  now prevents a second `.` if one already exists in the input value
- `onPaste` only validated integers; added `onPasteDecimal` for float fields and
  wired it to the num-scale increment input where `onFloatInput` was already used

## Out of scope / follow-up
The remaining ~20 `type="number"` inputs in the question **edit-details** forms
have complex dynamic `[min]`/`[max]` bindings currently enforced by the browser.
Migrating those requires a custom bounds-validation directive and is deferred
pending Angular signal forms stabilisation (see follow-up issue).

## Files changed
- `wheel-disabler/wheel-disabler.directive.ts`
- `question-edit-answer-form/question-edit-answer-form.ts`
- `question-edit-answer-form/num-scale-question-edit-answer-form.component.*`
- `question-edit-answer-form/constsum-options-question-edit-answer-form.component.*`
- `question-edit-answer-form/constsum-recipients-question-edit-answer-form.component.*`
- `question-edit-details-form/question-edit-details-form.component.ts`
- `question-edit-details-form/num-scale-question-edit-details-form.component.html`
- `question-edit-details-form/num-scale-question-edit-details-form.component.spec.ts`
