### PR TITLE
[#13738] Migrate CreateFeedbackSessionLogAction to use feedbackSessionId

### DIFF
--- a/src/it/java/teammates/it/sqllogic/core/FeedbackSessionLogsLogicIT.java
+++ b/src/it/java/teammates/it/sqllogic/core/FeedbackSessionLogsLogicIT.java
@@ -38,23 +38,13 @@ public class FeedbackSessionLogsLogicIT extends BaseTestCaseWithSqlDatabaseAcces
 
     @Test
         public void test_createFeedbackSessionLog_success() throws InvalidParametersException {
-        Course course = typicalDataBundle.courses.get("course1");
         FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
         Student student = typicalDataBundle.students.get("student1InCourse1");
         Instant timestamp = Instant.now();
-        FeedbackSessionLog newLog1 = new FeedbackSessionLog(student, fs, FeedbackSessionLogType.ACCESS, timestamp);
-        FeedbackSessionLog newLog2 = new FeedbackSessionLog(student, fs, FeedbackSessionLogType.SUBMISSION, timestamp);
-        FeedbackSessionLog newLog3 = new FeedbackSessionLog(student, fs, FeedbackSessionLogType.VIEW_RESULT, timestamp);
-        List<FeedbackSessionLog> expected = List.of(newLog1, newLog2, newLog3);
 
-        for (FeedbackSessionLog log : expected) {
-            fslLogic.createFeedbackSessionLog(log);
-        }
+        FeedbackSessionLog log = fslLogic.createFeedbackSessionLog(fs, student, FeedbackSessionLogType.ACCESS, timestamp);
 
-        List<FeedbackSessionLog> actual = fslLogic.getOrderedFeedbackSessionLogs(course.getId(), student.getId(),
-                fs.getId(), timestamp, timestamp.plusSeconds(1));
-
-        assertEquals(expected, actual);
+        assertNotNull(fslLogic.getFeedbackSessionLog(log.getId()));
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/CleanupFeedbackSessionLogsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CleanupFeedbackSessionLogsActionIT.java
@@ -65,30 +65,30 @@ public class CleanupFeedbackSessionLogsActionIT extends BaseActionIT<CleanupFeed
         FeedbackSessionLog oldLog = new FeedbackSessionLog(student, feedbackSession,
                 typicalBundle.feedbackSessionLogs.get("student1Session1Log1").getFeedbackSessionLogType(),
                 oldTimestamp);
-        logic.createFeedbackSessionLog(oldLog);
+        HibernateUtil.persist(oldLog);
 
         FeedbackSessionLog atCutoffLog = new FeedbackSessionLog(student, feedbackSession,
                 typicalBundle.feedbackSessionLogs.get("student1Session1Log1").getFeedbackSessionLogType(),
                 atCutoffTimestamp);
-        logic.createFeedbackSessionLog(atCutoffLog);
+        HibernateUtil.persist(atCutoffLog);
 
         // Create log just inside the 90-day boundary (should be preserved)
         FeedbackSessionLog boundaryLog = new FeedbackSessionLog(student, feedbackSession,
                 typicalBundle.feedbackSessionLogs.get("student1Session1Log1").getFeedbackSessionLogType(),
                 boundaryTimestamp);
-        logic.createFeedbackSessionLog(boundaryLog);
+        HibernateUtil.persist(boundaryLog);
 
         // Create log within retention period (should be preserved)
         FeedbackSessionLog recentLog = new FeedbackSessionLog(student, feedbackSession,
                 typicalBundle.feedbackSessionLogs.get("student1Session1Log1").getFeedbackSessionLogType(),
                 recentTimestamp);
-        logic.createFeedbackSessionLog(recentLog);
+        HibernateUtil.persist(recentLog);
 
         // Create very recent log (should be preserved)
         FeedbackSessionLog veryRecentLog = new FeedbackSessionLog(student, feedbackSession,
                 typicalBundle.feedbackSessionLogs.get("student1Session1Log1").getFeedbackSessionLogType(),
                 veryRecentTimestamp);
-        logic.createFeedbackSessionLog(veryRecentLog);
+        HibernateUtil.persist(veryRecentLog);
 
         HibernateUtil.flushSession();
         HibernateUtil.clearSession();

--- a/src/it/java/teammates/it/ui/webapi/CreateFeedbackSessionLogActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateFeedbackSessionLogActionIT.java
@@ -52,172 +52,90 @@ public class CreateFeedbackSessionLogActionIT extends BaseActionIT<CreateFeedbac
         FeedbackSession fs2 = typicalBundle.feedbackSessions.get("session2InTypicalCourse");
         Student student1 = typicalBundle.students.get("student1InCourse1");
         Student student2 = typicalBundle.students.get("student2InCourse1");
-        Student student3 = typicalBundle.students.get("student1InCourse3");
+
+        loginAsStudent(student1.getAccount().getGoogleId());
 
         ______TS("Failure case: not enough parameters");
-        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, courseId1);
+        verifyHttpParameterFailure();
         verifyHttpParameterFailure(
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName()
-        );
+                Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString());
         verifyHttpParameterFailure(
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail()
-        );
-        verifyHttpParameterFailure(
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail()
-        );
-        verifyHttpParameterFailure(
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fs2.getId().toString(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_SQL_ID, student2.getId().toString()
-        );
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name());
 
         ______TS("Failure case: invalid log type");
         String[] paramsInvalid = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, "invalid log type",
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
         };
         verifyHttpParameterFailure(paramsInvalid);
 
         ______TS("Success case: typical access");
         String[] paramsSuccessfulAccess = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
         };
         JsonResult response = getJsonResult(getAction(paramsSuccessfulAccess));
         MessageOutput output = (MessageOutput) response.getOutput();
         assertEquals("Successful", output.getMessage());
 
