### PR TITLE
[#13850] Optimize GetNotificationsAction with DB-level unread filtering

### DIFF
--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1225,14 +1225,11 @@ public class Logic {
     }
 
     /**
-     * Returns active unread notifications for the specified {@code targetUser} and account.
-     *
-     * <p>Performs a single optimized database query that excludes notifications already
-     * read by the account with the given {@code accountId}.</p>
+     * Returns active unread notifications for the specified {@code targetUsers} and {@code accountId}.
      */
     public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            NotificationTargetUser targetUser, UUID accountId) {
-        return notificationsLogic.getUnreadActiveNotificationsByTargetUser(targetUser, accountId);
+            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
+        return notificationsLogic.getUnreadActiveNotificationsByTargetUser(targetUsers, accountId, now);
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -1225,6 +1225,17 @@ public class Logic {
     }
 
     /**
+     * Returns active unread notifications for the specified {@code targetUser} and account.
+     *
+     * <p>Performs a single optimized database query that excludes notifications already
+     * read by the account with the given {@code accountId}.</p>
+     */
+    public List<Notification> getUnreadActiveNotificationsByTargetUser(
+            NotificationTargetUser targetUser, UUID accountId) {
+        return notificationsLogic.getUnreadActiveNotificationsByTargetUser(targetUser, accountId);
+    }
+
+    /**
      * Gets all questions for a feedback session.<br>
      * Returns an empty list if they are no questions
      * for the session.

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -133,6 +133,20 @@ public final class NotificationsLogic {
     }
 
     /**
+     * Gets a list of active notifications that have not been read by the account with {@code accountId}.
+     *
+     * <p>Performs a single optimized query at the database level to exclude already-read notifications.</p>
+     *
+     * @return a list of unread active notifications for the specified {@code targetUser} and {@code accountId}.
+     */
+    public List<Notification> getUnreadActiveNotificationsByTargetUser(
+            NotificationTargetUser targetUser, UUID accountId) {
+        assert targetUser != null;
+        assert accountId != null;
+        return notificationsDb.getUnreadActiveNotificationsByTargetUser(targetUser, accountId);
+    }
+
+    /**
      * Gets a list of notifications that have been read by the account with {@code accountId}.
      */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -133,17 +133,13 @@ public final class NotificationsLogic {
     }
 
     /**
-     * Gets a list of active notifications that have not been read by the account with {@code accountId}.
-     *
-     * <p>Performs a single optimized query at the database level to exclude already-read notifications.</p>
-     *
-     * @return a list of unread active notifications for the specified {@code targetUser} and {@code accountId}.
+     * Returns active unread notifications for the specified {@code targetUsers} and {@code accountId}.
      */
     public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            NotificationTargetUser targetUser, UUID accountId) {
-        assert targetUser != null;
+            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
+        assert targetUsers != null;
         assert accountId != null;
-        return notificationsDb.getUnreadActiveNotificationsByTargetUser(targetUser, accountId);
+        return notificationsDb.getUnreadActiveNotificationsByTargetUser(targetUsers, accountId, now);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -11,6 +11,7 @@ import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -97,6 +98,42 @@ public final class NotificationsDb {
                                 cb.equal(root.get("targetUser"), NotificationTargetUser.GENERAL)),
                         cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
                         cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now())))
