### PR TITLE
[#13829] Fix flaky InstructorFeedbackReportPageE2ETest

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -131,14 +131,18 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         comment = sqlComment;
     }
 
+    @Test
     @Override
     public void testAll() {
-        // not used; run individual test cases instead as the entire test cases take > 5 minutes to run
+        testQuestionView();
+        testGrqView();
+        testRgqView();
+        testGqrView();
+        testRqgView();
+        testActions();
     }
 
-    @Test
     public void testQuestionView() {
-        logout();
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("Question view: no missing responses");
@@ -175,9 +179,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyQnViewComment(qn2, comment, responseWithComment, instructors, students);
     }
 
-    @Test
     public void testGrqView() {
-        logout();
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("GRQ view: no missing responses");
@@ -210,9 +212,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyGrqViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    @Test
     public void testRgqView() {
-        logout();
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("RGQ view: no missing responses");
@@ -246,9 +246,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyRgqViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    @Test
     public void testGqrView() {
-        logout();
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("GQR view: no missing responses");
@@ -290,9 +288,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyGqrViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    @Test
     public void testRqgView() {
-        logout();
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("RQG view: no missing responses");
@@ -333,7 +329,6 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyRqgViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    @Test
     public void testActions() {
         logout();
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -142,7 +142,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         testActions();
     }
 
-    public void testQuestionView() {
+    private void testQuestionView() {
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("Question view: no missing responses");
@@ -179,7 +179,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyQnViewComment(qn2, comment, responseWithComment, instructors, students);
     }
 
-    public void testGrqView() {
+    private void testGrqView() {
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("GRQ view: no missing responses");
@@ -212,7 +212,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyGrqViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    public void testRgqView() {
+    private void testRgqView() {
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("RGQ view: no missing responses");
@@ -246,7 +246,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyRgqViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    public void testGqrView() {
+    private void testGqrView() {
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("GQR view: no missing responses");
@@ -288,7 +288,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyGqrViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    public void testRqgView() {
+    private void testRqgView() {
         resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPageSql.class, instructor.getGoogleId());
 
         ______TS("RQG view: no missing responses");
@@ -329,7 +329,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyRqgViewComment(qn2, comment, responseWithComment, instructors, students, false);
     }
 
-    public void testActions() {
+    private void testActions() {
         logout();
 
         Course course = testData.courses.get("tm.e2e.IFRep.CS2103");

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -379,4 +379,39 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
     public void setMaxPoint(int maxPoint) {
         this.maxPoint = maxPoint;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackConstantSumQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(getQuestionText(), other.getQuestionText())
+                && distributeToRecipients == other.distributeToRecipients
+                && pointsPerOption == other.pointsPerOption
+                && forceUnevenDistribution == other.forceUnevenDistribution
+                && points == other.points
+                && Objects.equals(constSumOptions, other.constSumOptions)
+                && Objects.equals(distributePointsFor, other.distributePointsFor)
+                && Objects.equals(minPoint, other.minPoint)
+                && Objects.equals(maxPoint, other.maxPoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getQuestionType(),
+                getQuestionText(),
+                constSumOptions,
+                distributeToRecipients,
+                pointsPerOption,
+                forceUnevenDistribution,
+                distributePointsFor,
+                points,
+                minPoint,
+                maxPoint);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumResponseDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains specific structure and processing logic for constant sum feedback responses.
@@ -26,5 +27,22 @@ public class FeedbackConstantSumResponseDetails extends FeedbackResponseDetails 
 
     public void setAnswers(List<Integer> answers) {
         this.answers = answers;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackConstantSumResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(answers, other.answers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answers);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -383,6 +383,25 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         isNotSureAllowed = notSureAllowed;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackContributionQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && isZeroSum == other.isZeroSum
+                && isNotSureAllowed == other.isNotSureAllowed;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(getQuestionType(), getQuestionText(), isZeroSum, isNotSureAllowed);
+    }
+
     /**
      * Represents a list of participants to their question statistics for one contribution question.
      */

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -392,14 +393,14 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             return false;
         }
         return getQuestionType() == other.getQuestionType()
-                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && Objects.equals(getQuestionText(), other.getQuestionText())
                 && isZeroSum == other.isZeroSum
                 && isNotSureAllowed == other.isNotSureAllowed;
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(getQuestionType(), getQuestionText(), isZeroSum, isNotSureAllowed);
+        return Objects.hash(getQuestionType(), getQuestionText(), isZeroSum, isNotSureAllowed);
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 import teammates.common.util.Const;
 
 /**
@@ -44,6 +46,6 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
 
     @Override
     public int hashCode() {
-        return 31 * getQuestionType().hashCode() + Integer.hashCode(answer);
+        return Objects.hash(getQuestionType(), answer);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -29,4 +29,21 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
     public void setAnswer(int answer) {
         this.answer = answer;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackContributionResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && answer == other.answer;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * getQuestionType().hashCode() + Integer.hashCode(answer);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.storage.sqlentity.FeedbackQuestion;
@@ -209,5 +210,38 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
 
     public void setGenerateOptionsFor(FeedbackParticipantType generateOptionsFor) {
         this.generateOptionsFor = generateOptionsFor;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackMcqQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(getQuestionText(), other.getQuestionText())
+                && hasAssignedWeights == other.hasAssignedWeights
+                && Double.compare(mcqOtherWeight, other.mcqOtherWeight) == 0
+                && otherEnabled == other.otherEnabled
+                && questionDropdownEnabled == other.questionDropdownEnabled
+                && generateOptionsFor == other.generateOptionsFor
+                && Objects.equals(mcqWeights, other.mcqWeights)
+                && Objects.equals(mcqChoices, other.mcqChoices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getQuestionType(),
+                getQuestionText(),
+                hasAssignedWeights,
+                mcqWeights,
+                mcqOtherWeight,
+                mcqChoices,
+                otherEnabled,
+                questionDropdownEnabled,
+                generateOptionsFor);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqResponseDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 /**
  * Contains specific structure and processing logic for MCQ feedback responses.
  */
@@ -45,5 +47,24 @@ public class FeedbackMcqResponseDetails extends FeedbackResponseDetails {
 
     public void setOtherFieldContent(String otherFieldContent) {
         this.otherFieldContent = otherFieldContent;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackMcqResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && isOther == other.isOther
+                && Objects.equals(answer, other.answer)
+                && Objects.equals(otherFieldContent, other.otherFieldContent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answer, isOther, otherFieldContent);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.util.Const;
@@ -333,6 +334,41 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
 
     public void setMinSelectableChoices(int minSelectableChoices) {
         this.minSelectableChoices = minSelectableChoices;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackMsqQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(getQuestionText(), other.getQuestionText())
+                && otherEnabled == other.otherEnabled
+                && hasAssignedWeights == other.hasAssignedWeights
+                && Double.compare(msqOtherWeight, other.msqOtherWeight) == 0
+                && generateOptionsFor == other.generateOptionsFor
+                && maxSelectableChoices == other.maxSelectableChoices
+                && minSelectableChoices == other.minSelectableChoices
+                && Objects.equals(msqChoices, other.msqChoices)
+                && Objects.equals(msqWeights, other.msqWeights);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getQuestionType(),
+                getQuestionText(),
+                msqChoices,
+                otherEnabled,
+                hasAssignedWeights,
+                msqWeights,
+                msqOtherWeight,
+                generateOptionsFor,
+                maxSelectableChoices,
+                minSelectableChoices);
     }
 
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqResponseDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.common.util.StringHelper;
 
@@ -47,5 +48,24 @@ public class FeedbackMsqResponseDetails extends FeedbackResponseDetails {
 
     public void setOtherFieldContent(String otherFieldContent) {
         this.otherFieldContent = otherFieldContent;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackMsqResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && isOther == other.isOther
+                && Objects.equals(answers, other.answers)
+                && Objects.equals(otherFieldContent, other.otherFieldContent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answers, isOther, otherFieldContent);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -115,4 +115,24 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
     public void setStep(double step) {
         this.step = step;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackNumericalScaleQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && minScale == other.minScale
+                && maxScale == other.maxScale
+                && Double.compare(step, other.step) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(getQuestionType(), getQuestionText(), minScale, maxScale, step);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.storage.sqlentity.FeedbackQuestion;
 
@@ -125,7 +126,7 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
             return false;
         }
         return getQuestionType() == other.getQuestionType()
-                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && Objects.equals(getQuestionText(), other.getQuestionText())
                 && minScale == other.minScale
                 && maxScale == other.maxScale
                 && Double.compare(step, other.step) == 0;
@@ -133,6 +134,6 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(getQuestionType(), getQuestionText(), minScale, maxScale, step);
+        return Objects.hash(getQuestionType(), getQuestionText(), minScale, maxScale, step);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
@@ -27,4 +27,21 @@ public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetai
     public void setAnswer(double answer) {
         this.answer = answer;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackNumericalScaleResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Double.compare(answer, other.answer) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * getQuestionType().hashCode() + Double.hashCode(answer);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleResponseDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 
@@ -42,6 +44,6 @@ public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetai
 
     @Override
     public int hashCode() {
-        return 31 * getQuestionType().hashCode() + Double.hashCode(answer);
+        return Objects.hash(getQuestionType(), answer);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -117,27 +117,6 @@ public abstract class FeedbackQuestionDetails {
                 && question.getRecipientType() != FeedbackParticipantType.TEAMS_EXCLUDING_SELF;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-
-        if (obj == null || obj.getClass() != this.getClass()) {
-            return false;
-        }
-
-        // Json string contains all attributes of a `FeedbackQuestionDetails` object,
-        // so it is sufficient to use it to compare two `FeedbackQuestionDetails` objects.
-        FeedbackQuestionDetails other = (FeedbackQuestionDetails) obj;
-        return this.getJsonString().equals(other.getJsonString());
-    }
-
-    @Override
-    public int hashCode() {
-        return this.getJsonString().hashCode();
-    }
-
     /**
      * Returns a JSON string representation of the question details.
      */

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import teammates.common.util.Const;
@@ -135,5 +136,22 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
 
     public void setOptions(List<String> options) {
         this.options = options;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackRankOptionsQuestionDetails other)) {
+            return false;
+        }
+        return super.equals(other)
+                && Objects.equals(options, other.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), options);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsResponseDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.common.util.Const;
 
@@ -44,5 +45,22 @@ public class FeedbackRankOptionsResponseDetails extends FeedbackResponseDetails 
 
     public void setAnswers(List<Integer> answers) {
         this.answers = answers;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackRankOptionsResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(answers, other.answers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answers);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 import teammates.common.util.Const;
 
 /**
@@ -51,7 +53,7 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
         }
         FeedbackRankQuestionDetails other = (FeedbackRankQuestionDetails) obj;
         return getQuestionType() == other.getQuestionType()
-                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && Objects.equals(getQuestionText(), other.getQuestionText())
                 && minOptionsToBeRanked == other.minOptionsToBeRanked
                 && maxOptionsToBeRanked == other.maxOptionsToBeRanked
                 && areDuplicatesAllowed == other.areDuplicatesAllowed;
@@ -59,7 +61,7 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(
+        return Objects.hash(
                 getQuestionType(),
                 getQuestionText(),
                 minOptionsToBeRanked,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankQuestionDetails.java
@@ -40,4 +40,30 @@ public abstract class FeedbackRankQuestionDetails extends FeedbackQuestionDetail
     public void setAreDuplicatesAllowed(boolean areDuplicatesAllowed) {
         this.areDuplicatesAllowed = areDuplicatesAllowed;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        FeedbackRankQuestionDetails other = (FeedbackRankQuestionDetails) obj;
+        return getQuestionType() == other.getQuestionType()
+                && java.util.Objects.equals(getQuestionText(), other.getQuestionText())
+                && minOptionsToBeRanked == other.minOptionsToBeRanked
+                && maxOptionsToBeRanked == other.maxOptionsToBeRanked
+                && areDuplicatesAllowed == other.areDuplicatesAllowed;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(
+                getQuestionType(),
+                getQuestionText(),
+                minOptionsToBeRanked,
+                maxOptionsToBeRanked,
+                areDuplicatesAllowed);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -65,14 +65,4 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     public String validateGiverRecipientVisibility(FeedbackQuestion feedbackQuestion) {
         return "";
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -65,4 +65,14 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     public String validateGiverRecipientVisibility(FeedbackQuestion feedbackQuestion) {
         return "";
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 import teammates.common.util.Const;
 
 /**
@@ -40,6 +42,6 @@ public class FeedbackRankRecipientsResponseDetails extends FeedbackResponseDetai
 
     @Override
     public int hashCode() {
-        return 31 * getQuestionType().hashCode() + Integer.hashCode(answer);
+        return Objects.hash(getQuestionType(), answer);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsResponseDetails.java
@@ -25,4 +25,21 @@ public class FeedbackRankRecipientsResponseDetails extends FeedbackResponseDetai
     public void setAnswer(int answer) {
         this.answer = answer;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackRankRecipientsResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && answer == other.answer;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * getQuestionType().hashCode() + Integer.hashCode(answer);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
@@ -34,7 +34,7 @@ import teammates.common.util.JsonUtils;
 public abstract class FeedbackResponseDetails {
     private FeedbackQuestionType questionType;
 
-    public FeedbackResponseDetails(FeedbackQuestionType questionType) {
+    protected FeedbackResponseDetails(FeedbackQuestionType questionType) {
         this.questionType = questionType;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import teammates.storage.sqlentity.FeedbackQuestion;
 
@@ -234,5 +235,34 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
     public void setRubricDescriptions(List<List<String>> rubricDescriptions) {
         this.rubricDescriptions = rubricDescriptions;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackRubricQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(getQuestionText(), other.getQuestionText())
+                && hasAssignedWeights == other.hasAssignedWeights
+                && Objects.equals(rubricWeightsForEachCell, other.rubricWeightsForEachCell)
+                && Objects.equals(rubricChoices, other.rubricChoices)
+                && Objects.equals(rubricSubQuestions, other.rubricSubQuestions)
+                && Objects.equals(rubricDescriptions, other.rubricDescriptions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getQuestionType(),
+                getQuestionText(),
+                hasAssignedWeights,
+                rubricWeightsForEachCell,
+                rubricChoices,
+                rubricSubQuestions,
+                rubricDescriptions);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains specific structure and processing logic for rubric feedback responses.
@@ -30,5 +31,22 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
 
     public void setAnswer(List<Integer> answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackRubricResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(answer, other.answer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answer);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer.questions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.annotation.Nullable;
 
@@ -71,5 +72,24 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
 
     public void setShouldAllowRichText(Boolean shouldAllowRichText) {
         this.shouldAllowRichText = shouldAllowRichText;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackTextQuestionDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(getQuestionText(), other.getQuestionText())
+                && Objects.equals(recommendedLength, other.recommendedLength)
+                && Objects.equals(shouldAllowRichText, other.shouldAllowRichText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), getQuestionText(), recommendedLength, shouldAllowRichText);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextResponseDetails.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import java.util.Objects;
+
 import teammates.common.util.SanitizationHelper;
 
 /**
@@ -30,5 +32,22 @@ public class FeedbackTextResponseDetails extends FeedbackResponseDetails {
 
     public void setAnswer(String answer) {
         this.answer = answer;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof FeedbackTextResponseDetails other)) {
+            return false;
+        }
+        return getQuestionType() == other.getQuestionType()
+                && Objects.equals(answer, other.answer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQuestionType(), answer);
     }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13829

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

`equals` method in response details not implemented correctly, causing Hibernate's change detection to run when responses are fetched. This results in occasional deadlocks that cause the test to fail.

This PR implements equals in `FeedbackResponseDetails` subclasses. `FeedbackQuestionDetails` have been updated to follow the same pattern. 

This pr also changes the e2e test to run tests sequentially to match the other E2E tests. Tests seem to run sequentially in CI anyways, so there shouldn't be a difference.

Equals and Hashcode methods generated by copilot.