### PR TITLE
[#13787] Make Copy button rightmost in copy instructors modal

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
@@ -128,14 +128,14 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when feedback
       id="btn-confirm-copy-instructor"
       type="button"
     >
-       Copy 
+       Cancel 
     </button>
     <button
       class="btn btn-light"
       id="btn-cancel-copy-instructor"
       type="button"
     >
-       Cancel 
+       Copy
     </button>
   </div>
 </tm-copy-instructors-from-other-courses-modal>
@@ -392,14 +392,14 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
       id="btn-confirm-copy-instructor"
       type="button"
     >
-       Copy 
+       Cancel 
     </button>
     <button
       class="btn btn-light"
       id="btn-cancel-copy-instructor"
       type="button"
     >
-       Cancel 
+       Copy
     </button>
   </div>
 </tm-copy-instructors-from-other-courses-modal>
@@ -530,14 +530,14 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
       id="btn-confirm-copy-instructor"
       type="button"
     >
-       Copy 
+       Cancel 
     </button>
     <button
       class="btn btn-light"
       id="btn-cancel-copy-instructor"
       type="button"
     >
-       Cancel 
+       Copy 
     </button>
   </div>
 </tm-copy-instructors-from-other-courses-modal>
@@ -681,14 +681,14 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with courses 
       id="btn-confirm-copy-instructor"
       type="button"
     >
-       Copy 
+       Cancel 
     </button>
     <button
       class="btn btn-light"
       id="btn-cancel-copy-instructor"
       type="button"
     >
-       Cancel 
+       Copy 
     </button>
   </div>
 </tm-copy-instructors-from-other-courses-modal>
@@ -742,14 +742,14 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap with default 
       id="btn-confirm-copy-instructor"
       type="button"
     >
-       Copy 
+       Cancel 
     </button>
     <button
       class="btn btn-light"
       id="btn-cancel-copy-instructor"
       type="button"
     >
-       Cancel 
+       Copy 
     </button>
   </div>
 </tm-copy-instructors-from-other-courses-modal>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Fixes #

**Outline of Solution**

Fixes #13787
Reordered the buttons in the Copy Instructors modal so that the primary action (Copy) appears as the rightmost button.