+                .orderBy(cb.asc(root.get("startTime")));
+        TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
+        return query.getResultList();
+    }
+
+    /**
+     * Gets active notifications by {@code targetUser} that have not been read by the account
+     * with the given {@code accountId}.
+     *
+     * <p>This performs a single query using a NOT EXISTS subquery to exclude notifications
+     * that the specified account has already read, avoiding the need for separate queries
+     * and in-memory filtering.</p>
+     *
+     * @return a list of unread active notifications for the specified targetUser and account.
+     */
+    public List<Notification> getUnreadActiveNotificationsByTargetUser(
+            NotificationTargetUser targetUser, UUID accountId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
+        Root<Notification> root = cq.from(Notification.class);
+
+        // Subquery: SELECT 1 FROM ReadNotification rn WHERE rn.notification.id = n.id AND rn.account.id = :accountId
+        Subquery<ReadNotification> subquery = cq.subquery(ReadNotification.class);
+        Root<ReadNotification> readRoot = subquery.from(ReadNotification.class);
+        subquery.select(readRoot)
+                .where(cb.and(
+                        cb.equal(readRoot.get("notification").get("id"), root.get("id")),
+                        cb.equal(readRoot.get("account").get("id"), accountId)));
+
+        cq.select(root)
+                .where(cb.and(
+                        cb.or(cb.equal(root.get("targetUser"), targetUser),
+                                cb.equal(root.get("targetUser"), NotificationTargetUser.GENERAL)),
+                        cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
+                        cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now()),
+                        cb.not(cb.exists(subquery))))
                 .orderBy(cb.asc(root.get("startTime")));
         TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
         return query.getResultList();

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -107,32 +107,26 @@ public final class NotificationsDb {
      * Gets active notifications by {@code targetUser} that have not been read by the account
      * with the given {@code accountId}.
      *
-     * <p>This performs a single query using a NOT EXISTS subquery to exclude notifications
-     * that the specified account has already read, avoiding the need for separate queries
-     * and in-memory filtering.</p>
-     *
      * @return a list of unread active notifications for the specified targetUser and account.
      */
     public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            NotificationTargetUser targetUser, UUID accountId) {
+            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
         Root<Notification> root = cq.from(Notification.class);
 
-        // Subquery: SELECT 1 FROM ReadNotification rn WHERE rn.notification.id = n.id AND rn.account.id = :accountId
-        Subquery<ReadNotification> subquery = cq.subquery(ReadNotification.class);
+        Subquery<Integer> subquery = cq.subquery(Integer.class);
         Root<ReadNotification> readRoot = subquery.from(ReadNotification.class);
-        subquery.select(readRoot)
+        subquery.select(cb.literal(1))
                 .where(cb.and(
                         cb.equal(readRoot.get("notification").get("id"), root.get("id")),
                         cb.equal(readRoot.get("account").get("id"), accountId)));
 
         cq.select(root)
                 .where(cb.and(
-                        cb.or(cb.equal(root.get("targetUser"), targetUser),
-                                cb.equal(root.get("targetUser"), NotificationTargetUser.GENERAL)),
-                        cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
-                        cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now()),
+                        root.get("targetUser").in(targetUsers),
+                        cb.lessThanOrEqualTo(root.get("startTime"), now),
+                        cb.greaterThanOrEqualTo(root.get("endTime"), now),
                         cb.not(cb.exists(subquery))))
                 .orderBy(cb.asc(root.get("startTime")));
         TypedQuery<Notification> query = HibernateUtil.createQuery(cq);

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -1,5 +1,6 @@
 package teammates.ui.webapi;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
@@ -72,14 +73,13 @@ public class GetNotificationsAction extends Action {
             return new JsonResult(new NotificationsData(notifications));
         }
 
-        // Optimized: single query at the database level to exclude already-read notifications,
-        // avoiding the overhead of separate queries and in-memory filtering.
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
-        notifications = sqlLogic.getUnreadActiveNotificationsByTargetUser(targetUser, account.getId());
+        notifications = sqlLogic.getUnreadActiveNotificationsByTargetUser(
+                List.of(targetUser, NotificationTargetUser.GENERAL), account.getId(), Instant.now());
 
         if (userInfo.isAdmin) {
             return new JsonResult(new NotificationsData(notifications));

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -1,9 +1,6 @@
 package teammates.ui.webapi;
 
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.apache.http.HttpStatus;
 
@@ -53,19 +50,18 @@ public class GetNotificationsAction extends Action {
             // if request is from admin and targetUser is not specified, retrieve all notifications
             notifications = sqlLogic.getAllNotifications();
             return new JsonResult(new NotificationsData(notifications));
-        } else {
-            // retrieve active notification for specified target user
-            String targetUserErrorMessage = FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUserString);
-            if (!targetUserErrorMessage.isEmpty()) {
-                throw new InvalidHttpParameterException(targetUserErrorMessage);
-            }
-            NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-            if (targetUser == NotificationTargetUser.GENERAL) {
-                throw new InvalidHttpParameterException(INVALID_TARGET_USER);
-            }
-            notifications =
-                    sqlLogic.getActiveNotificationsByTargetUser(targetUser);
         }
