### PR TITLE
[#13860] Add configuration option to enable sending of emails to test domain

### DIFF
--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -143,6 +143,9 @@ public final class Config {
     /** Value of {@code app.mailjet.secretkey}. */
     public static final String MAILJET_SECRETKEY;
 
+    /** Value of {@code app.email.sendToTestDomain}. */
+    public static final boolean EMAIL_SEND_TO_TEST_DOMAIN;
+
     /** Value of {@code app.maintenance}. */
     public static final boolean MAINTENANCE;
 
@@ -226,6 +229,8 @@ public final class Config {
         MAILGUN_DOMAINNAME = getProperty(properties, devProperties, "app.mailgun.domainname");
         MAILJET_APIKEY = getProperty(properties, devProperties, "app.mailjet.apikey");
         MAILJET_SECRETKEY = getProperty(properties, devProperties, "app.mailjet.secretkey");
+        EMAIL_SEND_TO_TEST_DOMAIN = Boolean.parseBoolean(
+                getProperty(properties, devProperties, "app.email.sendToTestDomain", "false"));
         MAINTENANCE = Boolean.parseBoolean(getProperty(properties, devProperties, "app.maintenance", "false"));
 
         ENABLE_DEVSERVER_LOGIN = Boolean.parseBoolean(
@@ -381,6 +386,10 @@ public final class Config {
      */
     public static String getDbConnectionUrl() {
         return String.format("jdbc:postgresql://%s:%s/%s", POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DATABASENAME);
+    }
+
+    public static boolean isEmailSendingToTestDomainEnabled() {
+        return IS_DEV_SERVER && EMAIL_SEND_TO_TEST_DOMAIN;
     }
 
     public static boolean isUsingSendgrid() {

--- a/src/main/java/teammates/logic/api/EmailSender.java
+++ b/src/main/java/teammates/logic/api/EmailSender.java
@@ -86,7 +86,7 @@ public class EmailSender {
     }
 
     private boolean isTestingAccount(String email) {
-        return email.endsWith(Const.TEST_EMAIL_DOMAIN);
+        return !Config.isEmailSendingToTestDomainEnabled() && email.endsWith(Const.TEST_EMAIL_DOMAIN);
     }
 
 }

--- a/src/main/resources/build-dev.template.properties
+++ b/src/main/resources/build-dev.template.properties
@@ -30,3 +30,7 @@ app.taskqueue.active = true
 # Task queue service implementation. Defaults to "local" in dev (in-memory, no real queueing).
 # Override to "google-cloud-tasks" if you want to exercise the Cloud Tasks code path locally.
 app.taskqueue.service = local
+
+# This flag sets whether emails to test domains (e.g. gmail.tmt) are sent.
+# This only works when the application is running in development environment.
+app.email.sendToTestDomain=false

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -123,6 +123,10 @@ app.taskqueue.service =
 # 2. An acceptable value is used but the configuration is not complete
 app.email.service =
 
+# This flag sets whether emails to test domains (e.g. gmail.tmt) are sent.
+# This only works when the application is running in development environment.
+app.email.sendToTestDomain=false
+
 # SMTP email service configurations
 app.smtp.host=
 app.smtp.port=

--- a/src/test/java/teammates/logic/api/EmailSenderUnitTest.java
+++ b/src/test/java/teammates/logic/api/EmailSenderUnitTest.java
@@ -1,0 +1,54 @@
+package teammates.logic.api;
+
+import org.apache.http.HttpStatus;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import teammates.common.util.Config;
+import teammates.common.util.Const;
+import teammates.common.util.EmailSendingStatus;
+import teammates.common.util.EmailWrapper;
+import teammates.test.BaseTestCase;
+
+/**
+ * Unit test for {@link EmailSender}.
+ */
+public class EmailSenderUnitTest extends BaseTestCase {
+
+    @Test
+    public void testSendEmail_testDomain_blockedByDefault() {
+        EmailSender emailSender = new EmailSender();
+        EmailWrapper email = new EmailWrapper();
+        email.setRecipient("test" + Const.TEST_EMAIL_DOMAIN);
+
+        // By default it should be blocked
+        EmailSendingStatus status = emailSender.sendEmail(email);
+        assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+        assertEquals("Not sending email to test account", status.getMessage());
+    }
+
+    @Test
+    public void testSendEmail_testDomain_allowedByConfig() {
+        try (MockedStatic<Config> configMock = Mockito.mockStatic(Config.class)) {
+            configMock.when(Config::isEmailSendingToTestDomainEnabled).thenReturn(true);
+            configMock.when(Config::isUsingSendgrid).thenReturn(false);
+            configMock.when(Config::isUsingMailgun).thenReturn(false);
+            configMock.when(Config::isUsingMailjet).thenReturn(false);
+            configMock.when(Config::isUsingSmtp).thenReturn(false);
+
+            EmailSender emailSender = new EmailSender();
+            EmailWrapper email = new EmailWrapper();
+            email.setRecipient("test" + Const.TEST_EMAIL_DOMAIN);
+            email.setSenderEmail("sender@email.com");
+            email.setSubject("Subject");
+            email.setContent("Content");
+
+            // Should NOT be blocked now
+            EmailSendingStatus status = emailSender.sendEmail(email);
+            // It should proceed to the service, which is EmptyEmailService (returns success but does nothing)
+            assertEquals(HttpStatus.SC_OK, status.getStatusCode());
+            assertNull(status.getMessage());
+        }
+    }
+}

--- a/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/rubric-question-statistics.component.ts
@@ -166,7 +166,7 @@ export class RubricQuestionStatisticsComponent extends RubricQuestionStatisticsC
     });
   }
 
-  private getDisplayWeight(weight: number): any {
-    return weight === null || weight === NO_VALUE ? '-' : weight;
+  private getDisplayWeight(weight: number): string {
+    return weight === null || weight === NO_VALUE ? '-' : String(weight);
   }
 }

--- a/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-rubric-question-details.impl.ts
@@ -162,7 +162,7 @@ ${
     return true;
   }
 
-  private getDisplayWeight(weight: number): any {
-    return weight === null || weight === NO_VALUE ? '-' : weight;
+  private getDisplayWeight(weight: number): string {
+    return weight === null || weight === NO_VALUE ? '-' : String(weight);
   }
 }


### PR DESCRIPTION
This PR implements a new configuration option `app.email.sendToTestDomain` that allows emails to be sent to test domains (e.g. `@gmail.tmt`) in development environments.

### Changes:
- Added `EMAIL_SEND_TO_TEST_DOMAIN` to `Config.java`, initialized from `app.email.sendToTestDomain` property (defaulting to `false`).
- Added `isEmailSendingToTestDomainEnabled()` getter in `Config.java` which returns `true` only if `IS_DEV_SERVER` is true and the property is enabled.
- Updated `EmailSender.java` to respect this new configuration.
- Added `app.email.sendToTestDomain` to `build.template.properties` and `build-dev.template.properties`.
- Added `EmailSenderUnitTest.java` to verify the fix using static mocking of `Config`.

This allows developers to test email delivery to test accounts in local environments if they have a mock email server configured, while maintaining the safety of blocking these emails in production.

Fixes #13860