### PR TITLE
[#13477] Fix environment dependency in instructor request form tests

### DIFF
--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.spec.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.spec.ts
@@ -8,6 +8,17 @@ import { InstructorRequestFormComponent } from './instructor-request-form.compon
 import { AccountService } from '../../../../services/account.service';
 import { AccountCreateRequest, AccountRequestStatus } from '../../../../types/api-request';
 
+// Mock the environment module to provide consistent test values
+jest.mock('../../../../environments/environment', () => ({
+  environment: {
+    production: false,
+    backendUrl: 'http://localhost:8080',
+    frontendUrl: 'http://localhost:4200',
+    captchaSiteKey: '',
+    withCredentials: true,
+  },
+}));
+
 describe('InstructorRequestFormComponent', () => {
   let component: InstructorRequestFormComponent;
   let fixture: ComponentFixture<InstructorRequestFormComponent>;
@@ -67,7 +78,6 @@ describe('InstructorRequestFormComponent', () => {
     fixture = TestBed.createComponent(InstructorRequestFormComponent);
     component = fixture.componentInstance;
     accountService = TestBed.inject(AccountService);
-    component.captchaSiteKey = ''; // Test ignores captcha
     fixture.detectChanges();
     jest.clearAllMocks();
   });


### PR DESCRIPTION
Fixes #13477

This PR addresses an issue where the InstructorRequestForm unit tests were dependent on the local developer's environment configuration. Specifically, the tests would fail if a user had a non-empty captchaSiteKey defined in their local config.ts.

Files Modified
src/web/app/instructor-request-form/instructor-request-form.component.spec.ts:

- Implemented module mocking and cleaned up the beforeEach setup.
- Added a jest.mock at the top of the test file to intercept the config import. This ensures that captchaSiteKey is always returned as an empty string during the test execution, regardless of the actual file content.