### PR TITLE
[#13721] Remove update methods in Db layer

### DIFF
--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AccountRequestStatus;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.AccountRequestsDb;
@@ -90,23 +89,4 @@ public class AccountRequestsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertEquals(expectedAccountRequest, actualAccountRequest);
     }
 
-    @Test
-    public void testUpdateAccountRequest() throws Exception {
-        ______TS("Update account request, does not exists, exception thrown");
-
-        AccountRequest accountRequest =
-                new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-
-        assertThrows(EntityDoesNotExistException.class,
-                () -> accountRequestDb.updateAccountRequest(accountRequest));
-
-        ______TS("Update account request, already exists, update successful");
-
-        accountRequestDb.createAccountRequest(accountRequest);
-        accountRequest.setName("new account request name");
-
-        accountRequestDb.updateAccountRequest(accountRequest);
-        AccountRequest actual = accountRequestDb.getAccountRequest(accountRequest.getId());
-        verifyEquals(accountRequest, actual);
-    }
 }

--- a/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountsDbIT.java
@@ -62,21 +62,6 @@ public class AccountsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
     }
 
     @Test
-    public void testUpdateAccount() throws Exception {
-        Account account = new Account("google-id", "name", "email@teammates.com");
-        accountsDb.createAccount(account);
-        HibernateUtil.flushSession();
-
-        ______TS("Update existing account, success");
-
-        account.setName("new account name");
-        accountsDb.updateAccount(account);
-
-        Account actual = accountsDb.getAccount(account.getId());
-        verifyEquals(account, actual);
-    }
-
-    @Test
     public void testDeleteAccount() throws InvalidParametersException, EntityAlreadyExistsException {
         Account account = new Account("google-id", "name", "email@teammates.com");
         accountsDb.createAccount(account);

--- a/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/CoursesDbIT.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.CoursesDb;
@@ -57,33 +56,6 @@ public class CoursesDbIT extends BaseTestCaseWithSqlDatabaseAccess {
         assertNotSame(course, identicalCourse);
 
         assertThrows(EntityAlreadyExistsException.class, () -> coursesDb.createCourse(identicalCourse));
-    }
-
-    @Test
-    public void testUpdateCourse() throws Exception {
-        ______TS("failure: update course that does not exist, exception thrown");
-        Course course = getTypicalCourse();
-        assertThrows(EntityDoesNotExistException.class, () -> coursesDb.updateCourse(course));
-
-        ______TS("failure: null course assertion exception thrown");
-        assertThrows(AssertionError.class, () -> coursesDb.updateCourse(null));
-
-        ______TS("success: update course that already exists");
-        coursesDb.createCourse(course);
-        course.setName("new course name");
-
-        coursesDb.updateCourse(course);
-        Course actual = coursesDb.getCourse("course-id");
-        verifyEquals(course, actual);
-
-        ______TS("success: update detached course that already exists");
-
-        // same id, different name
-        Course detachedCourse = getTypicalCourse();
-        detachedCourse.setName("different-name");
-
-        coursesDb.updateCourse(detachedCourse);
-        verifyEquals(course, detachedCourse);
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -122,17 +122,15 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private void setUserDeadlineExtension(FeedbackSession session, User user, int days)
             throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
-        DeadlineExtension newDeadline =
-                new DeadlineExtension(user, session, TimeHelper.getInstantDaysOffsetFromNow(days));
-
-        newDeadline.setFeedbackSession(session);
-        newDeadline.setUser(user);
-
-        DeadlineExtension existingDeadlineEndTime = logic.getDeadlineExtensionEntityForUser(session, user);
-        if (existingDeadlineEndTime != null) {
-            newDeadline.setId(existingDeadlineEndTime.getId());
-            logic.updateDeadlineExtension(newDeadline);
+        Instant endTime = TimeHelper.getInstantDaysOffsetFromNow(days);
+        DeadlineExtension existingDeadline = logic.getDeadlineExtensionEntityForUser(session, user);
+        if (existingDeadline != null) {
+            existingDeadline.setEndTime(endTime);
+            logic.updateDeadlineExtension(existingDeadline);
         } else {
+            DeadlineExtension newDeadline = new DeadlineExtension(user, session, endTime);
+            newDeadline.setFeedbackSession(session);
+            newDeadline.setUser(user);
             logic.createDeadlineExtension(newDeadline);
         }
     }

--- a/src/main/java/teammates/sqllogic/api/Logic.java
+++ b/src/main/java/teammates/sqllogic/api/Logic.java
@@ -129,7 +129,7 @@ public class Logic {
      * @return the updated account request.
      */
     public AccountRequest updateAccountRequest(AccountRequest accountRequest)
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         return accountRequestLogic.updateAccountRequest(accountRequest);
     }
 

--- a/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
@@ -65,9 +65,7 @@ public final class AccountRequestsLogic {
      */
     public AccountRequest updateAccountRequest(AccountRequest accountRequest)
             throws InvalidParametersException {
-        if (!accountRequest.isValid()) {
-            throw new InvalidParametersException(accountRequest.getInvalidityInfo());
-        }
+        validateAccountRequest(accountRequest);
         return accountRequest;
     }
 
@@ -104,6 +102,7 @@ public final class AccountRequestsLogic {
                     + "the given id cannot be found.");
         }
         accountRequest.setRegisteredAt(null);
+        validateAccountRequest(accountRequest);
 
         return accountRequest;
     }
@@ -130,5 +129,11 @@ public final class AccountRequestsLogic {
      */
     public List<AccountRequest> searchAccountRequestsInWholeSystem(String queryString) {
         return accountRequestDb.searchAccountRequestsInWholeSystem(queryString);
+    }
+
+    private void validateAccountRequest(AccountRequest accountRequest) throws InvalidParametersException {
+        if (!accountRequest.isValid()) {
+            throw new InvalidParametersException(accountRequest.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/AccountRequestsLogic.java
@@ -64,8 +64,11 @@ public final class AccountRequestsLogic {
      * Updates an account request.
      */
     public AccountRequest updateAccountRequest(AccountRequest accountRequest)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        return accountRequestDb.updateAccountRequest(accountRequest);
+            throws InvalidParametersException {
+        if (!accountRequest.isValid()) {
+            throw new InvalidParametersException(accountRequest.getInvalidityInfo());
+        }
+        return accountRequest;
     }
 
     /**
@@ -102,7 +105,7 @@ public final class AccountRequestsLogic {
         }
         accountRequest.setRegisteredAt(null);
 
-        return accountRequestDb.updateAccountRequest(accountRequest);
+        return accountRequest;
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/CoursesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/CoursesLogic.java
@@ -228,9 +228,7 @@ public final class CoursesLogic {
         course.setName(name);
         course.setTimeZone(timezone);
 
-        if (!course.isValid()) {
-            throw new InvalidParametersException(course.getInvalidityInfo());
-        }
+        validateCourse(course);
 
         return course;
     }
@@ -248,9 +246,7 @@ public final class CoursesLogic {
         Section section = new Section(course, sectionName);
         course.addSection(section);
 
-        if (!section.isValid()) {
-            throw new InvalidParametersException(section.getInvalidityInfo());
-        }
+        validateSection(section);
 
         return coursesDb.createSection(section);
     }
@@ -295,9 +291,7 @@ public final class CoursesLogic {
         Team team = new Team(section, teamName);
         section.addTeam(team);
 
-        if (!team.isValid()) {
-            throw new InvalidParametersException(team.getInvalidityInfo());
-        }
+        validateTeam(team);
 
         return coursesDb.createTeam(team);
     }
@@ -314,5 +308,23 @@ public final class CoursesLogic {
      */
     public static void sortById(List<Course> courses) {
         courses.sort(Comparator.comparing(Course::getId));
+    }
+
+    private void validateTeam(Team team) throws InvalidParametersException {
+        if (!team.isValid()) {
+            throw new InvalidParametersException(team.getInvalidityInfo());
+        }
+    }
+
+    private void validateSection(Section section) throws InvalidParametersException {
+        if (!section.isValid()) {
+            throw new InvalidParametersException(section.getInvalidityInfo());
+        }
+    }
+
+    private void validateCourse(Course course) throws InvalidParametersException {
+        if (!course.isValid()) {
+            throw new InvalidParametersException(course.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
@@ -106,9 +106,8 @@ public final class DeadlineExtensionsLogic {
         if (existing == null) {
             throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + de);
         }
-        if (!de.isValid()) {
-            throw new InvalidParametersException(de.getInvalidityInfo());
-        }
+
+        validateDeadlineExtension(de);
         return de;
     }
 
@@ -139,5 +138,11 @@ public final class DeadlineExtensionsLogic {
                 deleteDeadlineExtension(deadlineExtension);
             }
         });
+    }
+
+    private void validateDeadlineExtension(DeadlineExtension deadlineExtension) throws InvalidParametersException {
+        if (!deadlineExtension.isValid()) {
+            throw new InvalidParametersException(deadlineExtension.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/DeadlineExtensionsLogic.java
@@ -102,7 +102,14 @@ public final class DeadlineExtensionsLogic {
      */
     public DeadlineExtension updateDeadlineExtension(DeadlineExtension de)
             throws InvalidParametersException, EntityDoesNotExistException {
-        return deadlineExtensionsDb.updateDeadlineExtension(de);
+        DeadlineExtension existing = deadlineExtensionsDb.getDeadlineExtension(de.getId());
+        if (existing == null) {
+            throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + de);
+        }
+        if (!de.isValid()) {
+            throw new InvalidParametersException(de.getInvalidityInfo());
+        }
+        return de;
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackQuestionsLogic.java
@@ -225,6 +225,8 @@ public final class FeedbackQuestionsLogic {
             frLogic.deleteFeedbackResponsesForQuestionCascade(question);
         }
 
+        validateFeedbackQuestion(question);
+
         return question;
     }
 
@@ -319,6 +321,12 @@ public final class FeedbackQuestionsLogic {
         }
         default -> Optional.empty();
         };
+    }
+
+    private void validateFeedbackQuestion(FeedbackQuestion feedbackQuestion) throws InvalidParametersException {
+        if (!feedbackQuestion.isValid()) {
+            throw new InvalidParametersException(feedbackQuestion.getInvalidityInfo());
+        }
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -90,12 +90,14 @@ public final class FeedbackResponseCommentsLogic {
      *
      * @return updated comment
      * @throws InvalidParametersException if attributes to update are not valid
-     * @throws EntityDoesNotExistException if the comment cannot be found
      */
     public FeedbackResponseComment updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment)
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
+        if (!feedbackResponseComment.isValid()) {
+            throw new InvalidParametersException(feedbackResponseComment.getInvalidityInfo());
+        }
 
-        return frcDb.updateFeedbackResponseComment(feedbackResponseComment);
+        return feedbackResponseComment;
     }
 
     /**
@@ -130,12 +132,12 @@ public final class FeedbackResponseCommentsLogic {
      * Updates all feedback response comments with new sections.
      */
     public void updateFeedbackResponseCommentsForResponse(FeedbackResponse response)
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         List<FeedbackResponseComment> comments = response.getFeedbackResponseComments();
         for (FeedbackResponseComment comment : comments) {
             comment.setGiverSection(response.getGiverSection());
             comment.setRecipientSection(response.getRecipientSection());
-            frcDb.updateFeedbackResponseComment(comment);
+            updateFeedbackResponseComment(comment);
         }
     }
 

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponseCommentsLogic.java
@@ -93,10 +93,7 @@ public final class FeedbackResponseCommentsLogic {
      */
     public FeedbackResponseComment updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment)
             throws InvalidParametersException {
-        if (!feedbackResponseComment.isValid()) {
-            throw new InvalidParametersException(feedbackResponseComment.getInvalidityInfo());
-        }
-
+        validateFeedbackResponseComment(feedbackResponseComment);
         return feedbackResponseComment;
     }
 
@@ -281,6 +278,13 @@ public final class FeedbackResponseCommentsLogic {
         }
 
         return checkIsFeedbackParticipantNameVisibleToUser(response, userEmail, roster, showNameTo);
+    }
+
+    private void validateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment)
+            throws InvalidParametersException {
+        if (!feedbackResponseComment.isValid()) {
+            throw new InvalidParametersException(feedbackResponseComment.getInvalidityInfo());
+        }
     }
 
     private boolean checkIsFeedbackParticipantNameVisibleToUser(FeedbackResponse response,

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -199,25 +199,24 @@ public final class FeedbackResponsesLogic {
      */
     public FeedbackResponse updateFeedbackResponseCascade(FeedbackResponse feedbackResponse)
             throws InvalidParametersException, EntityDoesNotExistException {
-        validateFeedbackResponse(feedbackResponse);
-
-        // TODO: investigate for bugs, oldResponse and newResponse are the same object.
+        // TODO: do not pass detached entities around
         FeedbackResponse oldResponse = frDb.getFeedbackResponse(feedbackResponse.getId());
         if (oldResponse == null) {
             throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + feedbackResponse);
         }
-        FeedbackResponse newResponse = feedbackResponse;
 
         List<FeedbackResponseComment> oldResponseComments = oldResponse.getFeedbackResponseComments();
 
         for (FeedbackResponseComment oldResponseComment : oldResponseComments) {
-            oldResponseComment.setGiverSection(newResponse.getGiverSection());
-            oldResponseComment.setRecipientSection(newResponse.getRecipientSection());
+            oldResponseComment.setGiverSection(feedbackResponse.getGiverSection());
+            oldResponseComment.setRecipientSection(feedbackResponse.getRecipientSection());
 
             frcLogic.updateFeedbackResponseComment(oldResponseComment);
         }
 
-        return newResponse;
+        validateFeedbackResponse(oldResponse);
+
+        return oldResponse;
     }
 
     /**
@@ -462,14 +461,12 @@ public final class FeedbackResponsesLogic {
      *     This is done by deleting responses that are no longer relevant to him in his new team.
      * </p>
      */
-    public void updateFeedbackResponsesForChangingTeam(Course course, String newEmail, Team newTeam, Team oldTeam) {
-        FeedbackQuestion qn;
-
+    public void updateFeedbackResponsesForChangingTeam(Course course, String newEmail, Team oldTeam) {
         List<FeedbackResponse> responsesFromUser =
                 getFeedbackResponsesFromGiverForCourse(course.getId(), newEmail);
 
         for (FeedbackResponse response : responsesFromUser) {
-            qn = fqLogic.getFeedbackQuestion(response.getId());
+            FeedbackQuestion qn = response.getFeedbackQuestion();
             if (qn != null && qn.getGiverType() == FeedbackParticipantType.TEAMS) {
                 deleteFeedbackResponsesForQuestionCascade(qn);
             }
@@ -479,7 +476,7 @@ public final class FeedbackResponsesLogic {
                 getFeedbackResponsesForRecipientForCourse(course.getId(), newEmail);
 
         for (FeedbackResponse response : responsesToUser) {
-            qn = fqLogic.getFeedbackQuestion(response.getId());
+            FeedbackQuestion qn = response.getFeedbackQuestion();
             if (qn != null && qn.getGiverType() == FeedbackParticipantType.TEAMS) {
                 deleteFeedbackResponsesForQuestionCascade(qn);
             }

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -199,9 +199,16 @@ public final class FeedbackResponsesLogic {
      */
     public FeedbackResponse updateFeedbackResponseCascade(FeedbackResponse feedbackResponse)
             throws InvalidParametersException, EntityDoesNotExistException {
+        if (!feedbackResponse.isValid()) {
+            throw new InvalidParametersException(feedbackResponse.getInvalidityInfo());
+        }
+
         // TODO: investigate for bugs, oldResponse and newResponse are the same object.
         FeedbackResponse oldResponse = frDb.getFeedbackResponse(feedbackResponse.getId());
-        FeedbackResponse newResponse = frDb.updateFeedbackResponse(feedbackResponse);
+        if (oldResponse == null) {
+            throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + feedbackResponse);
+        }
+        FeedbackResponse newResponse = feedbackResponse;
 
         List<FeedbackResponseComment> oldResponseComments = oldResponse.getFeedbackResponseComments();
 
@@ -457,9 +464,7 @@ public final class FeedbackResponsesLogic {
      *     This is done by deleting responses that are no longer relevant to him in his new team.
      * </p>
      */
-    public void updateFeedbackResponsesForChangingTeam(Course course, String newEmail, Team newTeam, Team oldTeam)
-            throws InvalidParametersException, EntityDoesNotExistException {
-
+    public void updateFeedbackResponsesForChangingTeam(Course course, String newEmail, Team newTeam, Team oldTeam) {
         FeedbackQuestion qn;
 
         List<FeedbackResponse> responsesFromUser =
@@ -493,14 +498,16 @@ public final class FeedbackResponsesLogic {
      * Updates responses for a student when his section changes.
      */
     public void updateFeedbackResponsesForChangingSection(Course course, String newEmail, Section newSection)
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
 
         List<FeedbackResponse> responsesFromUser =
                 getFeedbackResponsesFromGiverForCourse(course.getId(), newEmail);
 
         for (FeedbackResponse response : responsesFromUser) {
             response.setGiverSection(newSection);
-            frDb.updateFeedbackResponse(response);
+            if (!response.isValid()) {
+                throw new InvalidParametersException(response.getInvalidityInfo());
+            }
             frcLogic.updateFeedbackResponseCommentsForResponse(response);
         }
 
@@ -509,7 +516,9 @@ public final class FeedbackResponsesLogic {
 
         for (FeedbackResponse response : responsesToUser) {
             response.setRecipientSection(newSection);
-            frDb.updateFeedbackResponse(response);
+            if (!response.isValid()) {
+                throw new InvalidParametersException(response.getInvalidityInfo());
+            }
             frcLogic.updateFeedbackResponseCommentsForResponse(response);
         }
     }
@@ -518,14 +527,15 @@ public final class FeedbackResponsesLogic {
      * Updates a student's email in their given/received responses.
      */
     public void updateFeedbackResponsesForChangingEmail(String courseId, String oldEmail, String newEmail)
-            throws InvalidParametersException, EntityDoesNotExistException {
-
+            throws InvalidParametersException {
         List<FeedbackResponse> responsesFromUser =
                 getFeedbackResponsesFromGiverForCourse(courseId, oldEmail);
 
         for (FeedbackResponse response : responsesFromUser) {
             response.setGiver(newEmail);
-            frDb.updateFeedbackResponse(response);
+            if (!response.isValid()) {
+                throw new InvalidParametersException(response.getInvalidityInfo());
+            }
         }
 
         List<FeedbackResponse> responsesToUser =
@@ -533,7 +543,9 @@ public final class FeedbackResponsesLogic {
 
         for (FeedbackResponse response : responsesToUser) {
             response.setRecipient(newEmail);
-            frDb.updateFeedbackResponse(response);
+            if (!response.isValid()) {
+                throw new InvalidParametersException(response.getInvalidityInfo());
+            }
         }
     }
 

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -199,9 +199,7 @@ public final class FeedbackResponsesLogic {
      */
     public FeedbackResponse updateFeedbackResponseCascade(FeedbackResponse feedbackResponse)
             throws InvalidParametersException, EntityDoesNotExistException {
-        if (!feedbackResponse.isValid()) {
-            throw new InvalidParametersException(feedbackResponse.getInvalidityInfo());
-        }
+        validateFeedbackResponse(feedbackResponse);
 
         // TODO: investigate for bugs, oldResponse and newResponse are the same object.
         FeedbackResponse oldResponse = frDb.getFeedbackResponse(feedbackResponse.getId());
@@ -1146,6 +1144,12 @@ public final class FeedbackResponsesLogic {
     private List<FeedbackResponse> getFeedbackResponsesForRecipientForQuestion(
             UUID feedbackQuestionId, String userEmail) {
         return frDb.getFeedbackResponsesForRecipientForQuestion(feedbackQuestionId, userEmail);
+    }
+
+    private void validateFeedbackResponse(FeedbackResponse feedbackResponse) throws InvalidParametersException {
+        if (!feedbackResponse.isValid()) {
+            throw new InvalidParametersException(feedbackResponse.getInvalidityInfo());
+        }
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackResponsesLogic.java
@@ -22,6 +22,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.HibernateUtil;
 import teammates.common.util.RequestTracer;
 import teammates.common.util.SanitizationHelper;
 import teammates.storage.sqlapi.FeedbackResponsesDb;
@@ -199,11 +200,14 @@ public final class FeedbackResponsesLogic {
      */
     public FeedbackResponse updateFeedbackResponseCascade(FeedbackResponse feedbackResponse)
             throws InvalidParametersException, EntityDoesNotExistException {
-        // TODO: do not pass detached entities around
+
         FeedbackResponse oldResponse = frDb.getFeedbackResponse(feedbackResponse.getId());
         if (oldResponse == null) {
             throw new EntityDoesNotExistException("Trying to update non-existent Entity: " + feedbackResponse);
         }
+
+        // TODO: do not pass detached entities around
+        HibernateUtil.merge(feedbackResponse);
 
         List<FeedbackResponseComment> oldResponseComments = oldResponse.getFeedbackResponseComments();
 
@@ -214,9 +218,9 @@ public final class FeedbackResponsesLogic {
             frcLogic.updateFeedbackResponseComment(oldResponseComment);
         }
 
-        validateFeedbackResponse(oldResponse);
+        validateFeedbackResponse(feedbackResponse);
 
-        return oldResponse;
+        return feedbackResponse;
     }
 
     /**

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionLogsLogic.java
@@ -50,9 +50,7 @@ public final class FeedbackSessionLogsLogic {
             FeedbackSessionLogType logType, Instant timestamp) throws InvalidParametersException {
         FeedbackSessionLog fsLog = new FeedbackSessionLog(student, feedbackSession, logType, timestamp);
 
-        if (!fsLog.isValid()) {
-            throw new InvalidParametersException("Invalid feedback session log: " + fsLog.getInvalidityInfo());
-        }
+        validateFeedbackSessionLog(fsLog);
 
         return fslDb.createFeedbackSessionLog(fsLog);
     }
@@ -76,5 +74,11 @@ public final class FeedbackSessionLogsLogic {
             UUID feedbackSessionId, Instant startTime, Instant endTime) {
         return fslDb.getOrderedFeedbackSessionLogs(courseId, studentId, feedbackSessionId, startTime,
                 endTime);
+    }
+
+    private void validateFeedbackSessionLog(FeedbackSessionLog feedbackSessionLog) throws InvalidParametersException {
+        if (!feedbackSessionLog.isValid()) {
+            throw new InvalidParametersException("Invalid feedback session log: " + feedbackSessionLog.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/FeedbackSessionsLogic.java
@@ -233,9 +233,7 @@ public final class FeedbackSessionsLogic {
         session.setClosingSoonEmailEnabled(updateRequest.isClosingSoonEmailEnabled());
         session.setPublishedEmailEnabled(updateRequest.isPublishedEmailEnabled());
 
-        if (!session.isValid()) {
-            throw new InvalidParametersException(session.getInvalidityInfo());
-        }
+        validateFeedbackSession(session);
 
         return session;
     }
@@ -606,5 +604,12 @@ public final class FeedbackSessionsLogic {
      */
     public int getActualTotalSubmission(FeedbackSession fs) {
         return getGiverSetThatAnsweredFeedbackSession(fs).size();
+    }
+
+    private void validateFeedbackSession(FeedbackSession feedbackSession)
+            throws InvalidParametersException {
+        if (!feedbackSession.isValid()) {
+            throw new InvalidParametersException(feedbackSession.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -52,9 +52,7 @@ public final class NotificationsLogic {
             throws InvalidParametersException, EntityAlreadyExistsException {
         assert notification != null;
 
-        if (!notification.isValid()) {
-            throw new InvalidParametersException(notification.getInvalidityInfo());
-        }
+        validateNotification(notification);
         return notificationsDb.createNotification(notification);
     }
 
@@ -93,9 +91,7 @@ public final class NotificationsLogic {
         notification.setTitle(title);
         notification.setMessage(message);
 
-        if (!notification.isValid()) {
-            throw new InvalidParametersException(notification.getInvalidityInfo());
-        }
+        validateNotification(notification);
 
         return notification;
     }
@@ -175,5 +171,11 @@ public final class NotificationsLogic {
         }
 
         notificationsDb.deleteReadNotification(readNotification);
+    }
+
+    private void validateNotification(Notification notification) throws InvalidParametersException {
+        if (!notification.isValid()) {
+            throw new InvalidParametersException(notification.getInvalidityInfo());
+        }
     }
 }

--- a/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/sqllogic/core/NotificationsLogic.java
@@ -97,8 +97,6 @@ public final class NotificationsLogic {
             throw new InvalidParametersException(notification.getInvalidityInfo());
         }
 
-        notificationsDb.updateNotification(notification);
-
         return notification;
     }
 

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -769,14 +769,16 @@ public final class UsersLogic {
 
         // cascade email changes to responses and comments
         if (changedEmail) {
-            feedbackResponsesLogic.updateFeedbackResponsesForChangingEmail(courseId, originalEmail, student.getEmail());
-            feedbackResponseCommentsLogic.updateFeedbackResponseCommentsEmails(courseId, originalEmail, student.getEmail());
+            feedbackResponsesLogic
+                    .updateFeedbackResponsesForChangingEmail(courseId, originalEmail, student.getEmail());
+            feedbackResponseCommentsLogic
+                    .updateFeedbackResponseCommentsEmails(courseId, originalEmail, student.getEmail());
         }
 
         // adjust submissions if moving to a different team
         if (changedTeam) {
-            feedbackResponsesLogic.updateFeedbackResponsesForChangingTeam(student.getCourse(), student.getEmail(),
-                    student.getTeam(), originalTeam);
+            feedbackResponsesLogic
+                    .updateFeedbackResponsesForChangingTeam(student.getCourse(), student.getEmail(), originalTeam);
         }
 
         // update the new section name in responses

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -385,8 +385,6 @@ public final class UsersLogic {
         } else {
             instructor.setGoogleId(googleId);
         }
-        usersDb.updateUser(instructor);
-
         // Update the googleId of the student entity for the instructor which was created from sample data.
         Student student = getStudentForEmail(instructor.getCourseId(), instructor.getEmail());
         if (student != null) {
@@ -396,7 +394,13 @@ public final class UsersLogic {
             } else {
                 student.getAccount().setGoogleId(googleId);
             }
-            usersDb.updateUser(student);
+            if (!student.isValid()) {
+                throw new InvalidParametersException(student.getInvalidityInfo());
+            }
+        }
+
+        if (!instructor.isValid()) {
+            throw new InvalidParametersException(instructor.getInvalidityInfo());
         }
 
         return instructor;
@@ -746,6 +750,9 @@ public final class UsersLogic {
 
         String courseId = student.getCourseId();
         Student originalStudent = getStudent(student.getId());
+        if (originalStudent == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
+        }
         String originalEmail = originalStudent.getEmail();
         boolean changedEmail = isEmailChanged(originalEmail, student.getEmail());
 
@@ -762,11 +769,16 @@ public final class UsersLogic {
         boolean changedSection = isSectionChanged(originalSection, student.getSection());
 
         // update student
-        usersDb.checkBeforeUpdateStudent(student);
+        if (!student.isValid()) {
+            throw new InvalidParametersException(student.getInvalidityInfo());
+        }
         originalStudent.setName(student.getName());
         originalStudent.setTeam(student.getTeam());
         originalStudent.setEmail(student.getEmail());
         originalStudent.setComments(student.getComments());
+        if (!originalStudent.isValid()) {
+            throw new InvalidParametersException(originalStudent.getInvalidityInfo());
+        }
 
         // cascade email changes to responses and comments
         if (changedEmail) {

--- a/src/main/java/teammates/sqllogic/core/UsersLogic.java
+++ b/src/main/java/teammates/sqllogic/core/UsersLogic.java
@@ -152,9 +152,7 @@ public final class UsersLogic {
             needsCascade = true;
         }
 
-        if (!instructor.isValid()) {
-            throw new InvalidParametersException(instructor.getInvalidityInfo());
-        }
+        validateUser(instructor);
 
         if (needsCascade) {
             // cascade responses
@@ -385,6 +383,8 @@ public final class UsersLogic {
         } else {
             instructor.setGoogleId(googleId);
         }
+        validateUser(instructor);
+
         // Update the googleId of the student entity for the instructor which was created from sample data.
         Student student = getStudentForEmail(instructor.getCourseId(), instructor.getEmail());
         if (student != null) {
@@ -394,13 +394,7 @@ public final class UsersLogic {
             } else {
                 student.getAccount().setGoogleId(googleId);
             }
-            if (!student.isValid()) {
-                throw new InvalidParametersException(student.getInvalidityInfo());
-            }
-        }
-
-        if (!instructor.isValid()) {
-            throw new InvalidParametersException(instructor.getInvalidityInfo());
+            validateUser(student);
         }
 
         return instructor;
@@ -747,7 +741,6 @@ public final class UsersLogic {
      */
     public Student updateStudentCascade(Student student)
             throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
-
         String courseId = student.getCourseId();
         Student originalStudent = getStudent(student.getId());
         if (originalStudent == null) {
@@ -769,16 +762,10 @@ public final class UsersLogic {
         boolean changedSection = isSectionChanged(originalSection, student.getSection());
 
         // update student
-        if (!student.isValid()) {
-            throw new InvalidParametersException(student.getInvalidityInfo());
-        }
         originalStudent.setName(student.getName());
         originalStudent.setTeam(student.getTeam());
         originalStudent.setEmail(student.getEmail());
         originalStudent.setComments(student.getComments());
-        if (!originalStudent.isValid()) {
-            throw new InvalidParametersException(originalStudent.getInvalidityInfo());
-        }
 
         // cascade email changes to responses and comments
         if (changedEmail) {
@@ -797,6 +784,8 @@ public final class UsersLogic {
             feedbackResponsesLogic.updateFeedbackResponsesForChangingSection(
                     student.getCourse(), student.getEmail(), student.getSection());
         }
+
+        validateUser(originalStudent);
 
         return originalStudent;
     }
@@ -983,4 +972,9 @@ public final class UsersLogic {
         return emailUserMap;
     }
 
+    private void validateUser(User user) throws InvalidParametersException {
+        if (!user.isValid()) {
+            throw new InvalidParametersException(user.getInvalidityInfo());
+        }
+    }
 }

--- a/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountRequestsDb.java
@@ -1,7 +1,5 @@
 package teammates.storage.sqlapi;
 
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +12,6 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.datatransfer.AccountRequestStatus;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
@@ -124,26 +121,6 @@ public final class AccountRequestsDb {
 
         TypedQuery<AccountRequest> query = HibernateUtil.createQuery(cr);
         return query.getResultList();
-    }
-
-    /**
-     * Updates or creates (if does not exist) the AccountRequest in the database.
-     */
-    public AccountRequest updateAccountRequest(AccountRequest accountRequest)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        assert accountRequest != null;
-
-        if (!accountRequest.isValid()) {
-            throw new InvalidParametersException(accountRequest.getInvalidityInfo());
-        }
-
-        if (getAccountRequest(accountRequest.getId()) == null) {
-            throw new EntityDoesNotExistException(
-                String.format(ERROR_UPDATE_NON_EXISTENT, accountRequest.toString()));
-        }
-
-        HibernateUtil.merge(accountRequest);
-        return accountRequest;
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/AccountsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/AccountsDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,7 +10,6 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Account;
@@ -82,23 +80,6 @@ public final class AccountsDb {
 
         HibernateUtil.persist(account);
         return account;
-    }
-
-    /**
-     * Saves an updated {@code Account} to the db.
-     */
-    public Account updateAccount(Account account) throws InvalidParametersException, EntityDoesNotExistException {
-        assert account != null;
-
-        if (!account.isValid()) {
-            throw new InvalidParametersException(account.getInvalidityInfo());
-        }
-
-        if (getAccount(account.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT + account.toString());
-        }
-
-        return HibernateUtil.merge(account);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/CoursesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/CoursesDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,7 +11,6 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
@@ -62,23 +60,6 @@ public final class CoursesDb {
         HibernateUtil.persist(course);
         HibernateUtil.flushSession();
         return course;
-    }
-
-    /**
-     * Saves an updated {@code Course} to the db.
-     */
-    public Course updateCourse(Course course) throws InvalidParametersException, EntityDoesNotExistException {
-        assert course != null;
-
-        if (!course.isValid()) {
-            throw new InvalidParametersException(course.getInvalidityInfo());
-        }
-
-        if (getCourse(course.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        return HibernateUtil.merge(course);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/DeadlineExtensionsDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
 import java.util.List;
@@ -14,7 +13,6 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.TimeHelper;
@@ -87,28 +85,6 @@ public final class DeadlineExtensionsDb {
 
         TypedQuery<DeadlineExtension> query = HibernateUtil.createQuery(cr);
         return query.getResultStream().findFirst().orElse(null);
-    }
-
-    /**
-     * Saves an updated {@code DeadlineExtension} to the db.
-     *
-     * @return updated deadline extension
-     * @throws InvalidParametersException  if attributes to update are not valid
-     * @throws EntityDoesNotExistException if the deadline extension cannot be found
-     */
-    public DeadlineExtension updateDeadlineExtension(DeadlineExtension deadlineExtension)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        assert deadlineExtension != null;
-
-        if (!deadlineExtension.isValid()) {
-            throw new InvalidParametersException(deadlineExtension.getInvalidityInfo());
-        }
-
-        if (getDeadlineExtension(deadlineExtension.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        return HibernateUtil.merge(deadlineExtension);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponseCommentsDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,7 +11,6 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.SanitizationHelper;
@@ -109,7 +107,6 @@ public final class FeedbackResponseCommentsDb {
 
         for (FeedbackResponseComment responseComment : responseComments) {
             responseComment.setGiver(updatedEmail);
-            HibernateUtil.merge(responseComment);
         }
     }
 
@@ -167,24 +164,6 @@ public final class FeedbackResponseCommentsDb {
                     cb.equal(root.get("lastEditorEmail"), lastEditorEmail)));
 
         return HibernateUtil.createQuery(cq).getResultList();
-    }
-
-    /**
-     * Updates the feedback response comment.
-     */
-    public FeedbackResponseComment updateFeedbackResponseComment(FeedbackResponseComment feedbackResponseComment)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        assert feedbackResponseComment != null;
-
-        if (!feedbackResponseComment.isValid()) {
-            throw new InvalidParametersException(feedbackResponseComment.getInvalidityInfo());
-        }
-
-        if (getFeedbackResponseComment(feedbackResponseComment.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        return HibernateUtil.merge(feedbackResponseComment);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/sqlapi/FeedbackResponsesDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,7 +13,6 @@ import jakarta.persistence.criteria.Root;
 
 import teammates.common.datatransfer.FeedbackResultFetchType;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
@@ -199,27 +197,6 @@ public final class FeedbackResponsesDb {
                 .where(cb.equal(courseJoin.get("id"), courseId));
 
         return !HibernateUtil.createQuery(cq).getResultList().isEmpty();
-    }
-
-    /**
-     * Updates a feedbackResponse.
-     *
-     * @throws EntityDoesNotExistException if the feedbackResponse does not exist
-     * @throws InvalidParametersException if the feedbackResponse is not valid
-     */
-    public FeedbackResponse updateFeedbackResponse(FeedbackResponse feedbackResponse)
-            throws InvalidParametersException, EntityDoesNotExistException {
-        assert feedbackResponse != null;
-
-        if (!feedbackResponse.isValid()) {
-            throw new InvalidParametersException(feedbackResponse.getInvalidityInfo());
-        }
-
-        if (getFeedbackResponse(feedbackResponse.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
-
-        return HibernateUtil.merge(feedbackResponse);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
+++ b/src/main/java/teammates/storage/sqlapi/NotificationsDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.sqlapi;
 
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
 import java.util.List;
@@ -15,7 +14,6 @@ import jakarta.persistence.criteria.Subquery;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Notification;
 import teammates.storage.sqlentity.ReadNotification;
@@ -131,22 +129,6 @@ public final class NotificationsDb {
                 .orderBy(cb.asc(root.get("startTime")));
         TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
         return query.getResultList();
-    }
-
-    /**
-     * Updates a notification.
-     *
-     * <p>Preconditions:</p>
-     * * Notification fields are valid.
-     */
-    public Notification updateNotification(Notification notification) throws EntityDoesNotExistException {
-        assert notification != null;
-
-        if (getNotification(notification.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT + Notification.class);
-        }
-
-        return HibernateUtil.merge(notification);
     }
 
     /**

--- a/src/main/java/teammates/storage/sqlapi/UsersDb.java
+++ b/src/main/java/teammates/storage/sqlapi/UsersDb.java
@@ -1,7 +1,5 @@
 package teammates.storage.sqlapi;
 
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +16,6 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
@@ -247,15 +244,6 @@ public final class UsersDb {
         studentsCr.select(studentsRoot).where(cb.equal(accountsJoin.get("googleId"), googleId));
 
         return HibernateUtil.createQuery(studentsCr).getResultList();
-    }
-
-    /**
-     * Gets all instructors.
-     */
-    public <T extends User> T updateUser(T user) {
-        assert user != null;
-
-        return HibernateUtil.merge(user);
     }
 
     /**
@@ -756,32 +744,6 @@ public final class UsersDb {
         }
 
         return team;
-    }
-
-    /**
-     * Updates a student.
-     */
-    public Student updateStudent(Student student)
-            throws EntityDoesNotExistException, InvalidParametersException, EntityAlreadyExistsException {
-        checkBeforeUpdateStudent(student);
-
-        return HibernateUtil.merge(student);
-    }
-
-    /**
-     * Performs checks on student without updating.
-     */
-    public void checkBeforeUpdateStudent(Student student)
-            throws EntityDoesNotExistException, InvalidParametersException, EntityAlreadyExistsException {
-        assert student != null;
-
-        if (!student.isValid()) {
-            throw new InvalidParametersException(student.getInvalidityInfo());
-        }
-
-        if (getStudent(student.getId()) == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT);
-        }
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import java.util.UUID;
 
 import teammates.common.datatransfer.AccountRequestStatus;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
@@ -57,8 +56,6 @@ public class ApproveAccountRequestAction extends AdminOnlyAction {
             emailSender.sendEmail(email);
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
         }
 
         return new JsonResult(new AccountRequestData(accountRequest));

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -70,8 +70,8 @@ public class CreateAccountAction extends Action {
 
         try {
             courseId = importDemoData(instructorEmail, instructorName, instructorInstitution, timezone);
-        } catch (InvalidParametersException | EntityAlreadyExistsException | EntityDoesNotExistException e) {
-            // There should not be any invalid parameter or entity conflict here
+        } catch (InvalidParametersException e) {
+            // There should not be any invalid parameter here
             log.severe("Unexpected error", e);
             return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
@@ -93,8 +93,7 @@ public class CreateAccountAction extends Action {
 
         try {
             setAccountRequestAsRegistered(accountRequest);
-        } catch (EntityDoesNotExistException | InvalidParametersException e) {
-            // EntityDoesNotExistException should not be thrown as existence of account request has been validated before.
+        } catch (InvalidParametersException e) {
             // InvalidParametersException should not be thrown as there should not be any invalid parameters.
             log.severe("Unexpected error", e);
             return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -109,7 +108,7 @@ public class CreateAccountAction extends Action {
      * @return the updated account request
      */
     private AccountRequest setAccountRequestAsRegistered(AccountRequest accountRequest)
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         accountRequest.setStatus(AccountRequestStatus.REGISTERED);
         accountRequest.setRegisteredAt(Instant.now());
         sqlLogic.updateAccountRequest(accountRequest);
@@ -126,7 +125,7 @@ public class CreateAccountAction extends Action {
      * @return the ID of demo course
      */
     private String importDemoData(String instructorEmail, String instructorName, String instructorInstitute, String timezone)
-            throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
+            throws InvalidParametersException {
 
         String courseId = generateDemoCourseId(instructorEmail);
         Instant now = Instant.now();

--- a/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import java.util.UUID;
 
 import teammates.common.datatransfer.AccountRequestStatus;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
@@ -47,8 +46,6 @@ public class RejectAccountRequestAction extends AdminOnlyAction {
             }
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
         }
 
         return new JsonResult(new AccountRequestData(accountRequest));

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -2,7 +2,6 @@ package teammates.ui.webapi;
 
 import java.util.UUID;
 
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.sqlentity.AccountRequest;
@@ -39,8 +38,6 @@ public class UpdateAccountRequestAction extends AdminOnlyAction {
             accountRequest = sqlLogic.updateAccountRequest(accountRequest);
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
         }
 
         return new JsonResult(new AccountRequestData(accountRequest));

--- a/src/test/java/teammates/sqllogic/core/AccountRequestsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/AccountRequestsLogicTest.java
@@ -74,24 +74,19 @@ public class AccountRequestsLogicTest extends BaseTestCase {
 
     @Test
     public void testUpdateAccountRequest_typicalRequest_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         AccountRequest ar = getTypicalAccountRequest();
-        when(accountRequestsDb.updateAccountRequest(ar)).thenReturn(ar);
         AccountRequest updatedAr = accountRequestsLogic.updateAccountRequest(ar);
 
         assertEquals(ar, updatedAr);
-        verify(accountRequestsDb, times(1)).updateAccountRequest(ar);
     }
 
     @Test
     public void testUpdateAccountRequest_requestNotFound_failure()
-            throws InvalidParametersException, EntityDoesNotExistException {
+            throws InvalidParametersException {
         AccountRequest arNotFound = getTypicalAccountRequest();
-        when(accountRequestsDb.updateAccountRequest(arNotFound)).thenThrow(new EntityDoesNotExistException("test message"));
-
-        assertThrows(EntityDoesNotExistException.class,
-                () -> accountRequestsLogic.updateAccountRequest(arNotFound));
-        verify(accountRequestsDb, times(1)).updateAccountRequest(any(AccountRequest.class));
+        AccountRequest updated = accountRequestsLogic.updateAccountRequest(arNotFound);
+        assertEquals(updated, arNotFound);
     }
 
     @Test
@@ -125,7 +120,7 @@ public class AccountRequestsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetAccountRequestByRegistrationKey_nonexistentRequest_shouldReturnNull() throws Exception {
+    public void testGetAccountRequestByRegistrationKey_nonexistentRequest_shouldReturnNull() {
         String nonexistentRegkey = "not_exist";
         when(accountRequestsDb.getAccountRequestByRegistrationKey(nonexistentRegkey)).thenReturn(null);
 
@@ -140,7 +135,6 @@ public class AccountRequestsLogicTest extends BaseTestCase {
         accountRequest.setRegisteredAt(Const.TIME_REPRESENTS_NOW);
         when(accountRequestsDb.getAccountRequest(accountRequest.getId()))
                 .thenReturn(accountRequest);
-        when(accountRequestsDb.updateAccountRequest(accountRequest)).thenReturn(accountRequest);
         accountRequest = accountRequestsLogic.resetAccountRequest(accountRequest.getId());
 
         assertNull(accountRequest.getRegisteredAt());
@@ -148,16 +142,13 @@ public class AccountRequestsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testResetAccountRequest_nonexistentRequest_failure()
-            throws InvalidParametersException, EntityDoesNotExistException {
+    public void testResetAccountRequest_nonexistentRequest_failure() {
         AccountRequest accountRequest = getTypicalAccountRequest();
         accountRequest.setRegisteredAt(Const.TIME_REPRESENTS_NOW);
         when(accountRequestsDb.getAccountRequest(accountRequest.getId()))
                 .thenReturn(null);
         assertThrows(EntityDoesNotExistException.class,
                 () -> accountRequestsLogic.resetAccountRequest(accountRequest.getId()));
-        verify(accountRequestsDb, times(1)).getAccountRequest(accountRequest.getId());
-        verify(accountRequestsDb, times(0)).updateAccountRequest(nullable(AccountRequest.class));
     }
 
     @Test

--- a/src/test/java/teammates/sqllogic/core/DeadlineExtensionsLogicTest.java
+++ b/src/test/java/teammates/sqllogic/core/DeadlineExtensionsLogicTest.java
@@ -200,21 +200,20 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
         Student student = getTypicalStudent();
-        Instant originalDeadline = Instant.now().plusSeconds(86400);
-        Instant updatedDeadline = Instant.now().plusSeconds(172800); // 2 days later
+        Instant originalDeadline = Instant.now().plusSeconds(8 * 24 * 60 * 60);
+        Instant updatedDeadline = Instant.now().plusSeconds(9 * 24 * 60 * 60);
 
         DeadlineExtension de = new DeadlineExtension(student, session, originalDeadline);
         de.setId(UUID.randomUUID());
         de.setEndTime(updatedDeadline);
 
-        when(deDb.updateDeadlineExtension(de)).thenReturn(de);
+        when(deDb.getDeadlineExtension(de.getId())).thenReturn(de);
 
         DeadlineExtension result = deLogic.updateDeadlineExtension(de);
 
         assertNotNull(result);
         assertEquals(de, result);
         assertEquals(updatedDeadline, result.getEndTime());
-        verify(deDb, times(1)).updateDeadlineExtension(de);
     }
 
     @Test

--- a/src/test/java/teammates/storage/sqlapi/AccountRequestsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountRequestsDbTest.java
@@ -1,8 +1,6 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 
 import java.util.List;
@@ -14,7 +12,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AccountRequestStatus;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.AccountRequest;
@@ -67,41 +64,6 @@ public class AccountRequestsDbTest extends BaseTestCase {
         AccountRequest actualAccountRequest = accountRequestDb.getAccountRequest(id);
         mockHibernateUtil.verify(() -> HibernateUtil.get(AccountRequest.class, id));
         assertEquals(expectedAccountRequest, actualAccountRequest);
-    }
-
-    @Test
-    public void testUpdateAccountRequest_invalidEmail_throwsInvalidParametersException() {
-        AccountRequest accountRequestWithInvalidEmail =
-                new AccountRequest("testgmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-
-        assertThrows(InvalidParametersException.class,
-                () -> accountRequestDb.updateAccountRequest(accountRequestWithInvalidEmail));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(accountRequestWithInvalidEmail), never());
-    }
-
-    @Test
-    public void testUpdateAccountRequest_accountRequestDoesNotExist_throwsEntityDoesNotExistException() {
-        AccountRequest accountRequest =
-                new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-        doReturn(null).when(accountRequestDb).getAccountRequest(accountRequest.getId());
-
-        assertThrows(EntityDoesNotExistException.class,
-                () -> accountRequestDb.updateAccountRequest(accountRequest));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(accountRequest), never());
-    }
-
-    @Test
-    public void testUpdateAccountRequest_success() throws InvalidParametersException, EntityDoesNotExistException {
-        AccountRequest accountRequest =
-                new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-        doReturn(accountRequest).when(accountRequestDb).getAccountRequest(accountRequest.getId());
-        mockHibernateUtil.when(() -> HibernateUtil.merge(accountRequest)).thenReturn(accountRequest);
-
-        accountRequestDb.updateAccountRequest(accountRequest);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(accountRequest));
     }
 
     @Test

--- a/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/AccountsDbTest.java
@@ -11,7 +11,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Account;
@@ -97,50 +96,6 @@ public class AccountsDbTest extends BaseTestCase {
 
         InvalidParametersException ex = assertThrows(InvalidParametersException.class,
                 () -> accountsDb.createAccount(account));
-
-        assertEquals(
-                "\"invalid\" is not acceptable to TEAMMATES as a/an email because it is not in the correct format. "
-                        + "An email address contains some text followed by one '@' sign followed by some more text, "
-                        + "and should end with a top level domain address like .com. "
-                        + "It cannot be longer than 254 characters, "
-                        + "cannot be empty and cannot contain spaces.",
-                ex.getMessage());
-        mockHibernateUtil.verify(() -> HibernateUtil.persist(account), never());
-    }
-
-    @Test
-    public void testUpdateAccount_accountAlreadyExists_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        Account account = getTypicalAccount();
-        mockHibernateUtil.when(() -> HibernateUtil.get(Account.class, account.getId()))
-                .thenReturn(account);
-        mockHibernateUtil.when(() -> HibernateUtil.merge(account)).thenReturn(account);
-        account.setName("new name");
-
-        accountsDb.updateAccount(account);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(account));
-    }
-
-    @Test
-    public void testUpdateAccount_accountDoesNotExist_throwsEntityDoesNotExistException()
-            throws InvalidParametersException, EntityAlreadyExistsException {
-        Account account = getTypicalAccount();
-
-        EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
-                () -> accountsDb.updateAccount(account));
-
-        assertEquals("Trying to update non-existent Entity: " + account.toString(), ex.getMessage());
-        mockHibernateUtil.verify(() -> HibernateUtil.persist(account), never());
-    }
-
-    @Test
-    public void testUpdateAccount_invalidEmail_throwsInvalidParametersException() {
-        Account account = getTypicalAccount();
-        account.setEmail("invalid");
-
-        InvalidParametersException ex = assertThrows(InvalidParametersException.class,
-                () -> accountsDb.updateAccount(account));
 
         assertEquals(
                 "\"invalid\" is not acceptable to TEAMMATES as a/an email because it is not in the correct format. "

--- a/src/test/java/teammates/storage/sqlapi/CoursesDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/CoursesDbTest.java
@@ -14,7 +14,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Course;
@@ -92,36 +91,6 @@ public class CoursesDbTest extends BaseTestCase {
         coursesDb.deleteCourse(c);
 
         mockHibernateUtil.verify(() -> HibernateUtil.remove(c));
-    }
-
-    @Test
-    public void testUpdateCourse_courseInvalid_throwsInvalidParametersException() {
-        Course c = new Course("", "new-course-name", null, "institute");
-
-        assertThrows(InvalidParametersException.class, () -> coursesDb.updateCourse(c));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(c), never());
-    }
-
-    @Test
-    public void testUpdateCourse_courseDoesNotExist_throwsEntityDoesNotExistException() {
-        Course c = new Course("course-id", "new-course-name", null, "institute");
-        doReturn(null).when(coursesDb).getCourse(anyString());
-
-        assertThrows(EntityDoesNotExistException.class, () -> coursesDb.updateCourse(c));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(c), never());
-    }
-
-    @Test
-    public void testUpdateCourse_success() throws InvalidParametersException, EntityDoesNotExistException {
-        Course c = new Course("course-id", "new-course-name", null, "institute");
-        doReturn(c).when(coursesDb).getCourse(anyString());
-        mockHibernateUtil.when(() -> HibernateUtil.merge(c)).thenReturn(c);
-
-        coursesDb.updateCourse(c);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(c));
     }
 
     @Test

--- a/src/test/java/teammates/storage/sqlapi/DeadlineExtensionsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/DeadlineExtensionsDbTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -17,7 +16,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.DeadlineExtension;
@@ -103,44 +101,6 @@ public class DeadlineExtensionsDbTest extends BaseTestCase {
 
         mockHibernateUtil.verify(() -> HibernateUtil.get(DeadlineExtension.class, id), times(1));
         assertNull(result);
-    }
-
-    @Test
-    public void testUpdateDeadlineExtension_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        DeadlineExtension de = getValidDeadlineExtension();
-
-        doReturn(de).when(deadlineExtensionsDb).getDeadlineExtension(de.getId());
-        mockHibernateUtil.when(() -> HibernateUtil.merge(de)).thenReturn(de);
-
-        DeadlineExtension result = deadlineExtensionsDb.updateDeadlineExtension(de);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(de), times(1));
-        assertEquals(de, result);
-    }
-
-    @Test
-    public void testUpdateDeadlineExtension_invalidDeadlineExtension_throwsInvalidParametersException() {
-        DeadlineExtension de = getInvalidDeadlineExtension();
-
-        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
-                () -> deadlineExtensionsDb.updateDeadlineExtension(de));
-
-        assertTrue(ipe.getMessage().contains("extended deadlines"));
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(de), never());
-    }
-
-    @Test
-    public void testUpdateDeadlineExtension_deadlineExtensionDoesNotExist_throwsEntityDoesNotExistException() {
-        DeadlineExtension de = getValidDeadlineExtension();
-
-        doReturn(null).when(deadlineExtensionsDb).getDeadlineExtension(de.getId());
-
-        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
-                () -> deadlineExtensionsDb.updateDeadlineExtension(de));
-
-        assertEquals(ERROR_UPDATE_NON_EXISTENT, ednee.getMessage());
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(de), never());
     }
 
     @Test

--- a/src/test/java/teammates/storage/sqlapi/FeedbackResponseCommentsDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/FeedbackResponseCommentsDbTest.java
@@ -1,7 +1,5 @@
 package teammates.storage.sqlapi;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -14,9 +12,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.FeedbackResponseComment;
@@ -98,39 +94,6 @@ public class FeedbackResponseCommentsDbTest extends BaseTestCase {
         feedbackResponseCommentsDb.deleteFeedbackResponseComment(comment);
 
         mockHibernateUtil.verify(() -> HibernateUtil.remove(comment));
-    }
-
-    @Test
-    public void testUpdateComment_commentInvalid_throwsInvalidParametersException() {
-        FeedbackResponseComment comment = getTypicalResponseComment(TYPICAL_ID);
-        comment.setGiverType(FeedbackParticipantType.SELF);
-
-        assertThrows(InvalidParametersException.class,
-                () -> feedbackResponseCommentsDb.updateFeedbackResponseComment(comment));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(comment), never());
-    }
-
-    @Test
-    public void testUpdateComment_commentDoesNotExist_throwsEntityDoesNotExistException() {
-        FeedbackResponseComment comment = getTypicalResponseComment(NOT_TYPICAL_ID);
-
-        assertThrows(EntityDoesNotExistException.class,
-                () -> feedbackResponseCommentsDb.updateFeedbackResponseComment(comment));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(comment), never());
-    }
-
-    @Test
-    public void testUpdateCourse_success() throws InvalidParametersException, EntityDoesNotExistException {
-        FeedbackResponseComment comment = getTypicalResponseComment(TYPICAL_ID);
-        comment.setCommentText("Placeholder Text");
-
-        doReturn(comment).when(feedbackResponseCommentsDb).getFeedbackResponseComment(any(UUID.class));
-        mockHibernateUtil.when(() -> HibernateUtil.merge(comment)).thenReturn(comment);
-        feedbackResponseCommentsDb.updateFeedbackResponseComment(comment);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(comment));
     }
 
 }

--- a/src/test/java/teammates/storage/sqlapi/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/FeedbackResponsesDbTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
-import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,7 +17,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.FeedbackResponse;
@@ -109,47 +107,6 @@ public class FeedbackResponsesDbTest extends BaseTestCase {
 
         assertEquals(spyFr.getInvalidityInfo(), List.of(ipe.getMessage()));
         mockHibernateUtil.verify(() -> HibernateUtil.persist(spyFr), never());
-    }
-
-    @Test
-    public void testUpdateFeedbackResponse_success()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        FeedbackResponse fr = getTypicalFeedbackResponse();
-
-        doReturn(fr).when(feedbackResponsesDb).getFeedbackResponse(fr.getId());
-        mockHibernateUtil.when(() -> HibernateUtil.merge(fr)).thenReturn(fr);
-
-        FeedbackResponse result = feedbackResponsesDb.updateFeedbackResponse(fr);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(fr), times(1));
-        assertEquals(fr, result);
-    }
-
-    @Test
-    public void testUpdateFeedbackResponse_invalidFeedbackResponse_throwsInvalidParametersException() {
-        FeedbackResponse fr = getInvalidFeedbackResponse();
-        // Spy on the entity to force invalidity info, since the base implementation returns empty list
-        FeedbackResponse spyFr = spy(fr);
-        doReturn(List.of("Invalid response")).when(spyFr).getInvalidityInfo();
-
-        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
-                () -> feedbackResponsesDb.updateFeedbackResponse(spyFr));
-
-        assertEquals(spyFr.getInvalidityInfo(), List.of(ipe.getMessage()));
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(spyFr), never());
-    }
-
-    @Test
-    public void testUpdateFeedbackResponse_feedbackResponseDoesNotExist_throwsEntityDoesNotExistException() {
-        FeedbackResponse fr = getTypicalFeedbackResponse();
-
-        doReturn(null).when(feedbackResponsesDb).getFeedbackResponse(fr.getId());
-
-        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
-                () -> feedbackResponsesDb.updateFeedbackResponse(fr));
-
-        assertEquals(ERROR_UPDATE_NON_EXISTENT, ednee.getMessage());
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(fr), never());
     }
 
     @Test

--- a/src/test/java/teammates/storage/sqlapi/UsersDbTest.java
+++ b/src/test/java/teammates/storage/sqlapi/UsersDbTest.java
@@ -14,7 +14,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.sqlentity.Instructor;
@@ -106,42 +105,6 @@ public class UsersDbTest extends BaseTestCase {
         usersDb.deleteUser(student);
 
         mockHibernateUtil.verify(() -> HibernateUtil.remove(student));
-    }
-
-    @Test
-    public void testUpdateStudent_invalidStudent_throwsInvalidParametersException() {
-        Student invalidStudent = getTypicalStudent();
-        invalidStudent.setEmail("");
-
-        assertThrows(InvalidParametersException.class,
-                () -> usersDb.updateStudent(invalidStudent));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(invalidStudent), never());
-    }
-
-    @Test
-    public void testUpdateStudent_studentDoesNotExist_throwsEntityDoesNotExistException() {
-        Student student = getTypicalStudent();
-
-        doReturn(null).when(usersDb).getStudent(any());
-
-        assertThrows(EntityDoesNotExistException.class,
-                () -> usersDb.updateStudent(student));
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(student), never());
-    }
-
-    @Test
-    public void testUpdateStudent_success()
-            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
-        Student existingStudent = getTypicalStudent();
-
-        doReturn(existingStudent).when(usersDb).getStudent(any());
-        mockHibernateUtil.when(() -> HibernateUtil.merge(existingStudent)).thenReturn(existingStudent);
-
-        usersDb.updateStudent(existingStudent);
-
-        mockHibernateUtil.verify(() -> HibernateUtil.merge(existingStudent));
     }
 
     @Test


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Original decision was to use HibernateUtil.merge to align with old update method and reduce confusion. However, this has had the opposite effect. 2 sources of confusion, one that calling this method updates the entity immediately. The other that not calling this method does not update the entity. 

We have decided to remove this for the reasons above. This is part 1 of a series of PRs to refactor Db layer methods.