### PR TITLE
[#13891] Unit tests failing due to line-ending mismatch

### DIFF
--- a/src/test/java/teammates/common/datatransfer/ErrorLogEntryTest.java
+++ b/src/test/java/teammates/common/datatransfer/ErrorLogEntryTest.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer;
 
+import static teammates.test.AssertHelper.assertJsonEquals;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -39,11 +41,12 @@ public class ErrorLogEntryTest extends BaseTestCase {
         logEntry.setDetails(instanceLogDetails);
 
         ErrorLogEntry errorLogEntry = ErrorLogEntry.fromLogEntry(logEntry);
-        assertEquals("{\n"
-                + "  \"event\": \"INSTANCE_LOG\",\n"
-                + "  \"instanceId\": \"instanceid123\",\n"
-                + "  \"instanceEvent\": \"STARTUP\"\n"
-                + "}", errorLogEntry.getMessage());
+        assertJsonEquals("""
+                {
+                  "event": "INSTANCE_LOG",
+                  "instanceId": "instanceid123",
+                  "instanceEvent": "STARTUP"
+                }""", errorLogEntry.getMessage());
         assertEquals("ERROR", errorLogEntry.getSeverity());
         assertEquals("traceid", errorLogEntry.getTraceId());
     }

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
@@ -1,5 +1,7 @@
 package teammates.common.datatransfer.questions;
 
+import static teammates.test.AssertHelper.assertJsonEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -374,354 +376,360 @@ public class FeedbackContributionQuestionDetailsTest extends BaseTestCase {
 
         ______TS("(student email specified): all students have response");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {\n"
-                + "    \"student1incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 10,\n"
-                + "      \"perceived\": 17,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": 20,\n"
-                + "        \"student3incourse1@gmail.tmt\": 30\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        24,\n"
-                + "        19\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {
+                            "student1incourse1@gmail.tmt": {
+                              "claimed": 10,
+                              "perceived": 17,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": 20,
+                                "student3incourse1@gmail.tmt": 30
+                              },
+                              "perceivedOthers": [
+                                24,
+                                19
+                              ]
+                            }
+                          }
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
                         "student1incourse1@gmail.tmt", resultsBundle));
 
         ______TS("(student email specified): mix of students with responses and students without responses");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {\n"
-                + "    \"student5incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 10,\n"
-                + "      \"perceived\": 15,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student4incourse1@gmail.tmt\": -999,\n"
-                + "        \"student6incourse1@gmail.tmt\": 20\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        15,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {
+                            "student5incourse1@gmail.tmt": {
+                              "claimed": 10,
+                              "perceived": 15,
+                              "claimedOthers": {
+                                "student4incourse1@gmail.tmt": -999,
+                                "student6incourse1@gmail.tmt": 20
+                              },
+                              "perceivedOthers": [
+                                15,
+                                -9999
+                              ]
+                            }
+                          }
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
                         "student5incourse1@gmail.tmt", resultsBundle));
 
         ______TS("(student email specified): all students do not have responses");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {}\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {}
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
                         "student8incourse1@gmail.tmt", resultsBundle));
 
         ______TS("(student email not specified): qn1");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {\n"
-                + "    \"student8incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student7incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student2incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 100,\n"
-                + "      \"perceived\": 93,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student1incourse1@gmail.tmt\": 80,\n"
-                + "        \"student3incourse1@gmail.tmt\": 120\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        107,\n"
-                + "        80\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student5incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student1incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 50,\n"
-                + "      \"perceived\": 87,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": 80,\n"
-                + "        \"student3incourse1@gmail.tmt\": 120\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        93,\n"
-                + "        80\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student4incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student3incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 113,\n"
-                + "      \"perceived\": 120,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": 107,\n"
-                + "        \"student1incourse1@gmail.tmt\": 93\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        120,\n"
-                + "        120\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student6incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student7incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student8incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {
+                            "student8incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student7incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            },
+                            "student2incourse1@gmail.tmt": {
+                              "claimed": 100,
+                              "perceived": 93,
+                              "claimedOthers": {
+                                "student1incourse1@gmail.tmt": 80,
+                                "student3incourse1@gmail.tmt": 120
+                              },
+                              "perceivedOthers": [
+                                107,
+                                80
+                              ]
+                            },
+                            "student5incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student4incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student1incourse1@gmail.tmt": {
+                              "claimed": 50,
+                              "perceived": 87,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": 80,
+                                "student3incourse1@gmail.tmt": 120
+                              },
+                              "perceivedOthers": [
+                                93,
+                                80
+                              ]
+                            },
+                            "student4incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student3incourse1@gmail.tmt": {
+                              "claimed": 113,
+                              "perceived": 120,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": 107,
+                                "student1incourse1@gmail.tmt": 93
+                              },
+                              "perceivedOthers": [
+                                120,
+                                120
+                              ]
+                            },
+                            "student6incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": -9999,
+                                "student4incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student7incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student8incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            }
+                          }
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
                         resultsBundle));
 
         ______TS("(student email not specified): qn2");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {\n"
-                + "    \"student8incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student7incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student2incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student1incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student3incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student5incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 67,\n"
-                + "      \"perceived\": 100,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": 100\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        100,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student1incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student3incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student4incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student3incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student1incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student6incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": 114,\n"
-                + "      \"perceived\": 100,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": 100,\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        100,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student7incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student8incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {
+                            "student8incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student7incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            },
+                            "student2incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student1incourse1@gmail.tmt": -9999,
+                                "student3incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student5incourse1@gmail.tmt": {
+                              "claimed": 67,
+                              "perceived": 100,
+                              "claimedOthers": {
+                                "student4incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": 100
+                              },
+                              "perceivedOthers": [
+                                100,
+                                -9999
+                              ]
+                            },
+                            "student1incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": -9999,
+                                "student3incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student4incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student3incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": -9999,
+                                "student1incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student6incourse1@gmail.tmt": {
+                              "claimed": 114,
+                              "perceived": 100,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": 100,
+                                "student4incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                100,
+                                -9999
+                              ]
+                            },
+                            "student7incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student8incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            }
+                          }
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
                         resultsBundle));
 
         ______TS("(student email not specified): qn3");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        assertEquals("{\n"
-                + "  \"results\": {\n"
-                + "    \"student8incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student7incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student2incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student1incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student3incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student5incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student1incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student3incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student4incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student6incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student3incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student2incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student1incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student6incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student5incourse1@gmail.tmt\": -9999,\n"
-                + "        \"student4incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999,\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    },\n"
-                + "    \"student7incourse1@gmail.tmt\": {\n"
-                + "      \"claimed\": -999,\n"
-                + "      \"perceived\": -9999,\n"
-                + "      \"claimedOthers\": {\n"
-                + "        \"student8incourse1@gmail.tmt\": -9999\n"
-                + "      },\n"
-                + "      \"perceivedOthers\": [\n"
-                + "        -9999\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  }\n"
-                + "}",
+        assertJsonEquals("""
+                        {
+                          "results": {
+                            "student8incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student7incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            },
+                            "student2incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student1incourse1@gmail.tmt": -9999,
+                                "student3incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student5incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student4incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student1incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": -9999,
+                                "student3incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student4incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": -9999,
+                                "student6incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student3incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student2incourse1@gmail.tmt": -9999,
+                                "student1incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student6incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student5incourse1@gmail.tmt": -9999,
+                                "student4incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999,
+                                -9999
+                              ]
+                            },
+                            "student7incourse1@gmail.tmt": {
+                              "claimed": -999,
+                              "perceived": -9999,
+                              "claimedOthers": {
+                                "student8incourse1@gmail.tmt": -9999
+                              },
+                              "perceivedOthers": [
+                                -9999
+                              ]
+                            }
+                          }
+                        }""",
                 feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
                         resultsBundle));
 

