### PR TITLE
[#13738] Migrate publish and unpublish session actions to use feedbackSessionId

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.HibernateUtil;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.sqllogic.core.FeedbackQuestionsLogic;
@@ -61,7 +61,7 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testPublishFeedbackSession()
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         FeedbackSession unpublishedFs = typicalDataBundle.feedbackSessions.get("unpublishedSession1InTypicalCourse");
 
         FeedbackSession publishedFs1 = fsLogic.publishFeedbackSession(unpublishedFs.getId());
@@ -70,7 +70,7 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertTrue(publishedFs1.isPublished());
         assertFalse(publishedFs1.isPublishedEmailSent());
 
-        assertThrows(InvalidParametersException.class, () -> fsLogic.publishFeedbackSession(
+        assertThrows(InvalidFeedbackSessionStateException.class, () -> fsLogic.publishFeedbackSession(
                 publishedFs1.getId()));
         assertThrows(EntityDoesNotExistException.class, () -> fsLogic.publishFeedbackSession(
                 UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c")));
@@ -78,7 +78,7 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testUnpublishFeedbackSession()
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         FeedbackSession publishedFs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
 
         FeedbackSession unpublishedFs1 = fsLogic.unpublishFeedbackSession(
@@ -87,7 +87,7 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertEquals(unpublishedFs1.getId(), publishedFs.getId());
         assertFalse(unpublishedFs1.isPublished());
 
-        assertThrows(InvalidParametersException.class, () -> fsLogic.unpublishFeedbackSession(
+        assertThrows(InvalidFeedbackSessionStateException.class, () -> fsLogic.unpublishFeedbackSession(
                 unpublishedFs1.getId()));
         assertThrows(EntityDoesNotExistException.class, () -> fsLogic.unpublishFeedbackSession(
                 UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c")));

--- a/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackSessionsLogicIT.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -63,18 +64,16 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
             throws InvalidParametersException, EntityDoesNotExistException {
         FeedbackSession unpublishedFs = typicalDataBundle.feedbackSessions.get("unpublishedSession1InTypicalCourse");
 
-        FeedbackSession publishedFs1 = fsLogic.publishFeedbackSession(
-                unpublishedFs.getName(), unpublishedFs.getCourseId());
+        FeedbackSession publishedFs1 = fsLogic.publishFeedbackSession(unpublishedFs.getId());
 
-        assertEquals(publishedFs1.getName(), unpublishedFs.getName());
+        assertEquals(publishedFs1.getId(), unpublishedFs.getId());
         assertTrue(publishedFs1.isPublished());
+        assertFalse(publishedFs1.isPublishedEmailSent());
 
         assertThrows(InvalidParametersException.class, () -> fsLogic.publishFeedbackSession(
-                publishedFs1.getName(), publishedFs1.getCourseId()));
+                publishedFs1.getId()));
         assertThrows(EntityDoesNotExistException.class, () -> fsLogic.publishFeedbackSession(
-                "non-existent name", unpublishedFs.getCourseId()));
-        assertThrows(EntityDoesNotExistException.class, () -> fsLogic.publishFeedbackSession(
-                unpublishedFs.getName(), "random-course-id"));
+                UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c")));
     }
 
     @Test
@@ -83,17 +82,15 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithSqlDatabaseAccess {
         FeedbackSession publishedFs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
 
         FeedbackSession unpublishedFs1 = fsLogic.unpublishFeedbackSession(
-                publishedFs.getName(), publishedFs.getCourseId());
+                publishedFs.getId());
 
-        assertEquals(unpublishedFs1.getName(), publishedFs.getName());
+        assertEquals(unpublishedFs1.getId(), publishedFs.getId());
         assertFalse(unpublishedFs1.isPublished());
 
         assertThrows(InvalidParametersException.class, () -> fsLogic.unpublishFeedbackSession(
-                unpublishedFs1.getName(), unpublishedFs1.getCourseId()));
+                unpublishedFs1.getId()));
         assertThrows(EntityDoesNotExistException.class, () -> fsLogic.unpublishFeedbackSession(
-                "non-existent name", publishedFs.getCourseId()));
-        assertThrows(EntityDoesNotExistException.class, () -> fsLogic.unpublishFeedbackSession(
-                publishedFs.getName(), "random-course-id"));
+                UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c")));
     }
 
     @Test

--- a/src/main/java/teammates/common/exception/InvalidFeedbackSessionStateException.java
+++ b/src/main/java/teammates/common/exception/InvalidFeedbackSessionStateException.java
@@ -1,0 +1,12 @@
+package teammates.common.exception;
+
+/**
+ * Exception thrown when an operation is attempted on a feedback session that is not in the expected state.
+ */
+public class InvalidFeedbackSessionStateException extends Exception {
+
+    public InvalidFeedbackSessionStateException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -20,6 +20,7 @@ import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InstructorUpdateException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.StudentUpdateException;
 import teammates.common.util.Const;
@@ -604,12 +605,24 @@ public class Logic {
      * Publishes a feedback session.
      *
      * @return the published feedback session
-     * @throws InvalidParametersException if session is already published
+     * @throws InvalidFeedbackSessionStateException if session is already published
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
     public FeedbackSession publishFeedbackSession(UUID feedbackSessionId)
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         return feedbackSessionsLogic.publishFeedbackSession(feedbackSessionId);
+    }
+
+    /**
+     * Unpublishes a feedback session.
+     *
+     * @return the unpublished feedback session
+     * @throws InvalidFeedbackSessionStateException if session is already unpublished
+     * @throws EntityDoesNotExistException if the feedback session cannot be found
+     */
+    public FeedbackSession unpublishFeedbackSession(UUID feedbackSessionId)
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
+        return feedbackSessionsLogic.unpublishFeedbackSession(feedbackSessionId);
     }
 
     /**
@@ -648,18 +661,6 @@ public class Logic {
     public FeedbackSession restoreFeedbackSessionFromRecycleBin(UUID feedbackSessionId)
             throws EntityDoesNotExistException {
         return feedbackSessionsLogic.restoreFeedbackSessionFromRecycleBin(feedbackSessionId);
-    }
-
-    /**
-     * Unpublishes a feedback session.
-     *
-     * @return the unpublished feedback session
-     * @throws InvalidParametersException if session is already unpublished
-     * @throws EntityDoesNotExistException if the feedback session cannot be found
-     */
-    public FeedbackSession unpublishFeedbackSession(UUID feedbackSessionId)
-            throws EntityDoesNotExistException, InvalidParametersException {
-        return feedbackSessionsLogic.unpublishFeedbackSession(feedbackSessionId);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -604,15 +604,12 @@ public class Logic {
      * Publishes a feedback session.
      *
      * @return the published feedback session
+     * @throws InvalidParametersException if session is already published
      * @throws EntityDoesNotExistException if the feedback session cannot be found
-     * @throws InvalidParametersException  if session is already published
      */
-    public FeedbackSession publishFeedbackSession(String feedbackSessionName, String courseId)
+    public FeedbackSession publishFeedbackSession(UUID feedbackSessionId)
             throws EntityDoesNotExistException, InvalidParametersException {
-        assert feedbackSessionName != null;
-        assert courseId != null;
-
-        return feedbackSessionsLogic.publishFeedbackSession(feedbackSessionName, courseId);
+        return feedbackSessionsLogic.publishFeedbackSession(feedbackSessionId);
     }
 
     /**
@@ -657,18 +654,12 @@ public class Logic {
      * Unpublishes a feedback session.
      *
      * @return the unpublished feedback session
+     * @throws InvalidParametersException if session is already unpublished
      * @throws EntityDoesNotExistException if the feedback session cannot be found
-     * @throws InvalidParametersException
-     *                                     if the feedback session is not ready to
-     *                                     be unpublished.
      */
-    public FeedbackSession unpublishFeedbackSession(String feedbackSessionName, String courseId)
+    public FeedbackSession unpublishFeedbackSession(UUID feedbackSessionId)
             throws EntityDoesNotExistException, InvalidParametersException {
-
-        assert feedbackSessionName != null;
-        assert courseId != null;
-
-        return feedbackSessionsLogic.unpublishFeedbackSession(feedbackSessionName, courseId);
+        return feedbackSessionsLogic.unpublishFeedbackSession(feedbackSessionId);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
@@ -228,11 +229,11 @@ public final class FeedbackSessionsLogic {
      * Unpublishes a feedback session.
      *
      * @return the unpublished feedback session
-     * @throws InvalidParametersException if session is already unpublished
+     * @throws InvalidFeedbackSessionStateException if session is already unpublished
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
     public FeedbackSession unpublishFeedbackSession(UUID feedbackSessionId)
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
 
         FeedbackSession sessionToUnpublish = getFeedbackSession(feedbackSessionId);
         if (sessionToUnpublish == null) {
@@ -241,7 +242,7 @@ public final class FeedbackSessionsLogic {
         }
 
         if (!sessionToUnpublish.isPublished()) {
-            throw new InvalidParametersException("Feedback Session is already unpublished.");
+            throw new InvalidFeedbackSessionStateException("Feedback Session is already unpublished.");
         }
 
         sessionToUnpublish.setResultsVisibleFromTime(Const.TIME_REPRESENTS_LATER);
@@ -254,11 +255,11 @@ public final class FeedbackSessionsLogic {
      * Publishes a feedback session.
      *
      * @return the published feedback session
-     * @throws InvalidParametersException if session is already published
+     * @throws InvalidFeedbackSessionStateException if session is already published
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
     public FeedbackSession publishFeedbackSession(UUID feedbackSessionId)
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
 
         FeedbackSession sessionToPublish = getFeedbackSession(feedbackSessionId);
 
@@ -268,7 +269,7 @@ public final class FeedbackSessionsLogic {
         }
 
         if (sessionToPublish.isPublished()) {
-            throw new InvalidParametersException("Feedback Session is already published.");
+            throw new InvalidFeedbackSessionStateException("Feedback Session is already published.");
         }
 
         sessionToPublish.setResultsVisibleFromTime(Instant.now());

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -31,13 +31,6 @@ public final class FeedbackSessionsLogic {
 
     private static final Logger log = Logger.getLogger();
 
-    private static final String ERROR_NON_EXISTENT_FS_STRING_FORMAT = "Trying to %s a non-existent feedback session: ";
-    private static final String ERROR_NON_EXISTENT_FS_UPDATE = String.format(ERROR_NON_EXISTENT_FS_STRING_FORMAT, "update");
-    private static final String ERROR_FS_ALREADY_PUBLISH = "Error publishing feedback session: "
-            + "Session has already been published.";
-    private static final String ERROR_FS_ALREADY_UNPUBLISH = "Error unpublishing feedback session: "
-            + "Session has already been unpublished.";
-
     private static final int NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT = 24;
     private static final int NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT = 24;
 
@@ -238,19 +231,21 @@ public final class FeedbackSessionsLogic {
      * @throws InvalidParametersException if session is already unpublished
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public FeedbackSession unpublishFeedbackSession(String feedbackSessionName, String courseId)
+    public FeedbackSession unpublishFeedbackSession(UUID feedbackSessionId)
             throws EntityDoesNotExistException, InvalidParametersException {
 
-        FeedbackSession sessionToUnpublish = getFeedbackSession(feedbackSessionName, courseId);
-
+        FeedbackSession sessionToUnpublish = getFeedbackSession(feedbackSessionId);
         if (sessionToUnpublish == null) {
-            throw new EntityDoesNotExistException(ERROR_NON_EXISTENT_FS_UPDATE + courseId + "/" + feedbackSessionName);
+            throw new EntityDoesNotExistException(
+                String.format("Feedback session with id %s not found.", feedbackSessionId));
         }
+
         if (!sessionToUnpublish.isPublished()) {
-            throw new InvalidParametersException(ERROR_FS_ALREADY_UNPUBLISH);
+            throw new InvalidParametersException("Feedback Session is already unpublished.");
         }
 
         sessionToUnpublish.setResultsVisibleFromTime(Const.TIME_REPRESENTS_LATER);
+        sessionToUnpublish.setPublishedEmailSent(false);
 
         return sessionToUnpublish;
     }
@@ -262,19 +257,22 @@ public final class FeedbackSessionsLogic {
      * @throws InvalidParametersException if session is already published
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public FeedbackSession publishFeedbackSession(String feedbackSessionName, String courseId)
+    public FeedbackSession publishFeedbackSession(UUID feedbackSessionId)
             throws EntityDoesNotExistException, InvalidParametersException {
 
-        FeedbackSession sessionToPublish = getFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession sessionToPublish = getFeedbackSession(feedbackSessionId);
 
         if (sessionToPublish == null) {
-            throw new EntityDoesNotExistException(ERROR_NON_EXISTENT_FS_UPDATE + courseId + "/" + feedbackSessionName);
+            throw new EntityDoesNotExistException(
+                String.format("Feedback session with id %s not found.", feedbackSessionId));
         }
+
         if (sessionToPublish.isPublished()) {
-            throw new InvalidParametersException(ERROR_FS_ALREADY_PUBLISH);
+            throw new InvalidParametersException("Feedback Session is already published.");
         }
 
         sessionToPublish.setResultsVisibleFromTime(Instant.now());
+        sessionToPublish.setPublishedEmailSent(false);
 
         return sessionToPublish;
     }
@@ -412,12 +410,6 @@ public final class FeedbackSessionsLogic {
             // also reset isClosingSoonEmailSent
             session.setClosingSoonEmailSent(
                     session.isClosed() || session.isClosedAfter(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT));
-        }
-
-        // reset isPublishedEmailSent if the session has been published but is
-        // going to be unpublished now, or else leave it as sent if so.
-        if (session.isPublishedEmailSent()) {
-            session.setPublishedEmailSent(session.isPublished());
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/InvalidOperationException.java
+++ b/src/main/java/teammates/ui/webapi/InvalidOperationException.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InstructorUpdateException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 
 /**
  * Exception thrown when a normally valid operation is not valid due to factors outside of the operation itself,
@@ -25,6 +26,10 @@ public class InvalidOperationException extends Exception {
     }
 
     public InvalidOperationException(InstructorUpdateException cause) {
+        super(cause.getMessage(), cause);
+    }
+
+    public InvalidOperationException(InvalidFeedbackSessionStateException cause) {
         super(cause.getMessage(), cause);
     }
 

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -1,14 +1,12 @@
 package teammates.ui.webapi;
 
 import java.util.List;
-
-import org.apache.http.HttpStatus;
+import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
-import teammates.common.util.Logger;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.FeedbackSessionData;
@@ -18,8 +16,6 @@ import teammates.ui.output.FeedbackSessionData;
  */
 public class PublishFeedbackSessionAction extends Action {
 
-    private static final Logger log = Logger.getLogger();
-
     @Override
     AuthType getMinAuthLevel() {
         return AuthType.LOGGED_IN;
@@ -27,44 +23,39 @@ public class PublishFeedbackSessionAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        gateKeeper.verifyAccessible(instructor, feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
+        Instructor instructor = sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+
+        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override
     public JsonResult execute() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        if (feedbackSession.isPublished()) {
-            // If feedback session was already published to begin with, return early
-            return new JsonResult(new FeedbackSessionData(feedbackSession));
-        }
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
         try {
-            FeedbackSession publishFeedbackSession = sqlLogic.publishFeedbackSession(feedbackSessionName, courseId);
+            FeedbackSession publishFeedbackSession = sqlLogic.publishFeedbackSession(feedbackSessionId);
 
-            if (publishFeedbackSession.isPublishedEmailEnabled()) {
-                // Generate and queue published emails to send-email-queue
-                List<EmailWrapper> emailsToBeSent =
-                        sqlEmailGenerator.generateFeedbackSessionPublishedEmails(publishFeedbackSession);
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
-                publishFeedbackSession.setPublishedEmailSent(true);
-                sqlLogic.adjustFeedbackSessionEmailStatusAfterUpdate(publishFeedbackSession);
-            }
+            sendPublishedEmails(publishFeedbackSession);
             return new JsonResult(new FeedbackSessionData(publishFeedbackSession));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
         } catch (InvalidParametersException e) {
-            // There should not be any invalid parameter here
-            log.severe("Unexpected error", e);
-            return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new InvalidHttpParameterException(e);
+        }
+    }
+
+    private void sendPublishedEmails(FeedbackSession feedbackSession) {
+        if (feedbackSession.isPublishedEmailEnabled()) {
+            List<EmailWrapper> emailsToBeSent =
+                    sqlEmailGenerator.generateFeedbackSessionPublishedEmails(feedbackSession);
+            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+            feedbackSession.setPublishedEmailSent(true);
         }
     }
 }

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -35,7 +35,7 @@ public class PublishFeedbackSessionAction extends Action {
     }
 
     @Override
-    public JsonResult execute() {
+    public JsonResult execute() throws InvalidOperationException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
         try {
@@ -45,8 +45,8 @@ public class PublishFeedbackSessionAction extends Action {
             return new JsonResult(new FeedbackSessionData(publishFeedbackSession));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
-        } catch (InvalidParametersException e) {
-            throw new InvalidHttpParameterException(e);
+        } catch (InvalidFeedbackSessionStateException e) {
+            throw new InvalidOperationException(e);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -1,14 +1,12 @@
 package teammates.ui.webapi;
 
 import java.util.List;
-
-import org.apache.http.HttpStatus;
+import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
-import teammates.common.util.Logger;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.ui.output.FeedbackSessionData;
@@ -18,8 +16,6 @@ import teammates.ui.output.FeedbackSessionData;
  */
 public class UnpublishFeedbackSessionAction extends Action {
 
-    private static final Logger log = Logger.getLogger();
-
     @Override
     AuthType getMinAuthLevel() {
         return AuthType.LOGGED_IN;
@@ -27,45 +23,39 @@ public class UnpublishFeedbackSessionAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        gateKeeper.verifyAccessible(instructor, feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
+        Instructor instructor = sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+
+        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override
     public JsonResult execute() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        if (!feedbackSession.isPublished()) {
-            // If feedback session was not published to begin with, return early
-            return new JsonResult(new FeedbackSessionData(feedbackSession));
-        }
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
         try {
             FeedbackSession unpublishFeedbackSession =
-                    sqlLogic.unpublishFeedbackSession(feedbackSessionName, courseId);
+                    sqlLogic.unpublishFeedbackSession(feedbackSessionId);
 
-            if (unpublishFeedbackSession.isPublishedEmailEnabled()) {
-                // Generate and queue unpublished emails to send-email-queue
-                List<EmailWrapper> emailsToBeSent =
-                        sqlEmailGenerator.generateFeedbackSessionUnpublishedEmails(unpublishFeedbackSession);
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
-                unpublishFeedbackSession.setPublishedEmailSent(false);
-                sqlLogic.adjustFeedbackSessionEmailStatusAfterUpdate(unpublishFeedbackSession);
-            }
+            sendUnpublishedEmails(unpublishFeedbackSession);
             return new JsonResult(new FeedbackSessionData(unpublishFeedbackSession));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
         } catch (InvalidParametersException e) {
-            // There should not be any invalid parameter here
-            log.severe("Unexpected error", e);
-            return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new InvalidHttpParameterException(e);
+        }
+    }
+
+    private void sendUnpublishedEmails(FeedbackSession feedbackSession) {
+        if (feedbackSession.isPublishedEmailEnabled()) {
+            List<EmailWrapper> emailsToBeSent =
+                    sqlEmailGenerator.generateFeedbackSessionUnpublishedEmails(feedbackSession);
+            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
         }
     }
 }

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -35,7 +35,7 @@ public class UnpublishFeedbackSessionAction extends Action {
     }
 
     @Override
-    public JsonResult execute() {
+    public JsonResult execute() throws InvalidOperationException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
         try {
@@ -46,8 +46,8 @@ public class UnpublishFeedbackSessionAction extends Action {
             return new JsonResult(new FeedbackSessionData(unpublishFeedbackSession));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
-        } catch (InvalidParametersException e) {
-            throw new InvalidHttpParameterException(e);
+        } catch (InvalidFeedbackSessionStateException e) {
+            throw new InvalidOperationException(e);
         }
     }
 

--- a/src/test/java/teammates/sqllogic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackSessionsLogicTest.java
@@ -166,15 +166,17 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException, InvalidParametersException {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        session.setPublishedEmailSent(true);
         session.setResultsVisibleFromTime(Instant.now().plusSeconds(86400)); // Not yet published
 
-        when(fsDb.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
+        when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
-        FeedbackSession result = fsLogic.publishFeedbackSession(session.getName(), course.getId());
+        FeedbackSession result = fsLogic.publishFeedbackSession(session.getId());
 
         assertNotNull(result);
         assertEquals(session, result);
         assertTrue(result.isPublished());
+        assertFalse(result.isPublishedEmailSent());
         assertNotNull(result.getResultsVisibleFromTime());
     }
 
@@ -184,20 +186,21 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
         session.setResultsVisibleFromTime(Instant.now().minusSeconds(3600)); // Already published
 
-        when(fsDb.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
+        when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
         InvalidParametersException ex = assertThrows(InvalidParametersException.class,
-                () -> fsLogic.publishFeedbackSession(session.getName(), course.getId()));
-        assertEquals("Error publishing feedback session: Session has already been published.", ex.getMessage());
+                () -> fsLogic.publishFeedbackSession(session.getId()));
+        assertEquals("Feedback Session is already published.", ex.getMessage());
     }
 
     @Test
     public void testPublishFeedbackSession_sessionDoesNotExist_throwsException() {
-        when(fsDb.getFeedbackSession("non-existent", "course")).thenReturn(null);
+        UUID nonExistentId = UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c");
+        when(fsDb.getFeedbackSession(nonExistentId)).thenReturn(null);
 
         EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
-                () -> fsLogic.publishFeedbackSession("non-existent", "course"));
-        assertTrue(ex.getMessage().contains("Trying to update a non-existent feedback session"));
+                () -> fsLogic.publishFeedbackSession(nonExistentId));
+        assertEquals(String.format("Feedback session with id %s not found.", nonExistentId), ex.getMessage());
     }
 
     @Test
@@ -205,15 +208,17 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
             throws EntityDoesNotExistException, InvalidParametersException {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        session.setPublishedEmailSent(false);
         session.setResultsVisibleFromTime(Instant.now().minusSeconds(3600)); // Published
 
-        when(fsDb.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
+        when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
-        FeedbackSession result = fsLogic.unpublishFeedbackSession(session.getName(), course.getId());
+        FeedbackSession result = fsLogic.unpublishFeedbackSession(session.getId());
 
         assertNotNull(result);
         assertEquals(session, result);
         assertFalse(result.isPublished());
+        assertFalse(result.isPublishedEmailSent());
         assertEquals(Const.TIME_REPRESENTS_LATER, result.getResultsVisibleFromTime());
     }
 
@@ -223,11 +228,21 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
         session.setResultsVisibleFromTime(Instant.now().plusSeconds(86400)); // Not published
 
-        when(fsDb.getFeedbackSession(session.getName(), course.getId())).thenReturn(session);
+        when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
         InvalidParametersException ex = assertThrows(InvalidParametersException.class,
-                () -> fsLogic.unpublishFeedbackSession(session.getName(), course.getId()));
-        assertEquals("Error unpublishing feedback session: Session has already been unpublished.", ex.getMessage());
+                () -> fsLogic.unpublishFeedbackSession(session.getId()));
+        assertEquals("Feedback Session is already unpublished.", ex.getMessage());
+    }
+
+    @Test
+    public void testUnpublishFeedbackSession_sessionDoesNotExist_throwsException() {
+        UUID nonExistentId = UUID.fromString("2da92144-63f3-4da5-9148-dbcbdef6dc2c");
+        when(fsDb.getFeedbackSession(nonExistentId)).thenReturn(null);
+
+        EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.unpublishFeedbackSession(nonExistentId));
+        assertEquals(String.format("Feedback session with id %s not found.", nonExistentId), ex.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/sqllogic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/FeedbackSessionsLogicTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.storage.sqlapi.FeedbackSessionsDb;
 import teammates.storage.sqlentity.Course;
@@ -163,7 +163,7 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
 
     @Test
     public void testPublishFeedbackSession_unpublishedSession_success()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
         session.setPublishedEmailSent(true);
@@ -188,7 +188,7 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
 
         when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
-        InvalidParametersException ex = assertThrows(InvalidParametersException.class,
+        InvalidFeedbackSessionStateException ex = assertThrows(InvalidFeedbackSessionStateException.class,
                 () -> fsLogic.publishFeedbackSession(session.getId()));
         assertEquals("Feedback Session is already published.", ex.getMessage());
     }
@@ -205,7 +205,7 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
 
     @Test
     public void testUnpublishFeedbackSession_publishedSession_success()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
         session.setPublishedEmailSent(false);
@@ -230,7 +230,7 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
 
         when(fsDb.getFeedbackSession(session.getId())).thenReturn(session);
 
-        InvalidParametersException ex = assertThrows(InvalidParametersException.class,
+        InvalidFeedbackSessionStateException ex = assertThrows(InvalidFeedbackSessionStateException.class,
                 () -> fsLogic.unpublishFeedbackSession(session.getId()));
         assertEquals("Feedback Session is already unpublished.", ex.getMessage());
     }

--- a/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.EmailWrapper;
@@ -73,7 +73,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
 
     @Test
     void testExecute_unpublishedFeedbackSessionWithEmailDisabled_succeedsWithNoTasksAdded()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
@@ -95,7 +95,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
 
     @Test
     void testExecute_unpublishedFeedbackSessionWithEmailEnabled_succeedsWithTasksAdded()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         typicalFeedbackSession.setPublishedEmailEnabled(true);
         EmailWrapper mockEmail = mock(EmailWrapper.class);
 

--- a/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/PublishFeedbackSessionActionTest.java
@@ -1,7 +1,6 @@
 package teammates.sqlui.webapi;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,56 +72,15 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
     }
 
     @Test
-    void testExecute_missingCourseId_throwsInvalidParametersException() {
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_missingFeedbackSessionName_throwsInvalidParametersException() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_publishedFeedbackSession_returnsEarly()
-            throws EntityDoesNotExistException, InvalidParametersException {
-        typicalFeedbackSession.setResultsVisibleFromTime(Instant.now());
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
-        };
-
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
-                .thenReturn(typicalFeedbackSession);
-
-        PublishFeedbackSessionAction action = getAction(params);
-        JsonResult result = getJsonResult(action);
-        FeedbackSessionData feedbackSessionData = (FeedbackSessionData) result.getOutput();
-
-        verifyFeedbackSessionData(feedbackSessionData, typicalFeedbackSession,
-                FeedbackSessionPublishStatus.PUBLISHED);
-        verify(mockLogic, never()).publishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
-        verifyNoTasksAdded();
-    }
-
-    @Test
     void testExecute_unpublishedFeedbackSessionWithEmailDisabled_succeedsWithNoTasksAdded()
             throws EntityDoesNotExistException, InvalidParametersException {
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.publishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.publishFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         PublishFeedbackSessionAction action = getAction(params);
@@ -131,7 +89,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
 
         verifyFeedbackSessionData(feedbackSessionData, typicalFeedbackSession,
                 FeedbackSessionPublishStatus.NOT_PUBLISHED);
-        verify(mockLogic).publishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verify(mockLogic).publishFeedbackSession(typicalFeedbackSession.getId());
         verifyNoTasksAdded();
     }
 
@@ -142,13 +100,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
         EmailWrapper mockEmail = mock(EmailWrapper.class);
 
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.publishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.publishFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
         when(mockSqlEmailGenerator.generateFeedbackSessionPublishedEmails(typicalFeedbackSession))
                 .thenReturn(List.of(mockEmail));
@@ -159,15 +116,14 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
 
         verifyFeedbackSessionData(feedbackSessionData, typicalFeedbackSession,
                 FeedbackSessionPublishStatus.NOT_PUBLISHED);
-        verify(mockLogic).publishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verify(mockLogic).publishFeedbackSession(typicalFeedbackSession.getId());
         verifySpecifiedTasksAdded(TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
     }
 
     @Test
     void testCheckSpecificAccessControl_withoutLogin_throwsUnauthorizedAccessException() {
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         verifyCannotAccess(params);
@@ -177,13 +133,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
     void testCheckSpecificAccessControl_unregisteredUser_throwsUnauthorizedAccessException() {
         String googleId = "unregistered-user";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsUnregistered(googleId);
@@ -195,13 +150,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
     void testCheckSpecificAccessControl_student_throwsUnauthorizedAccessException() {
         String googleId = "student";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsStudent(googleId);
@@ -213,13 +167,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
     void testCheckSpecificAccessControl_instructorOfOtherCourse_throwsUnauthorizedAccessException() {
         String googleId = "instructor-of-other-course";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(googleId);
@@ -233,13 +186,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
                 Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
         typicalInstructor.setPrivileges(instructorPrivileges);
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -250,13 +202,12 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
     @Test
     void testCheckSpecificAccessControl_instructorOfSameCourseWithPermission_canAccess() {
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(typicalInstructor.getGoogleId());

--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -1,13 +1,13 @@
 package teammates.sqlui.webapi;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -71,58 +71,18 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     }
 
     @Test
-    void testExecute_missingCourseId_throwsInvalidHttpParameterException() {
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_missingFeedbackSessionName_throwsInvalidHttpParameterException() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_unpublishedFeedbackSession_returnsEarly()
-            throws EntityDoesNotExistException, InvalidParametersException {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
-        };
-
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
-                .thenReturn(typicalFeedbackSession);
-
-        UnpublishFeedbackSessionAction action = getAction(params);
-        JsonResult result = getJsonResult(action);
-        FeedbackSessionData feedbackSessionData = (FeedbackSessionData) result.getOutput();
-
-        verifyFeedbackSessionData(feedbackSessionData, typicalFeedbackSession,
-                FeedbackSessionPublishStatus.NOT_PUBLISHED);
-        verify(mockLogic, never()).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
-        verifyNoTasksAdded();
-    }
-
-    @Test
     void testExecute_publishedFeedbackSessionWithEmailDisabled_succeedsWithNoTasksAdded()
             throws EntityDoesNotExistException, InvalidParametersException {
         typicalFeedbackSession.setResultsVisibleFromTime(Instant.now()); // set the input to be published
         FeedbackSession outputFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
         outputFeedbackSession.setCreatedAt(Instant.now());
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(outputFeedbackSession);
 
         UnpublishFeedbackSessionAction action = getAction(params);
@@ -131,7 +91,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
         verifyFeedbackSessionData(feedbackSessionData, outputFeedbackSession,
                 FeedbackSessionPublishStatus.NOT_PUBLISHED);
-        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getId());
         verifyNoTasksAdded();
     }
 
@@ -145,13 +105,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
         outputFeedbackSession.setPublishedEmailEnabled(true);
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
-        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.unpublishFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(outputFeedbackSession);
         when(mockSqlEmailGenerator.generateFeedbackSessionUnpublishedEmails(outputFeedbackSession))
                 .thenReturn(List.of(mockEmail));
@@ -162,7 +121,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
         verifyFeedbackSessionData(feedbackSessionData, outputFeedbackSession,
                 FeedbackSessionPublishStatus.NOT_PUBLISHED);
-        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId());
+        verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getId());
         verifySpecifiedTasksAdded(TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
     }
 
@@ -170,13 +129,13 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     void testCheckSpecificAccessControl_nonExistentCourse_throwsEntityNotFoundException() {
         String courseId = "abcRandomCourseId";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(courseId, typicalInstructor.getGoogleId()))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), courseId))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
+
                 .thenReturn(null);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -186,15 +145,14 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
     @Test
     void testCheckSpecificAccessControl_nonExistentFeedbackSession_throwsEntityNotFoundException() {
-        String feedbackSessionName = "abcRandomSession";
+        UUID feedbackSessionId = UUID.randomUUID();
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName,
+                Const.ParamsNames.FEEDBACK_SESSION_ID, feedbackSessionId.toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
-        when(mockLogic.getFeedbackSession(feedbackSessionName, typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(feedbackSessionId))
                 .thenReturn(null);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -205,8 +163,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     @Test
     void testCheckSpecificAccessControl_withoutLogin_throwsUnauthorizedAccessException() {
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         verifyCannotAccess(params);
@@ -216,13 +173,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     void testCheckSpecificAccessControl_unregisteredUser_throwsUnauthorizedAccessException() {
         String googleId = "unregistered-user";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsUnregistered(googleId);
@@ -234,13 +190,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     void testCheckSpecificAccessControl_student_throwsUnauthorizedAccessException() {
         String googleId = "student";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsStudent(googleId);
@@ -252,13 +207,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     void testCheckSpecificAccessControl_instructorOfOtherCourse_throwsUnauthorizedAccessException() {
         String googleId = "instructor-of-other-course";
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), googleId))
                 .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(googleId);
@@ -272,13 +226,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
         typicalInstructor.setPrivileges(instructorPrivileges);
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -289,13 +242,12 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
     @Test
     void testCheckSpecificAccessControl_instructorOfSameCourseWithPermission_canAccess() {
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, typicalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
 
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getName(), typicalCourse.getId()))
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
                 .thenReturn(typicalFeedbackSession);
 
         loginAsInstructor(typicalInstructor.getGoogleId());

--- a/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.EmailWrapper;
@@ -72,7 +72,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
     @Test
     void testExecute_publishedFeedbackSessionWithEmailDisabled_succeedsWithNoTasksAdded()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         typicalFeedbackSession.setResultsVisibleFromTime(Instant.now()); // set the input to be published
         FeedbackSession outputFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
         outputFeedbackSession.setCreatedAt(Instant.now());
@@ -97,7 +97,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
     @Test
     void testExecute_publishedFeedbackSessionWithEmailEnabled_succeedsWithTasksAdded()
-            throws EntityDoesNotExistException, InvalidParametersException {
+            throws EntityDoesNotExistException, InvalidFeedbackSessionStateException {
         typicalFeedbackSession.setResultsVisibleFromTime(Instant.now()); // set the input to be published
         typicalFeedbackSession.setPublishedEmailEnabled(true);
         FeedbackSession outputFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
@@ -123,24 +123,6 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
                 FeedbackSessionPublishStatus.NOT_PUBLISHED);
         verify(mockLogic).unpublishFeedbackSession(typicalFeedbackSession.getId());
         verifySpecifiedTasksAdded(TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
-    }
-
-    @Test
-    void testCheckSpecificAccessControl_nonExistentCourse_throwsEntityNotFoundException() {
-        String courseId = "abcRandomCourseId";
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
-        };
-
-        when(mockLogic.getInstructorByGoogleId(courseId, typicalInstructor.getGoogleId()))
-                .thenReturn(null);
-        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId()))
-
-                .thenReturn(null);
-
-        loginAsInstructor(typicalInstructor.getGoogleId());
-
-        verifyEntityNotFoundAcl(params);
     }
 
     @Test

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -502,7 +502,7 @@ export abstract class InstructorSessionBasePageComponent {
     );
 
     this.feedbackSessionsService
-      .publishFeedbackSession(model.feedbackSession.courseId, model.feedbackSession.feedbackSessionName)
+      .publishFeedbackSession(model.feedbackSession.feedbackSessionId)
       .pipe(finalize(() => {
           this.isResultActionLoading = false;
         }),
@@ -557,7 +557,7 @@ export abstract class InstructorSessionBasePageComponent {
     );
 
     this.feedbackSessionsService
-      .unpublishFeedbackSession(model.feedbackSession.courseId, model.feedbackSession.feedbackSessionName)
+      .unpublishFeedbackSession(model.feedbackSession.feedbackSessionId)
       .pipe(
         finalize(() => {
           this.isResultActionLoading = false;

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -505,10 +505,10 @@ export class InstructorSessionResultPageComponent implements OnInit {
     modalRef.result.then(() => {
       const response: Observable<any> = isPublished
           ? this.feedbackSessionsService.unpublishFeedbackSession(
-            this.session.courseId, this.session.feedbackSessionName,
+            this.session.feedbackSessionId,
           )
           : this.feedbackSessionsService.publishFeedbackSession(
-            this.session.courseId, this.session.feedbackSessionName,
+            this.session.feedbackSessionId,
           );
 
       response.subscribe({

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -81,26 +81,22 @@ describe('FeedbackSessionsService', () => {
 
   it('should call post when publishing', () => {
     const paramMap: { [key: string]: string } = {
-      courseid: model.feedbackSession.courseId,
-      fsname: model.feedbackSession.feedbackSessionName,
+      fsid: model.feedbackSession.feedbackSessionId,
     };
 
     service.publishFeedbackSession(
-        model.feedbackSession.courseId,
-        model.feedbackSession.feedbackSessionName,
+        model.feedbackSession.feedbackSessionId,
     );
     expect(spyHttpRequestService.post).toHaveBeenCalledWith(ResourceEndpoints.SESSION_PUBLISH, paramMap);
   });
 
   it('should call delete when unpublishing', () => {
     const paramMap: Record<string, string> = {
-      courseid: model.feedbackSession.courseId,
-      fsname: model.feedbackSession.feedbackSessionName,
+      fsid: model.feedbackSession.feedbackSessionId,
     };
 
     service.unpublishFeedbackSession(
-        model.feedbackSession.courseId,
-        model.feedbackSession.feedbackSessionName,
+        model.feedbackSession.feedbackSessionId,
     );
     expect(spyHttpRequestService.delete).toHaveBeenCalledWith(ResourceEndpoints.SESSION_PUBLISH, paramMap);
   });

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -325,10 +325,9 @@ export class FeedbackSessionsService {
   /**
    * publishes a feedback session.
    */
-  publishFeedbackSession(courseId: string, feedbackSessionName: string): Observable<FeedbackSession> {
+  publishFeedbackSession(feedbackSessionId: string): Observable<FeedbackSession> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
     };
 
     return this.httpRequestService.post(ResourceEndpoints.SESSION_PUBLISH, paramMap);
@@ -337,10 +336,9 @@ export class FeedbackSessionsService {
   /**
    * Unpublishes a feedback session.
    */
-  unpublishFeedbackSession(courseId: string, feedbackSessionName: string): Observable<FeedbackSession> {
+  unpublishFeedbackSession(feedbackSessionId: string): Observable<FeedbackSession> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
     };
 
     return this.httpRequestService.delete(ResourceEndpoints.SESSION_PUBLISH, paramMap);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13738

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

API semantics also changed slightly to throw an error if feedback session is already published/unpublished (rather than fail silently). This helps keeps things simple as we now only check for this once instead of twice.