+
+        // retrieve active notification for specified target user
+        String targetUserErrorMessage = FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUserString);
+        if (!targetUserErrorMessage.isEmpty()) {
+            throw new InvalidHttpParameterException(targetUserErrorMessage);
+        }
+        NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
+        if (targetUser == NotificationTargetUser.GENERAL) {
+            throw new InvalidHttpParameterException(INVALID_TARGET_USER);
+        }
+        notifications = sqlLogic.getActiveNotificationsByTargetUser(targetUser);
 
         boolean isFetchingAll = false;
         if (getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL) != null) {
@@ -76,21 +72,14 @@ public class GetNotificationsAction extends Action {
             return new JsonResult(new NotificationsData(notifications));
         }
 
-        // Filter unread notifications
-        // TODO: This should be a single query to the database instead of fetching all notifications and filtering in memory
+        // Optimized: single query at the database level to exclude already-read notifications,
+        // avoiding the overhead of separate queries and in-memory filtering.
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
-        Set<UUID> readNotifications = sqlLogic.getReadNotificationsByAccountId(account.getId())
-                .stream()
-                .map(n -> n.getNotification().getId())
-                .collect(Collectors.toSet());
-        notifications = notifications
-                .stream()
-                .filter(n -> !readNotifications.contains(n.getId()))
-                .toList();
+        notifications = sqlLogic.getUnreadActiveNotificationsByTargetUser(targetUser, account.getId());
 
         if (userInfo.isAdmin) {
             return new JsonResult(new NotificationsData(notifications));

--- a/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
@@ -1,12 +1,10 @@
 package teammates.sqlui.webapi;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -205,28 +203,13 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     public void testExecute_withFalseIsFetchingAll_shouldUpdateShownAndReturnUnreadNotifications() {
         loginAsInstructor(GOOGLE_ID);
 
-        List<Notification> testAllNotifications = new ArrayList<>();
         List<Notification> testUnreadNotifications = new ArrayList<>();
-        Set<UUID> readNotificationsId;
 
         for (int i = 0; i < UNREAD_NOTIFICATION_COUNT; i++) {
             testUnreadNotifications.add(getTypicalNotificationWithId());
         }
 
-        for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
-            Notification readNotification = getTypicalNotificationWithId();
-            readNotification.setShown();
-            testAllNotifications.add(readNotification);
-        }
-
-        readNotificationsId = testAllNotifications.stream()
-                .map(Notification::getId)
-                .collect(Collectors.toSet());
-
-        testAllNotifications.addAll(testUnreadNotifications);
-
-        when(mockLogic.getAllNotifications()).thenReturn(testAllNotifications);
-        when(mockLogic.getActiveNotificationsByTargetUser(NotificationTargetUser.INSTRUCTOR))
+        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any()))
                 .thenReturn(testUnreadNotifications);
 
         String[] requestParams = new String[] {
@@ -239,36 +222,25 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notifications = output.getNotifications();
-        verifyDoesNotContainNotifications(notifications, readNotificationsId);
 
-        // should update notification has shown attribute
-        List<Notification> activeNotifications =
-                mockLogic.getActiveNotificationsByTargetUser(NotificationTargetUser.INSTRUCTOR);
-        activeNotifications = activeNotifications.stream()
-                .filter(n -> !readNotificationsId.contains(n.getId()))
-                .toList();
-        activeNotifications.forEach(n -> assertTrue(n.isShown()));
+        // should only return unread notifications
+        assertEquals(UNREAD_NOTIFICATION_COUNT, notifications.size());
+
+        // should update notification shown attribute for non-admin users
+        testUnreadNotifications.forEach(n -> assertTrue(n.isShown()));
     }
 
     @Test
     public void testExecute_withoutIsFetchingAll_shouldUpdateShownAndReturnUnreadNotifications() {
-        List<Notification> testAllNotifications = new ArrayList<>();
         List<Notification> testUnreadNotifications = new ArrayList<>();
-        Set<UUID> readNotificationsId;
 
         loginAsInstructor(GOOGLE_ID);
 
-        for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
-            Notification readNotification = getTypicalNotificationWithId();
-            readNotification.setShown();
-            testAllNotifications.add(readNotification);
+        for (int i = 0; i < UNREAD_NOTIFICATION_COUNT; i++) {
+            testUnreadNotifications.add(getTypicalNotificationWithId());
         }
 
-        readNotificationsId = testAllNotifications.stream()
-                .map(Notification::getId)
-                .collect(Collectors.toSet());
-
-        when(mockLogic.getActiveNotificationsByTargetUser(NotificationTargetUser.INSTRUCTOR))
+        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any()))
                 .thenReturn(testUnreadNotifications);
 
         String[] requestParams = new String[] {
@@ -280,7 +252,9 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notifications = output.getNotifications();
-        verifyDoesNotContainNotifications(notifications, readNotificationsId);
+
+        // should return only unread notifications
+        assertEquals(UNREAD_NOTIFICATION_COUNT, notifications.size());
     }
 
     @Test
