### PR TITLE
[#13721] Remove getCopyForUser in FeedbackSession entity

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
@@ -14,6 +14,7 @@ import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.FeedbackSubmitPageSql;
 import teammates.e2e.pageobjects.InstructorFeedbackEditPageSql;
+import teammates.e2e.util.EntityCopyUtil;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackQuestion;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -138,8 +139,7 @@ public class InstructorFeedbackEditPageE2ETest extends BaseE2ETestCase {
         previewPage.closeCurrentWindowAndSwitchToParentWindow();
 
         ______TS("copy session to other course");
-        FeedbackSession copiedSession = feedbackSession.getCopy();
-        copiedSession.setId(null);
+        FeedbackSession copiedSession = EntityCopyUtil.copyFeedbackSession(feedbackSession);
         copiedSession.setCourse(copiedCourse);
         String copiedSessionName = "Copied Session";
         copiedSession.setName(copiedSessionName);

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
@@ -17,6 +17,7 @@ import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.e2e.pageobjects.InstructorFeedbackSessionsPageSql;
+import teammates.e2e.util.EntityCopyUtil;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
@@ -103,8 +104,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("add new copied session");
         String newName = "Copied Name";
-        FeedbackSession copiedSession = openSession.getCopy();
-        copiedSession.setId(null);
+        FeedbackSession copiedSession = EntityCopyUtil.copyFeedbackSession(openSession);
         copiedSession.setCourse(course);
         copiedSession.setName(newName);
         feedbackSessionsPage.addCopyOfSession(openSession, course, newName);
@@ -133,8 +133,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("copy session");
         newName = "Copied Name 2";
-        FeedbackSession copiedSession2 = copiedSession.getCopy();
-        copiedSession2.setId(null);
+        FeedbackSession copiedSession2 = EntityCopyUtil.copyFeedbackSession(copiedSession);
         copiedSession2.setName(newName);
         feedbackSessionsPage.copySession(copiedSession, course, newName);
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -16,6 +16,7 @@ import org.testng.annotations.Test;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.InstructorHomePageSql;
+import teammates.e2e.util.EntityCopyUtil;
 import teammates.e2e.util.TestProperties;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -96,8 +97,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         ______TS("copy session with modified session timings");
         int sessionIndex = 1;
         String newName = "Copied Name";
-        FeedbackSession copiedSession = feedbackSessionAwaiting.getCopy();
-        copiedSession.setId(null);
+        FeedbackSession copiedSession = EntityCopyUtil.copyFeedbackSession(feedbackSessionAwaiting);
         copiedSession.setCourse(otherCourse);
         copiedSession.setName(newName);
         copiedSession.setCreatedAt(Instant.now());
@@ -127,8 +127,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         ______TS("copy session with same session timings");
         sessionIndex = 0;
         newName = "Copied Name 2";
-        FeedbackSession copiedSession2 = copiedSession.getCopy();
-        copiedSession2.setId(null);
+        FeedbackSession copiedSession2 = EntityCopyUtil.copyFeedbackSession(copiedSession);
         copiedSession2.setName(newName);
         copiedSession2.setCreatedAt(Instant.now());
         homePage.copySession(otherCourseIndex, sessionIndex, otherCourse, newName);

--- a/src/e2e/java/teammates/e2e/util/EntityCopyUtil.java
+++ b/src/e2e/java/teammates/e2e/util/EntityCopyUtil.java
@@ -1,0 +1,35 @@
+package teammates.e2e.util;
+
+import teammates.storage.sqlentity.FeedbackSession;
+
+/**
+ * Utility class for copying entities for E2E tests.
+ *
+ * <p>This creates a copy with similar fields, but a null ID.
+ * The copy is not persisted to the database, and is only used for testing
+ * purposes.
+ */
+public final class EntityCopyUtil {
+    private EntityCopyUtil() {
+        // Utility class should not be instantiated
+    }
+
+    /**
+     * Creates a copy of the given {@link FeedbackSession} with a null ID.
+     * The copy is not persisted to the database, and is only used for testing purposes.
+     */
+    public static FeedbackSession copyFeedbackSession(FeedbackSession original) {
+        FeedbackSession fs = new FeedbackSession(
+                original.getName(), original.getCourse(), original.getCreatorEmail(), original.getInstructions(),
+                original.getStartTime(),
+                original.getEndTime(), original.getSessionVisibleFromTime(), original.getResultsVisibleFromTime(),
+                original.getGracePeriod(), original.isOpenedEmailEnabled(), original.isClosingSoonEmailEnabled(),
+                original.isPublishedEmailEnabled());
+        fs.setId(null);
+        fs.setCreatedAt(original.getCreatedAt());
+        fs.setUpdatedAt(original.getUpdatedAt());
+        fs.setDeletedAt(original.getDeletedAt());
+
+        return fs;
+    }
+}

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -126,26 +125,6 @@ public class FeedbackSession extends BaseEntity {
         this.setOpenedEmailEnabled(isOpenedEmailEnabled);
         this.setClosingSoonEmailEnabled(isClosingSoonEmailEnabled);
         this.setPublishedEmailEnabled(isPublishedEmailEnabled);
-    }
-
-    /**
-     * Creates a copy of the feedback session.
-     *
-     * @return The copy of this object.
-     */
-    public FeedbackSession getCopy() {
-        FeedbackSession fs = new FeedbackSession(
-                name, course, creatorEmail, instructions, startTime,
-                endTime, sessionVisibleFromTime, resultsVisibleFromTime,
-                gracePeriod, isOpenedEmailEnabled, isClosingSoonEmailEnabled, isPublishedEmailEnabled
-        );
-        fs.setId(getId());
-        fs.setCreatedAt(getCreatedAt());
-        fs.setUpdatedAt(getUpdatedAt());
-        fs.setDeletedAt(getDeletedAt());
-        fs.setDeadlineExtensions(getDeadlineExtensions());
-
-        return fs;
     }
 
     @Override

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSession.java
@@ -129,26 +129,6 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
-     * Creates a copy that uses the specific deadline for the given user.
-     *
-     * @param userEmail The email address of the given user.
-     * @return The copy of this object for the given user.
-     */
-    public FeedbackSession getCopyForUser(String userEmail) {
-        // TODO: DANGEROUS, remove this and replace with a safer way.
-        // In most cases a copy is not necessary or appropriate.
-        // If a copy is necessary, it should be created by copying the entity into a DTO instead.
-        // Copying this way risks accidentally modifying the entity which is persisted in the database.
-        FeedbackSession copy = getCopy();
-        copy.setDeadlineExtensions(copy.getDeadlineExtensions()
-                .stream().filter(
-                    de -> SanitizationHelper.areEmailsEqual(de.getUser().getEmail(), userEmail)
-                ).collect(Collectors.toList()));
-
-        return copy;
-    }
-
-    /**
      * Creates a copy of the feedback session.
      *
      * @return The copy of this object.

--- a/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicCommentSubmissionAction.java
@@ -32,7 +32,7 @@ abstract class BasicCommentSubmissionAction extends BasicFeedbackSubmissionActio
     /**
      * Verify response ownership for student.
      */
-    void verifyResponseOwnerShipForStudent(Student student, FeedbackResponse response,
+    void verifyResponseOwnershipForStudent(Student student, FeedbackResponse response,
             FeedbackQuestion question)
             throws UnauthorizedAccessException {
         if (question.getGiverType() == FeedbackParticipantType.TEAMS

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
@@ -52,7 +52,6 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             if (student == null) {
                 throw new EntityNotFoundException("Student does not exist.");
             }
-            session = session.getCopyForUser(student.getEmail());
 
             gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
             verifySessionOpenExceptForModeration(session, student);
@@ -61,14 +60,13 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
 
             checkAccessControlForStudentFeedbackSubmission(student, session);
 
-            verifyResponseOwnerShipForStudent(student, feedbackResponse, feedbackQuestion);
+            verifyResponseOwnershipForStudent(student, feedbackResponse, feedbackQuestion);
             break;
         case INSTRUCTOR_SUBMISSION:
             Instructor instructorAsFeedbackParticipant = getSqlInstructorOfCourseFromRequest(courseId);
             if (instructorAsFeedbackParticipant == null) {
                 throw new EntityNotFoundException("Instructor does not exist.");
             }
-            session = session.getCopyForUser(instructorAsFeedbackParticipant.getEmail());
 
             gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
             verifySessionOpenExceptForModeration(session, instructorAsFeedbackParticipant);

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -48,7 +48,6 @@ public class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionA
             verifyNotPreview();
 
             checkAccessControlForStudentFeedbackSubmission(student, session);
-            session = session.getCopyForUser(student.getEmail());
             verifySessionOpenExceptForModeration(session, student);
             gateKeeper.verifyOwnership(comment,
                     question.getGiverType() == FeedbackParticipantType.TEAMS
@@ -62,7 +61,6 @@ public class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionA
             verifyNotPreview();
 
             checkAccessControlForInstructorFeedbackSubmission(instructorAsFeedbackParticipant, session);
-            session = session.getCopyForUser(instructorAsFeedbackParticipant.getEmail());
             verifySessionOpenExceptForModeration(session, instructorAsFeedbackParticipant);
             gateKeeper.verifyOwnership(comment, instructorAsFeedbackParticipant.getEmail());
             break;

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -68,7 +68,6 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
             if (student == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent student entity");
             }
-            feedbackSession = feedbackSession.getCopyForUser(student.getEmail());
             verifySessionOpenExceptForModeration(feedbackSession, student);
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
@@ -78,7 +77,6 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
-            feedbackSession = feedbackSession.getCopyForUser(instructor.getEmail());
             verifySessionOpenExceptForModeration(feedbackSession, instructor);
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -52,7 +52,6 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             if (student == null) {
                 throw new EntityNotFoundException("Student does not exist.");
             }
-            session = session.getCopyForUser(student.getEmail());
 
             gateKeeper.verifyAnswerableForStudent(question);
             verifySessionOpenExceptForModeration(session, student);
@@ -69,7 +68,6 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             if (instructorAsFeedbackParticipant == null) {
                 throw new EntityNotFoundException("Instructor does not exist.");
             }
-            session = session.getCopyForUser(instructorAsFeedbackParticipant.getEmail());
 
             gateKeeper.verifyAnswerableForInstructor(question);
             verifySessionOpenExceptForModeration(session, instructorAsFeedbackParticipant);

--- a/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetHasResponsesActionTest.java
@@ -270,7 +270,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 // invisible session is skipped
                 continue;
             }
-            verify(mockLogic, times(3)).isFeedbackSessionAttemptedByStudent(
+            verify(mockLogic, times(1)).isFeedbackSessionAttemptedByStudent(
                     feedbackSession, typicalStudent.getEmail(), typicalStudent.getTeamName());
         }
     }
@@ -460,12 +460,11 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
     }
 
     private List<FeedbackSession> getTypicalFeedbackSessions(Course course) {
-        FeedbackSession feedbackSessionTemplate = getTypicalFeedbackSession(course);
-        FeedbackSession feedbackSession1 = feedbackSessionTemplate.getCopy();
+        FeedbackSession feedbackSession1 = getTypicalFeedbackSession(course);
         feedbackSession1.setName("First feedback session");
-        FeedbackSession feedbackSession2 = feedbackSessionTemplate.getCopy();
+        FeedbackSession feedbackSession2 = getTypicalFeedbackSession(course);
         feedbackSession2.setName("Second feedback session");
-        FeedbackSession feedbackSession3 = feedbackSessionTemplate.getCopy();
+        FeedbackSession feedbackSession3 = getTypicalFeedbackSession(course);
         feedbackSession3.setName("Third feedback session");
         FeedbackSession invisibleSession = getTypicalFeedbackSessionForCourse(course);
         invisibleSession.setName("invisible session");


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

`getCopyForUser` does not return a deep clone and should not be used in this way. It's dangerous because fields may accidentally be edited, which may cause unwanted updates to the entity in the DB.

Also moved getCopy from FeedbackSession to a dedicated test utility. This code should not be used in production, so it should not be in production code. 