### PR TITLE
[#13721] Enforce bidirectional association consistency for Data Bundles

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/DataBundleLogicIT.java
@@ -19,9 +19,8 @@ import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
-import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.HibernateUtil;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.DataBundleLogic;
 import teammates.storage.sqlentity.Account;
@@ -240,9 +239,10 @@ public class DataBundleLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testRemoveDataBundle_typicalValues_removedCorrectly()
-                throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+                throws InvalidParametersException {
         DataBundle dataBundle = loadDataBundle("/DataBundleLogicIT.json");
         dataBundleLogic.persistDataBundle(dataBundle);
+        HibernateUtil.flushSession();
 
         ______TS("verify notifications persisted correctly");
         Notification notification1 = dataBundle.notifications.get("notification1");

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackSessionLogsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackSessionLogsLogicIT.java
@@ -53,7 +53,9 @@ public class FeedbackSessionLogsLogicIT extends BaseTestCaseWithSqlDatabaseAcces
         FeedbackSessionLog newLog3 = new FeedbackSessionLog(student, fs, FeedbackSessionLogType.VIEW_RESULT, timestamp);
         List<FeedbackSessionLog> expected = List.of(newLog1, newLog2, newLog3);
 
-        fslLogic.createFeedbackSessionLogs(expected);
+        for (FeedbackSessionLog log : expected) {
+            fslLogic.createFeedbackSessionLog(log);
+        }
 
         List<FeedbackSessionLog> actual = fslLogic.getOrderedFeedbackSessionLogs(course.getId(), student.getId(),
                 fs.getId(), timestamp, timestamp.plusSeconds(1));

--- a/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
@@ -145,11 +145,13 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
     @Test
     public void testGetSectionByCourseIdAndTeam() throws InvalidParametersException, EntityAlreadyExistsException {
         Course course = getTypicalCourse();
+        coursesDb.createCourse(course);
         Section section = new Section(course, "section-name");
+        coursesDb.createSection(section);
         course.addSection(section);
         Team team = new Team(section, "team-name");
+        coursesDb.createTeam(team);
         section.addTeam(team);
-        coursesDb.createCourse(course);
 
         ______TS("failure: null courseId assertion exception thrown");
         assertThrows(AssertionError.class, () -> coursesDb.getSectionByCourseIdAndTeam(null, team.getName()));
@@ -170,6 +172,7 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         for (int i = 0; i < 5; i++) {
             Section newSection = new Section(course, "section-name" + i);
             expectedSections.add(newSection);
+            coursesDb.createSection(newSection);
             course.addSection(newSection);
             assertNotNull(coursesDb.getSectionByName(course.getId(), newSection.getName()));
         }
@@ -185,24 +188,29 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
     @Test
     public void testGetTeamsForCourse() throws InvalidParametersException, EntityAlreadyExistsException {
         Course course = getTypicalCourse();
+        coursesDb.createCourse(course);
 
         Section section1 = new Section(course, "section-name1");
+        coursesDb.createSection(section1);
         course.addSection(section1);
         Team team1 = new Team(section1, "team-name1");
+        coursesDb.createTeam(team1);
         section1.addTeam(team1);
         Team team2 = new Team(section1, "team-name2");
+        coursesDb.createTeam(team2);
         section1.addTeam(team2);
 
         Section section2 = new Section(course, "section-name2");
+        coursesDb.createSection(section2);
         course.addSection(section2);
         Team team3 = new Team(section2, "team-name3");
+        coursesDb.createTeam(team3);
         section2.addTeam(team3);
         Team team4 = new Team(section2, "team-name4");
+        coursesDb.createTeam(team4);
         section2.addTeam(team4);
 
         List<Team> expectedTeams = List.of(team1, team2, team3, team4);
-
-        coursesDb.createCourse(course);
 
         ______TS("failure: null courseId assertion exception thrown");
         assertThrows(AssertionError.class, () -> coursesDb.getTeamsForCourse(null));

--- a/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
@@ -1,6 +1,5 @@
 package teammates.it.storage.sqlapi;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.testng.annotations.Test;
@@ -162,27 +161,6 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         ______TS("success: typical case");
         Section actualSection = coursesDb.getSectionByCourseIdAndTeam(course.getId(), team.getName());
         verifyEquals(section, actualSection);
-    }
-
-    @Test
-    public void testDeleteSectionsByCourseId() throws Exception {
-        Course course = getTypicalCourse();
-        coursesDb.createCourse(course);
-        List<Section> expectedSections = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            Section newSection = new Section(course, "section-name" + i);
-            expectedSections.add(newSection);
-            coursesDb.createSection(newSection);
-            course.addSection(newSection);
-            assertNotNull(coursesDb.getSectionByName(course.getId(), newSection.getName()));
-        }
-
-        ______TS("success: delete sections by course id");
-        coursesDb.deleteSectionsByCourseId(course.getId());
-        for (Section section : expectedSections) {
-            Section actualSection = coursesDb.getSectionByName(course.getId(), section.getName());
-            assertNull(actualSection);
-        }
     }
 
     @Test

--- a/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/UsersDbIT.java
@@ -45,10 +45,11 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         coursesDb.createCourse(course);
 
         Section section = new Section(course, "test-section");
+        coursesDb.createSection(section);
         course.addSection(section);
         Team team = new Team(section, "test-team");
+        coursesDb.createTeam(team);
         section.addTeam(team);
-        coursesDb.updateCourse(course);
 
         Account instructorAccount = new Account("instructor-account", "instructor-name", "valid-instructor@email.tmt");
         accountsDb.createAccount(instructorAccount);
@@ -190,16 +191,18 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         ______TS("success: typical case");
         Section firstSection = new Section(course, "section-name1");
+        coursesDb.createSection(firstSection);
         course.addSection(firstSection);
         Team firstTeam = new Team(firstSection, "team-name1");
+        coursesDb.createTeam(firstTeam);
         firstSection.addTeam(firstTeam);
 
         Section secondSection = new Section(course, "section-name2");
+        coursesDb.createSection(secondSection);
         course.addSection(secondSection);
         Team secondTeam = new Team(secondSection, "team-name2");
+        coursesDb.createTeam(secondTeam);
         secondSection.addTeam(secondTeam);
-
-        coursesDb.updateCourse(course);
 
         Student firstStudent = getTypicalStudent();
         firstStudent.setEmail("valid-student-1@email.tmt");
@@ -229,16 +232,18 @@ public class UsersDbIT extends BaseTestCaseWithSqlDatabaseAccess {
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         ______TS("success: typical case");
         Section firstSection = new Section(course, "section-name1");
+        coursesDb.createSection(firstSection);
         course.addSection(firstSection);
         Team firstTeam = new Team(firstSection, "team-name1");
+        coursesDb.createTeam(firstTeam);
         firstSection.addTeam(firstTeam);
 
         Section secondSection = new Section(course, "section-name2");
+        coursesDb.createSection(secondSection);
         course.addSection(secondSection);
         Team secondTeam = new Team(secondSection, "team-name2");
+        coursesDb.createTeam(secondTeam);
         secondSection.addTeam(secondTeam);
-
-        coursesDb.updateCourse(course);
 
         Student firstStudent = getTypicalStudent();
         firstStudent.setEmail("valid-student-1@email.tmt");

--- a/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
+++ b/src/it/java/teammates/it/test/BaseTestCaseWithSqlDatabaseAccess.java
@@ -195,10 +195,16 @@ public abstract class BaseTestCaseWithSqlDatabaseAccess extends BaseTestCase {
     private BaseEntity getEntity(BaseEntity entity) {
         if (entity instanceof Course) {
             return logic.getCourse(((Course) entity).getId());
+        } else if (entity instanceof DeadlineExtension) {
+            return logic.getDeadlineExtension(((DeadlineExtension) entity).getId());
         } else if (entity instanceof FeedbackSession) {
             return logic.getFeedbackSession(((FeedbackSession) entity).getId());
         } else if (entity instanceof FeedbackQuestion) {
             return logic.getFeedbackQuestion(((FeedbackQuestion) entity).getId());
+        } else if (entity instanceof FeedbackResponse) {
+            return logic.getFeedbackResponse(((FeedbackResponse) entity).getId());
+        } else if (entity instanceof FeedbackResponseComment) {
+            return logic.getFeedbackResponseComment(((FeedbackResponseComment) entity).getId());
         } else if (entity instanceof Account) {
             return logic.getAccount(((Account) entity).getId());
         } else if (entity instanceof Notification) {

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -140,6 +140,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
             return;
         }
 
+        session.getDeadlineExtensions().remove(existingDeadlineEndTime);
         logic.deleteDeadlineExtension(existingDeadlineEndTime);
     }
 

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1454,7 +1454,7 @@ public class Logic {
      * Persists the given data bundle to the database.
      */
     public DataBundle persistDataBundle(DataBundle dataBundle)
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         return dataBundleLogic.persistDataBundle(dataBundle);
     }
 

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -433,6 +433,13 @@ public class Logic {
     }
 
     /**
+     * Gets a deadline extension by its id.
+     */
+    public DeadlineExtension getDeadlineExtension(UUID id) {
+        return deadlineExtensionsLogic.getDeadlineExtension(id);
+    }
+
+    /**
      * Creates a deadline extension.
      *
      * @return created deadline extension
@@ -1762,14 +1769,6 @@ public class Logic {
      */
     public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
         return feedbackSessionsLogic.getFeedbackSessionsOpeningWithinTimeLimit();
-    }
-
-    /**
-     * Create feedback session logs.
-     */
-    public void createFeedbackSessionLogs(List<FeedbackSessionLog> feedbackSessionLogs)
-            throws InvalidParametersException {
-        feedbackSessionLogsLogic.createFeedbackSessionLogs(feedbackSessionLogs);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/AccountsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountsLogic.java
@@ -93,6 +93,14 @@ public final class AccountsLogic {
         assert googleId != null;
 
         Account account = getAccountForGoogleId(googleId);
+        if (account == null) {
+            return;
+        }
+
+        List<User> users = usersLogic.getAllUsersByGoogleId(googleId);
+        for (User user : users) {
+            user.setAccount(null);
+        }
         accountsDb.deleteAccount(account);
     }
 

--- a/src/main/java/teammates/sqllogic/core/CoursesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/CoursesLogic.java
@@ -167,20 +167,20 @@ public final class CoursesLogic {
         }
 
         usersLogic.deleteStudentsInCourseCascade(courseId);
-        List<FeedbackSession> feedbackSessions = fsLogic.getFeedbackSessionsForCourse(courseId);
-        feedbackSessions.forEach(feedbackSession -> {
-            fsLogic.deleteFeedbackSessionCascade(feedbackSession.getName(), courseId);
-        });
+        List<FeedbackSession> feedbackSessions = course.getFeedbackSessions();
+        feedbackSessions.forEach(feedbackSession ->
+                fsLogic.deleteFeedbackSessionCascade(feedbackSession.getName(), courseId)
+        );
 
-        List<FeedbackSession> softDeletedFeedbackSessions = fsLogic.getSoftDeletedFeedbackSessionsForCourse(courseId);
-        softDeletedFeedbackSessions.forEach(feedbackSession -> {
-            fsLogic.deleteFeedbackSessionCascade(feedbackSession.getName(), courseId);
-        });
-        coursesDb.deleteSectionsByCourseId(courseId);
         List<Instructor> instructors = usersLogic.getInstructorsForCourse(courseId);
-        instructors.forEach(instructor -> {
-            usersLogic.deleteInstructorCascade(courseId, instructor.getEmail());
-        });
+        instructors.forEach(instructor ->
+                usersLogic.deleteInstructorCascade(courseId, instructor.getEmail())
+        );
+
+        List<Student> students = usersLogic.getStudentsForCourse(courseId);
+        students.forEach(student ->
+                usersLogic.deleteStudentCascade(courseId, student.getEmail())
+        );
 
         coursesDb.deleteCourse(course);
     }

--- a/src/main/java/teammates/sqllogic/core/CoursesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/CoursesLogic.java
@@ -166,7 +166,6 @@ public final class CoursesLogic {
             return;
         }
 
-        usersLogic.deleteStudentsInCourseCascade(courseId);
         List<FeedbackSession> feedbackSessions = course.getFeedbackSessions();
         feedbackSessions.forEach(feedbackSession ->
                 fsLogic.deleteFeedbackSessionCascade(feedbackSession.getName(), courseId)

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -3,16 +3,17 @@ package teammates.sqllogic.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import teammates.common.datatransfer.DataBundle;
-import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.JsonUtils;
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.AccountRequest;
+import teammates.storage.sqlentity.BaseEntity;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackQuestion;
@@ -40,14 +41,7 @@ public final class DataBundleLogic {
     private AccountsLogic accountsLogic;
     private AccountRequestsLogic accountRequestsLogic;
     private CoursesLogic coursesLogic;
-    private DeadlineExtensionsLogic deadlineExtensionsLogic;
-    private FeedbackSessionsLogic fsLogic;
-    private FeedbackSessionLogsLogic fslLogic;
-    private FeedbackQuestionsLogic fqLogic;
-    private FeedbackResponsesLogic frLogic;
-    private FeedbackResponseCommentsLogic frcLogic;
     private NotificationsLogic notificationsLogic;
-    private UsersLogic usersLogic;
 
     private DataBundleLogic() {
         // prevent initialization
@@ -58,20 +52,11 @@ public final class DataBundleLogic {
     }
 
     void initLogicDependencies(AccountsLogic accountsLogic, AccountRequestsLogic accountRequestsLogic,
-            CoursesLogic coursesLogic, DeadlineExtensionsLogic deadlineExtensionsLogic, FeedbackSessionsLogic fsLogic,
-            FeedbackSessionLogsLogic fslLogic, FeedbackQuestionsLogic fqLogic, FeedbackResponsesLogic frLogic,
-            FeedbackResponseCommentsLogic frcLogic, NotificationsLogic notificationsLogic, UsersLogic usersLogic) {
+            CoursesLogic coursesLogic, NotificationsLogic notificationsLogic) {
         this.accountsLogic = accountsLogic;
         this.accountRequestsLogic = accountRequestsLogic;
         this.coursesLogic = coursesLogic;
-        this.deadlineExtensionsLogic = deadlineExtensionsLogic;
-        this.fsLogic = fsLogic;
-        this.fslLogic = fslLogic;
-        this.fqLogic = fqLogic;
-        this.frLogic = frLogic;
-        this.frcLogic = frcLogic;
         this.notificationsLogic = notificationsLogic;
-        this.usersLogic = usersLogic;
     }
 
     /**
@@ -135,6 +120,7 @@ public final class DataBundleLogic {
             sectionsMap.put(placeholderId, section);
             Course course = coursesMap.get(section.getCourse().getId());
             section.setCourse(course);
+            course.addSection(section);
         }
 
         for (Team team : teams) {
@@ -143,6 +129,7 @@ public final class DataBundleLogic {
             teamsMap.put(placeholderId, team);
             Section section = sectionsMap.get(team.getSection().getId());
             team.setSection(section);
+            section.addTeam(team);
         }
 
         for (FeedbackSession session : sessions) {
@@ -151,6 +138,7 @@ public final class DataBundleLogic {
             sessionsMap.put(placeholderId, session);
             Course course = coursesMap.get(session.getCourseId());
             session.setCourse(course);
+            course.addFeedbackSession(session);
         }
 
         for (FeedbackQuestion question : questions) {
@@ -159,6 +147,7 @@ public final class DataBundleLogic {
             questionMap.put(placeholderId, question);
             FeedbackSession fs = sessionsMap.get(question.getFeedbackSession().getId());
             question.setFeedbackSession(fs);
+            fs.addFeedbackQuestion(question);
         }
 
         for (FeedbackResponse response : responses) {
@@ -172,19 +161,18 @@ public final class DataBundleLogic {
             response.setFeedbackQuestion(fq);
             response.setGiverSection(giverSection);
             response.setRecipientSection(recipientSection);
+            fq.addFeedbackResponse(response);
         }
 
         for (FeedbackResponseComment responseComment : responseComments) {
             responseComment.setId(UUID.randomUUID());
-        }
-
-        for (FeedbackResponseComment responseComment : responseComments) {
             FeedbackResponse fr = responseMap.get(responseComment.getFeedbackResponse().getId());
             Section giverSection = sectionsMap.get(responseComment.getGiverSection().getId());
             Section recipientSection = sectionsMap.get(responseComment.getRecipientSection().getId());
             responseComment.setFeedbackResponse(fr);
             responseComment.setGiverSection(giverSection);
             responseComment.setRecipientSection(recipientSection);
+            fr.addFeedbackResponseComment(responseComment);
         }
 
         for (Account account : accounts) {
@@ -250,6 +238,7 @@ public final class DataBundleLogic {
             deadlineExtension.setId(UUID.randomUUID());
             FeedbackSession session = sessionsMap.get(deadlineExtension.getFeedbackSession().getId());
             deadlineExtension.setFeedbackSession(session);
+            session.addDeadlineExtension(deadlineExtension);
             User user = usersMap.get(deadlineExtension.getUser().getId());
             deadlineExtension.setUser(user);
         }
@@ -263,12 +252,10 @@ public final class DataBundleLogic {
      * @throws InvalidParametersException if invalid data is encountered.
      */
     public DataBundle persistDataBundle(DataBundle dataBundle)
-            throws InvalidParametersException, EntityAlreadyExistsException {
+            throws InvalidParametersException {
         if (dataBundle == null) {
             throw new InvalidParametersException("Null data bundle");
         }
-
-        linkEntities(dataBundle);
 
         Collection<Account> accounts = dataBundle.accounts.values();
         Collection<AccountRequest> accountRequests = dataBundle.accountRequests.values();
@@ -286,65 +273,29 @@ public final class DataBundleLogic {
         Collection<Notification> notifications = dataBundle.notifications.values();
         Collection<ReadNotification> readNotifications = dataBundle.readNotifications.values();
 
-        for (AccountRequest accountRequest : accountRequests) {
-            accountRequestsLogic.createAccountRequest(accountRequest);
-        }
+        // Orders of persistence are determined by the dependencies between entities.
+        List<BaseEntity> allEntities = new ArrayList<>();
+        allEntities.addAll(accountRequests);
+        allEntities.addAll(notifications);
+        allEntities.addAll(accounts);
+        allEntities.addAll(courses);
+        allEntities.addAll(sections);
+        allEntities.addAll(teams);
+        allEntities.addAll(sessions);
+        allEntities.addAll(questions);
+        allEntities.addAll(responses);
+        allEntities.addAll(responseComments);
+        allEntities.addAll(instructors);
+        allEntities.addAll(students);
+        allEntities.addAll(sessionLogs);
+        allEntities.addAll(deadlineExtensions);
+        allEntities.addAll(readNotifications);
 
-        for (Notification notification : notifications) {
-            notificationsLogic.createNotification(notification);
-        }
-
-        for (Course course : courses) {
-            coursesLogic.createCourse(course);
-        }
-
-        for (Section section : sections) {
-            coursesLogic.createSection(section);
-        }
-
-        for (Team team : teams) {
-            coursesLogic.createTeam(team);
-        }
-
-        for (FeedbackSession session : sessions) {
-            fsLogic.createFeedbackSession(session);
-        }
-
-        for (FeedbackQuestion question : questions) {
-            fqLogic.createFeedbackQuestion(question);
-        }
-
-        for (FeedbackResponse response : responses) {
-            frLogic.createFeedbackResponse(response);
-        }
-
-        for (FeedbackResponseComment responseComment : responseComments) {
-            frcLogic.createFeedbackResponseComment(responseComment);
-        }
-
-        for (Account account : accounts) {
-            accountsLogic.createAccount(account);
-        }
-
-        for (Instructor instructor : instructors) {
-            usersLogic.createInstructor(instructor);
-        }
-
-        for (Student student : students) {
-            usersLogic.createStudent(student);
-        }
-
-        fslLogic.createFeedbackSessionLogs(new ArrayList<>(sessionLogs));
-
-        for (ReadNotification readNotification : readNotifications) {
-            if (!readNotification.isValid()) {
-                throw new InvalidParametersException(readNotification.getInvalidityInfo());
+        for (BaseEntity entity : allEntities) {
+            if (!entity.isValid()) {
+                throw new InvalidParametersException(entity.getInvalidityInfo());
             }
-            HibernateUtil.persist(readNotification);
-        }
-
-        for (DeadlineExtension deadlineExtension : deadlineExtensions) {
-            deadlineExtensionsLogic.createDeadlineExtension(deadlineExtension);
+            HibernateUtil.persist(entity);
         }
 
         return dataBundle;
@@ -358,7 +309,6 @@ public final class DataBundleLogic {
             throw new InvalidParametersException("Data bundle is null");
         }
 
-        linkEntities(dataBundle);
         dataBundle.courses.values().forEach(course -> {
             coursesLogic.deleteCourseCascade(course.getId());
         });
@@ -374,137 +324,5 @@ public final class DataBundleLogic {
         dataBundle.accountRequests.values().forEach(accountRequest -> {
             accountRequestsLogic.deleteAccountRequest(accountRequest.getId());
         });
-    }
-
-    private static void linkEntities(DataBundle dataBundle) {
-        Collection<Account> accounts = dataBundle.accounts.values();
-        Collection<Course> courses = dataBundle.courses.values();
-        Collection<Section> sections = dataBundle.sections.values();
-        Collection<Team> teams = dataBundle.teams.values();
-        Collection<Instructor> instructors = dataBundle.instructors.values();
-        Collection<Student> students = dataBundle.students.values();
-        Collection<FeedbackSession> sessions = dataBundle.feedbackSessions.values();
-        Collection<FeedbackSessionLog> sessionLogs = dataBundle.feedbackSessionLogs.values();
-        Collection<FeedbackQuestion> questions = dataBundle.feedbackQuestions.values();
-        Collection<FeedbackResponse> responses = dataBundle.feedbackResponses.values();
-        Collection<FeedbackResponseComment> responseComments = dataBundle.feedbackResponseComments.values();
-        Collection<DeadlineExtension> deadlineExtensions = dataBundle.deadlineExtensions.values();
-        Collection<Notification> notifications = dataBundle.notifications.values();
-        Collection<ReadNotification> readNotifications = dataBundle.readNotifications.values();
-
-        // Mapping of IDs or placeholder IDs to actual entity
-        Map<String, Course> coursesMap = new HashMap<>();
-        Map<UUID, Section> sectionsMap = new HashMap<>();
-        Map<UUID, Team> teamsMap = new HashMap<>();
-        Map<UUID, FeedbackSession> sessionsMap = new HashMap<>();
-        Map<UUID, FeedbackQuestion> questionMap = new HashMap<>();
-        Map<UUID, FeedbackResponse> responseMap = new HashMap<>();
-        Map<UUID, Account> accountsMap = new HashMap<>();
-        Map<UUID, User> usersMap = new HashMap<>();
-        Map<UUID, Notification> notificationsMap = new HashMap<>();
-
-        for (Course course : courses) {
-            coursesMap.put(course.getId(), course);
-        }
-
-        for (Section section : sections) {
-            sectionsMap.put(section.getId(), section);
-            Course course = coursesMap.get(section.getCourse().getId());
-            section.setCourse(course);
-        }
-
-        for (Team team : teams) {
-            teamsMap.put(team.getId(), team);
-            Section section = sectionsMap.get(team.getSection().getId());
-            team.setSection(section);
-        }
-
-        for (FeedbackSession session : sessions) {
-            sessionsMap.put(session.getId(), session);
-            Course course = coursesMap.get(session.getCourseId());
-            session.setCourse(course);
-        }
-
-        for (FeedbackQuestion question : questions) {
-            questionMap.put(question.getId(), question);
-            FeedbackSession fs = sessionsMap.get(question.getFeedbackSession().getId());
-            question.setFeedbackSession(fs);
-        }
-
-        for (FeedbackResponse response : responses) {
-            UUID placeholderId = response.getId();
-            responseMap.put(placeholderId, response);
-            FeedbackQuestion fq = questionMap.get(response.getFeedbackQuestion().getId());
-            Section giverSection = sectionsMap.get(response.getGiverSection().getId());
-            Section recipientSection = response.getRecipientSection() != null
-                    ? sectionsMap.get(response.getRecipientSection().getId()) : null;
-            response.setFeedbackQuestion(fq);
-            response.setGiverSection(giverSection);
-            response.setRecipientSection(recipientSection);
-        }
-
-        for (FeedbackResponseComment responseComment : responseComments) {
-            FeedbackResponse fr = responseMap.get(responseComment.getFeedbackResponse().getId());
-            Section giverSection = sectionsMap.get(responseComment.getGiverSection().getId());
-            Section recipientSection = sectionsMap.get(responseComment.getRecipientSection().getId());
-            responseComment.setFeedbackResponse(fr);
-            responseComment.setGiverSection(giverSection);
-            responseComment.setRecipientSection(recipientSection);
-        }
-
-        for (Account account : accounts) {
-            accountsMap.put(account.getId(), account);
-        }
-
-        for (Instructor instructor : instructors) {
-            usersMap.put(instructor.getId(), instructor);
-            Course course = coursesMap.get(instructor.getCourseId());
-            instructor.setCourse(course);
-            if (instructor.getAccount() != null) {
-                Account account = accountsMap.get(instructor.getAccount().getId());
-                instructor.setAccount(account);
-            }
-            instructor.generateNewRegistrationKey();
-        }
-
-        for (Student student : students) {
-            usersMap.put(student.getId(), student);
-            Course course = coursesMap.get(student.getCourseId());
-            student.setCourse(course);
-            Team team = teamsMap.get(student.getTeam().getId());
-            student.setTeam(team);
-            if (student.getAccount() != null) {
-                Account account = accountsMap.get(student.getAccount().getId());
-                student.setAccount(account);
-            }
-            student.generateNewRegistrationKey();
-        }
-
-        for (FeedbackSessionLog log : sessionLogs) {
-            FeedbackSession fs = log.getFeedbackSession() == null
-                    ? null : sessionsMap.get(log.getFeedbackSession().getId());
-            log.setFeedbackSession(fs);
-            Student student = log.getStudent() == null
-                    ? null : (Student) usersMap.get(log.getStudent().getId());
-            log.setStudent(student);
-        }
-
-        for (Notification notification : notifications) {
-            notificationsMap.put(notification.getId(), notification);
-        }
-
-        for (ReadNotification readNotification : readNotifications) {
-            Account account = accountsMap.get(readNotification.getAccount().getId());
-            readNotification.setAccount(account);
-            Notification notification = notificationsMap.get(readNotification.getNotification().getId());
-            readNotification.setNotification(notification);
-        }
-
-        for (DeadlineExtension deadlineExtension : deadlineExtensions) {
-            FeedbackSession session = sessionsMap.get(deadlineExtension.getFeedbackSession().getId());
-            deadlineExtension.setFeedbackSession(session);
-            User user = usersMap.get(deadlineExtension.getUser().getId());
-            deadlineExtension.setUser(user);
-        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DataBundleLogic.java
@@ -1,9 +1,7 @@
 package teammates.sqllogic.core;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -273,30 +271,21 @@ public final class DataBundleLogic {
         Collection<Notification> notifications = dataBundle.notifications.values();
         Collection<ReadNotification> readNotifications = dataBundle.readNotifications.values();
 
-        // Orders of persistence are determined by the dependencies between entities.
-        List<BaseEntity> allEntities = new ArrayList<>();
-        allEntities.addAll(accountRequests);
-        allEntities.addAll(notifications);
-        allEntities.addAll(accounts);
-        allEntities.addAll(courses);
-        allEntities.addAll(sections);
-        allEntities.addAll(teams);
-        allEntities.addAll(sessions);
-        allEntities.addAll(questions);
-        allEntities.addAll(responses);
-        allEntities.addAll(responseComments);
-        allEntities.addAll(instructors);
-        allEntities.addAll(students);
-        allEntities.addAll(sessionLogs);
-        allEntities.addAll(deadlineExtensions);
-        allEntities.addAll(readNotifications);
-
-        for (BaseEntity entity : allEntities) {
-            if (!entity.isValid()) {
-                throw new InvalidParametersException(entity.getInvalidityInfo());
-            }
-            HibernateUtil.persist(entity);
-        }
+        persistEntities(accountRequests);
+        persistEntities(notifications);
+        persistEntities(accounts);
+        persistEntities(courses);
+        persistEntities(sections);
+        persistEntities(teams);
+        persistEntities(sessions);
+        persistEntities(questions);
+        persistEntities(responses);
+        persistEntities(responseComments);
+        persistEntities(instructors);
+        persistEntities(students);
+        persistEntities(sessionLogs);
+        persistEntities(deadlineExtensions);
+        persistEntities(readNotifications);
 
         return dataBundle;
     }
@@ -324,5 +313,15 @@ public final class DataBundleLogic {
         dataBundle.accountRequests.values().forEach(accountRequest -> {
             accountRequestsLogic.deleteAccountRequest(accountRequest.getId());
         });
+    }
+
+    private void persistEntities(Collection<? extends BaseEntity> entities) throws InvalidParametersException {
+        for (BaseEntity entity : entities) {
+            if (!entity.isValid()) {
+                throw new InvalidParametersException(entity.getInvalidityInfo());
+            }
+            HibernateUtil.persist(entity);
+        }
+        HibernateUtil.flushSession();
     }
 }

--- a/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
@@ -2,6 +2,7 @@ package teammates.sqllogic.core;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -37,6 +38,13 @@ public final class DeadlineExtensionsLogic {
     void initLogicDependencies(DeadlineExtensionsDb deadlineExtensionsDb, FeedbackSessionsLogic feedbackSessionsLogic) {
         this.deadlineExtensionsDb = deadlineExtensionsDb;
         this.feedbackSessionsLogic = feedbackSessionsLogic;
+    }
+
+    /**
+     * Gets a deadline extension by its id.
+     */
+    public DeadlineExtension getDeadlineExtension(UUID id) {
+        return deadlineExtensionsDb.getDeadlineExtension(id);
     }
 
     /**
@@ -90,6 +98,11 @@ public final class DeadlineExtensionsLogic {
      * Deletes a deadline extension.
      */
     public void deleteDeadlineExtension(DeadlineExtension de) {
+        FeedbackSession feedbackSession = de.getFeedbackSession();
+        if (feedbackSession != null) {
+            feedbackSession.getDeadlineExtensions().remove(de);
+        }
+
         deadlineExtensionsDb.deleteDeadlineExtension(de);
     }
 

--- a/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
@@ -98,11 +98,6 @@ public final class DeadlineExtensionsLogic {
      * Deletes a deadline extension.
      */
     public void deleteDeadlineExtension(DeadlineExtension de) {
-        FeedbackSession feedbackSession = de.getFeedbackSession();
-        if (feedbackSession != null) {
-            feedbackSession.getDeadlineExtensions().remove(de);
-        }
-
         deadlineExtensionsDb.deleteDeadlineExtension(de);
     }
 

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
@@ -36,25 +36,14 @@ public final class FeedbackSessionLogsLogic {
     }
 
     /**
-     * Creates feedback session logs.
-     */
-    public void createFeedbackSessionLogs(List<FeedbackSessionLog> fsLogs) throws InvalidParametersException {
-        if (fsLogs == null) {
-            throw new InvalidParametersException("Feedback session logs list does not exist");
-        }
-
-        for (FeedbackSessionLog fsLog : fsLogs) {
-            createFeedbackSessionLog(fsLog);
-        }
-    }
-
-    /**
      * Creates feedback session log.
      */
     public void createFeedbackSessionLog(FeedbackSessionLog fsLog) throws InvalidParametersException {
         if (fsLog == null) {
             throw new InvalidParametersException("Feedback session log does not exist");
         }
+
+        // TODO: move validation to getInvalidityInfo
         validateFeedbackSessionLogContext(fsLog.getStudent(), fsLog.getFeedbackSession());
         fslDb.createFeedbackSessionLog(fsLog);
     }

--- a/src/main/java/teammates/sqllogic/core/LogicStarter.java
+++ b/src/main/java/teammates/sqllogic/core/LogicStarter.java
@@ -45,9 +45,7 @@ public class LogicStarter implements ServletContextListener {
         accountRequestsLogic.initLogicDependencies(AccountRequestsDb.inst());
         accountsLogic.initLogicDependencies(AccountsDb.inst(), usersLogic, coursesLogic);
         coursesLogic.initLogicDependencies(CoursesDb.inst(), fsLogic, usersLogic, accountsLogic);
-        dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic,
-                deadlineExtensionsLogic, fsLogic, fslLogic, fqLogic, frLogic, frcLogic,
-                notificationsLogic, usersLogic);
+        dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic, notificationsLogic);
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst(), fsLogic);
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), coursesLogic, frLogic, fqLogic, usersLogic);
         fslLogic.initLogicDependencies(FeedbackSessionLogsDb.inst());

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -7,11 +7,9 @@ import java.util.List;
 import java.util.UUID;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
-import jakarta.persistence.criteria.Subquery;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -147,22 +145,6 @@ public final class CoursesDb {
                 cb.equal(teamJoin.get("name"), teamName)));
 
         return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
-    }
-
-    /**
-     * Deletes all sections by {@code courseId}.
-     */
-    public void deleteSectionsByCourseId(String courseId) {
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaDelete<Section> cd = cb.createCriteriaDelete(Section.class);
-        Root<Section> sRoot = cd.from(Section.class);
-        Subquery<UUID> subquery = cd.subquery(UUID.class);
-        Root<Section> subqueryRoot = subquery.from(Section.class);
-        Join<Section, Course> sqJoin = subqueryRoot.join("course");
-        subquery.select(subqueryRoot.get("id"));
-        subquery.where(cb.equal(sqJoin.get("id"), courseId));
-        cd.where(cb.in(sRoot.get("id")).value(subquery));
-        HibernateUtil.createMutationQuery(cd).executeUpdate();
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlentity/Course.java
+++ b/src/main/java/teammates/storage/sqlentity/Course.java
@@ -40,7 +40,7 @@ public class Course extends BaseEntity {
     @OneToMany(mappedBy = "course")
     private List<FeedbackSession> feedbackSessions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "course", cascade = CascadeType.REMOVE)
     private List<Section> sections = new ArrayList<>();
 
     @UpdateTimestamp
@@ -75,6 +75,13 @@ public class Course extends BaseEntity {
      */
     public void addSection(Section section) {
         this.sections.add(section);
+    }
+
+    /**
+     * Adds a feedback session to the Course.
+     */
+    public void addFeedbackSession(FeedbackSession feedbackSession) {
+        this.feedbackSessions.add(feedbackSession);
     }
 
     public String getId() {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackQuestion.java
@@ -227,6 +227,13 @@ public abstract class FeedbackQuestion extends BaseEntity implements Comparable<
         return this.getQuestionDetailsCopy().shouldChangesRequireResponseDeletion(questionDetails);
     }
 
+    /**
+     * Adds a feedback response to the question.
+     */
+    public void addFeedbackResponse(FeedbackResponse feedbackResponse) {
+        this.feedbackResponses.add(feedbackResponse);
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackResponse.java
@@ -168,6 +168,13 @@ public abstract class FeedbackResponse extends BaseEntity {
      */
     public abstract FeedbackResponseDetails getFeedbackResponseDetailsCopy();
 
+    /**
+     * Add a comment to the feedback response.
+     */
+    public void addFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment) {
+        this.feedbackResponseComments.add(feedbackResponseComment);
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -134,12 +135,16 @@ public class FeedbackSession extends BaseEntity {
      * @return The copy of this object for the given user.
      */
     public FeedbackSession getCopyForUser(String userEmail) {
+        // TODO: DANGEROUS, remove this and replace with a safer way.
+        // In most cases a copy is not necessary or appropriate.
+        // If a copy is necessary, it should be created by copying the entity into a DTO instead.
+        // Copying this way risks accidentally modifying the entity which is persisted in the database.
         FeedbackSession copy = getCopy();
-        for (DeadlineExtension de : copy.getDeadlineExtensions()) {
-            if (!SanitizationHelper.areEmailsEqual(de.getUser().getEmail(), userEmail)) {
-                de.setEndTime(copy.getEndTime());
-            }
-        }
+        copy.setDeadlineExtensions(copy.getDeadlineExtensions()
+                .stream().filter(
+                    de -> SanitizationHelper.areEmailsEqual(de.getUser().getEmail(), userEmail)
+                ).collect(Collectors.toList()));
+
         return copy;
     }
 
@@ -216,10 +221,21 @@ public class FeedbackSession extends BaseEntity {
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
-        addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
-                endTime, deadlineExtensions), errors);
-
         return errors;
+    }
+
+    /**
+     * Adds a feedback question to the feedback session.
+     */
+    public void addFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
+        this.feedbackQuestions.add(feedbackQuestion);
+    }
+
+    /**
+     * Adds a deadline extension to the feedback session.
+     */
+    public void addDeadlineExtension(DeadlineExtension deadlineExtension) {
+        this.deadlineExtensions.add(deadlineExtension);
     }
 
     public UUID getId() {

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -221,6 +221,9 @@ public class FeedbackSession extends BaseEntity {
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForVisibilityStartAndResultsPublish(
                 actualSessionVisibleFromTime, resultsVisibleFromTime), errors);
 
+        addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForSessionEndAndExtendedDeadlines(
+                endTime, deadlineExtensions), errors);
+
         return errors;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/Section.java
+++ b/src/main/java/teammates/storage/sqlentity/Section.java
@@ -41,9 +41,9 @@ public class Section extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @OneToMany(mappedBy = "section", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
     @OnDelete(action = OnDeleteAction.CASCADE)
-    private List<Team> teams;
+    private List<Team> teams = new ArrayList<>();
 
     @UpdateTimestamp
     private Instant updatedAt;

--- a/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
@@ -1,8 +1,6 @@
 package teammates.ui.webapi;
 
 import teammates.common.datatransfer.DataBundle;
-import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
@@ -33,10 +31,6 @@ public class PutDataBundleAction extends Action {
             dataBundle = sqlLogic.persistDataBundle(dataBundle);
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);
-        } catch (EntityAlreadyExistsException e) {
-            throw new InvalidOperationException("Some entities in the databundle already exist", e);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
         }
 
         return new JsonResult(JsonUtils.toJson(dataBundle));

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionDeadlineExtensionsAction.java
@@ -150,6 +150,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsAction extends Action {
 
         deadlinesToRevoke.values().forEach(de ->
                 sqlLogic.deleteDeadlineExtension(de));
+        session.getDeadlineExtensions().removeAll(deadlinesToRevoke.values());
 
         // Create deadline extensions
         Map<String, Instant> deadlinesToCreate = new HashMap<>(newDeadlines);

--- a/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
@@ -205,7 +205,6 @@ public class CoursesLogicTest extends BaseTestCase {
 
         coursesLogic.deleteCourseCascade(course.getId());
 
-        verify(usersLogic, times(1)).deleteStudentsInCourseCascade(course.getId());
         verify(usersLogic, times(1)).getInstructorsForCourse(course.getId());
         verify(usersLogic, times(1)).deleteInstructorCascade(course.getId(), instructors.get(0).getEmail());
         verify(fsLogic, times(1)).deleteFeedbackSessionCascade(fs.getName(), course.getId());

--- a/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/CoursesLogicTest.java
@@ -187,24 +187,19 @@ public class CoursesLogicTest extends BaseTestCase {
     public void testDeleteCourseCascade_shouldDeleteCourse_success() {
         Course course = getTypicalCourse();
         List<Instructor> instructors = new ArrayList<>();
-        List<FeedbackSession> feedbackSessions = new ArrayList<>();
-        List<FeedbackSession> softDeletedFeedbackSessions = new ArrayList<>();
 
         FeedbackSession fs = new FeedbackSession("test-fs", course, "test@email.com",
                 "test", Instant.now(), Instant.now(), Instant.now(), Instant.now(), Duration.ofSeconds(60),
                 false, false, false);
-        feedbackSessions.add(fs);
+        course.addFeedbackSession(fs);
 
         FeedbackSession softDeletedFs = new FeedbackSession("soft-deleted-fs", course, "test@email.com",
                 "test", Instant.now(), Instant.now(), Instant.now(), Instant.now(), Duration.ofSeconds(60),
                 false, false, false);
         softDeletedFs.setDeletedAt(Instant.now());
-        softDeletedFeedbackSessions.add(softDeletedFs);
+        course.addFeedbackSession(softDeletedFs);
         instructors.add(getTypicalInstructor());
 
-        when(fsLogic.getFeedbackSessionsForCourse(course.getId())).thenReturn(feedbackSessions);
-        when(fsLogic.getSoftDeletedFeedbackSessionsForCourse(course.getId()))
-                .thenReturn(softDeletedFeedbackSessions);
         when(usersLogic.getInstructorsForCourse(course.getId())).thenReturn(instructors);
         when(coursesDb.getCourse(course.getId())).thenReturn(course);
 
@@ -215,10 +210,7 @@ public class CoursesLogicTest extends BaseTestCase {
         verify(usersLogic, times(1)).deleteInstructorCascade(course.getId(), instructors.get(0).getEmail());
         verify(fsLogic, times(1)).deleteFeedbackSessionCascade(fs.getName(), course.getId());
         verify(fsLogic, times(1)).deleteFeedbackSessionCascade(softDeletedFs.getName(), course.getId());
-        verify(fsLogic, times(1)).getFeedbackSessionsForCourse(course.getId());
-        verify(fsLogic, times(1)).getSoftDeletedFeedbackSessionsForCourse(course.getId());
         verify(coursesDb, times(1)).deleteCourse(course);
-        verify(coursesDb, times(1)).deleteSectionsByCourseId(course.getId());
     }
 
     @Test

--- a/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/DataBundleLogicTest.java
@@ -51,18 +51,12 @@ public class DataBundleLogicTest extends BaseTestCase {
         accountsLogic = mock(AccountsLogic.class);
         accountRequestsLogic = mock(AccountRequestsLogic.class);
         coursesLogic = mock(CoursesLogic.class);
-        DeadlineExtensionsLogic deadlineExtensionsLogic = mock(DeadlineExtensionsLogic.class);
         fsLogic = mock(FeedbackSessionsLogic.class);
-        FeedbackSessionLogsLogic fslLogic = mock(FeedbackSessionLogsLogic.class);
-        FeedbackQuestionsLogic fqLogic = mock(FeedbackQuestionsLogic.class);
-        FeedbackResponsesLogic frLogic = mock(FeedbackResponsesLogic.class);
-        FeedbackResponseCommentsLogic frcLogic = mock(FeedbackResponseCommentsLogic.class);
         notificationsLogic = mock(NotificationsLogic.class);
         usersLogic = mock(UsersLogic.class);
 
         dataBundleLogic.initLogicDependencies(
-                accountsLogic, accountRequestsLogic, coursesLogic, deadlineExtensionsLogic,
-                fsLogic, fslLogic, fqLogic, frLogic, frcLogic, notificationsLogic, usersLogic);
+                accountsLogic, accountRequestsLogic, coursesLogic, notificationsLogic);
     }
 
     @AfterMethod
@@ -79,7 +73,7 @@ public class DataBundleLogicTest extends BaseTestCase {
 
     @Test
     public void testPersistDataBundle_emptyBundle_success()
-            throws InvalidParametersException, EntityAlreadyExistsException {
+            throws InvalidParametersException {
         DataBundle emptyBundle = new DataBundle();
 
         DataBundle result = dataBundleLogic.persistDataBundle(emptyBundle);
@@ -107,7 +101,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(1, result.courses.size());
         assertTrue(result.courses.containsKey("course1"));
         assertEquals(course, result.courses.get("course1"));
-        verify(coursesLogic, times(1)).createCourse(course);
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(course), times(1));
     }
 
     @Test
@@ -123,7 +118,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(dataBundle, result);
         assertEquals(1, result.accounts.size());
         assertEquals(account, result.accounts.get("account1"));
-        verify(accountsLogic, times(1)).createAccount(account);
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(account), times(1));
     }
 
     @Test
@@ -142,12 +138,13 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(1, result.notifications.size());
         assertTrue(result.notifications.containsKey("notification1"));
         assertEquals(notification, result.notifications.get("notification1"));
-        verify(notificationsLogic, times(1)).createNotification(notification);
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(notification), times(1));
     }
 
     @Test
     public void testPersistDataBundle_withAccountRequest_createsAccountRequest()
-            throws InvalidParametersException, EntityAlreadyExistsException {
+            throws InvalidParametersException {
         DataBundle dataBundle = new DataBundle();
         AccountRequest accountRequest = getTypicalAccountRequest();
         dataBundle.accountRequests.put("accountRequest1", accountRequest);
@@ -160,7 +157,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(dataBundle, result);
         assertEquals(1, result.accountRequests.size());
         assertEquals(accountRequest, result.accountRequests.get("accountRequest1"));
-        verify(accountRequestsLogic, times(1)).createAccountRequest(accountRequest);
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest), times(1));
     }
 
     @Test
@@ -199,10 +197,10 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(notification, result.notifications.get("notification1"));
         assertEquals(accountRequest, result.accountRequests.get("accountRequest1"));
 
-        verify(coursesLogic, times(1)).createCourse(course);
-        verify(accountsLogic, times(1)).createAccount(account);
-        verify(notificationsLogic, times(1)).createNotification(notification);
-        verify(accountRequestsLogic, times(1)).createAccountRequest(accountRequest);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(course), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(account), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(notification), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(accountRequest), times(1));
     }
 
     @Test
@@ -235,9 +233,9 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(section, result.sections.get("section1"));
         assertEquals(team, result.teams.get("team1"));
 
-        verify(coursesLogic, times(1)).createCourse(course);
-        verify(coursesLogic, times(1)).createSection(section);
-        verify(coursesLogic, times(1)).createTeam(team);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(course), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(section), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(team), times(1));
     }
 
     @Test
@@ -277,8 +275,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(student, result.students.get("student1"));
         assertEquals(instructor, result.instructors.get("instructor1"));
 
-        verify(usersLogic, times(1)).createStudent(student);
-        verify(usersLogic, times(1)).createInstructor(instructor);
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(student), times(1));
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(instructor), times(1));
     }
 
     @Test
@@ -300,7 +298,8 @@ public class DataBundleLogicTest extends BaseTestCase {
         assertEquals(dataBundle, result);
         assertEquals(1, result.feedbackSessions.size());
         assertEquals(session, result.feedbackSessions.get("session1"));
-        verify(fsLogic, times(1)).createFeedbackSession(session);
+
+        mockHibernateUtil.verify(() -> HibernateUtil.persist(session), times(1));
     }
 
     @Test


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Enforce bi-directional association consistency for data bundles. This is important so that     we don't get stale object graphs in memory, so hibernate managed cascade deletions work correctly.

This will also have to be done for entities, but left to another PR as it's more involved. 

Also fixes some bugs:

1. getDeadlineForUser results in deadline extensions for other users being updated (end time is set to session end time).
2. Fixes silent failure of `removeDataBundle`.