### PR TITLE
[#13832] TypeScript cannot find describe even with jest types installed

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
+    "rootDir": "./src/web",
     "types": []
   },
   "include": ["src/web/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,14 @@
     "strictTemplates": true,
     "typeCheckHostBindings": true,
     "strictStandalone": true
-  }
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
+    "rootDir": "./src/web",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["src/web/test-helpers/**/*.ts", "src/web/**/*.spec.ts", "src/web/**/*.d.ts"]
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13832

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

This pull request updates the TypeScript configuration to resolve type resolution errors.

Root cause was that test files were using either tsconfig.json or tsconfig.app.json and not the tsconfig.spec.json.