### PR TITLE
[#13710] Admin Search: Unable to expand account requests row

### DIFF
--- a/src/web/app/components/account-requests-table/account-request-table.component.html
+++ b/src/web/app/components/account-requests-table/account-request-table.component.html
@@ -35,7 +35,7 @@
         </thead>
         <tbody>
           @for (accountRequest of accountRequests; track trackAccountRequest(i, accountRequest); let i = $index) {
-            <tr>
+           <tr (click)="accountRequest.showLinks = !accountRequest.showLinks" style="cursor: pointer;">
               <td [innerHtml]="accountRequest.name | highlighter:searchString:true">
                 <br>
                   <div class="col-sm-1">


### PR DESCRIPTION
Fixes #13710. Added a click handler to the account request row to allow expansion.