### PR TITLE
Fix styling issue in notification style column

### DIFF
--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
@@ -176,11 +176,12 @@
               >
             </td>
             <td class="text-break">{{ notificationsTableRowModel.notification.targetUser }}</td>
-            <!-- <td class="text-break" [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">
-              {{ notificationsTableRowModel.notification.style | notificationStyleDescription }}
-            </td> -->
-            <td class="text-break">
-              <span [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">
+            
+            <td 
+                class="text-break"
+                [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass"
+            >
+              <span>  
                 {{ notificationsTableRowModel.notification.style | notificationStyleDescription }}
               </span>
             </td>

--- a/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notifications-table/notifications-table.component.html
@@ -176,8 +176,13 @@
               >
             </td>
             <td class="text-break">{{ notificationsTableRowModel.notification.targetUser }}</td>
-            <td class="text-break" [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">
+            <!-- <td class="text-break" [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">
               {{ notificationsTableRowModel.notification.style | notificationStyleDescription }}
+            </td> -->
+            <td class="text-break">
+              <span [ngClass]="notificationsTableRowModel.notification.style | notificationStyleClass">
+                {{ notificationsTableRowModel.notification.style | notificationStyleDescription }}
+              </span>
             </td>
             <td class="text-break">
               <span


### PR DESCRIPTION
[#13469] Fix styling on style column

**Outline of Solution**

The style class was previously applied directly to the <td> element, which could cause layout and styling issues.

Moved the style class to a <span> inside the table cell instead, so that only the content is styled while preserving the table layout.