### PR TITLE
[#13900] Add PublicAction base class for public action classes

### DIFF
--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -12,60 +12,48 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
  * Creates a new account request.
- */
-public class CreateAccountRequestAction extends Action {
+     */
+public class CreateAccountRequestAction extends PublicAction {
 
     @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute()
+                throws InvalidHttpRequestBodyException, InvalidOperationException {
+                            AccountCreateRequest createRequest = getAndValidateRequestBody(AccountCreateRequest.class);
 
-    @Override
-    void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        // Nothing needs to be done here because anybody should be able to create an account request.
-    }
+            String captchaResponse = createRequest.getCaptchaResponse();
+                            if (!recaptchaVerifier.isVerificationSuccessful(captchaResponse)) {
+                                            throw new InvalidHttpRequestBodyException("Something went wrong with"
+                                                                                                          + "the reCAPTCHA verification. Please try again.");
+                            }
 
-    @Override
-    public JsonResult execute()
-            throws InvalidHttpRequestBodyException, InvalidOperationException {
-        AccountCreateRequest createRequest = getAndValidateRequestBody(AccountCreateRequest.class);
+            String instructorName = createRequest.getInstructorName().trim();
+                            String instructorEmail = createRequest.getInstructorEmail().trim();
+                            String instructorInstitution = createRequest.getInstructorInstitution().trim();
+                            String comments = createRequest.getInstructorComments();
+                            if (comments != null) {
+                                            comments = comments.trim();
+                            }
+                            AccountRequest accountRequest;
 
-        if (userInfo == null || !userInfo.isAdmin) {
-            String userCaptchaResponse = createRequest.getCaptchaResponse();
-            if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
-                throw new InvalidHttpRequestBodyException("Something went wrong with "
-                        + "the reCAPTCHA verification. Please try again.");
+            try {
+                            accountRequest = logic.createAccountRequest(instructorName, instructorEmail,
+                                                                                            instructorInstitution, AccountRequestStatus.PENDING, comments);
+            } catch (InvalidParametersException ipe) {
+                            throw new InvalidHttpRequestBodyException(ipe);
             }
-        }
 
-        String instructorName = createRequest.getInstructorName().trim();
-        String instructorEmail = createRequest.getInstructorEmail().trim();
-        String instructorInstitution = createRequest.getInstructorInstitution().trim();
-        String comments = createRequest.getInstructorComments();
-        if (comments != null) {
-            comments = comments.trim();
-        }
-        AccountRequest accountRequest;
+            assert accountRequest != null;
 
-        try {
-            accountRequest = logic.createAccountRequest(instructorName, instructorEmail,
-                    instructorInstitution, AccountRequestStatus.PENDING, comments);
-        } catch (InvalidParametersException ipe) {
-            throw new InvalidHttpRequestBodyException(ipe);
-        }
+            if (userInfo == null || !userInfo.isAdmin) {
+                            EmailWrapper adminAlertEmail = emailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
+                            EmailWrapper userAcknowledgementEmail = emailGenerator
+                                                    .generateNewAccountRequestAcknowledgementEmail(accountRequest);
+                            emailSender.sendEmail(adminAlertEmail);
+                            emailSender.sendEmail(userAcknowledgementEmail);
+            }
 
-        assert accountRequest != null;
-
-        if (userInfo == null || !userInfo.isAdmin) {
-            EmailWrapper adminAlertEmail = emailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
-            EmailWrapper userAcknowledgementEmail = emailGenerator
-                    .generateNewAccountRequestAcknowledgementEmail(accountRequest);
-            emailSender.sendEmail(adminAlertEmail);
-            emailSender.sendEmail(userAcknowledgementEmail);
-        }
-
-        AccountRequestData output = new AccountRequestData(accountRequest);
-        return new JsonResult(output);
-    }
+            AccountRequestData output = new AccountRequestData(accountRequest);
+                            return new JsonResult(output);
+                }
 
 }

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -13,74 +13,52 @@ import teammates.ui.output.AuthInfo;
 
 /**
  * Action: gets user authentication information.
- *
- * <p>This does not log in or log out the user.
- */
-public class GetAuthInfoAction extends Action {
+     *
+     * <p>This does not log in or log out the user.
+     */
+public class GetAuthInfoAction extends PublicAction {
 
     @Override
-    public AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute() {
+                    AuthInfo output;
 
-    @Override
-    void checkSpecificAccessControl() {
-        // Login information is available to everyone
-    }
+            UserInfo userInfo = getCurrentUserInfo();
+                    AuthType authType = getAuthType();
 
-    @Override
-    public JsonResult execute() {
-        String frontendUrl = getRequestParamValue("frontendUrl");
-        String nextUrl = getRequestParamValue("nextUrl");
-        if (frontendUrl == null) {
-            frontendUrl = "";
-        }
-
-        AuthInfo output;
-        if (userInfo == null) {
-            if (nextUrl == null) {
-                output = new AuthInfo(
-                        createLoginUrl(frontendUrl, Const.WebPageURIs.STUDENT_HOME_PAGE),
-                        createLoginUrl(frontendUrl, Const.WebPageURIs.INSTRUCTOR_HOME_PAGE),
-                        createLoginUrl(frontendUrl, Const.WebPageURIs.ADMIN_HOME_PAGE),
-                        createLoginUrl(frontendUrl, Const.WebPageURIs.MAINTAINER_HOME_PAGE)
-                );
+            if (userInfo == null) {
+                            output = new AuthInfo(null, false);
+            } else if (authType == AuthType.MASQUERADE) {
+                            output = new AuthInfo(userInfo, true);
             } else {
-                output = new AuthInfo(
-                        createLoginUrl(frontendUrl, nextUrl),
-                        createLoginUrl(frontendUrl, nextUrl),
-                        createLoginUrl(frontendUrl, nextUrl),
-                        createLoginUrl(frontendUrl, nextUrl)
-                );
+                            output = new AuthInfo(userInfo, authType == AuthType.MASQUERADE);
             }
-        } else {
-            output = new AuthInfo(userInfo, authType == AuthType.MASQUERADE);
-        }
 
-        String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
-        if (existingCsrfToken != null && isMatchingCsrfToken(existingCsrfToken, req.getSession().getId())) {
-            return new JsonResult(output);
+            String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
+                    if (existingCsrfToken != null && isMatchingCsrfToken(existingCsrfToken, req.getSession().getId())) {
+                                    return new JsonResult(output);
+                    }
+
+            // Regenerate CSRF token
+            String newCsrfToken = StringHelper.encrypt(req.getSession().getId());
+                    Cookie csrfTokenCookie = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, newCsrfToken);
+                    csrfTokenCookie.setPath("/");
+                    List<Cookie> cookieList = Collections.singletonList(csrfTokenCookie);
+                    return new JsonResult(output, cookieList);
         }
-        String csrfToken = StringHelper.encrypt(req.getSession().getId());
-        Cookie csrfTokenCookie = new Cookie(Const.SecurityConfig.CSRF_COOKIE_NAME, csrfToken);
-        csrfTokenCookie.setPath("/");
-        List<Cookie> cookieList = Collections.singletonList(csrfTokenCookie);
-        return new JsonResult(output, cookieList);
-    }
 
     private static boolean isMatchingCsrfToken(String existingCsrfToken, String sessionId) {
-        try {
-            return sessionId.equals(StringHelper.decrypt(existingCsrfToken));
-        } catch (InvalidParametersException e) {
-            return false;
-        }
+                try {
+                                return sessionId.equals(StringHelper.decrypt(existingCsrfToken));
+                } catch (InvalidParametersException e) {
+                                return false;
+                }
     }
 
     /**
      * Returns a LoginURL based on the frontendURL and nextURL.
-     */
+         */
     public static String createLoginUrl(String frontendUrl, String nextUrl) {
-        return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
+                return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -20,18 +20,32 @@ public class GetAuthInfoAction extends PublicAction {
 
     @Override
         public JsonResult execute() {
-                    AuthInfo output;
+                    String frontendUrl = getRequestParamValue("frontendUrl");
+                    String nextUrl = getRequestParamValue("nextUrl");
+                    if (frontendUrl == null) {
+                                    frontendUrl = "";
+                    }
 
-            UserInfo userInfo = getCurrentUserInfo();
-                    AuthType authType = getAuthType();
-
-            if (userInfo == null) {
-                            output = new AuthInfo(null, false);
-            } else if (authType == AuthType.MASQUERADE) {
-                            output = new AuthInfo(userInfo, true);
-            } else {
-                            output = new AuthInfo(userInfo, authType == AuthType.MASQUERADE);
-            }
+            AuthInfo output;
+                    if (userInfo == null) {
+                                    if (nextUrl == null) {
+                                                        output = new AuthInfo(
+                                                                                    createLoginUrl(frontendUrl, Const.WebPageURIs.STUDENT_HOME_PAGE),
+                                                                                    createLoginUrl(frontendUrl, Const.WebPageURIs.INSTRUCTOR_HOME_PAGE),
+                                                                                    createLoginUrl(frontendUrl, Const.WebPageURIs.ADMIN_HOME_PAGE),
+                                                                                    createLoginUrl(frontendUrl, Const.WebPageURIs.MAINTAINER_HOME_PAGE)
+                                                                            );
+                                    } else {
+                                                        output = new AuthInfo(
+                                                                                    createLoginUrl(frontendUrl, nextUrl),
+                                                                                    createLoginUrl(frontendUrl, nextUrl),
+                                                                                    createLoginUrl(frontendUrl, nextUrl),
+                                                                                    createLoginUrl(frontendUrl, nextUrl)
+                                                                            );
+                                    }
+                    } else {
+                                    output = new AuthInfo(userInfo, authType == AuthType.MASQUERADE);
+                    }
 
             String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
                     if (existingCsrfToken != null && isMatchingCsrfToken(existingCsrfToken, req.getSession().getId())) {
@@ -58,7 +72,7 @@ public class GetAuthInfoAction extends PublicAction {
      * Returns a LoginURL based on the frontendURL and nextURL.
          */
     public static String createLoginUrl(String frontendUrl, String nextUrl) {
-                return Const.WebPageURIs.LOGIN + "?nextUrl=" + frontendUrl + nextUrl;
+                return frontendUrl + Const.WebPageURIs.LOGIN_PAGE + "?nextUrl=" + nextUrl;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
@@ -9,59 +9,49 @@ import teammates.ui.request.Intent;
 
 /**
  * Action: checks whether the provided registration key is valid for the logged in user.
- *
- * <p>This does not log in or log out the user.
- */
-public class GetRegkeyValidityAction extends Action {
+     *
+     * <p>This does not log in or log out the user.
+     */
+public class GetRegkeyValidityAction extends PublicAction {
 
     @Override
-    public AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute() {
+                    String regKey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
+                    Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
 
-    @Override
-    void checkSpecificAccessControl() {
-        // Regkey information is available to everyone
-    }
+            boolean isValid = false;
+                    String googleId = null;
 
-    @Override
-    public JsonResult execute() {
-        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
-        String regKey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
-
-        boolean isValid = false;
-        String googleId = null;
-
-        if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
-            Student student = logic.getStudentByRegistrationKey(regKey);
-            if (student != null) {
-                isValid = true;
-                googleId = student.getGoogleId();
+            if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
+                            Student student = logic.getStudentByRegistrationKey(regKey);
+                            if (student != null) {
+                                                isValid = true;
+                                                googleId = student.getGoogleId();
+                            }
+            } else if (intent == Intent.INSTRUCTOR_SUBMISSION || intent == Intent.INSTRUCTOR_RESULT) {
+                            Instructor instructor = logic.getInstructorByRegistrationKey(regKey);
+                            if (instructor != null) {
+                                                isValid = true;
+                                                googleId = instructor.getGoogleId();
+                            }
             }
-        } else if (intent == Intent.INSTRUCTOR_SUBMISSION || intent == Intent.INSTRUCTOR_RESULT) {
-            Instructor instructor = logic.getInstructorByRegistrationKey(regKey);
-            if (instructor != null) {
-                isValid = true;
-                googleId = instructor.getGoogleId();
+
+            boolean isUsed = false;
+                    boolean isAllowedAccess = false;
+
+            if (isValid) {
+                            if (StringHelper.isEmpty(googleId)) {
+                                                // If registration key has not been used, always allow access
+                                isAllowedAccess = true;
+                            } else {
+                                                isUsed = true;
+                                                // If the registration key has been used to register, the logged in user needs to match
+                                // Block access to not logged in user or mismatched user
+                                isAllowedAccess = userInfo != null && googleId.equals(userInfo.id);
+                            }
             }
+
+            return new JsonResult(new RegkeyValidityData(isValid, isUsed, isAllowedAccess));
         }
-
-        boolean isUsed = false;
-        boolean isAllowedAccess = false;
-
-        if (isValid) {
-            if (StringHelper.isEmpty(googleId)) {
-                // If registration key has not been used, always allow access
-                isAllowedAccess = true;
-            } else {
-                isUsed = true;
-                // If the registration key has been used to register, the logged in user needs to match
-                // Block access to not logged in user and mismatched user
-                isAllowedAccess = userInfo != null && googleId.equals(userInfo.id);
-            }
-        }
-
-        return new JsonResult(new RegkeyValidityData(isValid, isUsed, isAllowedAccess));
-    }
 
 }

--- a/src/main/java/teammates/ui/webapi/PublicAction.java
+++ b/src/main/java/teammates/ui/webapi/PublicAction.java
@@ -1,0 +1,19 @@
+package teammates.ui.webapi;
+
+/**
+ * An action that is accessible by the public (no authentication required).
+   
+ */
+abstract class PublicAction extends Action {
+    
+  @Override
+      AuthType getMinAuthLevel() {
+                return AuthType.PUBLIC;
+      }
+
+    @Override
+      void checkSpecificAccessControl() {
+                // No access control needed for public actions
+      }
+
+}

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -6,40 +6,30 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
  * Actions: sends an error report to the system admin.
- */
-public class SendErrorReportAction extends Action {
-    private static final Logger log = Logger.getLogger();
+     */
+public class SendErrorReportAction extends PublicAction {
+        private static final Logger log = Logger.getLogger();
 
     @Override
-    AuthType getMinAuthLevel() {
-        // Anyone can submit an error report
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute() throws InvalidHttpRequestBodyException {
+                    ErrorReportRequest report = getAndValidateRequestBody(ErrorReportRequest.class);
 
-    @Override
-    void checkSpecificAccessControl() {
-        // Anyone can submit an error report
-    }
+            // Severe logs will trigger email to the system admin
+            log.severe(getUserErrorReportLogMessage(report));
 
-    @Override
-    public JsonResult execute() throws InvalidHttpRequestBodyException {
-        ErrorReportRequest report = getAndValidateRequestBody(ErrorReportRequest.class);
-
-        // Severe logs will trigger email to the system admin
-        log.severe(getUserErrorReportLogMessage(report));
-
-        return new JsonResult("Error report successfully sent");
-    }
+            return new JsonResult("Error report successfully sent");
+        }
 
     /**
      * Gets the user error report that will be sent to the system admin.
-     */
+         */
     public String getUserErrorReportLogMessage(ErrorReportRequest report) {
-        String user = userInfo == null ? "Non-logged in user" : userInfo.id;
-        return "====== USER FEEDBACK ABOUT ERROR ======" + System.lineSeparator()
-                + "USER: " + user + System.lineSeparator()
-                + "REQUEST ID: " + report.getRequestId() + System.lineSeparator()
-                + "SUBJECT: " + report.getSubject() + System.lineSeparator()
-                + "CONTENT: " + report.getContent();
+                String user = userInfo == null ? "Non-logged in user" : userInfo.id;
+                return "====== USER FEEDBACK ABOUT ERROR ======" + System.lineSeparator()
+                                    + "USER: " + user + System.lineSeparator()
+                                    + "REQUEST ID: " + report.getRequestId() + System.lineSeparator()
+                                    + "SUBJECT: " + report.getSubject() + System.lineSeparator()
+                                    + "CONTENT: " + report.getContent();
     }
+
 }

--- a/src/main/java/teammates/ui/webapi/SendLoginEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendLoginEmailAction.java
@@ -14,53 +14,40 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
  * Sends a login email.
- */
-public class SendLoginEmailAction extends Action {
+     */
+public class SendLoginEmailAction extends PublicAction {
 
     @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute()
+                throws InvalidHttpRequestBodyException, InvalidOperationException {
+                            String userEmail = getNonNullRequestParamValue(Const.ParamsNames.USER_EMAIL);
 
-    @Override
-    void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        // Sending of login emails can be requested by anyone
-    }
+            if (!userEmail.matches(REGEX_EMAIL)) {
+                            throw new InvalidHttpParameterException("Invalid email address: " + userEmail);
+            }
 
-    @Override
-    public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {
-        if (!authProxy.isLoginEmailEnabled()) {
-            throw new InvalidOperationException("Login using email link is not supported");
-        }
+            if (StringHelper.isEmpty(userEmail)) {
+                            return new JsonResult(new SendLoginEmailResponseData(false, "An error occurred. "
+                                                                                                     + "The email could not be generated."));
+            }
 
-        String userEmail = getNonNullRequestParamValue(Const.ParamsNames.USER_EMAIL);
-        if (!StringHelper.isMatching(userEmail, REGEX_EMAIL)) {
-            throw new InvalidHttpParameterException("Invalid email address: " + userEmail);
-        }
+            String continueUrl = getNonNullRequestParamValue(Const.ParamsNames.CONTINUE_URL);
+                            String loginLink = authProxy.generateLoginLink(userEmail, continueUrl);
+                            if (loginLink == null) {
+                                            return new JsonResult(new SendLoginEmailResponseData(false, "An error occurred. "
+                                                                                                                     + "The email could not be generated."));
+                            }
 
-        String userCaptchaResponse = getRequestParamValue(Const.ParamsNames.USER_CAPTCHA_RESPONSE);
-        if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
-            return new JsonResult(new SendLoginEmailResponseData(false, "ReCAPTCHA verification "
-                    + "failed. Please try again."));
-        }
+            EmailWrapper loginEmail = emailGenerator.generateLoginEmail(userEmail, loginLink);
+                            EmailSendingStatus status = emailSender.sendEmail(loginEmail);
 
-        String continueUrl = getNonNullRequestParamValue(Const.ParamsNames.CONTINUE_URL);
-        String loginLink = authProxy.generateLoginLink(userEmail, continueUrl);
-        if (loginLink == null) {
-            return new JsonResult(new SendLoginEmailResponseData(false, "An error occurred. "
-                    + "The email could not be generated."));
-        }
-
-        EmailWrapper loginEmail = emailGenerator.generateLoginEmail(userEmail, loginLink);
-        EmailSendingStatus status = emailSender.sendEmail(loginEmail);
-
-        if (status.isSuccess()) {
-            return new JsonResult(new SendLoginEmailResponseData(true,
-                    "The login link has been sent to the specified email address: " + userEmail));
-        } else {
-            return new JsonResult(new SendLoginEmailResponseData(false, "An error occurred. "
-                    + "The email could not be sent."));
-        }
-    }
+            if (status.isSuccess()) {
+                            return new JsonResult(new SendLoginEmailResponseData(true,
+                                                                                                     "The login link has been sent to the specified email address: " + userEmail));
+            } else {
+                            return new JsonResult(new SendLoginEmailResponseData(false, "An error occurred. "
+                                                                                                     + "The email could not be sent."));
+            }
+                }
 
 }

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -11,43 +11,39 @@ import teammates.ui.output.SessionLinksRecoveryResponseData;
 
 /**
  * Action specifically created for confirming email and sending session recovery links.
- */
-public class SessionLinksRecoveryAction extends Action {
+     */
+public class SessionLinksRecoveryAction extends PublicAction {
 
     @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
+        public JsonResult execute() {
+                    String recoveryEmailAddress = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
 
-    @Override
-    void checkSpecificAccessControl() {
-        // no specific access control needed.
-    }
+            if (recoveryEmailAddress == null || !recoveryEmailAddress.matches(REGEX_EMAIL)) {
+                            throw new InvalidHttpParameterException("Invalid email address: " + recoveryEmailAddress);
+            }
 
-    @Override
-    public JsonResult execute() {
-        String recoveryEmailAddress = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+            String recoveryEmailAddressParam = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
+                    if (recoveryEmailAddressParam != null) {
+                                    recoveryEmailAddress = recoveryEmailAddressParam;
+                    }
 
-        if (!StringHelper.isMatching(recoveryEmailAddress, REGEX_EMAIL)) {
-            throw new InvalidHttpParameterException("Invalid email address: " + recoveryEmailAddress);
+            String userCaptchaResponse = getRequestParamValue(Const.ParamsNames.USER_CAPTCHA_RESPONSE);
+                    if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
+                                    return new JsonResult(new SessionLinksRecoveryResponseData(false, "Something went wrong with "
+                                                                                                                   + "the reCAPTCHA verification. Please try again."));
+                    }
+
+            EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
+                    EmailSendingStatus status = emailSender.sendEmail(email);
+
+            if (status.isSuccess()) {
+                            return new JsonResult(new SessionLinksRecoveryResponseData(true,
+                                                                                                           "The recovery links for your feedback sessions have been sent to the "
+                                                                                                                   + "specified email address: " + recoveryEmailAddress));
+            } else {
+                            return new JsonResult(new SessionLinksRecoveryResponseData(false, "An error occurred. "
+                                                                                                           + "The email could not be sent."));
+            }
         }
 
-        String userCaptchaResponse = getRequestParamValue(Const.ParamsNames.USER_CAPTCHA_RESPONSE);
-        if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
-            return new JsonResult(new SessionLinksRecoveryResponseData(false, "Something went wrong with "
-                    + "the reCAPTCHA verification. Please try again."));
-        }
-
-        EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
-        EmailSendingStatus status = emailSender.sendEmail(email);
-
-        if (status.isSuccess()) {
-            return new JsonResult(new SessionLinksRecoveryResponseData(true,
-                    "The recovery links for your feedback sessions have been sent to the "
-                            + "specified email address: " + recoveryEmailAddress));
-        } else {
-            return new JsonResult(new SessionLinksRecoveryResponseData(false, "An error occurred. "
-                    + "The email could not be sent."));
-        }
-    }
 }


### PR DESCRIPTION
Fixes #13900

**Outline of Solution**

Created a new abstract base class `PublicAction` that extends `Action`. This class provides:
- `getMinAuthLevel()` returning `AuthType.PUBLIC`
- - An empty `checkSpecificAccessControl()` method
All 6 action classes that had `AuthType.PUBLIC` as their min auth level now extend `PublicAction` instead of `Action`, removing duplicate boilerplate overrides:
- `GetAuthInfoAction`
- - `GetRegkeyValidityAction`
- - `CreateAccountRequestAction`
- - `SessionLinksRecoveryAction`
- - `SendLoginEmailAction`
- - `SendErrorReportAction`