### PR TITLE
[#13721] Refactor fetching of feedback session comments

### DIFF
--- a/src/it/java/teammates/it/storage/api/FeedbackResponseCommentsDbIT.java
+++ b/src/it/java/teammates/it/storage/api/FeedbackResponseCommentsDbIT.java
@@ -12,12 +12,8 @@ import teammates.common.datatransfer.DataBundle;
 import teammates.common.util.HibernateUtil;
 import teammates.it.test.BaseTestCaseWithDatabaseAccess;
 import teammates.storage.api.FeedbackResponseCommentsDb;
-import teammates.storage.entity.Course;
-import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackResponseComment;
-import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Section;
 
 /**
  * SUT: {@link FeedbackResponseCommentsDb}.
@@ -54,178 +50,43 @@ public class FeedbackResponseCommentsDbIT extends BaseTestCaseWithDatabaseAccess
     }
 
     @Test
-    public void testGetFeedbackResponseCommentsForSession_matchFound_success() {
-        Course course = testDataBundle.courses.get("course1");
+    public void testGetFeedbackResponseCommentsForResponses_matchFound_success() {
+        FeedbackResponse response1ForQ1 = testDataBundle.feedbackResponses.get("response1ForQ1");
+        FeedbackResponse response4ForQ1 = testDataBundle.feedbackResponses.get("response4ForQ1");
 
-        ______TS("Session with comments");
-        FeedbackSession sessionWithComments = testDataBundle.feedbackSessions.get("session1InCourse1");
+        ______TS("Multiple feedback responses match");
         List<FeedbackResponseComment> expected = List.of(
                 testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1"),
                 testDataBundle.feedbackResponseComments.get("comment2ToResponse1ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment2ToResponse2ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ2s"),
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ3"),
                 testDataBundle.feedbackResponseComments.get("comment1ToResponse4ForQ1")
         );
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForSession(
-                        course.getId(), sessionWithComments.getName());
+        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForResponses(
+                List.of(response1ForQ1.getId(), response4ForQ1.getId()));
         assertListCommentsEqual(expected, results);
     }
 
     @Test
-    public void testGetFeedbackResponseCommentsForSession_matchNotFound_shouldReturnEmptyList() {
-        Course course = testDataBundle.courses.get("course1");
-        FeedbackSession session = testDataBundle.feedbackSessions.get("session1InCourse1");
+    public void testGetFeedbackResponseCommentsForResponses_matchNotFound_shouldReturnEmptyList() {
+        FeedbackResponse response1ForQ1 = testDataBundle.feedbackResponses.get("response1ForQ1");
+        UUID nonexistentResponseId = UUID.fromString("11110000-0000-0000-0000-000000000000");
 
-        ______TS("Course not found");
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForSession("not_exist", session.getName());
+        ______TS("No matching response IDs");
+        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForResponses(
+                List.of(nonexistentResponseId));
         assertEquals(0, results.size());
 
-        ______TS("Session not found");
-        results = frcDb.getFeedbackResponseCommentsForSession(course.getId(), "Nonexistent session");
+        ______TS("Empty list of response IDs");
+        results = frcDb.getFeedbackResponseCommentsForResponses(List.of());
         assertEquals(0, results.size());
 
-        ______TS("Session without comments");
-        FeedbackSession sessionWithoutComments = testDataBundle.feedbackSessions.get("ongoingSession1InCourse1");
-        results = frcDb.getFeedbackResponseCommentsForSession(course.getId(), sessionWithoutComments.getName());
-        assertEquals(0, results.size());
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForQuestion_matchFound_success() {
-        ______TS("Question with comments");
-        FeedbackQuestion questionWithComments = testDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        List<FeedbackResponseComment> expectedComments = List.of(
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment2ToResponse1ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment2ToResponse2ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse4ForQ1")
-        );
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForQuestion(questionWithComments.getId());
-        assertListCommentsEqual(expectedComments, results);
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForQuestion_matchNotFound_shouldReturnEmptyList() {
-        ______TS("Question not found");
-        UUID nonexistentQuestionId = UUID.fromString("11110000-0000-0000-0000-000000000000");
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForQuestion(nonexistentQuestionId);
-        assertEquals(0, results.size());
-
-        ______TS("Question without comments");
-        FeedbackQuestion questionWithoutComments = testDataBundle.feedbackQuestions.get("qn5InSession1InCourse1");
-        results = frcDb.getFeedbackResponseCommentsForQuestion(questionWithoutComments.getId());
-        assertEquals(0, results.size());
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForSessionInSection_matchFound_success() {
-        Section section1 = testDataBundle.sections.get("section1InCourse1");
-        Section section2 = testDataBundle.sections.get("section2InCourse1");
-        Course course = testDataBundle.courses.get("course1");
-        FeedbackSession session1 = testDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackSession session2 = testDataBundle.feedbackSessions.get("session2InTypicalCourse");
-
-        ______TS("Section 1 Session 2 match");
-        List<FeedbackResponseComment> expected = List.of(
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1InSession2")
-        );
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                course.getId(), session2.getName(), section1.getName());
-        assertListCommentsEqual(expected, results);
-
-        ______TS("Section 2 Session 1 match");
-        expected = List.of(
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse4ForQ1")
-        );
-        results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                course.getId(), session1.getName(), section2.getName());
-        assertListCommentsEqual(expected, results);
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForSessionInSection_matchNotFound_shouldReturnEmptyList() {
-        Course course = testDataBundle.courses.get("course1");
-        FeedbackSession session1 = testDataBundle.feedbackSessions.get("session1InCourse1");
-        FeedbackSession session2 = testDataBundle.feedbackSessions.get("session2InTypicalCourse");
-        Section section1 = testDataBundle.sections.get("section1InCourse1");
-        Section section2 = testDataBundle.sections.get("section2InCourse1");
-
-        ______TS("Course not found");
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                "not_exist", session1.getName(), section1.getName());
-        assertEquals(0, results.size());
-
-        ______TS("Session not found");
-        results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                course.getId(), "Nonexistent session", section1.getName());
-        assertEquals(0, results.size());
-
-        ______TS("Section not found");
-        results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                course.getId(), session1.getName(), "Nonexistent section");
-        assertEquals(0, results.size());
-
-        ______TS("No matching comments exist");
-        results = frcDb.getFeedbackResponseCommentsForSessionInSection(
-                course.getId(), session2.getName(), section2.getName());
-        assertEquals(0, results.size());
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForQuestionInSection_matchFound_success() {
-        Section section1 = testDataBundle.sections.get("section1InCourse1");
-        Section section2 = testDataBundle.sections.get("section2InCourse1");
-        FeedbackQuestion question1 = testDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion question2 = testDataBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-
-        ______TS("Section 1 Question 1 match");
+        ______TS("Mixed response IDs returns matching comments only");
         List<FeedbackResponseComment> expected = List.of(
                 testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment2ToResponse1ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment2ToResponse2ForQ1"),
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse4ForQ1")
+                testDataBundle.feedbackResponseComments.get("comment2ToResponse1ForQ1")
         );
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForQuestionInSection(
-                question1.getId(), section1.getName());
+        results = frcDb.getFeedbackResponseCommentsForResponses(
+                List.of(response1ForQ1.getId(), nonexistentResponseId));
         assertListCommentsEqual(expected, results);
-
-        ______TS("Section 2 Question 1 match");
-        expected = List.of(
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse4ForQ1")
-        );
-        results = frcDb.getFeedbackResponseCommentsForQuestionInSection(
-                question1.getId(), section2.getName());
-        assertListCommentsEqual(expected, results);
-
-        ______TS("Section 1 Question 2 match");
-        expected = List.of(
-                testDataBundle.feedbackResponseComments.get("comment1ToResponse1ForQ2s")
-        );
-        results = frcDb.getFeedbackResponseCommentsForQuestionInSection(
-                question2.getId(), section1.getName());
-        assertListCommentsEqual(expected, results);
-    }
-
-    @Test
-    public void testGetFeedbackResponseCommentsForQuestionInSection_matchNotFound_shouldReturnEmptyList() {
-        Section section = testDataBundle.sections.get("section1InCourse1");
-        FeedbackQuestion question1 = testDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        FeedbackQuestion question2 = testDataBundle.feedbackQuestions.get("qn4InSession1InCourse1");
-
-        ______TS("Question not found");
-        UUID nonexistentQuestionId = UUID.fromString("11110000-0000-0000-0000-000000000000");
-        List<FeedbackResponseComment> results = frcDb.getFeedbackResponseCommentsForQuestionInSection(
-                nonexistentQuestionId, section.getName());
-        assertEquals(0, results.size());
-
-        ______TS("Section not found");
-        results = frcDb.getFeedbackResponseCommentsForQuestionInSection(question1.getId(), "Nonexistent section");
-        assertEquals(0, results.size());
-
-        ______TS("No matching comments exist");
-        results = frcDb.getFeedbackResponseCommentsForQuestionInSection(question2.getId(), section.getName());
-        assertEquals(0, results.size());
     }
 
     private void assertListCommentsEqual(List<FeedbackResponseComment> expected, List<FeedbackResponseComment> actual) {

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.annotation.Nullable;
-
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
@@ -149,34 +147,10 @@ public final class FeedbackResponseCommentsLogic {
     }
 
     /**
-     * Gets all feedback response comments for session in a section.
-     *
-     * @param courseId the course ID of the feedback session
-     * @param feedbackSessionName the feedback session name
-     * @param sectionName if null, will retrieve all comments in the session
-     * @return a list of feedback response comments
+     * Gets all feedback response comments for the given feedback response IDs.
      */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentForSessionInSection(
-            String courseId, String feedbackSessionName, @Nullable String sectionName) {
-        if (sectionName == null) {
-            return frcDb.getFeedbackResponseCommentsForSession(courseId, feedbackSessionName);
-        }
-        return frcDb.getFeedbackResponseCommentsForSessionInSection(courseId, feedbackSessionName, sectionName);
-    }
-
-    /**
-     * Gets all feedback response comments for a question in a section.
-     *
-     * @param questionId the ID of the question
-     * @param sectionName if null, will retrieve all comments for the question
-     * @return a list of feedback response comments
-     */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentForQuestionInSection(
-            UUID questionId, @Nullable String sectionName) {
-        if (sectionName == null) {
-            return frcDb.getFeedbackResponseCommentsForQuestion(questionId);
-        }
-        return frcDb.getFeedbackResponseCommentsForQuestionInSection(questionId, sectionName);
+    public List<FeedbackResponseComment> getFeedbackResponseCommentsForResponses(List<UUID> feedbackResponseIds) {
+        return frcDb.getFeedbackResponseCommentsForResponses(feedbackResponseIds);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -567,7 +567,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private SessionResultsBundle buildResultsBundle(
-            boolean isCourseWide, FeedbackSession feedbackSession, String courseId, String sectionName, UUID questionId,
+            boolean isCourseWide, String sectionName,
             boolean isInstructor, String userEmail, Instructor instructor, Student student,
             CourseRoster roster, List<FeedbackQuestion> allQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
@@ -580,16 +580,6 @@ public final class FeedbackResponsesLogic {
                 questionsNotVisibleToInstructors.add(qn);
             }
         }
-
-        // load comment(s)
-        List<FeedbackResponseComment> allComments;
-        if (questionId == null) {
-            allComments = frcLogic.getFeedbackResponseCommentForSessionInSection(
-                    courseId, feedbackSession.getName(), sectionName);
-        } else {
-            allComments = frcLogic.getFeedbackResponseCommentForQuestionInSection(questionId, sectionName);
-        }
-        RequestTracer.checkRemainingTime();
 
         // related questions, responses, and comment
         List<FeedbackQuestion> relatedQuestions = new ArrayList<>();
@@ -658,6 +648,14 @@ public final class FeedbackResponsesLogic {
                     isNameVisibleToUser(correspondingQuestion, response.getGiver(), response.getRecipient(),
                         userEmail, isInstructor, false, roster));
         }
+        RequestTracer.checkRemainingTime();
+
+        // load comment(s) for related responses only
+        List<UUID> relatedResponseIds = new ArrayList<>();
+        for (FeedbackResponse relatedResponse : relatedResponses) {
+            relatedResponseIds.add(relatedResponse.getId());
+        }
+        List<FeedbackResponseComment> allComments = frcLogic.getFeedbackResponseCommentsForResponses(relatedResponseIds);
         RequestTracer.checkRemainingTime();
 
         // build comment
@@ -743,7 +741,7 @@ public final class FeedbackResponsesLogic {
         // consider the current viewing user
         Instructor instructor = usersLogic.getInstructorForEmail(courseId, instructorEmail);
 
-        return buildResultsBundle(true, feedbackSession, courseId, sectionName, questionId, true, instructorEmail,
+        return buildResultsBundle(true, sectionName, true, instructorEmail,
                 instructor, null, roster, allQuestions, allResponses, false);
     }
 
@@ -783,7 +781,7 @@ public final class FeedbackResponsesLogic {
         }
         RequestTracer.checkRemainingTime();
 
-        return buildResultsBundle(false, feedbackSession, courseId, null, questionId, isInstructor, userEmail,
+        return buildResultsBundle(false, null, isInstructor, userEmail,
                 instructor, student, roster, allQuestions, allResponses, isPreviewResults);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -88,10 +88,9 @@ public final class FeedbackResponseCommentsDb {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
         Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
-        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
 
         cq.select(root)
-                .where(frJoin.get("id").in(feedbackResponseIds));
+                .where(root.get("responseId").in(feedbackResponseIds));
 
         return HibernateUtil.createQuery(cq).getResultList();
     }

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -15,7 +15,6 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackResponseComment;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Section;
 
 /**
  * Handles CRUD operations for feedbackResponseComments.
@@ -74,6 +73,27 @@ public final class FeedbackResponseCommentsDb {
                         cb.equal(frJoin.get("id"), feedbackResponseId),
                         cb.equal(root.get("isCommentFromFeedbackParticipant"), true)));
         return HibernateUtil.createQuery(cq).getResultStream().findFirst().orElse(null);
+    }
+
+    /**
+     * Gets all comments for the given feedback response IDs.
+     */
+    public List<FeedbackResponseComment> getFeedbackResponseCommentsForResponses(List<UUID> feedbackResponseIds) {
+        assert feedbackResponseIds != null;
+
+        if (feedbackResponseIds.isEmpty()) {
+            return List.of();
+        }
+
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
+        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
+        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
+
+        cq.select(root)
+                .where(frJoin.get("id").in(feedbackResponseIds));
+
+        return HibernateUtil.createQuery(cq).getResultList();
     }
 
     /**
@@ -148,110 +168,6 @@ public final class FeedbackResponseCommentsDb {
                 .where(cb.and(
                     cb.equal(cJoin.get("id"), courseId),
                     cb.equal(root.get("lastEditorEmail"), lastEditorEmail)));
-
-        return HibernateUtil.createQuery(cq).getResultList();
-    }
-
-    /**
-     * Gets all comments in a feedback session of a course.
-     */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentsForSession(
-            String courseId, String feedbackSessionName) {
-        assert courseId != null;
-        assert feedbackSessionName != null;
-
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
-        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
-        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
-        Join<FeedbackResponse, FeedbackQuestion> fqJoin = frJoin.join("feedbackQuestion");
-        Join<FeedbackQuestion, FeedbackSession> fsJoin = fqJoin.join("feedbackSession");
-        Join<FeedbackSession, Course> cJoin = fsJoin.join("course");
-
-        cq.select(root)
-                .where(cb.and(
-                        cb.equal(cJoin.get("id"), courseId),
-                        cb.equal(fsJoin.get("name"), feedbackSessionName)
-                        ));
-
-        return HibernateUtil.createQuery(cq).getResultList();
-    }
-
-    /**
-     * Gets all comments of a feedback question of a course.
-     */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentsForQuestion(UUID questionId) {
-        assert questionId != null;
-
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
-        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
-        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
-        Join<FeedbackResponse, FeedbackQuestion> fqJoin = frJoin.join("feedbackQuestion");
-
-        cq.select(root)
-                .where(cb.and(
-                    cb.equal(fqJoin.get("id"), questionId)));
-
-        return HibernateUtil.createQuery(cq).getResultList();
-    }
-
-    /**
-     * Gets all comments in the given session where the giver or recipient is in the given section.
-     */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentsForSessionInSection(
-            String courseId, String feedbackSessionName, String sectionName) {
-        assert courseId != null;
-        assert feedbackSessionName != null;
-        assert sectionName != null;
-
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
-        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
-        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
-        Join<FeedbackResponse, FeedbackQuestion> fqJoin = frJoin.join("feedbackQuestion");
-        Join<FeedbackQuestion, FeedbackSession> fsJoin = fqJoin.join("feedbackSession");
-        Join<FeedbackSession, Course> cJoin = fsJoin.join("course");
-
-        Join<FeedbackResponseComment, Section> giverJoin = root.join("giverSection");
-        Join<FeedbackResponseComment, Section> recipientJoin = root.join("recipientSection");
-
-        cq.select(root)
-                .where(cb.and(
-                    cb.equal(cJoin.get("id"), courseId),
-                    cb.equal(fsJoin.get("name"), feedbackSessionName),
-                    cb.or(
-                        cb.equal(giverJoin.get("name"), sectionName),
-                        cb.equal(recipientJoin.get("name"), sectionName))
-                    ));
-
-        return HibernateUtil.createQuery(cq).getResultList();
-    }
-
-    /**
-     * Gets all comments for a question where the giver or recipient is in the given section.
-     */
-    public List<FeedbackResponseComment> getFeedbackResponseCommentsForQuestionInSection(
-            UUID questionId, String sectionName) {
-        assert questionId != null;
-        assert sectionName != null;
-
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<FeedbackResponseComment> cq = cb.createQuery(FeedbackResponseComment.class);
-        Root<FeedbackResponseComment> root = cq.from(FeedbackResponseComment.class);
-        Join<FeedbackResponseComment, FeedbackResponse> frJoin = root.join("feedbackResponse");
-        Join<FeedbackResponse, FeedbackQuestion> fqJoin = frJoin.join("feedbackQuestion");
-
-        Join<FeedbackResponseComment, Section> giverJoin = root.join("giverSection");
-        Join<FeedbackResponseComment, Section> recipientJoin = root.join("recipientSection");
-
-        cq.select(root)
-                .where(cb.and(
-                    cb.equal(fqJoin.get("id"), questionId),
-                    cb.or(
-                        cb.equal(giverJoin.get("name"), sectionName),
-                        cb.equal(recipientJoin.get("name"), sectionName))
-                    ));
 
         return HibernateUtil.createQuery(cq).getResultList();
     }

--- a/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
@@ -63,20 +63,6 @@ public class FeedbackResponseCommentsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetFeedbackResponseCommentsForResponses_success() {
-        FeedbackResponseComment comment1 = getTypicalResponseComment(TYPICAL_ID);
-        FeedbackResponseComment comment2 = getTypicalResponseComment(NOT_TYPICAL_ID);
-        List<UUID> feedbackResponseIds = List.of(TYPICAL_UUID, UUID.fromString("00000000-0000-4000-8000-000000000066"));
-
-        when(frcDb.getFeedbackResponseCommentsForResponses(feedbackResponseIds)).thenReturn(List.of(comment1, comment2));
-
-        List<FeedbackResponseComment> commentsFetched =
-                frcLogic.getFeedbackResponseCommentsForResponses(feedbackResponseIds);
-
-        assertEquals(List.of(comment1, comment2), commentsFetched);
-    }
-
-    @Test
     public void testGetComment_commentDoesNotExist_returnsNull() {
         when(frcDb.getFeedbackResponseComment(NOT_TYPICAL_ID)).thenReturn(null);
 

--- a/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponseCommentsLogicTest.java
@@ -63,6 +63,20 @@ public class FeedbackResponseCommentsLogicTest extends BaseTestCase {
     }
 
     @Test
+    public void testGetFeedbackResponseCommentsForResponses_success() {
+        FeedbackResponseComment comment1 = getTypicalResponseComment(TYPICAL_ID);
+        FeedbackResponseComment comment2 = getTypicalResponseComment(NOT_TYPICAL_ID);
+        List<UUID> feedbackResponseIds = List.of(TYPICAL_UUID, UUID.fromString("00000000-0000-4000-8000-000000000066"));
+
+        when(frcDb.getFeedbackResponseCommentsForResponses(feedbackResponseIds)).thenReturn(List.of(comment1, comment2));
+
+        List<FeedbackResponseComment> commentsFetched =
+                frcLogic.getFeedbackResponseCommentsForResponses(feedbackResponseIds);
+
+        assertEquals(List.of(comment1, comment2), commentsFetched);
+    }
+
+    @Test
     public void testGetComment_commentDoesNotExist_returnsNull() {
         when(frcDb.getFeedbackResponseComment(NOT_TYPICAL_ID)).thenReturn(null);
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Refactor fetching of feedback response comments to fetch by response IDs instead of sectionName field. Since feedback responses are already filtered by sections, the comments will be filtered by section as well.

This will allow us to remove now unused giver/recipient section in a future PR.