### PR TITLE
[#13831] Fix ngbCollapse not calculating height correctly when using loading retry

### DIFF
--- a/src/web/app/components/loading-retry/loading-retry.component.html
+++ b/src/web/app/components/loading-retry/loading-retry.component.html
@@ -1,3 +1,6 @@
+<!-- Dummy content so ngbCollapse can calculate height correctly.
+ Removing this causes projected content overflow during expand animation. -->
+<div aria-hidden="true"></div>
 @if (shouldShowRetry) {
   <div class="text-center">
     <p class="text-muted m-1">{{ message || '' }}</p>

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -17,6 +17,9 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
     <div />
     <tm-loading-retry>
       <div
+        aria-hidden="true"
+      />
+      <div
         class="card bg-light mt-4"
         id="question-1-responses"
       >
@@ -120,6 +123,9 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
   >
     <div />
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <div
         class="card bg-light mt-4"
         id="question-2-responses"
@@ -271,6 +277,9 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
   >
     <div />
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <div
         class="card bg-light mt-4"
         id="question-3-responses"
@@ -450,6 +459,9 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
   >
     <div />
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <div
         class="card bg-light mt-4"
         id="question-1-responses"
@@ -644,6 +656,9 @@ exports[`QuestionResponsePanelComponent should snap with feedback session with q
     <div />
     <tm-loading-retry>
       <div
+        aria-hidden="true"
+      />
+      <div
         class="card bg-light mt-4"
         id="question-2-responses"
       >
@@ -758,6 +773,9 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
     <div />
     <tm-loading-retry>
       <div
+        aria-hidden="true"
+      />
+      <div
         class="card bg-light mt-4"
         id="question-1-responses"
       >
@@ -804,6 +822,9 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
   >
     <div />
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <div
         class="card bg-light mt-4"
         id="question-3-responses"
@@ -977,6 +998,9 @@ exports[`QuestionResponsePanelComponent should snap with questions and responses
   >
     <div />
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <div
         class="card bg-light mt-4"
         id="question-4-responses"

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -56,6 +56,9 @@ exports[`UserNotificationsListComponent should snap when all loaded notification
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
     <div
@@ -182,6 +185,9 @@ exports[`UserNotificationsListComponent should snap when it fails to load 1`] = 
     </p>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -259,6 +265,9 @@ exports[`UserNotificationsListComponent should snap when it loads the provided n
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
     <div
@@ -438,6 +447,9 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
     <div
@@ -617,6 +629,9 @@ exports[`UserNotificationsListComponent should snap when it sorts the notificati
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
     <div
@@ -762,6 +777,9 @@ exports[`UserNotificationsListComponent should snap with default fields when loa
       All dates are displayed in UTC time.
     </p>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -808,6 +826,9 @@ exports[`UserNotificationsListComponent should snap with no notifications 1`] = 
       All dates are displayed in UTC time.
     </p>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="alert alert-warning margin-top-30px"

--- a/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
@@ -656,6 +656,9 @@ exports[`AdminNotificationsPageComponent should snap when notification edit form
     </tm-notification-edit-form>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="margin-top-30px"
     >
       <div>
@@ -1326,6 +1329,9 @@ exports[`AdminNotificationsPageComponent should snap when notifications are load
       </div>
     </tm-notification-edit-form>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="margin-top-30px"
     >
@@ -2005,6 +2011,9 @@ exports[`AdminNotificationsPageComponent should snap when notifications failed t
     </tm-notification-edit-form>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -2680,6 +2689,9 @@ exports[`AdminNotificationsPageComponent should snap with default view 1`] = `
       </div>
     </tm-notification-edit-form>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="margin-top-30px"
     >

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -24,6 +24,9 @@ exports[`InstructorCourseDetailsPageComponent should snap when students are stil
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -67,6 +70,9 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Course Details
@@ -230,6 +236,9 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Course Details
@@ -639,6 +648,9 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"

--- a/src/web/app/pages-instructor/instructor-course-edit-page/__snapshots__/instructor-course-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/__snapshots__/instructor-course-edit-page.component.spec.ts.snap
@@ -35,6 +35,9 @@ exports[`InstructorCourseEditPageComponent should snap when editing course detai
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -51,6 +54,9 @@ exports[`InstructorCourseEditPageComponent should snap when editing course detai
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="right top-padded"
     >
@@ -126,6 +132,9 @@ exports[`InstructorCourseEditPageComponent should snap with course details 1`] =
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -142,6 +151,9 @@ exports[`InstructorCourseEditPageComponent should snap with course details 1`] =
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="right top-padded"
     >
@@ -217,6 +229,9 @@ exports[`InstructorCourseEditPageComponent should snap with default fields 1`] =
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -233,6 +248,9 @@ exports[`InstructorCourseEditPageComponent should snap with default fields 1`] =
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="right top-padded"
     >
@@ -308,6 +326,9 @@ exports[`InstructorCourseEditPageComponent should snap with some instructor deta
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -324,6 +345,9 @@ exports[`InstructorCourseEditPageComponent should snap with some instructor deta
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="right top-padded"
     >

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/__snapshots__/copy-instructors-from-other-courses-modal.component.spec.ts.snap
@@ -98,6 +98,9 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when feedback
         <div>
           <tm-loading-retry>
             <div
+              aria-hidden="true"
+            />
+            <div
               class="text-center"
             >
               <p
@@ -238,6 +241,9 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
         </div>
         <div>
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <div>
               <div
                 class="card-body"
@@ -503,6 +509,9 @@ exports[`CopyInstructorsFromOtherCoursesModalComponent should snap when instruct
         </div>
         <div>
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <tm-loading-spinner>
               <div
                 class="loading-container"

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/__snapshots__/instructor-course-student-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/__snapshots__/instructor-course-student-details-page.component.spec.ts.snap
@@ -12,6 +12,9 @@ exports[`InstructorCourseStudentDetailsPageComponent should snap with default fi
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -43,6 +46,9 @@ exports[`InstructorCourseStudentDetailsPageComponent should snap with populated 
   studentService={[Function StudentService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/__snapshots__/instructor-course-student-edit-page.component.spec.ts.snap
@@ -23,6 +23,9 @@ exports[`InstructorCourseStudentEditPageComponent should snap when student is st
   teamFieldSubscription="undefined"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -65,6 +68,9 @@ exports[`InstructorCourseStudentEditPageComponent should snap with default field
   teamFieldSubscription="undefined"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -107,6 +113,9 @@ exports[`InstructorCourseStudentEditPageComponent should snap with student detai
   teamFieldSubscription="undefined"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card border-primary"

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -54,6 +54,9 @@ exports[`InstructorCoursesPageComponent should snap when courses are still loadi
     </button>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="course-section"
     >
       <h2
@@ -165,6 +168,9 @@ exports[`InstructorCoursesPageComponent should snap when it is undeletable and u
        Add New Course 
     </button>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="course-section"
     >
@@ -778,6 +784,9 @@ exports[`InstructorCoursesPageComponent should snap when new course form is expa
     </tm-course-edit-form>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="course-section"
     >
       <h2
@@ -875,6 +884,9 @@ exports[`InstructorCoursesPageComponent should snap with all courses in course s
        Add New Course 
     </button>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="course-section"
     >
@@ -1258,6 +1270,9 @@ exports[`InstructorCoursesPageComponent should snap with default fields 1`] = `
     </button>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="course-section"
     >
       <h2
@@ -1369,6 +1384,9 @@ exports[`InstructorCoursesPageComponent should snap with no courses in course st
        Add New Course 
     </button>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="course-section"
     >

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -58,6 +58,9 @@ exports[`InstructorHomePageComponent should snap when courses are still loading 
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -135,6 +138,9 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -252,6 +258,9 @@ exports[`InstructorHomePageComponent should snap with one course with error load
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -271,6 +280,9 @@ exports[`InstructorHomePageComponent should snap with one course with error load
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
           >
             <tm-loading-retry>
+              <div
+                aria-hidden="true"
+              />
               <tm-loading-spinner
                 style=""
               >
@@ -395,6 +407,9 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -558,6 +573,9 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
           >
             <tm-loading-retry>
+              <div
+                aria-hidden="true"
+              />
               <tm-sessions-table
                 id="sessions-table-0"
                 style=""
@@ -987,6 +1005,9 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -1127,6 +1148,9 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
           >
             <tm-loading-retry>
+              <div
+                aria-hidden="true"
+              />
               <tm-sessions-table
                 id="sessions-table-0"
                 style=""
@@ -1736,6 +1760,9 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -2000,6 +2027,9 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -2163,6 +2193,9 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
           >
             <tm-loading-retry>
+              <div
+                aria-hidden="true"
+              />
               <tm-loading-spinner
                 style=""
               >
@@ -2287,6 +2320,9 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div>
         <div
@@ -2450,6 +2486,9 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
             class="card-body padding-0 table-responsive ng-trigger ng-trigger-collapseAnim ng-animating"
           >
             <tm-loading-retry>
+              <div
+                aria-hidden="true"
+              />
               <tm-sessions-table
                 id="sessions-table-0"
                 style=""

--- a/src/web/app/pages-instructor/instructor-notifications-page/__snapshots__/instructor-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-notifications-page/__snapshots__/instructor-notifications-page.component.spec.ts.snap
@@ -17,6 +17,9 @@ exports[`InstructorNotificationsPageComponent should snap with default fields 1`
       </p>
     </div>
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <tm-loading-spinner>
         <div
           class="loading-container"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -54,6 +54,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback question f
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -70,6 +73,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback question f
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="text-center"
     >
@@ -146,6 +152,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback questions 
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -162,6 +171,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback questions 
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -239,6 +251,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session fa
 >
   <tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -257,6 +272,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session fa
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -333,6 +351,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session is
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -349,6 +370,9 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session is
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -425,6 +449,9 @@ exports[`InstructorSessionEditPageComponent should snap with default fields 1`] 
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -441,6 +468,9 @@ exports[`InstructorSessionEditPageComponent should snap with default fields 1`] 
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -517,6 +547,9 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-session-edit-form>
       <div
         class="card card-plain"
@@ -1854,6 +1887,9 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
       </div>
     </tm-session-edit-form>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="offset-md-10 margin-vertical-20px"
     >
@@ -3778,6 +3814,9 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-session-edit-form>
       <div
         class="card card-plain"
@@ -5112,6 +5151,9 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
       </div>
     </tm-session-edit-form>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <a
         class="d-block text-end cursor-pointer"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/copy-questions-from-other-sessions-modal/__snapshots__/copy-questions-from-other-sessions-modal.component.spec.ts.snap
@@ -95,6 +95,9 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
         </div>
         <div>
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <div>
               <div
                 class="card-body"
@@ -306,6 +309,9 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
         </div>
         <div>
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <tm-loading-spinner>
               <div
                 class="loading-container"
@@ -441,6 +447,9 @@ exports[`CopyQuestionsFromOtherSessionsModalComponent should snap when feedback 
         </div>
         <div>
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <div
               class="text-center"
             >

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
@@ -40,6 +40,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -136,6 +139,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -154,9 +160,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -356,6 +368,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -519,6 +534,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -615,6 +633,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -633,6 +654,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -651,6 +675,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -850,6 +877,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -1064,6 +1094,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -1160,6 +1193,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -1178,6 +1214,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -1196,6 +1235,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -1395,6 +1437,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -1609,6 +1654,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -1705,6 +1753,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -1723,6 +1774,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -1741,6 +1795,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -1940,6 +1997,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -2154,6 +2214,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -2170,12 +2233,21 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -2290,6 +2362,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -2455,6 +2530,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -2551,6 +2629,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -2569,9 +2650,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -2771,6 +2858,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -2936,6 +3026,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -3032,9 +3125,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -3053,6 +3152,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -3167,6 +3269,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -3383,6 +3488,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -3479,6 +3587,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -3497,6 +3608,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -3515,6 +3629,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -3714,6 +3831,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -3930,6 +4050,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -4025,9 +4148,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -4044,6 +4173,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -4158,6 +4290,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -4240,6 +4375,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -4335,6 +4473,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -4351,9 +4492,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -4370,6 +4517,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
       </div>
     </tm-loading-spinner>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -4536,6 +4686,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
 >
   <tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -4554,12 +4707,21 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -4674,6 +4836,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -4839,6 +5004,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -4936,6 +5104,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -4954,6 +5125,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="text-center"
     >
@@ -4974,6 +5148,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -4992,6 +5169,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="text-center"
     >
@@ -5078,6 +5258,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
 >
   <tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -5096,12 +5279,21 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -5216,6 +5408,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -5381,6 +5576,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -5477,6 +5675,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -5496,6 +5697,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -5514,6 +5718,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -5714,6 +5921,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -5798,6 +6008,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -5895,6 +6108,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -5913,6 +6129,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -5932,6 +6151,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
     </div>
   </tm-loading-retry><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -5950,6 +6172,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
       </button>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -6166,6 +6391,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -6262,9 +6490,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -6283,6 +6517,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -6397,6 +6634,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors
@@ -6612,6 +6852,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
   tableComparatorService={[Function TableComparatorService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="card bg-light top-padded text-center text-sm-start"
@@ -6708,6 +6951,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
       </p>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="form-check"
@@ -6726,9 +6972,15 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
       </div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Students
@@ -6928,6 +7180,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
       </div>
     </div>
   </tm-loading-retry><br /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <h1>
         Instructors

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -1470,6 +1470,9 @@ exports[`InstructorSessionsPageComponent should snap when courses are loading 1`
     </div>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="margin-top-30px"
     >
       <tm-loading-spinner>
@@ -2992,6 +2995,9 @@ exports[`InstructorSessionsPageComponent should snap when feedback sessions are 
       </tm-session-edit-form>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="margin-top-30px"
     >
@@ -4516,6 +4522,9 @@ exports[`InstructorSessionsPageComponent should snap when feedback sessions fail
     </div>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -6019,6 +6028,9 @@ exports[`InstructorSessionsPageComponent should snap when new session form is ex
       </tm-session-edit-form>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="margin-top-30px"
     >
@@ -7547,6 +7559,9 @@ exports[`InstructorSessionsPageComponent should snap when recycle bin section is
     </div>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="margin-top-30px"
     >
       <tm-loading-spinner>
@@ -9070,6 +9085,9 @@ exports[`InstructorSessionsPageComponent should snap with active sessions 1`] = 
     </div>
   </div><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="margin-top-30px"
     >
       <tm-loading-spinner>
@@ -10590,6 +10608,9 @@ exports[`InstructorSessionsPageComponent should snap with default fields 1`] = `
       </tm-session-edit-form>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="margin-top-30px"
     >

--- a/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-list-page/__snapshots__/instructor-student-list-page.component.spec.ts.snap
@@ -25,6 +25,9 @@ exports[`InstructorStudentListPageComponent should snap with a course with stude
     </a>
      if you need to locate the details of a specific student by name or email.
   </p><hr /><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div
       class="row mb-3"
@@ -103,6 +106,9 @@ exports[`InstructorStudentListPageComponent should snap with a course with stude
           class="ng-trigger ng-trigger-collapseAnim ng-animating"
         >
           <tm-loading-retry>
+            <div
+              aria-hidden="true"
+            />
             <div
               style=""
             >

--- a/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
@@ -30,6 +30,9 @@ exports[`InstructorStudentRecordsPageComponent should snap when student results 
   </h1><h2>
     Records in feedback sessions
   </h2><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -79,6 +82,9 @@ exports[`InstructorStudentRecordsPageComponent should snap with default fields 1
   </h1><h2>
     Records in feedback sessions
   </h2><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -128,6 +134,9 @@ exports[`InstructorStudentRecordsPageComponent should snap with populated fields
   </h1><h2>
     Records in feedback sessions
   </h2><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
     </div>
   </tm-loading-retry>

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -129,6 +129,9 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="mt-4"
@@ -278,6 +281,9 @@ exports[`SessionResultPageComponent should snap when session results failed to l
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="text-center"
     >
@@ -430,6 +436,9 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="mt-4"
@@ -579,6 +588,9 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="mt-4"
@@ -810,6 +822,9 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -960,6 +975,9 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="mt-4"
@@ -1109,6 +1127,9 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <div
         class="mt-4"

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -137,6 +137,9 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
     </div>
   </tm-loading-spinner><tm-loading-retry>
     <div
+      aria-hidden="true"
+    />
+    <div
       class="text-center"
     >
       <p
@@ -294,6 +297,9 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -449,6 +455,9 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -737,6 +746,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -990,6 +1002,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <tm-question-submission-form
         id="feedback-question-id-mcq"
@@ -4025,6 +4040,9 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
       </div>
     </div>
   </div><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div>
       <tm-question-submission-form
         id="feedback-question-id-mcq"
@@ -6999,6 +7017,9 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -7155,6 +7176,9 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
       </div>
     </div>
   </tm-loading-spinner><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"

--- a/src/web/app/pages-student/student-course-details-page/__snapshots__/student-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-course-details-page/__snapshots__/student-course-details-page.component.spec.ts.snap
@@ -22,6 +22,9 @@ exports[`StudentCourseDetailsPageComponent should snap when all data are still l
   teammateProfilesSortBy="0"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
   </tm-loading-retry><tm-loading-spinner>
     <div
       class="loading-container"
@@ -62,6 +65,9 @@ exports[`StudentCourseDetailsPageComponent should snap when it fails to load 1`]
   teammateProfilesSortBy="0"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
   </tm-loading-retry><div
     class="section"
   >
@@ -103,6 +109,9 @@ exports[`StudentCourseDetailsPageComponent should snap with default fields 1`] =
   teammateProfilesSortBy="0"
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
   </tm-loading-retry><div
     class="section"
   >
@@ -148,6 +157,9 @@ exports[`StudentCourseDetailsPageComponent should snap with populated fields 1`]
   >
     Team Details for 1.1.c-demo2
   </h1><tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="section"
     >

--- a/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
@@ -25,6 +25,9 @@ exports[`StudentHomePageComponent should snap when courses are still loading 1`]
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -69,6 +72,9 @@ exports[`StudentHomePageComponent should snap when there is course loading faile
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div
       class="text-center"
     >
@@ -116,6 +122,9 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div>
       <div
@@ -196,6 +205,9 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
           </div>
         </div>
         <tm-loading-retry>
+          <div
+            aria-hidden="true"
+          />
           <div
             class="table-responsive"
           >
@@ -362,6 +374,9 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
         </div>
         <tm-loading-retry>
           <div
+            aria-hidden="true"
+          />
+          <div
             class="table-responsive"
           >
             <div
@@ -518,6 +533,9 @@ exports[`StudentHomePageComponent should snap with default fields 1`] = `
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <tm-loading-spinner>
       <div
         class="loading-container"
@@ -562,6 +580,9 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div>
       <div
@@ -601,6 +622,9 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
           </div>
         </div>
         <tm-loading-retry>
+          <div
+            aria-hidden="true"
+          />
           <div
             class="table-responsive"
           >
@@ -758,6 +782,9 @@ exports[`StudentHomePageComponent should snap with no course 1`] = `
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div>
       <div>
@@ -800,6 +827,9 @@ exports[`StudentHomePageComponent should snap with no feedback session over 2 co
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div>
       <div
@@ -880,6 +910,9 @@ exports[`StudentHomePageComponent should snap with no feedback session over 2 co
         </div>
         <tm-loading-retry>
           <div
+            aria-hidden="true"
+          />
+          <div
             class="table-responsive"
           >
             <div
@@ -927,6 +960,9 @@ exports[`StudentHomePageComponent should snap with no feedback session over 2 co
         </div>
         <tm-loading-retry>
           <div
+            aria-hidden="true"
+          />
+          <div
             class="table-responsive"
           >
             <div
@@ -966,6 +1002,9 @@ exports[`StudentHomePageComponent should snap with no feedback sessions 1`] = `
   timezoneService={[Function TimezoneService]}
 >
   <tm-loading-retry>
+    <div
+      aria-hidden="true"
+    />
     <div />
     <div>
       <div
@@ -1005,6 +1044,9 @@ exports[`StudentHomePageComponent should snap with no feedback sessions 1`] = `
           </div>
         </div>
         <tm-loading-retry>
+          <div
+            aria-hidden="true"
+          />
           <div
             class="table-responsive"
           >

--- a/src/web/app/pages-student/student-notifications-page/__snapshots__/student-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-notifications-page/__snapshots__/student-notifications-page.component.spec.ts.snap
@@ -17,6 +17,9 @@ exports[`StudentNotificationsPageComponent should snap with default fields 1`] =
       </p>
     </div>
     <tm-loading-retry>
+      <div
+        aria-hidden="true"
+      />
       <tm-loading-spinner>
         <div
           class="loading-container"


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13831

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

loading retry in ngbCollapse causes overflow when collapsed element is expanded. A dummy node in loading retry is added which seems to fix the issue. 

Long term, we probably need to take another look at this component. This component has been causing layout issues for awhile. 