@@ -303,11 +277,5 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         assertEquals(expected.getMessage(), actual.getMessage());
         assertEquals(expected.getStartTimestamp(), actual.getStartTimestamp());
         assertEquals(expected.getEndTimestamp(), actual.getEndTimestamp());
-    }
-
-    private void verifyDoesNotContainNotifications(List<NotificationData> notifications, Set<UUID> readIds) {
-        for (NotificationData n : notifications) {
-            assertFalse(readIds.contains(n.getNotificationId()));
-        }
     }
 }

--- a/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/GetNotificationsActionTest.java
@@ -209,7 +209,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
             testUnreadNotifications.add(getTypicalNotificationWithId());
         }
 
-        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any()))
+        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any(), any()))
                 .thenReturn(testUnreadNotifications);
 
         String[] requestParams = new String[] {
@@ -223,8 +223,10 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notifications = output.getNotifications();
 
-        // should only return unread notifications
-        assertEquals(UNREAD_NOTIFICATION_COUNT, notifications.size());
+        assertEquals(testUnreadNotifications.size(), notifications.size());
+        for (int i = 0; i < testUnreadNotifications.size(); i++) {
+            verifyNotificationEquals(new NotificationData(testUnreadNotifications.get(i)), notifications.get(i));
+        }
 
         // should update notification shown attribute for non-admin users
         testUnreadNotifications.forEach(n -> assertTrue(n.isShown()));
@@ -240,7 +242,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
             testUnreadNotifications.add(getTypicalNotificationWithId());
         }
 
-        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any()))
+        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any(), any()))
                 .thenReturn(testUnreadNotifications);
 
         String[] requestParams = new String[] {
@@ -253,8 +255,10 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notifications = output.getNotifications();
 
-        // should return only unread notifications
-        assertEquals(UNREAD_NOTIFICATION_COUNT, notifications.size());
+        assertEquals(testUnreadNotifications.size(), notifications.size());
+        for (int i = 0; i < testUnreadNotifications.size(); i++) {
+            verifyNotificationEquals(new NotificationData(testUnreadNotifications.get(i)), notifications.get(i));
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #13850 

This pull request addresses a performance bottleneck in the notification fetching logic. Previously, GetNotificationsAction fetched all notifications for a user and filtered out read ones in memory using Java streams, which caused the N+1 query problem and degraded performance as users accumulated more notifications over time.

Key changes:

Data Access Layer: Added a new method getUnreadActiveNotificationsByTargetUser in NotificationsDb that uses a NOT EXISTS subquery via the JPA CriteriaBuilder. This pushes the filtering down to the PostgreSQL database level.
Logic Layer: Exposed the new query through NotificationsLogic and the central Logic facade.
Action Layer: Refactored GetNotificationsAction to utilize the optimized query instead of fetching all notifications. Removed the existing technical debt TODO comment and cleaned up unnecessary imports.
Testing: Updated GetNotificationsActionTest to accurately mock the new database query method, removing the outdated in-memory mock configuration and ensuring test coverage remains robust.