### PR TITLE
[#13714] Update Liquibase configuration and schema migration documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ if (project.gradle.startParameter.taskNames.any { it.contains("liquibaseDiffChan
     if (!project.hasProperty("migrationName")) {
         throw new GradleException("Pass -PmigrationName=foo when running liquibaseDiffChangelog")
     }
-    
+
     project.ext.set("runList", "diffMain")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,8 @@ dependencies {
 
     compileOnly("org.liquibase.ext:liquibase-hibernate6:5.0.2")
 
+    liquibaseRuntime("org.springframework:spring-core:6.2.10")
+    liquibaseRuntime("org.springframework:spring-beans:6.2.10")
     liquibaseRuntime("info.picocli:picocli:4.7.7")
     liquibaseRuntime("org.liquibase.ext:liquibase-hibernate6:5.0.2")
     liquibaseRuntime(sourceSets.main.output)
@@ -136,16 +138,13 @@ sourceSets {
     }
 }
 
-if (!project.hasProperty("runList")) {
-    project.ext.set("runList", "main")
+if (project.gradle.startParameter.taskNames.any { it.contains("liquibaseDiffChangelog") }) {
+    if (!project.hasProperty("migrationName")) {
+        throw new GradleException("Pass -PmigrationName=foo when running liquibaseDiffChangelog")
+    }
+    
+    project.ext.set("runList", "diffMain")
 }
-
-if (project.ext.runList == "diffMain" && !project.hasProperty("migrationName")) {
-    throw new GradleException("Pass -PmigrationName=foo when running diffMain")
-}
-def liquibaseDiffTimestamp = new Date().format("yyyyMMdd")
-def migrationName = findProperty("migrationName")
-def liquibaseDiffChangelogFile = "src/main/resources/db/changelog/migrations/${liquibaseDiffTimestamp}-${migrationName}.xml"
 
 liquibase {
     activities {
@@ -155,17 +154,22 @@ liquibase {
             url project.properties['liquibaseDbUrl']
             username project.properties['liquibaseUsername']
             password project.properties['liquibasePassword']
+            if (project.hasProperty('count')) {
+                count project.properties['count']
+            }
         }
         diffMain {
+            def migrationName = project.properties["migrationName"]
+            def liquibaseDiffTimestamp = new Date().format("yyyyMMdd")
             searchPath "${projectDir}"
-            changelogFile liquibaseDiffChangelogFile
+            changelogFile "src/main/resources/db/changelog/migrations/${liquibaseDiffTimestamp}-${migrationName}.xml"
             referenceUrl "hibernate:classic:teammates.liquibase.LiquibaseHibernateConfigFactory"
             url project.properties['liquibaseDbUrl']
             username project.properties['liquibaseUsername']
             password project.properties['liquibasePassword']
         }
     }
-    runList = project.ext.runList
+    runList = project.findProperty("runList") ?: "main"
 }
 
 // TODO: remove this workaround after cz.habarta.typescript.generator is patched to fix this issue

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -50,6 +50,23 @@ Start the database if it is not already running:
 docker compose up -d
 ```
 
+Apply database migrations if necessary:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseUpdate
+```
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseUpdate
+```
+</tab>
+</tabs>
+
 Then start the backend server:
 
 <tabs>

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -14,7 +14,19 @@ If you encounter any issues, refer to the [Troubleshooting Guide](../troubleshoo
 
 ## Running the Frontend Server
 
-First, generate type definitions from the backend:
+Start the frontend server:
+```sh
+npm run start
+```
+
+The server will be available at `http://localhost:4200`. It runs in watch and live reload mode by default — any saved changes will be reflected immediately.
+
+To disable live reload:
+```sh
+npm run start -- --no-live-reload
+```
+
+Type definitions for the frontend are generated from backend API types and must be kept in sync. Run the following after making changes to any backend API types:
 
 <tabs>
 <tab header="Mac / Linux">
@@ -30,18 +42,6 @@ gradlew.bat generateTypes
 ```
 </tab>
 </tabs>
-
-Then start the frontend server:
-```sh
-npm run start
-```
-
-The server will be available at `http://localhost:4200`. It runs in watch and live reload mode by default — any saved changes will be reflected immediately.
-
-To disable live reload:
-```sh
-npm run start -- --no-live-reload
-```
 
 ## Running the Backend Server
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,24 +75,7 @@ npm ci
 
 **Verification:** A `node_modules` folder should appear in the project root.
 
-3. Generate frontend type definitions
-
-<tabs>
-<tab header="Mac / Linux">
-
-```sh
-./gradlew generateTypes
-```
-</tab>
-<tab header="Windows">
-
-```sh
-gradlew.bat generateTypes
-```
-</tab>
-</tabs>
-
-## Step 4: Run the Application
+## Step 3: Run the Application
 
 1. Start the database:
 ```sh
@@ -142,7 +125,7 @@ npm run start
 
 The frontend will be available at `http://localhost:4200`.
 
-## Step 5: Set up test accounts
+## Step 4: Set up test accounts
 
 To test TEAMMATES locally, you will need an instructor and a student account.
 
@@ -153,7 +136,7 @@ To test TEAMMATES locally, you will need an instructor and a student account.
 5. Use the admin search feature to find the student, expand the row, and retrieve the course join link to activate the student account.
 6. You now have access to all TEAMMATES features.
 
-## Step 6: Next Steps
+## Step 5: Next Steps
 
 Your environment is now ready. Here's what to do next:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,25 @@ gradlew.bat generateTypes
 ```sh
 docker compose up -d
 ```
-2. Start the backend server:
+
+2. Apply database migrations:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseUpdate
+```
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseUpdate
+```
+</tab>
+</tabs>
+
+3. Start the backend server:
 
 <tabs>
 <tab header="Mac / Linux">
@@ -117,7 +135,7 @@ gradlew.bat serverRun
 
 The backend will be available at `http://localhost:8080`.
 
-3. Start the frontend server:
+4. Start the frontend server:
 ```sh
 npm run start
 ```

--- a/docs/how-to/schema-migration.md
+++ b/docs/how-to/schema-migration.md
@@ -2,46 +2,157 @@
   title: "Schema Migration"
 </frontmatter>
 
-# SQL Schema Migration
+# Schema Migration
 
-Teammates uses _[Liquibase]_(https://docs.liquibase.com/start/home.html), a database schema change management tool. Whenever a schema change is needed, contributors should add or generate a new changelog so the application code and database schema remain in sync.
+TEAMMATES uses [Liquibase](https://docs.liquibase.com/start/home.html) to manage database schema changes. Changelogs are written in XML and live in `src/main/resources/db/changelog/migrations/`.
 
-## Liquibase in Teammates
-_Liquibase_ is made available using the [gradle plugin](https://github.com/liquibase/liquibase-gradle-plugin), providing _liquibase_ functions as tasks. Try `gradle tasks | grep "liquibase"` to see all the tasks available. In teammates, change logs (more in the next section) are written in _XML_.
+## Configuration
 
-### Liquibase connection
-Amend the `liquibaseDbUrl`, `liquibaseUsername` and `liquibasePassword` in `gradle.properties` to allow the _Liquibase_ plugin to connect your database.
+The following variables can be configured in `gradle.properties`. Defaults are pre-configured for local development.
 
-## Change logs, change sets and change types
-A _change log_ is a file that contains a series of _change sets_ (analagous to a transaction) which applies _change types_ (actions). You can refer to this page on liquibase on the types of [change types](https://docs.liquibase.com/change-types/home.html) that can be used.
+- `liquibaseDbUrl`
+- `liquibaseUsername`
+- `liquibasePassword`
 
-## Gradle Activities for Liquibase
-Activities in Gradle are a way of specifying different variables provided by gradle to the Liquibase plugin. The argument `runList` provided by `-pRunList=<activity_name>` e.g `./gradlew liquibaseDiffChangelog -PrunList=diffMain` is used to specify which activity to be used for the Liquibase command. In this case the `liquibaseDiffChangelog` command is run using the `diffMain` activity.
+## Applying Migrations
 
-Here is a brief description of the activities defined for Liquibase
-1. Main: The default activity used by Liquibase commands and is used for running changelogs against a database. This is used by default if a `runList` is not defined.
-2. diffMain: Compares the Hibernate entity model (`hibernate.cfg.xml`) as the reference against the live database to generate a diff changelog. No snapshot file or `schemaMode=migrate` server run is needed.
+<tabs>
+<tab header="Mac / Linux">
 
-## Generating/Updating Liquibase Changelogs
+```sh
+./gradlew liquibaseUpdate
+```
+</tab>
+<tab header="Windows">
 
-1. Run `./gradlew liquibaseUpdate -PrunList=main` to apply all existing migrations to your local database.
-2. Run `./gradlew serverRun` to verify the current schema passes Hibernate validation.
-3. Make your entity/model changes.
-4. Run `./gradlew liquibaseDiffChangelog -PrunList=diffMain -PmigrationName=<descriptive-name>` to generate a changelog (e.g. `-PmigrationName=add-feedback-indexes`). This compares the Hibernate entity model (the desired schema) against the live database (the current state) and produces changesets that bring the database up to match the model. Review the generated changelog manually before committing — auto-diff output can be noisy or incorrect depending on type mappings.
-6. Add rollback blocks to every new changeset.
-7. New files in `src/main/resources/db/changelog/migrations` are auto-included by the root changelog via `includeAll`, so no manual root changelog edits are needed.
+```sh
+gradlew.bat liquibaseUpdate
+```
+</tab>
+</tabs>
 
-## Handling Schema-Validation Failures
+Run this after pulling changes that include new migration files, or after a fresh database setup.
 
-Hibernate validates the database schema against your entity model on every startup. If they do not match, the server will fail to start with a schema-validation error. This usually means you pulled changes that include new or updated migrations but have not applied them yet.
+## Generating a Migration
+
+1. Apply all existing migrations and verify the server starts cleanly:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseUpdate
+./gradlew serverRun
+```
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseUpdate
+gradlew.bat serverRun
+```
+</tab>
+</tabs>
+
+2. Make your entity/model changes.
+
+3. Generate a diff changelog:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseDiffChangelog -PmigrationName=<descriptive-name>
+```
+
+This compares your Hibernate entity model against the live database and produces the necessary changesets. Review and edit the output before committing.
+
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseDiffChangelog -PmigrationName=<descriptive-name>
+```
+
+This compares your Hibernate entity model against the live database and produces the necessary changesets. Review and edit the output before committing.
+
+</tab>
+</tabs>
+
+<box type="info">
+  <md>
+Liquibase auto-generates rollback for most change types. If you use a `<sql>` tag, add a `<rollback>` block manually.
+  </md>
+</box>
+
+## Rolling Back
+
+To roll back the last N changesets:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseRollbackCount -Pcount=<N>
+```
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseRollbackCount -Pcount=<N>
+```
+</tab>
+</tabs>
+
+Note that a single migration file may contain multiple changesets — check the file to determine the correct count.
+
+## Schema Validation Failures
+
+Hibernate validates the database schema on every startup. If the schema does not match the entity model, the server will fail to start. This usually means new migrations have not been applied yet.
 
 **Recovery steps:**
-1. Run `./gradlew liquibaseUpdate -PrunList=main` to apply missing migrations.
-2. Run `./gradlew serverRun` to confirm validation passes.
 
-**If that does not resolve it:**
-1. Stop local services: `docker compose down`.
-2. Remove the database data directory (e.g. `rm -rf postgres-data`).
-3. Restart services: `docker compose up -d`.
-4. Run `./gradlew liquibaseUpdate -PrunList=main` to rebuild the schema from changelogs.
-5. Run `./gradlew serverRun` to confirm validation passes.
+1. Apply missing migrations and restart:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+./gradlew liquibaseUpdate
+./gradlew serverRun
+```
+</tab>
+<tab header="Windows">
+
+```sh
+gradlew.bat liquibaseUpdate
+gradlew.bat serverRun
+```
+</tab>
+</tabs>
+
+2. If that does not resolve it, you may have to reset the database as a last resort:
+
+<tabs>
+<tab header="Mac / Linux">
+
+```sh
+docker compose down
+rm -rf postgres-data
+docker compose up -d
+./gradlew liquibaseUpdate
+./gradlew serverRun
+```
+</tab>
+<tab header="Windows">
+
+```sh
+docker compose down
+rm -rf postgres-data
+docker compose up -d
+gradlew.bat liquibaseUpdate
+gradlew.bat serverRun
+```
+</tab>
+</tabs>
+

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -19,21 +19,15 @@ This can be resolved by moving the repository to another directory.
 This is the expected behaviour if you are running the server in the foreground.
 </panel>
 
-<panel header="The frontend dev server fails with `Cannot find module '../api-output'` or similar" no-close>
-
-[The frontend type definitions need to be built](contributing/development-guide.md#running-the-frontend-server) before running the dev server.
-</panel>
-
-<panel header="After pulling changes from the `master` branch, the previously working frontend dev server fails to start" no-close>
-
-This is possible if a part of API input/output definition changes.
-Simply rerun the command to build the type definitions to resolve the problem.
-</panel>
-
-<panel header="When running ./gradlew serverRun, the authentication fails with 'org.postgresql.util.PSQLException: FATAL: password authentication failed for user &quot;teammates&quot;'" no-close>
+<panel header="`PSQLException: FATAL: password authentication failed for user 'teammates'` when connecting to database" no-close>
 
 This is possible if a local PostgreSQL instance is already running on port 5432. 
 This can be fixed by manually killing the local PostgreSQL server process before running ./gradlew serverRun again.
+</panel>
+
+<panel header="Backend fails to start with `org.hibernate.tool.schema.spi.SchemaManagementException`" no-close>
+
+Refer to troubleshooting steps for [Schema Validation Failures](./how-to/schema-migration.html#schema-validation-failures).
 </panel>
 
 <br>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #13714

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Functional Changes:

1. Liquibase Hibernate extension unfortunately requires Spring classes at runtime. These have been added to the liquibaseRuntime classpath.
2. Simplified runList configuration. If task is `liquibaseDiffChangelog`, runList is set to `diffMain` (note: `diffChangelog` is only configured to work with runList `diffMain` at the moment). Otherwise, it defaults to `main` if `runList` is not specified. This means we no longer need to specify runList when running commands.

Documentation Changes:

1. Added migration steps to getting-started and development-guide.
2. Revamped schema-migration page.
3. Added troubleshooting FAQ for schema migration.