--- a/src/test/java/teammates/common/util/JsonUtilsTest.java
+++ b/src/test/java/teammates/common/util/JsonUtilsTest.java
@@ -1,5 +1,7 @@
 package teammates.common.util;
 
+import static teammates.test.AssertHelper.assertJsonEquals;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
@@ -22,7 +24,7 @@ public class JsonUtilsTest extends BaseTestCase {
                 + "  \"shouldAllowRichText\": true\n"
                 + "}";
 
-        assertEquals(expectedQuestionDetailsJson, JsonUtils.toJson(qd));
+        assertJsonEquals(expectedQuestionDetailsJson, JsonUtils.toJson(qd));
 
         expectedQuestionDetailsJson = "{\"questionType\":\"TEXT\",\"questionText\":\"Question text.\","
                 + "\"shouldAllowRichText\":true}";
@@ -39,7 +41,7 @@ public class JsonUtilsTest extends BaseTestCase {
                 + "  \"answer\": \"My answer\"\n"
                 + "}";
 
-        assertEquals(expectedFeedbackResponseDetailsJson, JsonUtils.toJson(frd));
+        assertJsonEquals(expectedFeedbackResponseDetailsJson, JsonUtils.toJson(frd));
 
         expectedFeedbackResponseDetailsJson = "{\"questionType\":\"TEXT\",\"answer\":\"My answer\"}";
 

--- a/src/test/java/teammates/test/AssertHelper.java
+++ b/src/test/java/teammates/test/AssertHelper.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import com.google.common.base.Joiner;
 
+import teammates.common.util.JsonUtils;
 import teammates.common.util.TimeHelperExtension;
 
 /**
@@ -62,4 +63,10 @@ public final class AssertHelper {
 
     }
 
+    /**
+     * Asserts that the given json strings have the same parsed value.
+     */
+    public static void assertJsonEquals(String expected, String actual) {
+        assertEquals(JsonUtils.parse(expected), JsonUtils.parse(actual));
+    }
 }


### PR DESCRIPTION
Fixes #13891

**Outline of Solution**

* Added a small helper in `AssertHelper.java` for parsed json comparisons `assertJsonEquals()`.
* Replaced failing assertions using the above method in all the affected unit tests.
* Minor Improvement: Replaced string concatenations with text blocks for readability.
