### PR TITLE
[#13900] Introduce PublicAction base class for public-facing actions

### DIFF
--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -5,7 +5,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.InvalidOperationException;
-import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -13,17 +12,7 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 /**
  * Creates a new account request.
  */
-public class CreateAccountRequestAction extends Action {
-
-    @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        // Nothing needs to be done here because anybody should be able to create an account request.
-    }
+public class CreateAccountRequestAction extends PublicAction {
 
     @Override
     public JsonResult execute()

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -16,17 +16,7 @@ import teammates.ui.output.AuthInfo;
  *
  * <p>This does not log in or log out the user.
  */
-public class GetAuthInfoAction extends Action {
-
-    @Override
-    public AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() {
-        // Login information is available to everyone
-    }
+public class GetAuthInfoAction extends PublicAction {
 
     @Override
     public JsonResult execute() {

--- a/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
@@ -12,17 +12,7 @@ import teammates.ui.request.Intent;
  *
  * <p>This does not log in or log out the user.
  */
-public class GetRegkeyValidityAction extends Action {
-
-    @Override
-    public AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() {
-        // Regkey information is available to everyone
-    }
+public class GetRegkeyValidityAction extends PublicAction {
 
     @Override
     public JsonResult execute() {

--- a/src/main/java/teammates/ui/webapi/PublicAction.java
+++ b/src/main/java/teammates/ui/webapi/PublicAction.java
@@ -2,11 +2,6 @@ package teammates.ui.webapi;
 
 /**
  * Base class for actions that are accessible to the public.
- *
- * <p>This class ensures that the minimum authentication level is set to
- * {@code AuthType.PUBLIC} and provides a default empty implementation
- * for access control checks. Subclasses only need to implement the
- * {@code execute()} method.
  */
 abstract class PublicAction extends Action {
 

--- a/src/main/java/teammates/ui/webapi/PublicAction.java
+++ b/src/main/java/teammates/ui/webapi/PublicAction.java
@@ -1,0 +1,24 @@
+package teammates.ui.webapi;
+
+/**
+ * Base class for actions that are accessible to the public.
+ *
+ * <p>This class ensures that the minimum authentication level is set to
+ * {@code AuthType.PUBLIC} and provides a default empty implementation
+ * for access control checks. Subclasses only need to implement the
+ * {@code execute()} method.
+ */
+abstract class PublicAction extends Action {
+
+    @Override
+    AuthType getMinAuthLevel() {
+        return AuthType.PUBLIC;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    void checkSpecificAccessControl() {
+        // No specific access control needed for public actions.
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -7,19 +7,8 @@ import teammates.ui.request.InvalidHttpRequestBodyException;
 /**
  * Actions: sends an error report to the system admin.
  */
-public class SendErrorReportAction extends Action {
+public class SendErrorReportAction extends PublicAction {
     private static final Logger log = Logger.getLogger();
-
-    @Override
-    AuthType getMinAuthLevel() {
-        // Anyone can submit an error report
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() {
-        // Anyone can submit an error report
-    }
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException {

--- a/src/main/java/teammates/ui/webapi/SendLoginEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendLoginEmailAction.java
@@ -8,24 +8,13 @@ import teammates.common.util.EmailWrapper;
 import teammates.common.util.StringHelper;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
-import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.SendLoginEmailResponseData;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
  * Sends a login email.
  */
-public class SendLoginEmailAction extends Action {
-
-    @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        // Sending of login emails can be requested by anyone
-    }
+public class SendLoginEmailAction extends PublicAction {
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -12,17 +12,7 @@ import teammates.ui.output.SessionLinksRecoveryResponseData;
 /**
  * Action specifically created for confirming email and sending session recovery links.
  */
-public class SessionLinksRecoveryAction extends Action {
-
-    @Override
-    AuthType getMinAuthLevel() {
-        return AuthType.PUBLIC;
-    }
-
-    @Override
-    void checkSpecificAccessControl() {
-        // no specific access control needed.
-    }
+public class SessionLinksRecoveryAction extends PublicAction {
 
     @Override
     public JsonResult execute() {


### PR DESCRIPTION
Fixes #13900

**Outline of Solution**

While looking through the action classes, I noticed six publicly accessible actions all repeating the same boilerplate — each one overriding `getMinAuthLevel()` to return `AuthType.PUBLIC` and providing an empty `checkSpecificAccessControl()`. We already have `AdminOnlyAction` that handles this cleanly for admin-only actions, but there was no equivalent for public actions.

To fix this, I created a `PublicAction` abstract base class modeled directly after `AdminOnlyAction`. It sets `AuthType.PUBLIC` as the min auth level and provides a no-op `checkSpecificAccessControl()` (with the required PMD suppression for the empty method) so subclasses don't need to override either method.

**Changes:**

- Created `PublicAction.java` in `teammates.ui.webapi`.
- Refactored `GetAuthInfoAction`, `GetRegkeyValidityAction`, `CreateAccountRequestAction`, `SessionLinksRecoveryAction`, `SendLoginEmailAction`, and `SendErrorReportAction` to extend `PublicAction`.
- Removed redundant overrides and unused `UnauthorizedAccessException` imports.

No behavior changes — auth logic works exactly the same at runtime and no `execute()` methods were touched.
