### PR TITLE
[#13869] Flag package-lock.json changes without package.json changes

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -82,7 +82,8 @@ module.exports = async ({ github, context }) => {
     const formatted = orphanLockDirs
       .map((d) => (d === '' ? '`package-lock.json`' : `\`${d}/package-lock.json\``))
       .join(', ');
-    body += `- ${formatted} changed without a corresponding \`package.json\` change. ` +
+    body +=
+      `- ${formatted} changed without a corresponding \`package.json\` change. ` +
       'Lockfile updates should accompany dependency changes in `package.json`; if this PR is intentionally only refreshing the lockfile, please call that out in the description.\n';
   }
   body += '\nPlease address the above before we proceed to review your PR.';

--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -21,9 +21,50 @@ module.exports = async ({ github, context }) => {
       issue_number: issueNumber,
     });
     isIssueOpen = issue.data.state === 'open';
-    if (isTitleValid && isDescriptionValid && isIssueOpen) {
-      return;
+  }
+
+  // Detect package-lock.json changes that aren't accompanied by package.json changes.
+  // Walks paginated file lists so PRs touching > 100 files still get an accurate signal.
+  const changedPaths = new Set();
+  const perPage = 100;
+  for (let page = 1; ; page += 1) {
+    const files = await github.rest.pulls.listFiles({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.issue.number,
+      per_page: perPage,
+      page,
+    });
+    for (const f of files.data) {
+      changedPaths.add(f.filename);
     }
+    if (files.data.length < perPage) {
+      break;
+    }
+  }
+  const lockfileBasename = 'package-lock.json';
+  const manifestBasename = 'package.json';
+  const changedLockDirs = new Set();
+  for (const p of changedPaths) {
+    const lastSlash = p.lastIndexOf('/');
+    const basename = lastSlash === -1 ? p : p.slice(lastSlash + 1);
+    if (basename === lockfileBasename) {
+      changedLockDirs.add(lastSlash === -1 ? '' : p.slice(0, lastSlash));
+    }
+  }
+  const changedManifestDirs = new Set();
+  for (const p of changedPaths) {
+    const lastSlash = p.lastIndexOf('/');
+    const basename = lastSlash === -1 ? p : p.slice(lastSlash + 1);
+    if (basename === manifestBasename) {
+      changedManifestDirs.add(lastSlash === -1 ? '' : p.slice(0, lastSlash));
+    }
+  }
+  const orphanLockDirs = [...changedLockDirs].filter((d) => !changedManifestDirs.has(d));
+  const isLockfileChangeValid = orphanLockDirs.length === 0;
+
+  if (isTitleValid && isDescriptionValid && isIssueOpen && isLockfileChangeValid) {
+    return;
   }
   let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
               However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
@@ -36,6 +77,13 @@ module.exports = async ({ github, context }) => {
   }
   if (!isIssueOpen && issueNumber) {
     body += `- The issue referenced in the description (#${issueNumber}) is not open.\n`;
+  }
+  if (!isLockfileChangeValid) {
+    const formatted = orphanLockDirs
+      .map((d) => (d === '' ? '`package-lock.json`' : `\`${d}/package-lock.json\``))
+      .join(', ');
+    body += `- ${formatted} changed without a corresponding \`package.json\` change. ` +
+      'Lockfile updates should accompany dependency changes in `package.json`; if this PR is intentionally only refreshing the lockfile, please call that out in the description.\n';
   }
   body += '\nPlease address the above before we proceed to review your PR.';
   await github.rest.issues.createComment({


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

Fixes #13869

**Outline of Solution**

The existing PR check workflow (`.github/scripts/check-pr.js`) already nudges contributors when the title or description formatting deviates from the guidelines, but it didn't catch a common dependency-hygiene mistake: a `package-lock.json` refresh unaccompanied by a `package.json` change (often from a stale local install, a forgotten `npm install`, or a lockfile sync from a different branch).

This patch threads a fourth check into the same comment.

**Behavior**

The script now walks the PR's changed-files list (paginated, so PRs touching > 100 files still get an accurate signal) and groups `package-lock.json` and `package.json` basenames by their containing directory. If a directory has a lockfile change but no manifest change, that lockfile path is added to the comment with a one-line note pointing out the missing `package.json` update.

The repo has lockfiles in both `./` and `./docs/`, so the check is directory-scoped on purpose: changing `./package.json` shouldn't suppress a warning for an orphaned `./docs/package-lock.json`, and vice versa.

**Examples of what the comment will say**

- One orphan: `` `package-lock.json` changed without a corresponding `package.json` change. ... ``
- Multiple orphans: `` `package-lock.json`, `docs/package-lock.json` changed without a corresponding `package.json` change. ... ``

The new line is appended below the existing title / description / open-issue rules, then the existing single `createComment` call posts the combined message. PRs that fail multiple checks get one comment, not several.

**Other notes**

- The early-return `if (...) return;` was previously nested inside the `if (issueNumber)` branch; I moved it out so the lockfile boolean is part of the same all-valid gate. The control flow for PRs without an issue reference is unchanged: `isIssueOpen` stays `false`, the gate fails, and the existing description-violation message is posted.
- No new dependencies. `pulls.listFiles` is already part of the `actions/github-script@v8` Octokit surface that `pr.yml` loads.
- The wording acknowledges the legitimate "intentional lockfile-only refresh" case and asks the contributor to call it out in the description rather than treating the warning as a hard block.

**Tested** with `node -c` (syntax) and by walking through the directory-grouping logic for the two known lockfile locations in this repo. Happy to add a unit-test scaffold if the team wants one — there's no existing test harness for `.github/scripts/`, so I left that out of this PR.
