### PR TITLE
[#13738] Migrate Get and Update Deadline Extensions actions to use feedbackSessionId

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -618,9 +618,8 @@ public abstract class BaseE2ETestCase extends BaseTestCase {
     /**
      * Gets feedback session deadline extensions data from the database.
      */
-    protected FeedbackSessionDeadlineExtensionsData getFeedbackSessionDeadlineExtensions(
-            String courseId, String feedbackSessionName) {
-        return BACKDOOR.getFeedbackSessionDeadlineExtensionsData(courseId, feedbackSessionName);
+    protected FeedbackSessionDeadlineExtensionsData getFeedbackSessionDeadlineExtensions(UUID feedbackSessionId) {
+        return BACKDOOR.getFeedbackSessionDeadlineExtensionsData(feedbackSessionId.toString());
     }
 
     /**

--- a/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
@@ -65,7 +65,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         individualExtensionPage.extendDeadlineByTwelveHours(true);
 
         FeedbackSessionDeadlineExtensionsData updatedExtensionsData =
-                getFeedbackSessionDeadlineExtensions(feedbackSession.getCourseId(), feedbackSession.getName());
+                getFeedbackSessionDeadlineExtensions(feedbackSession.getId());
         Map<String, Long> updatedStudentDeadlines = updatedExtensionsData.getStudentDeadlines();
         Map<String, Long> updatedInstructorDeadlines = updatedExtensionsData.getInstructorDeadlines();
         Instant expectedDeadline = feedbackSession.getEndTime().plus(Duration.ofHours(12));
@@ -90,7 +90,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         individualExtensionPage.extendDeadlineByOneDay(true);
 
         updatedExtensionsData =
-                getFeedbackSessionDeadlineExtensions(feedbackSession.getCourseId(), feedbackSession.getName());
+                getFeedbackSessionDeadlineExtensions(feedbackSession.getId());
         updatedStudentDeadlines = updatedExtensionsData.getStudentDeadlines();
         updatedInstructorDeadlines = updatedExtensionsData.getInstructorDeadlines();
 
@@ -111,7 +111,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         individualExtensionPage.deleteDeadlines(true);
 
         updatedExtensionsData =
-                getFeedbackSessionDeadlineExtensions(feedbackSession.getCourseId(), feedbackSession.getName());
+                getFeedbackSessionDeadlineExtensions(feedbackSession.getId());
         updatedStudentDeadlines = updatedExtensionsData.getStudentDeadlines();
         updatedInstructorDeadlines = updatedExtensionsData.getInstructorDeadlines();
 
@@ -133,7 +133,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         individualExtensionPage.extendDeadlineToOneDayAway(feedbackSession, false);
 
         updatedExtensionsData =
-                getFeedbackSessionDeadlineExtensions(feedbackSession.getCourseId(), feedbackSession.getName());
+                getFeedbackSessionDeadlineExtensions(feedbackSession.getId());
         updatedStudentDeadlines = updatedExtensionsData.getStudentDeadlines();
         updatedInstructorDeadlines = updatedExtensionsData.getInstructorDeadlines();
 
@@ -150,7 +150,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         individualExtensionPage.deleteDeadlines(false);
 
         updatedExtensionsData =
-                getFeedbackSessionDeadlineExtensions(feedbackSession.getCourseId(), feedbackSession.getName());
+                getFeedbackSessionDeadlineExtensions(feedbackSession.getId());
         updatedStudentDeadlines = updatedExtensionsData.getStudentDeadlines();
         updatedInstructorDeadlines = updatedExtensionsData.getInstructorDeadlines();
 

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -105,7 +105,7 @@ public final class ActionFactory {
         map(ResourceURIs.SESSION, PUT, UpdateFeedbackSessionAction.class);
         map(ResourceURIs.SESSION, POST, CreateFeedbackSessionAction.class);
         map(ResourceURIs.SESSION, DELETE, DeleteFeedbackSessionAction.class);
-        map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, GET, GetFeedbackSessionDeadlineExtensionsAction.class);
+        map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, GET, GetDeadlineExtensionsAction.class);
         map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, PUT, UpdateFeedbackSessionDeadlineExtensionsAction.class);
         map(ResourceURIs.SESSION_PUBLISH, POST, PublishFeedbackSessionAction.class);
         map(ResourceURIs.SESSION_PUBLISH, DELETE, UnpublishFeedbackSessionAction.class);

--- a/src/main/java/teammates/ui/webapi/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/ActionFactory.java
@@ -106,7 +106,7 @@ public final class ActionFactory {
         map(ResourceURIs.SESSION, POST, CreateFeedbackSessionAction.class);
         map(ResourceURIs.SESSION, DELETE, DeleteFeedbackSessionAction.class);
         map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, GET, GetDeadlineExtensionsAction.class);
-        map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, PUT, UpdateFeedbackSessionDeadlineExtensionsAction.class);
+        map(ResourceURIs.SESSION_DEADLINE_EXTENSIONS, PUT, UpdateDeadlineExtensionsAction.class);
         map(ResourceURIs.SESSION_PUBLISH, POST, PublishFeedbackSessionAction.class);
         map(ResourceURIs.SESSION_PUBLISH, DELETE, UnpublishFeedbackSessionAction.class);
         map(ResourceURIs.SESSION_SUBMITTED_GIVER_SET, GET, GetFeedbackSessionSubmittedGiverSetAction.class);

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -24,23 +24,25 @@ public class GetDeadlineExtensionsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
 
         gateKeeper.verifyAccessible(
-                sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()),
+                sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override
     public JsonResult execute() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        String courseId = feedbackSession.getCourseId();
 
         Map<UUID, Student> studentsByUserId = sqlLogic.getStudentsForCourse(courseId).stream()
                 .collect(Collectors.toMap(Student::getId, s -> s));

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -15,7 +15,7 @@ import teammates.ui.output.FeedbackSessionDeadlineExtensionsData;
 /**
  * Gets the deadline extensions for a feedback session.
  */
-public class GetFeedbackSessionDeadlineExtensionsAction extends Action {
+public class GetDeadlineExtensionsAction extends Action {
 
     @Override
     AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -42,27 +42,32 @@ public class UpdateDeadlineExtensionsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
 
         gateKeeper.verifyAccessible(
-                sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId()),
+                sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
 
         FeedbackSessionDeadlineExtensionsUpdateRequest updateRequest =
                 getAndValidateRequestBody(FeedbackSessionDeadlineExtensionsUpdateRequest.class);
 
         List<DeadlineExtension> prevDeadlineExtensions = feedbackSession.getDeadlineExtensions();
+        String courseId = feedbackSession.getCourseId();
 
         // Use userIds to map to users to avoid querying the db for each user multiple times during processing later on
         Map<UUID, Student> studentsByUserId = sqlLogic.getStudentsForCourse(courseId).stream()
@@ -122,7 +127,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
         taskQueuer.scheduleEmailsForSending(emailsToSend);
 
         // Refresh to get updated deadline extensions
-        feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
         List<DeadlineExtension> deadlineExtensions = feedbackSession.getDeadlineExtensions();
         String updatedTimeZone = feedbackSession.getCourse().getTimeZone();
         FeedbackSessionDeadlineExtensionsData responseData = new FeedbackSessionDeadlineExtensionsData(

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -31,7 +31,7 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 /**
  * Updates the deadline extensions for a feedback session.
  */
-public class UpdateFeedbackSessionDeadlineExtensionsAction extends Action {
+public class UpdateDeadlineExtensionsAction extends Action {
 
     private static final Logger log = Logger.getLogger();
 

--- a/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
@@ -104,10 +104,10 @@ import teammates.ui.webapi.SubmitFeedbackResponsesAction;
 import teammates.ui.webapi.UnpublishFeedbackSessionAction;
 import teammates.ui.webapi.UpdateAccountRequestAction;
 import teammates.ui.webapi.UpdateCourseAction;
+import teammates.ui.webapi.UpdateDeadlineExtensionsAction;
 import teammates.ui.webapi.UpdateFeedbackQuestionAction;
 import teammates.ui.webapi.UpdateFeedbackResponseCommentAction;
 import teammates.ui.webapi.UpdateFeedbackSessionAction;
-import teammates.ui.webapi.UpdateFeedbackSessionDeadlineExtensionsAction;
 import teammates.ui.webapi.UpdateInstructorAction;
 import teammates.ui.webapi.UpdateInstructorPrivilegeAction;
 import teammates.ui.webapi.UpdateNotificationAction;
@@ -161,7 +161,7 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 CreateFeedbackSessionAction.class,
                 GetFeedbackSessionAction.class,
                 UpdateFeedbackSessionAction.class,
-                UpdateFeedbackSessionDeadlineExtensionsAction.class,
+                UpdateDeadlineExtensionsAction.class,
                 FeedbackSessionClosingSoonRemindersAction.class,
                 GetTimeZonesAction.class,
                 GetFeedbackResponsesAction.class,

--- a/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
@@ -59,7 +59,7 @@ import teammates.ui.webapi.GetFeedbackQuestionsAction;
 import teammates.ui.webapi.GetFeedbackResponseCommentAction;
 import teammates.ui.webapi.GetFeedbackResponsesAction;
 import teammates.ui.webapi.GetFeedbackSessionAction;
-import teammates.ui.webapi.GetFeedbackSessionDeadlineExtensionsAction;
+import teammates.ui.webapi.GetDeadlineExtensionsAction;
 import teammates.ui.webapi.GetFeedbackSessionLogsAction;
 import teammates.ui.webapi.GetFeedbackSessionSubmittedGiverSetAction;
 import teammates.ui.webapi.GetFeedbackSessionsAction;
@@ -233,7 +233,7 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
                 SendLoginEmailAction.class,
                 PutDataBundleAction.class,
                 DeleteDataBundleAction.class,
-                GetFeedbackSessionDeadlineExtensionsAction.class
+                GetDeadlineExtensionsAction.class
         );
         List<String> expectedActionClassesNames = expectedActionClasses.stream()
                 .map(Class::getSimpleName)

--- a/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetActionClassesActionTest.java
@@ -3,7 +3,6 @@ package teammates.sqlui.webapi;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
 
@@ -54,12 +53,12 @@ import teammates.ui.webapi.GetCourseJoinStatusAction;
 import teammates.ui.webapi.GetCourseSectionNamesAction;
 import teammates.ui.webapi.GetCoursesAction;
 import teammates.ui.webapi.GetDeadlineExtensionAction;
+import teammates.ui.webapi.GetDeadlineExtensionsAction;
 import teammates.ui.webapi.GetFeedbackQuestionRecipientsAction;
 import teammates.ui.webapi.GetFeedbackQuestionsAction;
 import teammates.ui.webapi.GetFeedbackResponseCommentAction;
 import teammates.ui.webapi.GetFeedbackResponsesAction;
 import teammates.ui.webapi.GetFeedbackSessionAction;
-import teammates.ui.webapi.GetDeadlineExtensionsAction;
 import teammates.ui.webapi.GetFeedbackSessionLogsAction;
 import teammates.ui.webapi.GetFeedbackSessionSubmittedGiverSetAction;
 import teammates.ui.webapi.GetFeedbackSessionsAction;
@@ -238,7 +237,7 @@ public class GetActionClassesActionTest extends BaseActionTest<GetActionClassesA
         List<String> expectedActionClassesNames = expectedActionClasses.stream()
                 .map(Class::getSimpleName)
                 .sorted()
-                .collect(Collectors.toList());
+                .toList();
 
         GetActionClassesAction action = getAction();
         action.execute();

--- a/src/test/java/teammates/sqlui/webapi/GetDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetDeadlineExtensionsActionTest.java
@@ -54,7 +54,7 @@ public class GetDeadlineExtensionsActionTest
         typicalInstructor = getTypicalInstructor();
         typicalStudent = getTypicalStudent();
 
-        when(mockLogic.getFeedbackSession(FEEDBACK_SESSION_NAME, COURSE_ID)).thenReturn(typicalFeedbackSession);
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId())).thenReturn(typicalFeedbackSession);
         when(mockLogic.getStudentsForCourse(COURSE_ID)).thenReturn(new ArrayList<>());
         when(mockLogic.getInstructorsByCourse(COURSE_ID)).thenReturn(new ArrayList<>());
     }
@@ -78,7 +78,7 @@ public class GetDeadlineExtensionsActionTest
 
     @Test
     void testExecute_sessionNotFound_throwsEntityNotFoundException() {
-        when(mockLogic.getFeedbackSession(FEEDBACK_SESSION_NAME, COURSE_ID)).thenReturn(null);
+        when(mockLogic.getFeedbackSession(typicalFeedbackSession.getId())).thenReturn(null);
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         verifyEntityNotFoundAcl(getTypicalParams());
@@ -144,8 +144,7 @@ public class GetDeadlineExtensionsActionTest
 
     private String[] getTypicalParams() {
         return new String[] {
-                Const.ParamsNames.COURSE_ID, COURSE_ID,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, FEEDBACK_SESSION_NAME,
+                Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetDeadlineExtensionsActionTest.java
@@ -16,14 +16,14 @@ import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Student;
 import teammates.ui.output.FeedbackSessionDeadlineExtensionsData;
-import teammates.ui.webapi.GetFeedbackSessionDeadlineExtensionsAction;
+import teammates.ui.webapi.GetDeadlineExtensionsAction;
 import teammates.ui.webapi.JsonResult;
 
 /**
- * SUT: {@link GetFeedbackSessionDeadlineExtensionsAction}.
+ * SUT: {@link GetDeadlineExtensionsAction}.
  */
-public class GetFeedbackSessionDeadlineExtensionsActionTest
-        extends BaseActionTest<GetFeedbackSessionDeadlineExtensionsAction> {
+public class GetDeadlineExtensionsActionTest
+        extends BaseActionTest<GetDeadlineExtensionsAction> {
 
     private static final String COURSE_ID = "course-id";
     private static final String FEEDBACK_SESSION_NAME = "feedback-session-name";
@@ -90,7 +90,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
         when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
-        GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
+        GetDeadlineExtensionsAction action = getAction(getTypicalParams());
         JsonResult result = getJsonResult(action);
 
         FeedbackSessionDeadlineExtensionsData response =
@@ -110,7 +110,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
         when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
-        GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
+        GetDeadlineExtensionsAction action = getAction(getTypicalParams());
         JsonResult result = getJsonResult(action);
 
         FeedbackSessionDeadlineExtensionsData response =
@@ -132,7 +132,7 @@ public class GetFeedbackSessionDeadlineExtensionsActionTest
         when(mockLogic.getInstructorByGoogleId(COURSE_ID, typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
 
-        GetFeedbackSessionDeadlineExtensionsAction action = getAction(getTypicalParams());
+        GetDeadlineExtensionsAction action = getAction(getTypicalParams());
         JsonResult result = getJsonResult(action);
 
         FeedbackSessionDeadlineExtensionsData response =

--- a/src/test/java/teammates/sqlui/webapi/UpdateDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateDeadlineExtensionsActionTest.java
@@ -53,7 +53,7 @@ public class UpdateDeadlineExtensionsActionTest
     }
 
     @BeforeMethod
-    void setUp() throws InvalidParametersException, EntityAlreadyExistsException {
+    void setUp() {
         nearestHour = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.HOURS);
         endHour = Instant.now().plus(2, java.time.temporal.ChronoUnit.HOURS)
                 .truncatedTo(java.time.temporal.ChronoUnit.HOURS);
@@ -79,8 +79,7 @@ public class UpdateDeadlineExtensionsActionTest
         FeedbackSession originalFeedbackSession = generateSession1InCourse(course, instructor);
 
         String[] param = new String[] {
-                Const.ParamsNames.COURSE_ID, originalFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, originalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, originalFeedbackSession.getId().toString(),
                 Const.ParamsNames.NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
@@ -88,7 +87,7 @@ public class UpdateDeadlineExtensionsActionTest
         originalDeadlines.add(new DeadlineExtension(instructor, originalFeedbackSession, nearestHour));
         originalFeedbackSession.setDeadlineExtensions(originalDeadlines);
 
-        when(mockLogic.getFeedbackSession(any(), any())).thenReturn(originalFeedbackSession);
+        when(mockLogic.getFeedbackSession(originalFeedbackSession.getId())).thenReturn(originalFeedbackSession);
 
         FeedbackSessionDeadlineExtensionsUpdateRequest updateRequest =
                 buildUpdateRequest(instructor.getEmail(), endHour);
@@ -101,19 +100,18 @@ public class UpdateDeadlineExtensionsActionTest
 
     @Test
     void testExecute_createDeadlineExtensionEndTime_success()
-            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         loginAsInstructor(instructor.getGoogleId());
         FeedbackSession originalFeedbackSession = generateSession1InCourse(course, instructor);
 
         String[] param = new String[] {
-                Const.ParamsNames.COURSE_ID, originalFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, originalFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, originalFeedbackSession.getId().toString(),
                 Const.ParamsNames.NOTIFY_ABOUT_DEADLINES, String.valueOf(false),
         };
 
         originalFeedbackSession.setDeadlineExtensions(new ArrayList<>());
 
-        when(mockLogic.getFeedbackSession(any(), any())).thenReturn(originalFeedbackSession);
+        when(mockLogic.getFeedbackSession(originalFeedbackSession.getId())).thenReturn(originalFeedbackSession);
         when(mockLogic.getInstructorForEmail(originalFeedbackSession.getCourseId(), instructor.getEmail()))
                 .thenReturn(instructor);
 

--- a/src/test/java/teammates/sqlui/webapi/UpdateDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/UpdateDeadlineExtensionsActionTest.java
@@ -28,13 +28,13 @@ import teammates.storage.sqlentity.DeadlineExtension;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.ui.request.FeedbackSessionDeadlineExtensionsUpdateRequest;
-import teammates.ui.webapi.UpdateFeedbackSessionDeadlineExtensionsAction;
+import teammates.ui.webapi.UpdateDeadlineExtensionsAction;
 
 /**
- * SUT: {@link UpdateFeedbackSessionDeadlineExtensionsAction}.
+ * SUT: {@link UpdateDeadlineExtensionsAction}.
  */
-public class UpdateFeedbackSessionDeadlineExtensionsActionTest
-        extends BaseActionTest<UpdateFeedbackSessionDeadlineExtensionsAction> {
+public class UpdateDeadlineExtensionsActionTest
+        extends BaseActionTest<UpdateDeadlineExtensionsAction> {
 
     private Course course;
     private Instructor instructor;
@@ -92,7 +92,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
 
         FeedbackSessionDeadlineExtensionsUpdateRequest updateRequest =
                 buildUpdateRequest(instructor.getEmail(), endHour);
-        UpdateFeedbackSessionDeadlineExtensionsAction a = getAction(updateRequest, param);
+        UpdateDeadlineExtensionsAction a = getAction(updateRequest, param);
         getJsonResult(a);
 
         verify(mockLogic, times(1)).updateDeadlineExtension(any());
@@ -119,7 +119,7 @@ public class UpdateFeedbackSessionDeadlineExtensionsActionTest
 
         FeedbackSessionDeadlineExtensionsUpdateRequest updateRequest =
                 buildUpdateRequest(instructor.getEmail(), nearestHour);
-        UpdateFeedbackSessionDeadlineExtensionsAction a = getAction(updateRequest, param);
+        UpdateDeadlineExtensionsAction a = getAction(updateRequest, param);
         getJsonResult(a);
 
         verify(mockLogic, times(1)).createDeadlineExtension(any());

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -547,10 +547,9 @@ public abstract class AbstractBackDoor {
      * Gets feedback session deadline extensions data from the database.
      */
     public FeedbackSessionDeadlineExtensionsData getFeedbackSessionDeadlineExtensionsData(
-            String courseId, String feedbackSessionName) {
+            String feedbackSessionId) {
         Map<String, String> params = new HashMap<>();
-        params.put(Const.ParamsNames.COURSE_ID, courseId);
-        params.put(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
+        params.put(Const.ParamsNames.FEEDBACK_SESSION_ID, feedbackSessionId);
 
         ResponseBodyAndCode response = executeGetRequest(Const.ResourceURIs.SESSION_DEADLINE_EXTENSIONS, params);
         if (response.responseCode == HttpStatus.SC_NOT_FOUND) {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -236,8 +236,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             feedbackSessionId: this.feedbackSessionId,
             intent: Intent.FULL_DETAIL,
           }),
-          this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(
-            this.courseId, this.feedbackSessionName),
+          this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
         ]).pipe(finalize(() => {
           this.isLoadingFeedbackSession = false;
         }))

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -476,7 +476,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         const updatedInstructorDeadlines = DeadlineExtensionHelper.getUpdatedDeadlinesForDeletion(
           affectedInstructorModels, this.instructorDeadlines);
         this.feedbackSessionsService.updateFeedbackSessionDeadlineExtensions(
-          this.courseId, this.feedbackSessionName,
+          this.feedbackSessionId,
           { studentDeadlines: updatedStudentDeadlines, instructorDeadlines: updatedInstructorDeadlines },
           isNotifyDeadlines,
         ).subscribe({

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -144,8 +144,7 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
         feedbackSessionId: this.feedbackSessionId,
         intent: Intent.FULL_DETAIL,
       }),
-      this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(
-        this.courseId, this.feedbackSessionName),
+      this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
     ])
       .pipe(finalize(() => {
         this.isLoadingFeedbackSession = false;

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -401,7 +401,7 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
   ): void {
     this.isSubmittingDeadlines = true;
     this.feedbackSessionsService
-      .updateFeedbackSessionDeadlineExtensions(this.courseId, this.feedbackSessionName, request, isNotifyDeadlines)
+      .updateFeedbackSessionDeadlineExtensions(this.feedbackSessionId, request, isNotifyDeadlines)
       .pipe(finalize(() => { this.isSubmittingDeadlines = false; }))
       .subscribe({
         next: () => {

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -114,11 +114,9 @@ export class FeedbackSessionsService {
   /**
    * Gets the deadline extensions for a feedback session by calling API.
    */
-  getFeedbackSessionDeadlineExtensions(
-    courseId: string, feedbackSessionName: string): Observable<FeedbackSessionDeadlineExtensions> {
+  getFeedbackSessionDeadlineExtensions(feedbackSessionId: string): Observable<FeedbackSessionDeadlineExtensions> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
     };
     return this.httpRequestService.get(ResourceEndpoints.SESSION_DEADLINE_EXTENSIONS, paramMap);
   }

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -124,12 +124,11 @@ export class FeedbackSessionsService {
   /**
    * Updates the deadline extensions for a feedback session by calling API.
    */
-  updateFeedbackSessionDeadlineExtensions(courseId: string, feedbackSessionName: string,
+  updateFeedbackSessionDeadlineExtensions(feedbackSessionId: string,
     request: FeedbackSessionDeadlineExtensionsUpdateRequest,
     isNotifyDeadlines: boolean): Observable<FeedbackSessionDeadlineExtensions> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
       notifydeadlines: String(isNotifyDeadlines),
     };
     return this.httpRequestService.put(ResourceEndpoints.SESSION_DEADLINE_EXTENSIONS, paramMap, request);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13738

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Migrate these actions to use feedbackSessionId. They have also been renamed for clarity (since deadline extensions are a distinct entity in our system now).

Note: UpdateDeadlineExtensionsAction has some issues, but I've retained the original behaviour. This action will be cleaned up and re-written in another PR. 