### PR TITLE
[#13733] Add UnexpectedServerException for unexpected server-side errors

### DIFF
--- a/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
@@ -16,6 +16,7 @@ import teammates.ui.webapi.InvalidHttpParameterException;
 import teammates.ui.webapi.InvalidOperationException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UnauthorizedAccessException;
+import teammates.ui.webapi.UnexpectedServerException;
 
 /**
  * Maps servlet-layer exceptions to HTTP responses. Extracted from {@link WebApiServlet} for unit testing.
@@ -74,6 +75,13 @@ final class WebApiServletExceptionHandler {
             int statusCode = HttpStatus.SC_GATEWAY_TIMEOUT;
             log.severe(dee.getClass().getSimpleName() + " caught by WebApiServlet", dee);
             throwError(resp, statusCode, "The request exceeded the server timeout limit. Please try again later.");
+            return statusCode;
+        }
+        if (t instanceof UnexpectedServerException) {
+            UnexpectedServerException use = (UnexpectedServerException) t;
+            int statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+            log.severe(use.getClass().getSimpleName() + " caught by WebApiServlet: " + use.getMessage(), use);
+            throwError(resp, statusCode, use.getMessage());
             return statusCode;
         }
         if (t instanceof HibernateException) {

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -73,7 +73,7 @@ public class CreateAccountAction extends Action {
         } catch (InvalidParametersException | EntityAlreadyExistsException | EntityDoesNotExistException e) {
             // There should not be any invalid parameter or entity conflict here
             log.severe("Unexpected error", e);
-            return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException(e);
         }
 
         List<Instructor> instructorList = sqlLogic.getInstructorsByCourse(courseId);
@@ -88,7 +88,7 @@ public class CreateAccountAction extends Action {
             // conflict with generated entities in new demo course.
             // InvalidParametersException should not be thrown as as there should not be any invalid parameters.
             log.severe("Unexpected error", e);
-            return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException(e);
         }
 
         try {
@@ -97,7 +97,7 @@ public class CreateAccountAction extends Action {
             // EntityDoesNotExistException should not be thrown as existence of account request has been validated before.
             // InvalidParametersException should not be thrown as there should not be any invalid parameters.
             log.severe("Unexpected error", e);
-            return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException(e);
         }
 
         return new JsonResult("Account successfully created", HttpStatus.SC_OK);

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -5,8 +5,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.apache.http.HttpStatus;
-
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
@@ -81,7 +79,7 @@ public class GetNotificationsAction extends Action {
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
-            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException("Account not found");
         }
         Set<UUID> readNotifications = sqlLogic.getReadNotificationsByAccountId(account.getId())
                 .stream()

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -3,8 +3,6 @@ package teammates.ui.webapi;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.http.HttpStatus;
-
 import teammates.storage.sqlentity.Account;
 import teammates.ui.output.ReadNotificationsData;
 
@@ -27,7 +25,7 @@ public class GetReadNotificationsAction extends Action {
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
-            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException("Account not found");
         }
         List<UUID> readNotifications =
                 sqlLogic.getReadNotificationsByAccountId(account.getId()).stream()

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -1,7 +1,5 @@
 package teammates.ui.webapi;
 
-import org.apache.http.HttpStatus;
-
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -56,7 +54,7 @@ public class JoinCourseAction extends Action {
         } catch (InvalidParametersException ipe) {
             // There should not be any invalid parameter here
             log.severe("Unexpected error", ipe);
-            return new JsonResult(ipe.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException(ipe);
         }
 
         sendJoinEmail(student.getCourseId(), student.getName(), student.getEmail(), false);
@@ -76,7 +74,7 @@ public class JoinCourseAction extends Action {
         } catch (InvalidParametersException ipe) {
             // There should not be any invalid parameter here
             log.severe("Unexpected error", ipe);
-            return new JsonResult(ipe.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException(ipe);
         }
 
         sendJoinEmail(instructor.getCourseId(), instructor.getName(), instructor.getEmail(), true);

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -2,8 +2,6 @@ package teammates.ui.webapi;
 
 import java.util.UUID;
 
-import org.apache.http.HttpStatus;
-
 import teammates.storage.sqlentity.Account;
 import teammates.storage.sqlentity.ReadNotification;
 import teammates.ui.output.ReadNotificationData;
@@ -34,7 +32,7 @@ public class MarkNotificationAsReadAction extends Action {
         Account account = sqlLogic.getAccountForGoogleId(userInfo.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
-            return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new UnexpectedServerException("Account not found");
         }
         ReadNotification readNotification = sqlLogic.createReadNotification(account.getId(), notificationId);
         ReadNotificationData output = new ReadNotificationData(readNotification);

--- a/src/main/java/teammates/ui/webapi/UnexpectedServerException.java
+++ b/src/main/java/teammates/ui/webapi/UnexpectedServerException.java
@@ -1,0 +1,28 @@
+package teammates.ui.webapi;
+
+/**
+ * Exception thrown when an action catches a checked exception that should not occur given upstream
+ * validation, e.g. an {@link teammates.common.exception.InvalidParametersException} bubbling up
+ * from a code path whose parameters were already validated.
+ *
+ * <p>Routing this through the centralised {@link teammates.ui.servlets.WebApiServlet} error handler
+ * (rather than returning a {@link JsonResult} with HTTP 500 directly) keeps logging and the response
+ * body consistent with the other named exceptions defined in this package.
+ *
+ * <p>This corresponds to HTTP 500 error.
+ */
+public class UnexpectedServerException extends RuntimeException {
+
+    public UnexpectedServerException(String message) {
+        super(message);
+    }
+
+    public UnexpectedServerException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+
+    public UnexpectedServerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/BaseActionTest.java
@@ -47,6 +47,7 @@ import teammates.ui.webapi.InvalidHttpParameterException;
 import teammates.ui.webapi.InvalidOperationException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UnauthorizedAccessException;
+import teammates.ui.webapi.UnexpectedServerException;
 
 /**
  * Base class for all action tests.
@@ -373,6 +374,15 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     protected InvalidOperationException verifyInvalidOperation(BasicRequest requestBody, String... params) {
         Action c = getAction(requestBody, params);
         return assertThrows(InvalidOperationException.class, c::execute);
+    }
+
+    /**
+     * Verifies that the executed action results in
+     * {@link UnexpectedServerException} being thrown.
+     */
+    protected UnexpectedServerException verifyUnexpectedServerException(String... params) {
+        Action c = getAction(params);
+        return assertThrows(UnexpectedServerException.class, c::execute);
     }
 
     /**

--- a/src/test/java/teammates/sqlui/webapi/JoinCourseActionTest.java
+++ b/src/test/java/teammates/sqlui/webapi/JoinCourseActionTest.java
@@ -130,9 +130,7 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
                 Const.ParamsNames.REGKEY, "invalid-reg-key",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
         };
-        JoinCourseAction action = getAction(params);
-        JsonResult jsonResult = getJsonResult(action, 500);
-        assertEquals(500, jsonResult.getStatusCode());
+        verifyUnexpectedServerException(params);
         verifyNoEmailsSent();
     }
 
@@ -202,9 +200,7 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
                 Const.ParamsNames.REGKEY, "invalid-reg-key",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
         };
-        JoinCourseAction action = getAction(params);
-        JsonResult jsonResult = getJsonResult(action, 500);
-        assertEquals(500, jsonResult.getStatusCode());
+        verifyUnexpectedServerException(params);
         verifyNoEmailsSent();
     }
 

--- a/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
+++ b/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
@@ -15,6 +15,7 @@ import teammates.ui.webapi.EntityNotFoundException;
 import teammates.ui.webapi.InvalidHttpParameterException;
 import teammates.ui.webapi.InvalidOperationException;
 import teammates.ui.webapi.UnauthorizedAccessException;
+import teammates.ui.webapi.UnexpectedServerException;
 
 /**
  * SUT: {@link WebApiServletExceptionHandler}.
@@ -100,6 +101,15 @@ public class WebApiServletExceptionHandlerTest extends BaseTestCase {
         assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT,
                 handleException(resp, new DeadlineExceededException()));
         assertEquals(HttpStatus.SC_GATEWAY_TIMEOUT, resp.getStatus());
+    }
+
+    @Test
+    public void testUnexpectedServerException_internalServerError() throws Exception {
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                handleException(resp, new UnexpectedServerException("unexpected")));
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, resp.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Fixes #13733.

**Outline of Solution**

Adds `teammates.ui.webapi.UnexpectedServerException`, a `RuntimeException`
that mirrors the shape of `InvalidHttpParameterException` and
`EntityNotFoundException` already in this package, plus a matching case
in `WebApiServletExceptionHandler` so it produces a 500 response with
the same logging style as the other named exceptions.

Replaces the seven `return new JsonResult(message, SC_INTERNAL_SERVER_ERROR)`
sites in the action files called out on #13733 / #13740 review:

- `CreateAccountAction` — 3 sites (`importDemoData`, `joinCourseForInstructor`, `setAccountRequestAsRegistered`)
- `JoinCourseAction` — 2 sites (student and instructor branches)
- `GetReadNotificationsAction` — 1 site
- `MarkNotificationAsReadAction` — 1 site
- `GetNotificationsAction` — 1 site

Other 500-returning files in `src/main/java/teammates/ui/webapi/`
(`ResetAccountRequestAction`, `CreateNotificationAction`,
`RegenerateStudentKeyAction`, `RegenerateInstructorKeyAction`) are left
for a follow-up PR — the goal here is to keep this change focused on
the files explicitly listed during the prior review thread (#13740).

**Why a `RuntimeException`**

Following the precedent set by `InvalidHttpParameterException` and
`EntityNotFoundException` in this package: an "unexpected" condition by
definition cannot be reasonably handled by the caller, and making it
unchecked avoids cascading `throws` clauses across every `Action`
subclass and the abstract `Action.execute()` signature.

**Tests**

- `WebApiServletExceptionHandlerTest` gains
  `testUnexpectedServerException_internalServerError`.
- `BaseActionTest` gains a `verifyUnexpectedServerException(String...)`
  helper paralleling the existing `verifyInvalidOperation` /
  `verifyHttpParameterFailure` helpers.
- `JoinCourseActionTest`'s two `getJsonResult(action, 500)` assertions
  (`testExecute_studentInvalidAccount_errorMessage`,
  `testExecute_instructorInvalidAccount_errorMessage`) now use the new
  helper and expect the exception, since the action no longer returns
  a 500-coded `JsonResult` from the unexpected `InvalidParametersException`
  branches.

**Local verification (Java 21):**

```
./gradlew :compileJava :compileTestJava
```

Both tasks compile clean. I have not run the full test suite locally
since it requires the Gradle test infrastructure that the CI workflow
already covers; happy to amend if anything shows up there.
