### PR TITLE
[#13738] Migrate remind session submission and result API to use feedbackSessionId

### DIFF
--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -225,6 +225,13 @@ public class Logic {
     }
 
     /**
+     * Gets user associated with {@code id}.
+     */
+    public User getUser(UUID id) {
+        return usersLogic.getUser(id);
+    }
+
+    /**
      * Gets all students associated with a googleId.
      */
     public List<Student> getStudentsByGoogleId(String googleId) {

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -84,6 +84,13 @@ public final class UsersLogic {
     }
 
     /**
+     * Gets user associated with {@code id}.
+     */
+    public User getUser(UUID id) {
+        return usersDb.getUser(id);
+    }
+
+    /**
      * Create an instructor.
      *
      * @return the created instructor

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -48,6 +48,13 @@ public final class UsersDb {
     }
 
     /**
+     * Gets a user by its {@code id}.
+     */
+    public User getUser(UUID id) {
+        return HibernateUtil.get(User.class, id);
+    }
+
+    /**
      * Creates an instructor.
      */
     public Instructor createInstructor(Instructor instructor)

--- a/src/main/java/teammates/ui/request/FeedbackSessionRespondentRemindRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionRespondentRemindRequest.java
@@ -1,17 +1,19 @@
 package teammates.ui.request;
 
+import java.util.UUID;
+
 /**
  * Sends a reminder email each to a list of respondents from a feedback session.
  */
 public class FeedbackSessionRespondentRemindRequest extends BasicRequest {
-    private String[] usersToRemind;
+    private UUID[] usersToRemind;
     private boolean isSendingCopyToInstructor;
 
-    public String[] getUsersToRemind() {
+    public UUID[] getUsersToRemind() {
         return usersToRemind;
     }
 
-    public void setUsersToRemind(String[] usersToRemind) {
+    public void setUsersToRemind(UUID[] usersToRemind) {
         this.usersToRemind = usersToRemind;
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -3,12 +3,14 @@ package teammates.ui.webapi;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.User;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 
@@ -23,20 +25,26 @@ public class RemindFeedbackSessionResultAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
-        Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
+
+        Instructor instructor = sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
+
         if (!feedbackSession.isPublished()) {
             throw new InvalidOperationException("Published email could not be resent "
                     + "as the feedback session is not published.");
@@ -44,30 +52,32 @@ public class RemindFeedbackSessionResultAction extends Action {
 
         FeedbackSessionRespondentRemindRequest remindRequest =
                 getAndValidateRequestBody(FeedbackSessionRespondentRemindRequest.class);
-        String[] usersToEmail = remindRequest.getUsersToRemind();
+        UUID[] usersToRemind = remindRequest.getUsersToRemind();
 
         // Generate reminder emails for specified users
-        List<Student> studentsToEmailList = new ArrayList<>();
-        List<Instructor> instructorsToEmailList = new ArrayList<>();
-        Instructor instructorToNotify = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+        List<Student> studentsToRemindList = new ArrayList<>();
+        List<Instructor> instructorsToRemindList = new ArrayList<>();
+        Instructor instructorToNotify = sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
 
-        for (String userEmail : usersToEmail) {
-            Student student = sqlLogic.getStudentForEmail(courseId, userEmail);
-            if (student != null) {
-                studentsToEmailList.add(student);
+        for (UUID userId : usersToRemind) {
+            User user = sqlLogic.getUser(userId);
+            if (user == null) {
+                throw new EntityNotFoundException("User with ID " + userId + " not found");
             }
 
-            Instructor instructor = sqlLogic.getInstructorForEmail(courseId, userEmail);
-            if (instructor != null) {
-                instructorsToEmailList.add(instructor);
+            if (user instanceof Student student) {
+                studentsToRemindList.add(student);
+            } else if (user instanceof Instructor instructor) {
+                instructorsToRemindList.add(instructor);
             }
         }
+
         List<EmailWrapper> emails = sqlEmailGenerator.generateFeedbackSessionPublishedEmails(
-                feedbackSession, studentsToEmailList, instructorsToEmailList,
+                feedbackSession, studentsToRemindList, instructorsToRemindList,
                 Collections.singletonList(instructorToNotify));
 
-        // Queue to priority queue for immediate sending (user-triggered)
         taskQueuer.scheduleEmailsForPrioritySending(emails);
+
         return new JsonResult("Reminders sent");
     }
 }

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import teammates.common.util.Const;
@@ -63,6 +64,11 @@ public class RemindFeedbackSessionResultAction extends Action {
             User user = sqlLogic.getUser(userId);
             if (user == null) {
                 throw new EntityNotFoundException("User with ID " + userId + " not found");
+            }
+
+            if (!Objects.equals(user.getCourseId(), feedbackSession.getCourseId())) {
+                throw new InvalidOperationException("User with ID "
+                    + userId + " does not belong to the same course as the feedback session");
             }
 
             if (user instanceof Student student) {

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -2,12 +2,14 @@ package teammates.ui.webapi;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.sqlentity.FeedbackSession;
 import teammates.storage.sqlentity.Instructor;
 import teammates.storage.sqlentity.Student;
+import teammates.storage.sqlentity.User;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 
@@ -23,12 +25,14 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
 
-        Instructor instructor = sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
         gateKeeper.verifyAccessible(
                 instructor,
                 feedbackSession,
@@ -37,10 +41,12 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(feedbackSessionName, courseId);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("Feedback session not found");
+        }
 
         if (!feedbackSession.isOpened()) {
             throw new InvalidOperationException("Reminder email could not be sent out "
@@ -49,24 +55,25 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
 
         FeedbackSessionRespondentRemindRequest remindRequest =
                 getAndValidateRequestBody(FeedbackSessionRespondentRemindRequest.class);
-        String[] usersToRemind = remindRequest.getUsersToRemind();
+        UUID[] usersToRemind = remindRequest.getUsersToRemind();
         boolean isSendingCopyToInstructor = remindRequest.getIsSendingCopyToInstructor();
 
         // Generate reminder emails for specified users
         List<Student> studentsToRemindList = new ArrayList<>();
         List<Instructor> instructorsToRemindList = new ArrayList<>();
         Instructor instructorToNotify = isSendingCopyToInstructor
-                ? sqlLogic.getInstructorByGoogleId(courseId, userInfo.getId())
+                ? sqlLogic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId())
                 : null;
 
-        for (String userEmail : usersToRemind) {
-            Student student = sqlLogic.getStudentForEmail(courseId, userEmail);
-            if (student != null) {
-                studentsToRemindList.add(student);
+        for (UUID userId : usersToRemind) {
+            User user = sqlLogic.getUser(userId);
+            if (user == null) {
+                throw new EntityNotFoundException("User with ID " + userId + " not found");
             }
 
-            Instructor instructor = sqlLogic.getInstructorForEmail(courseId, userEmail);
-            if (instructor != null) {
+            if (user instanceof Student student) {
+                studentsToRemindList.add(student);
+            } else if (user instanceof Instructor instructor) {
                 instructorsToRemindList.add(instructor);
             }
         }
@@ -74,7 +81,6 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         List<EmailWrapper> emails = sqlEmailGenerator.generateFeedbackSessionReminderEmails(
                 feedbackSession, studentsToRemindList, instructorsToRemindList, instructorToNotify);
 
-        // Queue to priority queue for immediate sending (user-triggered)
         taskQueuer.scheduleEmailsForPrioritySending(emails);
 
         return new JsonResult("Reminders sent");

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import teammates.common.util.Const;
@@ -69,6 +70,11 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
             User user = sqlLogic.getUser(userId);
             if (user == null) {
                 throw new EntityNotFoundException("User with ID " + userId + " not found");
+            }
+
+            if (!Objects.equals(user.getCourseId(), feedbackSession.getCourseId())) {
+                throw new InvalidOperationException("User with ID "
+                    + userId + " does not belong to the same course as the feedback session");
             }
 
             if (user instanceof Student student) {

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionResultActionTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -67,15 +68,14 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
     protected void testExecute_feedbackSessionNotPublished_warningMessage() {
         FeedbackSession unpublishedFeedbackSession = generateUnpublishedSessionInCourse(course, instructor);
 
-        when(mockLogic.getFeedbackSession(isA(String.class), isA(String.class)))
+        when(mockLogic.getFeedbackSession(unpublishedFeedbackSession.getId()))
                 .thenReturn(unpublishedFeedbackSession);
 
         String[] paramsFeedbackSessionNotPublished = new String[] {
-                Const.ParamsNames.COURSE_ID, unpublishedFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, unpublishedFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, unpublishedFeedbackSession.getId().toString(),
         };
 
-        String[] usersToRemind = {instructor.getEmail(), student.getEmail()};
+        UUID[] usersToRemind = {instructor.getId(), student.getId()};
         FeedbackSessionRespondentRemindRequest remindRequest = new FeedbackSessionRespondentRemindRequest();
         remindRequest.setUsersToRemind(usersToRemind);
 
@@ -92,20 +92,19 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
 
-        when(mockLogic.getFeedbackSession(isA(String.class), isA(String.class)))
+        when(mockLogic.getFeedbackSession(publishedFeedbackSession.getId()))
                 .thenReturn(publishedFeedbackSession);
-        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
-        when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
+        when(mockLogic.getUser(student.getId())).thenReturn(student);
+        when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockSqlEmailGenerator.generateFeedbackSessionPublishedEmails(
                 isA(FeedbackSession.class), anyList(), anyList(), anyList()))
                 .thenReturn(List.of(mockEmail));
 
         String[] paramsTypical = new String[] {
-                Const.ParamsNames.COURSE_ID, publishedFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, publishedFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, publishedFeedbackSession.getId().toString(),
         };
 
-        String[] usersToRemind = {instructor.getEmail(), student.getEmail()};
+        UUID[] usersToRemind = {instructor.getId(), student.getId()};
         FeedbackSessionRespondentRemindRequest remindRequest = new FeedbackSessionRespondentRemindRequest();
         remindRequest.setUsersToRemind(usersToRemind);
 

--- a/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/RemindFeedbackSessionSubmissionActionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -67,15 +68,14 @@ public class RemindFeedbackSessionSubmissionActionTest
     protected void testExecute_feedbackSessionNotPublished_warningMessage() {
         FeedbackSession closedFeedbackSession = generateClosedSessionInCourse(course, instructor);
 
-        when(mockLogic.getFeedbackSession(isA(String.class), isA(String.class)))
+        when(mockLogic.getFeedbackSession(closedFeedbackSession.getId()))
                 .thenReturn(closedFeedbackSession);
 
         String[] paramsFeedbackSessionNotOpen = new String[] {
-                Const.ParamsNames.COURSE_ID, closedFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, closedFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, closedFeedbackSession.getId().toString(),
         };
 
-        String[] usersToRemind = {instructor.getEmail(), student.getEmail()};
+        UUID[] usersToRemind = {instructor.getId(), student.getId()};
         FeedbackSessionRespondentRemindRequest remindRequest = new FeedbackSessionRespondentRemindRequest();
         remindRequest.setUsersToRemind(usersToRemind);
 
@@ -91,21 +91,20 @@ public class RemindFeedbackSessionSubmissionActionTest
         FeedbackSession openedFeedbackSession = generateOpenedSessionInCourse(course, instructor);
         EmailWrapper mockEmail = mock(EmailWrapper.class);
 
-        when(mockLogic.getFeedbackSession(isA(String.class), isA(String.class)))
+        when(mockLogic.getFeedbackSession(openedFeedbackSession.getId()))
                 .thenReturn(openedFeedbackSession);
-        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
-        when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
+        when(mockLogic.getUser(student.getId())).thenReturn(student);
+        when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockSqlEmailGenerator.generateFeedbackSessionReminderEmails(
                 isA(FeedbackSession.class), anyList(), anyList(), isNull()))
                 .thenReturn(List.of(mockEmail));
 
-        String[] usersToRemind = {instructor.getEmail(), student.getEmail()};
+        UUID[] usersToRemind = {instructor.getId(), student.getId()};
         FeedbackSessionRespondentRemindRequest remindRequest = new FeedbackSessionRespondentRemindRequest();
         remindRequest.setUsersToRemind(usersToRemind);
 
         String[] paramsTypical = new String[] {
-                Const.ParamsNames.COURSE_ID, openedFeedbackSession.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, openedFeedbackSession.getName(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, openedFeedbackSession.getId().toString(),
         };
 
         RemindFeedbackSessionSubmissionAction validAction = getAction(remindRequest, paramsTypical);

--- a/src/web/app/components/sessions-table/resend-results-link-to-respondent-modal/resend-results-link-to-respondent-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/resend-results-link-to-respondent-modal/resend-results-link-to-respondent-modal.component.spec.ts
@@ -66,9 +66,9 @@ describe('ResendResultsLinkToRespondentModalComponent', () => {
     ];
 
     const expectedModels = [
-      studentModelBuilder.id('61aa0796-9513-49ae-9c48-eac426625b04').email('student1@gmail.com').isSelected(true).build(),
-      studentModelBuilder.id('446f0b3f-d8f2-4afa-95bd-f703f5f3db5e').email('student3@gmail.com').isSelected(true).build(),
-      instructorModelBuilder.id('24a0b376-0bd7-4ca4-8ed9-3f362b7176bd').email('instructor2@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('ddd32f6b-e86e-42a1-868b-0e9da107fce6').email('student1@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('c0bb4887-99c0-46fb-9bb2-b8ed8305021c').email('student3@gmail.com').isSelected(true).build(),
+      instructorModelBuilder.id('246f2052-1c08-48e7-b0cd-a4c052d0dda1').email('instructor2@gmail.com').isSelected(true).build(),
     ];
 
     component.studentListInfoTableRowModels = studentListInfoTableRowModels;

--- a/src/web/app/components/sessions-table/resend-results-link-to-respondent-modal/resend-results-link-to-respondent-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/resend-results-link-to-respondent-modal/resend-results-link-to-respondent-modal.component.spec.ts
@@ -14,6 +14,7 @@ describe('ResendResultsLinkToRespondentModalComponent', () => {
   let fixture: ComponentFixture<ResendResultsLinkToRespondentModalComponent>;
 
   const studentModelBuilder = createBuilder<StudentListInfoTableRowModel>({
+    id: 'ee47e471-fbd8-478e-a350-51152802215b',
     email: 'student@gmail.com',
     name: 'Student',
     teamName: 'Team A',
@@ -23,6 +24,7 @@ describe('ResendResultsLinkToRespondentModalComponent', () => {
   });
 
   const instructorModelBuilder = createBuilder<InstructorListInfoTableRowModel>({
+    id: '71a1ceac-d24a-4f34-9593-e25ecbeff847',
     email: 'instructor@gmail.com',
     name: 'Instructor',
     hasSubmittedSession: false,
@@ -53,20 +55,20 @@ describe('ResendResultsLinkToRespondentModalComponent', () => {
   it('collateRespondentsToSendHandler: should return an array containing only selected rows'
     + 'from student and instructor lists', () => {
     const studentListInfoTableRowModels: StudentListInfoTableRowModel[] = [
-      studentModelBuilder.email('student1@gmail.com').isSelected(true).build(),
-      studentModelBuilder.email('student2@gmail.com').isSelected(false).build(),
-      studentModelBuilder.email('student3@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('ddd32f6b-e86e-42a1-868b-0e9da107fce6').email('student1@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('94e6a227-c731-482b-bd8d-acdbc74e3e53').email('student2@gmail.com').isSelected(false).build(),
+      studentModelBuilder.id('c0bb4887-99c0-46fb-9bb2-b8ed8305021c').email('student3@gmail.com').isSelected(true).build(),
     ];
 
     const instructorListInfoTableRowModels: InstructorListInfoTableRowModel[] = [
-      instructorModelBuilder.email('instructor1@gmail.com').isSelected(false).build(),
-      instructorModelBuilder.email('instructor2@gmail.com').isSelected(true).build(),
+      instructorModelBuilder.id('95404edf-53f6-4f93-9100-ac82beb651ea').email('instructor1@gmail.com').isSelected(false).build(),
+      instructorModelBuilder.id('246f2052-1c08-48e7-b0cd-a4c052d0dda1').email('instructor2@gmail.com').isSelected(true).build(),
     ];
 
     const expectedModels = [
-      studentModelBuilder.email('student1@gmail.com').isSelected(true).build(),
-      studentModelBuilder.email('student3@gmail.com').isSelected(true).build(),
-      instructorModelBuilder.email('instructor2@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('61aa0796-9513-49ae-9c48-eac426625b04').email('student1@gmail.com').isSelected(true).build(),
+      studentModelBuilder.id('446f0b3f-d8f2-4afa-95bd-f703f5f3db5e').email('student3@gmail.com').isSelected(true).build(),
+      instructorModelBuilder.id('24a0b376-0bd7-4ca4-8ed9-3f362b7176bd').email('instructor2@gmail.com').isSelected(true).build(),
     ];
 
     component.studentListInfoTableRowModels = studentListInfoTableRowModels;

--- a/src/web/app/components/sessions-table/respondent-list-info-table/respondent-list-info-table-model.ts
+++ b/src/web/app/components/sessions-table/respondent-list-info-table/respondent-list-info-table-model.ts
@@ -2,6 +2,7 @@
  * The model for a row of the student list info table.
  */
 export interface StudentListInfoTableRowModel {
+  id: string;
   email: string;
   name: string;
   teamName: string;
@@ -16,6 +17,7 @@ export interface StudentListInfoTableRowModel {
  * The model for a row of the instructor list info table.
  */
 export interface InstructorListInfoTableRowModel {
+  id: string;
   email: string;
   name: string;
 

--- a/src/web/app/components/sessions-table/respondent-list-info-table/respondent-list-info-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/respondent-list-info-table/respondent-list-info-table.component.spec.ts
@@ -16,6 +16,7 @@ describe('StudentListInfoTableComponent', () => {
   const instructorTableId = '#instructor-list-table';
 
   const studentModelBuilder = createBuilder<StudentListInfoTableRowModel>({
+    id: 'bd7e9a08-39cd-4a6c-87d1-a8bb63c3304a',
     email: 'student@gmail.com',
     name: 'Student',
     teamName: 'Team A',
@@ -25,6 +26,7 @@ describe('StudentListInfoTableComponent', () => {
   });
 
   const instructorModelBuilder = createBuilder<InstructorListInfoTableRowModel>({
+    id: 'd9c8b955-c01f-4085-84f1-18cc48446b2e',
     email: 'instructor@gmail.com',
     name: 'Instructor',
     hasSubmittedSession: false,

--- a/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-respondents-modal/send-reminders-to-respondents-modal.component.spec.ts
@@ -14,6 +14,7 @@ describe('SendRemindersToRespondentsModalComponent', () => {
   let fixture: ComponentFixture<SendRemindersToRespondentsModalComponent>;
 
   const studentModelBuilder = createBuilder<StudentListInfoTableRowModel>({
+    id: 'd6a66c69-6ea6-4d7b-84f0-7701277503e4',
     email: 'student@gmail.com',
     name: 'Student',
     teamName: 'Team A',
@@ -23,6 +24,7 @@ describe('SendRemindersToRespondentsModalComponent', () => {
   });
 
   const instructorModelBuilder = createBuilder<InstructorListInfoTableRowModel>({
+    id: '76a78858-f8bd-4b30-81b7-7a0c541cc0b0',
     email: 'instructor@gmail.com',
     name: 'Instructor',
     hasSubmittedSession: false,

--- a/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
@@ -67,8 +67,9 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
    */
   resendResultsLinkToRespondentsEventHandler(model: SessionsTableRowModel): void {
     this.isSendReminderLoading = true;
-    const courseId: string = model.feedbackSession.courseId;
-    const feedbackSessionName: string = model.feedbackSession.feedbackSessionName;
+    const courseId = model.feedbackSession.courseId;
+    const feedbackSessionName = model.feedbackSession.feedbackSessionName;
+    const feedbackSessionId = model.feedbackSession.feedbackSessionId;
 
     forkJoin([
       this.studentService.getStudentsFromCourse({ courseId }),
@@ -86,6 +87,7 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
           modalRef.componentInstance.courseId = courseId;
           modalRef.componentInstance.feedbackSessionName = feedbackSessionName;
           modalRef.componentInstance.studentListInfoTableRowModels = students.map((student: Student) => ({
+            id: student.userId,
             email: student.email,
             name: student.name,
             teamName: student.teamName,
@@ -94,20 +96,22 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
             hasSubmittedSession: false,
 
             isSelected: false,
-          } as StudentListInfoTableRowModel));
+          } satisfies StudentListInfoTableRowModel));
           modalRef.componentInstance.instructorListInfoTableRowModels = instructors.map((instructor: Instructor) => ({
+            id: instructor.userId,
             email: instructor.email,
             name: instructor.name,
 
             hasSubmittedSession: false,
 
             isSelected: false,
-          } as InstructorListInfoTableRowModel));
+          } satisfies InstructorListInfoTableRowModel));
 
-          modalRef.result.then((respondentsToRemind: any[]) => {
+          modalRef.result.then(
+              (respondentsToRemind: (StudentListInfoTableRowModel | InstructorListInfoTableRowModel)[]) => {
             this.isSendReminderLoading = true;
-            this.feedbackSessionsService.remindResultsLinkToRespondents(courseId, feedbackSessionName, {
-              usersToRemind: respondentsToRemind.map((m: any) => m.email), isSendingCopyToInstructor: true,
+            this.feedbackSessionsService.remindResultsLinkToRespondents(feedbackSessionId, {
+              usersToRemind: respondentsToRemind.map((m) => m.id), isSendingCopyToInstructor: true,
             }).pipe(finalize(() => {
               this.isSendReminderLoading = false;
             }))
@@ -134,8 +138,9 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
    */
   sendRemindersToRespondentsEventHandler(model: SessionsTableRowModel, selectAllRespondents: boolean): void {
     this.isSendReminderLoading = true;
-    const courseId: string = model.feedbackSession.courseId;
-    const feedbackSessionName: string = model.feedbackSession.feedbackSessionName;
+    const courseId = model.feedbackSession.courseId;
+    const feedbackSessionName = model.feedbackSession.feedbackSessionName;
+    const feedbackSessionId = model.feedbackSession.feedbackSessionId;
 
     forkJoin([
       this.studentService.getStudentsFromCourse({ courseId }),
@@ -154,6 +159,7 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
         modalRef.componentInstance.courseId = courseId;
         modalRef.componentInstance.feedbackSessionName = feedbackSessionName;
         modalRef.componentInstance.studentListInfoTableRowModels = students.map((student: Student) => ({
+          id: student.userId,
           email: student.email,
           name: student.name,
           teamName: student.teamName,
@@ -162,20 +168,21 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
           hasSubmittedSession: giverSet.has(student.email),
 
           isSelected: selectAllRespondents && !giverSet.has(student.email),
-        } as StudentListInfoTableRowModel));
+        } satisfies StudentListInfoTableRowModel));
         modalRef.componentInstance.instructorListInfoTableRowModels = instructors.map((instructor: Instructor) => ({
+          id: instructor.userId,
           email: instructor.email,
           name: instructor.name,
 
           hasSubmittedSession: giverSet.has(instructor.email),
 
           isSelected: selectAllRespondents && !giverSet.has(instructor.email),
-        } as InstructorListInfoTableRowModel));
+        } satisfies InstructorListInfoTableRowModel));
 
         modalRef.result.then((reminderResponse: ReminderResponseModel) => {
           this.isSendReminderLoading = true;
-          this.feedbackSessionsService.remindFeedbackSessionSubmissionForRespondents(courseId, feedbackSessionName, {
-            usersToRemind: reminderResponse.respondentsToSend.map((m) => m.email),
+          this.feedbackSessionsService.remindFeedbackSessionSubmissionForRespondents(feedbackSessionId, {
+            usersToRemind: reminderResponse.respondentsToSend.map((m) => m.id),
             isSendingCopyToInstructor: reminderResponse.isSendingCopyToInstructor,
           }).pipe(finalize(() => {
             this.isSendReminderLoading = false;

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -110,6 +110,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
     modalRef.componentInstance.feedbackSessionName = feedbackSessionName;
     modalRef.componentInstance.studentListInfoTableRowModels =
       this.allStudents.map((student: Student) => ({
+        id: student.userId,
         email: student.email,
         name: student.name,
         teamName: student.teamName,
@@ -117,7 +118,7 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
 
         hasSubmittedSession: !nonResponseStudentEmailSet.has(student.email),
         isSelected: nonResponseStudentEmailSet.has(student.email),
-      } as StudentListInfoTableRowModel));
+      } satisfies StudentListInfoTableRowModel));
 
     modalRef.result.then((reminderResponse: ReminderResponseModel) => {
       this.studentsToRemindEvent.emit(reminderResponse);

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -642,8 +642,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
    */
   sendReminderToStudents(reminderResponse: ReminderResponseModel): void {
     this.feedbackSessionsService
-      .remindFeedbackSessionSubmissionForRespondents(this.session.courseId, this.session.feedbackSessionName, {
-        usersToRemind: reminderResponse.respondentsToSend.map((m) => m.email),
+      .remindFeedbackSessionSubmissionForRespondents(this.session.feedbackSessionId, {
+        usersToRemind: reminderResponse.respondentsToSend.map((m) => m.id),
         isSendingCopyToInstructor: reminderResponse.isSendingCopyToInstructor,
       })
         .subscribe({

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -246,11 +246,10 @@ export class FeedbackSessionsService {
    * Sends e-mails to remind respondents who have not submitted their feedback.
    */
   remindFeedbackSessionSubmissionForRespondents(
-      courseId: string, feedbackSessionName: string, request: FeedbackSessionRespondentRemindRequest)
+      feedbackSessionId: string, request: FeedbackSessionRespondentRemindRequest)
       : Observable<MessageOutput> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
     };
 
     return this.httpRequestService.post(ResourceEndpoints.SESSION_REMIND_SUBMISSION, paramMap, request);
@@ -260,11 +259,10 @@ export class FeedbackSessionsService {
    * Sends e-mails to remind respondents on the published results link.
    */
   remindResultsLinkToRespondents(
-      courseId: string, feedbackSessionName: string, request: FeedbackSessionRespondentRemindRequest)
+      feedbackSessionId: string, request: FeedbackSessionRespondentRemindRequest)
       : Observable<MessageOutput> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      fsname: feedbackSessionName,
+      fsid: feedbackSessionId,
     };
 
     return this.httpRequestService.post(ResourceEndpoints.SESSION_REMIND_RESULT, paramMap, request);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13738

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Migrate endpoints to use feedbackSessionId. Also modified endpoint to take in userId instead of userEmail as userEmail no longer (has never) uniquely identified a user (a user can be both an instructor and student). 