### PR TITLE
[#13895] Flaky CI check: lint cache keys collapse into static values when cache files do not exist

### DIFF
--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: |
             ./.eslintcache
-          key: ${{ runner.os }}-eslint-${{ hashFiles('.eslintcache') }}
+          key: ${{ runner.os }}-eslint-${{ hashFiles('package-lock.json', 'eslint.config.*') }}
           restore-keys: |
             ${{ runner.os }}-eslint-
       - name: Cache stylelint
@@ -49,7 +49,7 @@ jobs:
         with:
           path: |
             ./.stylelintcache
-          key: ${{ runner.os }}-stylelint-${{ hashFiles('.stylelintcache') }}
+          key: ${{ runner.os }}-stylelint-${{ hashFiles('package-lock.json', 'stylelint.config.*') }}
           restore-keys: |
             ${{ runner.os }}-stylelint-
       - name: Run Backend Linting


### PR DESCRIPTION
Fixes #13895

**Outline of Solution**

* Replaced `.eslintcache` & `.stylelintcache` as dependencies from `hashFiles(...)` in [Component Tests](https://github.com/TEAMMATES/teammates/blob/9215f01328568c05feec77cbf5cb2c85b5d340d8/.github/workflows/component.yml#L44) lint workflow with `package-lock.json`, `eslint.config.*` & `stylelint.config.*` respectively.
* This makes caching and restore stable for lint artifacts.
