### PR TITLE
[#13861] Change getDisplayWeight return type from any to string

### DIFF
--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -166,7 +166,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
     });
   }
 
-  private getDisplayWeight(weight: number): any {
-    return weight === null || weight === NO_VALUE ? '-' : weight;
+  private getDisplayWeight(weight: number): string {
+    return weight === null || weight === NO_VALUE ? '-' : String(weight);
   }
 }

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -69,7 +69,7 @@ ${
         }),
       ];
       if (statsCalculation.hasWeights) {
-        currRow.push(String(this.getDisplayWeight(statsCalculation.subQuestionWeightAverage[questionIndex])));
+        currRow.push(this.getDisplayWeight(statsCalculation.subQuestionWeightAverage[questionIndex]));
       }
       statsRows.push(currRow);
     });
@@ -108,8 +108,8 @@ ${
 (${perRecipientStats.answers[questionIndex][choiceIndex]}) \
 [${this.getDisplayWeight(statsCalculation.weights[questionIndex][choiceIndex])}]`;
             }),
-            String(this.getDisplayWeight(perRecipientStats.subQuestionTotalChosenWeight[questionIndex])),
-            String(this.getDisplayWeight(perRecipientStats.subQuestionWeightAverage[questionIndex])),
+            this.getDisplayWeight(perRecipientStats.subQuestionTotalChosenWeight[questionIndex]),
+            this.getDisplayWeight(perRecipientStats.subQuestionWeightAverage[questionIndex]),
           ]);
         });
       });
@@ -145,9 +145,9 @@ ${
 (${perRecipientStats.answersSum[choiceIndex]}) \
 [${this.getDisplayWeight(perRecipientStats.weightsAverage[choiceIndex])}]`;
           }),
-          String(this.getDisplayWeight(perRecipientStats.overallWeightedSum)),
-          String(this.getDisplayWeight(perRecipientStats.overallWeightAverage)),
-          String(perCriterionAverage),
+          this.getDisplayWeight(perRecipientStats.overallWeightedSum),
+          this.getDisplayWeight(perRecipientStats.overallWeightAverage),
+          perCriterionAverage,
         ]);
       });
 

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -162,7 +162,7 @@ ${
     return true;
   }
 
-  private getDisplayWeight(weight: number): any {
-    return weight === null || weight === NO_VALUE ? '-' : weight;
+  private getDisplayWeight(weight: number): string {
+    return weight === null || weight === NO_VALUE ? '-' : String(weight);
   }
 }


### PR DESCRIPTION
Fixes #13861

The `getDisplayWeight` method in both `RubricQuestionStatisticsComponent` and `FeedbackRubricQuestionDetailsImpl` previously returned `any` type, bypassing TypeScript's type checking.

Changed the return type to `string` and wrapped the weight value in `String()` when not null or NO_VALUE.