-        List<FeedbackSessionLog> persistedAccessLogs = logic.getOrderedFeedbackSessionLogs(courseId1, student1.getId(),
+        List<FeedbackSessionLog> persistedAccessLogs = logic.getOrderedFeedbackSessionLogs(courseId1,
+                student1.getId(),
                 fs1.getId(), Instant.now().minusSeconds(60), Instant.now().plusSeconds(60));
-        assertEquals(persistedAccessLogs.size(), 1);
-        assertEquals(persistedAccessLogs.get(0).getFeedbackSessionLogType(), FeedbackSessionLogType.ACCESS);
+        assertEquals(1, persistedAccessLogs.size());
+        assertEquals(fs1.getId(), persistedAccessLogs.get(0).getFeedbackSession().getId());
+        assertEquals(student1.getId(), persistedAccessLogs.get(0).getStudent().getId());
+        assertEquals(FeedbackSessionLogType.ACCESS, persistedAccessLogs.get(0).getFeedbackSessionLogType());
 
         ______TS("Success case: typical submission");
+        loginAsStudent(student2.getAccount().getGoogleId());
+
         String[] paramsSuccessfulSubmission = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs2.getName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student2.getEmail(),
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fs2.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student2.getId().toString(),
         };
         response = getJsonResult(getAction(paramsSuccessfulSubmission));
         output = (MessageOutput) response.getOutput();
         assertEquals("Successful", output.getMessage());
 
         List<FeedbackSessionLog> persistedSubmissionLogs = logic.getOrderedFeedbackSessionLogs(courseId1,
-                student2.getId(), fs2.getId(), Instant.now().minusSeconds(60), Instant.now().plusSeconds(60));
-        assertEquals(persistedSubmissionLogs.size(), 1);
-        assertEquals(persistedSubmissionLogs.get(0).getFeedbackSessionLogType(), FeedbackSessionLogType.SUBMISSION);
-
-        ______TS("Success case: should create even for invalid parameters");
-        String[] paramsNonExistentCourseId = {
-                Const.ParamsNames.COURSE_ID, "non-existent-course-id",
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
-        };
-        response = getJsonResult(getAction(paramsNonExistentCourseId));
-        output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-        assertEquals(logic.getOrderedFeedbackSessionLogs(courseId1, null, null, Instant.now().minusSeconds(60),
-                Instant.now().plusSeconds(60)).size(), 3);
+                student2.getId(), fs2.getId(), Instant.now().minusSeconds(60),
+                Instant.now().plusSeconds(60));
+        assertEquals(1, persistedSubmissionLogs.size());
+        assertEquals(fs2.getId(), persistedSubmissionLogs.get(0).getFeedbackSession().getId());
+        assertEquals(student2.getId(), persistedSubmissionLogs.get(0).getStudent().getId());
+        assertEquals(FeedbackSessionLogType.SUBMISSION,
+                persistedSubmissionLogs.get(0).getFeedbackSessionLogType());
 
         ______TS("Failure case: should fail for missing feedback session");
         String[] paramsNonExistentFsName = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, "non-existent-feedback-session-name",
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
                 Const.ParamsNames.FEEDBACK_SESSION_ID, UUID.randomUUID().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
         };
         verifyHttpParameterFailure(paramsNonExistentFsName);
