### PR TITLE
Strengthen HTTP security headers

### DIFF
--- a/src/main/java/teammates/ui/servlets/RequestTraceFilter.java
+++ b/src/main/java/teammates/ui/servlets/RequestTraceFilter.java
@@ -31,7 +31,7 @@ public class RequestTraceFilter implements Filter {
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
         HttpServletResponse response = (HttpServletResponse) resp;
 
-        response.setHeader("Strict-Transport-Security", "max-age=31536000");
+        SecurityHeaders.addCommonHeaders(response);
         response.setHeader("Cache-Control", "no-store");
         response.setHeader("Pragma", "no-cache");
 

--- a/src/main/java/teammates/ui/servlets/SecurityHeaders.java
+++ b/src/main/java/teammates/ui/servlets/SecurityHeaders.java
@@ -1,0 +1,59 @@
+package teammates.ui.servlets;
+
+import java.util.Arrays;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import teammates.common.util.Config;
+
+/**
+ * Shared HTTP security headers used across servlet filters.
+ */
+final class SecurityHeaders {
+
+    static final String STRICT_TRANSPORT_SECURITY = "max-age=31536000";
+    static final String X_CONTENT_TYPE_OPTIONS = "nosniff";
+    static final String REFERRER_POLICY = "strict-origin-when-cross-origin";
+    static final String PERMISSIONS_POLICY =
+            "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+    static final String X_FRAME_OPTIONS = "SAMEORIGIN";
+    static final String X_XSS_PROTECTION = "1; mode=block";
+
+    static final String IMG_SRC_CSP = Config.IS_DEV_SERVER
+            ? "'self' data: http: https:"
+            : "'self' data: https:";
+
+    static final String CONTENT_SECURITY_POLICY = String.join("; ", Arrays.asList(
+            "default-src 'none'",
+            "script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ "
+                    + "https://cdn.jsdelivr.net/  https://apis.google.com/",
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/ https://fonts.googleapis.com/",
+            "frame-src 'self' docs.google.com https://www.google.com/recaptcha/ https://*.firebaseapp.com/",
+            "img-src " + IMG_SRC_CSP,
+            "font-src 'self' https://cdn.jsdelivr.net/ https://fonts.gstatic.com/",
+            "connect-src 'self' https://*.googleapis.com/",
+            "manifest-src 'self'",
+            "form-action 'none'",
+            "frame-ancestors 'self'",
+            "base-uri 'self'"
+    ));
+
+    private SecurityHeaders() {
+        // Utility class.
+    }
+
+    static void addCommonHeaders(HttpServletResponse response) {
+        response.setHeader("Strict-Transport-Security", STRICT_TRANSPORT_SECURITY);
+        response.setHeader("X-Content-Type-Options", X_CONTENT_TYPE_OPTIONS);
+        response.setHeader("Referrer-Policy", REFERRER_POLICY);
+        response.setHeader("Permissions-Policy", PERMISSIONS_POLICY);
+    }
+
+    static void addDocumentHeaders(HttpServletResponse response) {
+        addCommonHeaders(response);
+        response.setHeader("Content-Security-Policy", CONTENT_SECURITY_POLICY);
+        response.setHeader("X-Frame-Options", X_FRAME_OPTIONS);
+        response.setHeader("X-XSS-Protection", X_XSS_PROTECTION);
+    }
+
+}

--- a/src/main/java/teammates/ui/servlets/WebSecurityHeaderFilter.java
+++ b/src/main/java/teammates/ui/servlets/WebSecurityHeaderFilter.java
@@ -1,7 +1,6 @@
 package teammates.ui.servlets;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -10,40 +9,16 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletResponse;
 
-import teammates.common.util.Config;
-
 /**
  * Filter to add web security headers.
  */
 public class WebSecurityHeaderFilter implements Filter {
 
-    private static final String IMG_SRC_CSP = Config.IS_DEV_SERVER
-            ? "'self' data: http: https:"
-            : "'self' data: https:";
-
-    private static final String CSP_POLICY = String.join("; ", Arrays.asList(
-            "default-src 'none'",
-            "script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://cdn.jsdelivr.net/  https://apis.google.com/",
-            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/ https://fonts.googleapis.com/",
-            "frame-src 'self' docs.google.com https://www.google.com/recaptcha/ https://*.firebaseapp.com/",
-            "img-src " + IMG_SRC_CSP,
-            "font-src 'self' https://cdn.jsdelivr.net/ https://fonts.gstatic.com/",
-            "connect-src 'self' https://*.googleapis.com/",
-            "manifest-src 'self'",
-            "form-action 'none'",
-            "frame-ancestors 'self'",
-            "base-uri 'self'"
-    ));
-
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         HttpServletResponse resp = (HttpServletResponse) response;
-        resp.setHeader("Content-Security-Policy", CSP_POLICY);
-        resp.setHeader("X-Content-Type-Options", "nosniff");
-        resp.setHeader("X-Frame-Options", "SAMEORIGIN");
-        resp.setHeader("X-XSS-Protection", "1; mode=block");
-        resp.setHeader("Strict-Transport-Security", "max-age=31536000");
+        SecurityHeaders.addDocumentHeaders(resp);
 
         chain.doFilter(request, resp);
     }

--- a/src/test/java/teammates/test/MockFilterChain.java
+++ b/src/test/java/teammates/test/MockFilterChain.java
@@ -11,9 +11,15 @@ import jakarta.servlet.ServletResponse;
  */
 public class MockFilterChain implements FilterChain {
 
+    private boolean invoked;
+
     @Override
     public void doFilter(ServletRequest request, ServletResponse response) {
-        // not used
+        invoked = true;
+    }
+
+    public boolean wasInvoked() {
+        return invoked;
     }
 
 }

--- a/src/test/java/teammates/test/MockHttpServletResponse.java
+++ b/src/test/java/teammates/test/MockHttpServletResponse.java
@@ -4,8 +4,10 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.Cookie;
@@ -25,6 +27,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
     private int statusCode = HttpStatus.SC_OK;
     private String redirectUrl;
     private List<Cookie> cookies = new ArrayList<>();
+    private Map<String, List<String>> headers = new LinkedHashMap<>();
 
     @Override
     public void addCookie(Cookie cookie) {
@@ -33,7 +36,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
     @Override
     public boolean containsHeader(String name) {
-        return false;
+        return headers.containsKey(name);
     }
 
     @Override
@@ -87,12 +90,12 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void setHeader(String name, String value) {
-        // not used
+        headers.put(name, new ArrayList<>(Collections.singletonList(value)));
     }
 
     @Override
     public void addHeader(String name, String value) {
-        // not used
+        headers.computeIfAbsent(name, key -> new ArrayList<>()).add(value);
     }
 
     @Override
@@ -122,17 +125,18 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
     @Override
     public String getHeader(String s) {
-        return null;
+        List<String> values = headers.get(s);
+        return values == null || values.isEmpty() ? null : values.get(0);
     }
 
     @Override
     public Collection<String> getHeaders(String s) {
-        return Collections.emptyList();
+        return headers.getOrDefault(s, Collections.emptyList());
     }
 
     @Override
     public Collection<String> getHeaderNames() {
-        return Collections.emptyList();
+        return headers.keySet();
     }
 
     @Override

--- a/src/test/java/teammates/ui/servlets/RequestTraceFilterTest.java
+++ b/src/test/java/teammates/ui/servlets/RequestTraceFilterTest.java
@@ -1,0 +1,36 @@
+package teammates.ui.servlets;
+
+import org.apache.http.client.methods.HttpGet;
+import org.testng.annotations.Test;
+
+import teammates.test.BaseTestCase;
+import teammates.test.MockFilterChain;
+import teammates.test.MockHttpServletRequest;
+import teammates.test.MockHttpServletResponse;
+
+/**
+ * SUT: {@link RequestTraceFilter}.
+ */
+public class RequestTraceFilterTest extends BaseTestCase {
+
+    private static final RequestTraceFilter FILTER = new RequestTraceFilter();
+
+    @Test
+    public void doFilter_setsCommonSecurityHeadersForApiRequests() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(HttpGet.METHOD_NAME, "http://localhost:8080/webapi/course");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        FILTER.doFilter(request, response, filterChain);
+
+        assertTrue(filterChain.wasInvoked());
+        assertEquals(response.getHeader("Strict-Transport-Security"), SecurityHeaders.STRICT_TRANSPORT_SECURITY);
+        assertEquals(response.getHeader("X-Content-Type-Options"), SecurityHeaders.X_CONTENT_TYPE_OPTIONS);
+        assertEquals(response.getHeader("Referrer-Policy"), SecurityHeaders.REFERRER_POLICY);
+        assertEquals(response.getHeader("Permissions-Policy"), SecurityHeaders.PERMISSIONS_POLICY);
+        assertEquals(response.getHeader("Cache-Control"), "no-store");
+        assertEquals(response.getHeader("Pragma"), "no-cache");
+        assertNull(response.getHeader("Content-Security-Policy"));
+    }
+
+}

--- a/src/test/java/teammates/ui/servlets/WebSecurityHeaderFilterTest.java
+++ b/src/test/java/teammates/ui/servlets/WebSecurityHeaderFilterTest.java
@@ -1,0 +1,36 @@
+package teammates.ui.servlets;
+
+import org.apache.http.client.methods.HttpGet;
+import org.testng.annotations.Test;
+
+import teammates.test.BaseTestCase;
+import teammates.test.MockFilterChain;
+import teammates.test.MockHttpServletRequest;
+import teammates.test.MockHttpServletResponse;
+
+/**
+ * SUT: {@link WebSecurityHeaderFilter}.
+ */
+public class WebSecurityHeaderFilterTest extends BaseTestCase {
+
+    private static final WebSecurityHeaderFilter FILTER = new WebSecurityHeaderFilter();
+
+    @Test
+    public void doFilter_setsDocumentSecurityHeaders() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(HttpGet.METHOD_NAME, "http://localhost:8080/web/home");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        FILTER.doFilter(request, response, filterChain);
+
+        assertTrue(filterChain.wasInvoked());
+        assertEquals(response.getHeader("Content-Security-Policy"), SecurityHeaders.CONTENT_SECURITY_POLICY);
+        assertEquals(response.getHeader("Strict-Transport-Security"), SecurityHeaders.STRICT_TRANSPORT_SECURITY);
+        assertEquals(response.getHeader("X-Content-Type-Options"), SecurityHeaders.X_CONTENT_TYPE_OPTIONS);
+        assertEquals(response.getHeader("Referrer-Policy"), SecurityHeaders.REFERRER_POLICY);
+        assertEquals(response.getHeader("Permissions-Policy"), SecurityHeaders.PERMISSIONS_POLICY);
+        assertEquals(response.getHeader("X-Frame-Options"), SecurityHeaders.X_FRAME_OPTIONS);
+        assertEquals(response.getHeader("X-XSS-Protection"), SecurityHeaders.X_XSS_PROTECTION);
+    }
+
+}


### PR DESCRIPTION
## Summary
- centralize shared HTTP security headers in a helper
- add referrer-policy and permissions-policy to the baseline headers
- cover page and request filters with unit tests

## Testing
- .\\gradlew.bat unitTests --tests teammates.ui.servlets.WebSecurityHeaderFilterTest --tests teammates.ui.servlets.RequestTraceFilterTest