### PR TITLE
[#13721] Add getUserType to User entity

### DIFF
--- a/src/main/java/teammates/common/datatransfer/UserType.java
+++ b/src/main/java/teammates/common/datatransfer/UserType.java
@@ -1,0 +1,9 @@
+package teammates.common.datatransfer;
+
+/**
+ * Represents the type of a user.
+ */
+public enum UserType {
+  INSTRUCTOR,
+  STUDENT,
+}

--- a/src/main/java/teammates/storage/sqlentity/Instructor.java
+++ b/src/main/java/teammates/storage/sqlentity/Instructor.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Table;
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.UserType;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
@@ -50,6 +51,11 @@ public class Instructor extends User {
         this.setDisplayName(displayName);
         this.setRole(role);
         this.setPrivileges(privileges);
+    }
+
+    @Override
+    public UserType getUserType() {
+        return UserType.INSTRUCTOR;
     }
 
     public boolean isDisplayedToStudents() {

--- a/src/main/java/teammates/storage/sqlentity/Student.java
+++ b/src/main/java/teammates/storage/sqlentity/Student.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import teammates.common.datatransfer.UserType;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
@@ -40,6 +41,11 @@ public class Student extends User {
         super(course, name, email);
         this.setComments(comments);
         this.setTeam(team);
+    }
+
+    @Override
+    public UserType getUserType() {
+        return UserType.STUDENT;
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlentity/User.java
+++ b/src/main/java/teammates/storage/sqlentity/User.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import teammates.common.datatransfer.UserType;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
 
@@ -74,6 +75,11 @@ public abstract class User extends BaseEntity {
         this.setEmail(email);
         this.generateNewRegistrationKey();
     }
+
+    /**
+     * Gets the user type of the user.
+     */
+    public abstract UserType getUserType();
 
     public UUID getId() {
         return id;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Adds a getUserType method to User entity. This will allow us to differentiate between Student and Instructor entities, which will allow us to simplify code significantly.

For example, instead of passing both a student and instructor to methods (one of which is null), we can now pass a single user and perform actions based on the user type. 