-        assertEquals(logic.getOrderedFeedbackSessionLogs(courseId1, null, null, Instant.now().minusSeconds(60),
-                Instant.now().plusSeconds(60)).size(), 3);
-
-        ______TS("Failure case: should fail for missing student");
-        String[] paramsNonExistentStudentEmail = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, "non-existent-student@email.com",
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, UUID.randomUUID().toString(),
-        };
-        verifyHttpParameterFailure(paramsNonExistentStudentEmail);
-        assertEquals(logic.getOrderedFeedbackSessionLogs(courseId1, null, null, Instant.now().minusSeconds(60),
-                Instant.now().plusSeconds(60)).size(), 3);
-
-        ______TS("Failure case: should fail when student does not belong to feedback session course");
-        String[] paramsWithoutAccess = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student3.getEmail(),
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student3.getId().toString(),
-        };
-        verifyHttpParameterFailure(paramsWithoutAccess);
-        assertEquals(logic.getOrderedFeedbackSessionLogs(courseId1, student3.getId(), fs1.getId(),
-                Instant.now().minusSeconds(60), Instant.now().plusSeconds(60)).size(), 0);
-
-        ______TS("Success case: different log type should still be persisted");
-        String[] paramsViewResult = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.VIEW_RESULT.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
-        };
-        response = getJsonResult(getAction(paramsViewResult));
-        output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-
-        List<FeedbackSessionLog> allStudent1Session1Logs = logic.getOrderedFeedbackSessionLogs(courseId1,
-                student1.getId(), fs1.getId(), Instant.now().minusSeconds(60), Instant.now().plusSeconds(60));
-        assertEquals(allStudent1Session1Logs.size(), 3);
-        assertTrue(allStudent1Session1Logs.stream()
-                .anyMatch(logEntry -> logEntry.getFeedbackSessionLogType() == FeedbackSessionLogType.VIEW_RESULT));
+        assertEquals(2, logic
+                .getOrderedFeedbackSessionLogs(courseId1, null, null, Instant.now().minusSeconds(60),
+                        Instant.now().plusSeconds(60))
+                .size());
     }
 
     @Test
     @Override
     protected void testAccessControl() throws Exception {
         Student student1 = typicalBundle.students.get("student1InCourse1");
-        Student student2 = typicalBundle.students.get("student2InCourse1");
         FeedbackSession fs1 = typicalBundle.feedbackSessions.get("session1InCourse1");
+        FeedbackSession fs2 = typicalBundle.feedbackSessions.get("ongoingSession1InCourse3");
         String[] params = {
-                Const.ParamsNames.COURSE_ID, student1.getCourseId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fs1.getName(),
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1.getEmail(),
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
-                Const.ParamsNames.STUDENT_SQL_ID, student1.getId().toString(),
         };
 
         loginAsStudent(student1.getAccount().getGoogleId());
         verifyCanAccess(params);
 
-        loginAsStudent(student2.getAccount().getGoogleId());
+        params = new String[] {
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, fs2.getId().toString(),
+        };
         verifyCannotAccess(params);
 
         verifyInaccessibleForUnregisteredUsers(params);

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -16,6 +16,7 @@ import teammates.common.datatransfer.FeedbackResultFetchType;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SessionResultsBundle;
+import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -1592,10 +1593,12 @@ public class Logic {
     }
 
     /**
-     * Create feedback session log.
+     * Creates feedback session log.
      */
-    public void createFeedbackSessionLog(FeedbackSessionLog feedbackSessionLog) throws InvalidParametersException {
-        feedbackSessionLogsLogic.createFeedbackSessionLog(feedbackSessionLog);
+    public FeedbackSessionLog createFeedbackSessionLog(
+            FeedbackSession feedbackSession, Student student,
+            FeedbackSessionLogType logType, Instant timestamp) throws InvalidParametersException {
+        return feedbackSessionLogsLogic.createFeedbackSessionLog(feedbackSession, student, logType, timestamp);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
@@ -2,9 +2,9 @@ package teammates.sqllogic.core;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
+import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.exception.InvalidParametersException;
 import teammates.storage.sqlapi.FeedbackSessionLogsDb;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -36,16 +36,25 @@ public final class FeedbackSessionLogsLogic {
     }
 
     /**
+     * Gets the feedback session log with the given id.
+     */
+    public FeedbackSessionLog getFeedbackSessionLog(UUID id) {
+        return fslDb.getFeedbackSessionLog(id);
+    }
+
+    /**
      * Creates feedback session log.
      */
-    public void createFeedbackSessionLog(FeedbackSessionLog fsLog) throws InvalidParametersException {
-        if (fsLog == null) {
-            throw new InvalidParametersException("Feedback session log does not exist");
+    public FeedbackSessionLog createFeedbackSessionLog(
+            FeedbackSession feedbackSession, Student student,
+            FeedbackSessionLogType logType, Instant timestamp) throws InvalidParametersException {
+        FeedbackSessionLog fsLog = new FeedbackSessionLog(student, feedbackSession, logType, timestamp);
+
+        if (!fsLog.isValid()) {
+            throw new InvalidParametersException("Invalid feedback session log: " + fsLog.getInvalidityInfo());
         }
 
-        // TODO: move validation to getInvalidityInfo
-        validateFeedbackSessionLogContext(fsLog.getStudent(), fsLog.getFeedbackSession());
-        fslDb.createFeedbackSessionLog(fsLog);
+        return fslDb.createFeedbackSessionLog(fsLog);
     }
 
     /**
@@ -53,25 +62,6 @@ public final class FeedbackSessionLogsLogic {
      */
     public int deleteFeedbackSessionLogsOlderThan(Instant cutoffTime) {
         return fslDb.deleteFeedbackSessionLogsOlderThan(cutoffTime);
-    }
-
-    /**
-     * Validates that feedback session log entities belong to the same course.
-     */
-    private void validateFeedbackSessionLogContext(Student student, FeedbackSession feedbackSession)
-            throws InvalidParametersException {
-        if (student == null) {
-            throw new InvalidParametersException("Student for feedback session log does not exist");
-        }
-        if (feedbackSession == null) {
-            throw new InvalidParametersException("Feedback session for feedback session log does not exist");
-        }
-
-        String studentCourseId = student.getCourseId();
-        String feedbackSessionCourseId = feedbackSession.getCourseId();
-        if (!Objects.equals(studentCourseId, feedbackSessionCourseId)) {
-            throw new InvalidParametersException("Student and feedback session belong to different courses");
-        }
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackSessionLogsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackSessionLogsDb.java
@@ -35,6 +35,13 @@ public final class FeedbackSessionLogsDb {
     }
 
     /**
+     * Gets a feedback session log by its id.
+     */
+    public FeedbackSessionLog getFeedbackSessionLog(UUID id) {
+        return HibernateUtil.get(FeedbackSessionLog.class, id);
+    }
+
+    /**
      * Gets the feedback session logs as filtered by the given parameters ordered by
      * ascending timestamp. Logs with the same timestamp will be ordered by the
      * student's email.
@@ -78,10 +85,7 @@ public final class FeedbackSessionLogsDb {
      * Creates feedback session logs.
      */
     public FeedbackSessionLog createFeedbackSessionLog(FeedbackSessionLog log) {
-        assert log != null;
-
         HibernateUtil.persist(log);
-
         return log;
     }
 

--- a/src/main/java/teammates/storage/sqlentity/FeedbackSessionLog.java
+++ b/src/main/java/teammates/storage/sqlentity/FeedbackSessionLog.java
@@ -30,12 +30,12 @@ public class FeedbackSessionLog extends BaseEntity {
     private UUID id;
 
     @ManyToOne
-    @JoinColumn(name = "studentId")
+    @JoinColumn(name = "studentId", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Student student;
 
     @ManyToOne
-    @JoinColumn(name = "sessionId")
+    @JoinColumn(name = "sessionId", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private FeedbackSession feedbackSession;
 
@@ -126,6 +126,28 @@ public class FeedbackSessionLog extends BaseEntity {
 
     @Override
     public List<String> getInvalidityInfo() {
-        return new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+
+        if (this.student == null) {
+            errors.add("Student for feedback session log does not exist");
+        }
+
+        if (this.feedbackSession == null) {
+            errors.add("Feedback session for feedback session log does not exist");
+        }
+
+        if (this.timestamp == null) {
+            errors.add("Timestamp for feedback session log does not exist");
+        }
+
+        if (!errors.isEmpty()) {
+            return errors;
+        }
+
+        if (!Objects.equals(this.student.getCourseId(), this.feedbackSession.getCourseId())) {
+            errors.add("Student and feedback session for feedback session log do not belong to the same course");
+        }
+
+        return errors;
     }
 }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -26,12 +26,18 @@ public class CreateFeedbackSessionLogAction extends Action {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
         FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
         if (feedbackSession == null) {
-            throw new UnauthorizedAccessException("The feedback session does not exist.");
+            throw new EntityNotFoundException("The feedback session does not exist.");
         }
 
         Student authenticatedStudent = getPossiblyUnregisteredSqlStudent(feedbackSession.getCourseId());
         if (authenticatedStudent == null) {
             throw new UnauthorizedAccessException("No authenticated student found for the course.");
+        }
+
+        if (authenticatedStudent.getAccount() != null
+                && (userInfo == null || !userInfo.getId().equals(authenticatedStudent.getAccount().getGoogleId()))) {
+            throw new UnauthorizedAccessException(
+                    "Login is required to create a feedback session log for a student with an associated account.");
         }
 
         if (!authenticatedStudent.getCourseId().equals(feedbackSession.getCourseId())) {

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -8,7 +8,6 @@ import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.FeedbackSession;
-import teammates.storage.sqlentity.FeedbackSessionLog;
 import teammates.storage.sqlentity.Student;
 
 /**
@@ -24,23 +23,20 @@ public class CreateFeedbackSessionLogAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo != null && !userInfo.isStudent) {
-            throw new UnauthorizedAccessException("Only students can create feedback session logs.");
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
 
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        UUID studentId = getUuidRequestParamValue(Const.ParamsNames.STUDENT_SQL_ID);
-        Student requestedStudent = sqlLogic.getStudent(studentId);
-        Student authenticatedStudent = getPossiblyUnregisteredSqlStudent(courseId);
-
-        // Student has account but isn't logged in
-        if (authenticatedStudent != null && userInfo == null && authenticatedStudent.getAccount() != null) {
-            throw new UnauthorizedAccessException("Login is required to access this feedback session");
+        Student authenticatedStudent = getPossiblyUnregisteredSqlStudent(feedbackSession.getCourseId());
+        if (authenticatedStudent == null) {
+            throw new UnauthorizedAccessException("No authenticated student found for the course.");
         }
 
-        if (requestedStudent == null || authenticatedStudent == null
-                || !requestedStudent.getId().equals(authenticatedStudent.getId())) {
-            throw new UnauthorizedAccessException("You are not allowed to create logs for this student.");
+        if (!authenticatedStudent.getCourseId().equals(feedbackSession.getCourseId())) {
+            throw new UnauthorizedAccessException(
+                    "Authenticated student does not belong to the course of the feedback session.");
         }
     }
 
@@ -54,20 +50,17 @@ public class CreateFeedbackSessionLogAction extends Action {
             throw new InvalidHttpParameterException("Invalid log type: " + fslType, e);
         }
 
-        getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-
-        UUID studentId = getUuidRequestParamValue(Const.ParamsNames.STUDENT_SQL_ID);
         UUID fsId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
+        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(fsId);
+        if (feedbackSession == null) {
+            throw new InvalidHttpParameterException("The feedback session does not exist.");
+        }
 
         Instant now = Instant.now(clock);
-        Student student = sqlLogic.getStudent(studentId);
-        FeedbackSession feedbackSession = sqlLogic.getFeedbackSession(fsId);
-        FeedbackSessionLog feedbackSessionLog =
-                new FeedbackSessionLog(student, feedbackSession, convertedFslType, now);
+        Student student = getPossiblyUnregisteredSqlStudent(feedbackSession.getCourseId());
+
         try {
-            sqlLogic.createFeedbackSessionLog(feedbackSessionLog);
+            sqlLogic.createFeedbackSessionLog(feedbackSession, student, convertedFslType, now);
         } catch (InvalidParametersException ipe) {
             throw new InvalidHttpParameterException(ipe);
         }

--- a/src/main/resources/db/changelog/migrations/20260429-fs-log-non-null-fields.xml
+++ b/src/main/resources/db/changelog/migrations/20260429-fs-log-non-null-fields.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="samuelfangjw" id="1777405915134-1">
+        <addNotNullConstraint columnDataType="uuid" columnName="session_id" tableName="feedback_session_logs" validate="true"/>
+        <rollback>
+            <dropNotNullConstraint tableName="feedback_session_logs" columnName="session_id" columnDataType="uuid"/>
+        </rollback>
+    </changeSet>
+    <changeSet author="samuelfangjw" id="1777405915134-2">
+        <addNotNullConstraint columnDataType="uuid" columnName="student_id" tableName="feedback_session_logs" validate="true"/>
+        <rollback>
+            <dropNotNullConstraint tableName="feedback_session_logs" columnName="student_id" columnDataType="uuid"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionLogActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionLogActionTest.java
@@ -1,6 +1,7 @@
 package teammates.sqlui.webapi;
 
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -35,19 +36,10 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
     FeedbackSession fsaCourse1;
     FeedbackSession fsaCourseNoStudent;
     String fsaCourse1Id;
-    String fsaCourse1Name;
-    String fsaCourseNoStudentId;
-    String fsaCourseNoStudentName;
 
     Student student1InCourse1;
     Student student2InCourse2;
     Student student3InCourse2;
-    String student1Email;
-    String student2Email;
-    String student3Email;
-    String student1Id;
-    String student2Id;
-    String student3Id;
     String student1RegKey;
 
     @Override
@@ -72,9 +64,6 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
         fsaCourse1 = getTypicalFeedbackSessionForCourse(course1);
         fsaCourseNoStudent = getTypicalFeedbackSessionForCourse(courseNoStudent);
         fsaCourse1Id = fsaCourse1.getId().toString();
-        fsaCourseNoStudentId = fsaCourseNoStudent.getId().toString();
-        fsaCourse1Name = fsaCourse1.getName();
-        fsaCourseNoStudentName = fsaCourseNoStudent.getName();
 
         student1InCourse1 = getTypicalStudent();
         student2InCourse2 = getTypicalStudent();
@@ -82,12 +71,6 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
         student1InCourse1.setCourse(course1);
         student2InCourse2.setCourse(courseNoStudent);
         student3InCourse2.setCourse(course2);
-        student1Email = student1InCourse1.getEmail();
-        student2Email = student2InCourse2.getEmail();
-        student3Email = student3InCourse2.getEmail();
-        student1Id = student1InCourse1.getId().toString();
-        student2Id = student2InCourse2.getId().toString();
-        student3Id = student3InCourse2.getId().toString();
         student1RegKey = student1InCourse1.getRegKey();
     }
 
@@ -99,7 +82,8 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
         when(mockLogic.getStudent(student3InCourse2.getId())).thenReturn(student3InCourse2);
         when(mockLogic.getStudentByRegistrationKey(student1RegKey)).thenReturn(student1InCourse1);
         when(mockLogic.getStudentByGoogleId(courseId1, MATCHING_STUDENT_USER_ID)).thenReturn(student1InCourse1);
-        when(mockLogic.getStudentByGoogleId(courseId1, NON_MATCHING_STUDENT_USER_ID)).thenReturn(student2InCourse2);
+        when(mockLogic.getStudentByGoogleId(courseId1, NON_MATCHING_STUDENT_USER_ID))
+                .thenReturn(student2InCourse2);
         when(mockLogic.getFeedbackSession(fsaCourse1.getId())).thenReturn(fsaCourse1);
         when(mockLogic.getFeedbackSession(fsaCourseNoStudent.getId())).thenReturn(fsaCourseNoStudent);
     }
@@ -107,12 +91,8 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
     @Test
     void testAccessControl() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
         };
 
         loginAsStudent(MATCHING_STUDENT_USER_ID);
@@ -134,218 +114,74 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
         verifyCannotAccess(params);
 
         String[] paramsWithRegKey = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
                 Const.ParamsNames.REGKEY, student1RegKey,
         };
         verifyCanAccess(paramsWithRegKey);
     }
 
     @Test
-        void testExecute_typicalAccess_shouldSucceed() throws Exception {
+    void testExecute_typicalAccess_shouldSucceed() throws Exception {
+        loginAsStudent(MATCHING_STUDENT_USER_ID);
         String[] paramsSuccessfulAccess = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
         };
+
         CreateFeedbackSessionLogAction action = getAction(paramsSuccessfulAccess);
         JsonResult response = getJsonResult(action);
         MessageOutput output = (MessageOutput) response.getOutput();
+
         assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student1InCourse1.equals(log.getStudent())
-                        && fsaCourse1.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.ACCESS == log.getFeedbackSessionLogType()));
+        verify(mockLogic).createFeedbackSessionLog(eq(fsaCourse1), eq(student1InCourse1),
+                eq(FeedbackSessionLogType.ACCESS), any());
     }
 
     @Test
-        void testExecute_duplicateLog_shouldStillPersist() throws Exception {
-        String[] paramsSuccessfulAccess = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.ACCESS.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
-        };
-
-        JsonResult response = getJsonResult(getAction(paramsSuccessfulAccess));
-        MessageOutput output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student1InCourse1.equals(log.getStudent())
-                        && fsaCourse1.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.ACCESS == log.getFeedbackSessionLogType()));
-    }
-
-    @Test
-        void testExecute_duplicateLogWithDifferentType_shouldPersist() throws Exception {
+    void testExecute_typicalSubmission_shouldSucceed() throws Exception {
+        loginAsStudent(MATCHING_STUDENT_USER_ID);
         String[] paramsSuccessfulSubmission = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
         };
 
         JsonResult response = getJsonResult(getAction(paramsSuccessfulSubmission));
         MessageOutput output = (MessageOutput) response.getOutput();
         assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student1InCourse1.equals(log.getStudent())
-                        && fsaCourse1.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.SUBMISSION == log.getFeedbackSessionLogType()));
-    }
-
-    @Test
-        void testExecute_typicalSubmission_shouldSucceed() throws Exception {
-        String[] paramsSuccessfulSubmission = {
-                Const.ParamsNames.COURSE_ID, courseNoStudent.getId(),
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourseNoStudentName,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourseNoStudentId,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student2Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student2Id,
-
-        };
-        JsonResult response = getJsonResult(getAction(paramsSuccessfulSubmission));
-        MessageOutput output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student2InCourse2.equals(log.getStudent())
-                        && fsaCourseNoStudent.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.SUBMISSION == log.getFeedbackSessionLogType()));
-    }
-
-    @Test
-        void testExecute_invalidSessionName_shouldStillSucceed() throws Exception {
-        String nonExistentSessionName = "non-existent-feedback-session-name";
-        String[] paramsNonExistentFsName = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, nonExistentSessionName,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
-        };
-        JsonResult response = getJsonResult(getAction(paramsNonExistentFsName));
-        MessageOutput output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student1InCourse1.equals(log.getStudent())
-                        && fsaCourse1.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.SUBMISSION == log.getFeedbackSessionLogType()));
-    }
-
-    @Test
-        void testExecute_invalidEmail_shouldStillSucceed() throws Exception {
-        String nonExistentEmail = "non-existent-student@email.com";
-        String[] paramsNonExistentStudentEmail = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, nonExistentEmail,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
-        };
-        JsonResult response = getJsonResult(getAction(paramsNonExistentStudentEmail));
-        MessageOutput output = (MessageOutput) response.getOutput();
-        assertEquals("Successful", output.getMessage());
-        verify(mockLogic).createFeedbackSessionLog(argThat(log ->
-                student1InCourse1.equals(log.getStudent())
-                        && fsaCourse1.equals(log.getFeedbackSession())
-                        && FeedbackSessionLogType.SUBMISSION == log.getFeedbackSessionLogType()));
-    }
-
-    @Test
-    void testExecute_studentHasNoAccessToCourseFeedback_shouldFail() throws Exception {
-        doThrow(new InvalidParametersException("Student and feedback session belong to different courses"))
-                .when(mockLogic).createFeedbackSessionLog(argThat(log ->
-                        student3InCourse2.equals(log.getStudent())
-                                && fsaCourse1.equals(log.getFeedbackSession())));
-
-        String[] paramsWithoutAccess = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student3Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student3Id,
-        };
-        assertThrows(teammates.ui.webapi.InvalidHttpParameterException.class,
-                () -> getAction(paramsWithoutAccess).execute());
+        verify(mockLogic).createFeedbackSessionLog(eq(fsaCourse1), eq(student1InCourse1),
+                eq(FeedbackSessionLogType.SUBMISSION), any());
     }
 
     @Test
     void testExecute_missingFeedbackSession_shouldFail() throws Exception {
         doThrow(new InvalidParametersException("Feedback session for feedback session log does not exist"))
-                .when(mockLogic).createFeedbackSessionLog(argThat(log ->
-                        student1InCourse1.equals(log.getStudent())
-                                && log.getFeedbackSession() == null));
+                .when(mockLogic)
+                .createFeedbackSessionLog(any(), any(), any(), any());
 
         String[] paramsMissingFeedbackSession = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, "00000000-0000-0000-0000-000000000000",
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
         };
         assertThrows(teammates.ui.webapi.InvalidHttpParameterException.class,
                 () -> getAction(paramsMissingFeedbackSession).execute());
     }
 
     @Test
-    void testExecute_missingStudent_shouldFail() throws Exception {
-        doThrow(new InvalidParametersException("Student for feedback session log does not exist"))
-                .when(mockLogic).createFeedbackSessionLog(argThat(log ->
-                        log.getStudent() == null
-                                && fsaCourse1.equals(log.getFeedbackSession())));
-
-        String[] paramsMissingStudent = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
-                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, "00000000-0000-0000-0000-000000000000",
-        };
-        assertThrows(teammates.ui.webapi.InvalidHttpParameterException.class,
-                () -> getAction(paramsMissingStudent).execute());
-    }
-
-    @Test
     void testExecute_notEnoughParameters_shouldFail() {
-        verifyHttpParameterFailure(Const.ParamsNames.COURSE_ID, courseId1);
+        verifyHttpParameterFailure();
         verifyHttpParameterFailure(
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name
-        );
+                Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id);
         verifyHttpParameterFailure(
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
-                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
-                Const.ParamsNames.STUDENT_EMAIL, student1Email
-        );
+                Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name());
     }
 
     @Test
     void testExecute_invalidLogType_shouldFail() {
         String invalidLogType = "invalid log type";
         String[] paramsInvalid = {
-                Const.ParamsNames.COURSE_ID, courseId1,
-                Const.ParamsNames.FEEDBACK_SESSION_NAME, fsaCourse1Name,
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsaCourse1Id,
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, invalidLogType,
-                Const.ParamsNames.STUDENT_EMAIL, student1Email,
-                Const.ParamsNames.STUDENT_SQL_ID, student1Id,
         };
         verifyHttpParameterFailure(paramsInvalid);
     }

--- a/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionLogActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/CreateFeedbackSessionLogActionTest.java
@@ -2,7 +2,6 @@ package teammates.sqlui.webapi;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,7 +11,6 @@ import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
-import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.Course;
 import teammates.storage.sqlentity.FeedbackSession;
@@ -154,15 +152,12 @@ public class CreateFeedbackSessionLogActionTest extends BaseActionTest<CreateFee
     }
 
     @Test
-    void testExecute_missingFeedbackSession_shouldFail() throws Exception {
-        doThrow(new InvalidParametersException("Feedback session for feedback session log does not exist"))
-                .when(mockLogic)
-                .createFeedbackSessionLog(any(), any(), any(), any());
-
+    void testExecute_missingFeedbackSession_shouldFail() {
         String[] paramsMissingFeedbackSession = {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, "00000000-0000-0000-0000-000000000000",
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
         };
+
         assertThrows(teammates.ui.webapi.InvalidHttpParameterException.class,
                 () -> getAction(paramsMissingFeedbackSession).execute());
     }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -392,13 +392,9 @@ export class SessionResultPageComponent implements OnInit {
     }
 
     this.logService.createFeedbackSessionLog({
-      courseId: this.courseId,
-      feedbackSessionName: this.feedbackSessionName,
-      studentEmail: this.personEmail,
       key: this.regKey,
       logType: FeedbackSessionLogType.VIEW_RESULT,
       feedbackSessionId: this.feedbackSessionId,
-      studentId: this.studentId,
     }).subscribe();
   }
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -1157,13 +1157,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     }
 
     this.logService.createFeedbackSessionLog({
-      courseId: this.courseId,
-      feedbackSessionName: this.feedbackSessionName,
-      studentEmail: this.personEmail,
       logType: FeedbackSessionLogType.ACCESS,
       key: this.regKey,
       feedbackSessionId: this.feedbackSessionId,
-      studentId: this.studentId,
     }).subscribe();
   }
 }

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -21,31 +21,17 @@ export class LogService {
    * Creates a log for feedback session by calling API.
    */
   createFeedbackSessionLog(queryParams: {
-    courseId: string,
-    feedbackSessionName: string,
-    studentEmail: string,
     logType: FeedbackSessionLogType,
+    feedbackSessionId: string,
     key?: string,
-    feedbackSessionId?: string,
-    studentId?: string,
   }): Observable<string> {
     const paramMap: Record<string, string> = {
-      courseid: queryParams.courseId,
-      fsname: queryParams.feedbackSessionName,
-      studentemail: queryParams.studentEmail,
       fsltype: queryParams.logType.toString(),
+      fsid: queryParams.feedbackSessionId
     };
 
     if (queryParams.key) {
       paramMap['key'] = queryParams.key;
-    }
-
-    if (queryParams.feedbackSessionId) {
-      paramMap['fsid'] = queryParams.feedbackSessionId;
-    }
-
-    if (queryParams.studentId) {
-      paramMap['studentid'] = queryParams.studentId;
     }
 
     return this.httpRequestService.post(ResourceEndpoints.SESSION_LOGS, paramMap);

--- a/src/web/services/log.service.ts
+++ b/src/web/services/log.service.ts
@@ -27,7 +27,7 @@ export class LogService {
   }): Observable<string> {
     const paramMap: Record<string, string> = {
       fsltype: queryParams.logType.toString(),
-      fsid: queryParams.feedbackSessionId
+      fsid: queryParams.feedbackSessionId,
     };
 
     if (queryParams.key) {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->
Part of #13738

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

Migration to use feedbackSessionId and remove redundant parameters. 

Also changed feedbackSession and student to be non-null and cleaned up related methods.
