### PR TITLE
#[13924]: Remove regKey from RequestLogUser

### DIFF
--- a/src/main/java/teammates/common/datatransfer/logs/RequestLogUser.java
+++ b/src/main/java/teammates/common/datatransfer/logs/RequestLogUser.java
@@ -5,17 +5,8 @@ package teammates.common.datatransfer.logs;
  */
 public class RequestLogUser {
 
-    private String regkey;
     private String email;
     private String googleId;
-
-    public String getRegkey() {
-        return regkey;
-    }
-
-    public void setRegkey(String regkey) {
-        this.regkey = regkey;
-    }
 
     public String getEmail() {
         return email;

--- a/src/main/java/teammates/common/util/Logger.java
+++ b/src/main/java/teammates/common/util/Logger.java
@@ -125,9 +125,6 @@ public final class Logger {
         details.setRequestParams(HttpRequestHelper.getRequestParameters(request));
         details.setRequestHeaders(HttpRequestHelper.getRequestHeaders(request));
 
-        if (request.getParameter(Const.ParamsNames.REGKEY) != null && userInfo.getRegkey() == null) {
-            userInfo.setRegkey(request.getParameter(Const.ParamsNames.REGKEY));
-        }
         details.setUserInfo(userInfo);
         details.setRequestBody(requestBody);
         details.setActionClass(actionClass);

--- a/src/main/java/teammates/logic/external/GoogleCloudLoggingService.java
+++ b/src/main/java/teammates/logic/external/GoogleCloudLoggingService.java
@@ -149,9 +149,6 @@ public class GoogleCloudLoggingService implements LogService {
             if (q.getUserInfoParams().getGoogleId() != null) {
                 logFilters.add("jsonPayload.userInfo.googleId=\"" + q.getUserInfoParams().getGoogleId() + "\"");
             }
-            if (q.getUserInfoParams().getRegkey() != null) {
-                logFilters.add("jsonPayload.userInfo.regkey=\"" + q.getUserInfoParams().getRegkey() + "\"");
-            }
             if (q.getUserInfoParams().getEmail() != null) {
                 logFilters.add("jsonPayload.userInfo.email=\"" + q.getUserInfoParams().getEmail() + "\"");
             }

--- a/src/main/java/teammates/logic/external/LocalLoggingService.java
+++ b/src/main/java/teammates/logic/external/LocalLoggingService.java
@@ -105,12 +105,11 @@ public class LocalLoggingService implements LogService {
         String statusFilter = queryLogsParams.getStatus();
 
         RequestLogUser userInfoFilter = queryLogsParams.getUserInfoParams();
-        String regkeyFilter = userInfoFilter.getRegkey();
         String emailFilter = userInfoFilter.getEmail();
         String googleIdFilter = userInfoFilter.getGoogleId();
 
         if (actionClassFilter == null && exceptionClassFilter == null && logEventFilter == null
-                && latencyFilter == null && statusFilter == null && regkeyFilter == null
+                && latencyFilter == null && statusFilter == null
                 && emailFilter == null && googleIdFilter == null) {
             return true;
         }
@@ -125,7 +124,7 @@ public class LocalLoggingService implements LogService {
             return false;
         }
         return isRequestFilterSatisfied(details, actionClassFilter, latencyFilter, statusFilter,
-                regkeyFilter, emailFilter, googleIdFilter);
+                emailFilter, googleIdFilter);
     }
 
     private boolean isExceptionFilterSatisfied(LogDetails details, String exceptionClassFilter) {
@@ -140,9 +139,9 @@ public class LocalLoggingService implements LogService {
     }
 
     private boolean isRequestFilterSatisfied(LogDetails details, String actionClassFilter,
-            String latencyFilter, String statusFilter, String regkeyFilter, String emailFilter, String googleIdFilter) {
+            String latencyFilter, String statusFilter, String emailFilter, String googleIdFilter) {
         if (actionClassFilter == null && latencyFilter == null && statusFilter == null
-                && regkeyFilter == null && emailFilter == null && googleIdFilter == null) {
+                 && emailFilter == null && googleIdFilter == null) {
             return true;
         }
         if (details.getEvent() != LogEvent.REQUEST_LOG) {
@@ -185,9 +184,6 @@ public class LocalLoggingService implements LogService {
             }
         }
         RequestLogUser userInfo = requestDetails.getUserInfo();
-        if (regkeyFilter != null && (userInfo == null || !regkeyFilter.equals(userInfo.getRegkey()))) {
-            return false;
-        }
         if (emailFilter != null && (userInfo == null
                 || !SanitizationHelper.areEmailsEqual(emailFilter, userInfo.getEmail()))) {
             return false;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -133,7 +133,7 @@ public abstract class Action {
         user.setGoogleId(googleId);
         if (unregisteredStudent != null) {
             user.setEmail(unregisteredStudent.getEmail());
-        } else if(unregisteredInstructor != null) {
+        } else if (unregisteredInstructor != null) {
             user.setEmail(unregisteredInstructor.getEmail());
         }
         return user;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -133,7 +133,7 @@ public abstract class Action {
         user.setGoogleId(googleId);
         if (unregisteredStudent != null) {
             user.setEmail(unregisteredStudent.getEmail());
-        } else {
+        } else if(unregisteredInstructor != null) {
             user.setEmail(unregisteredInstructor.getEmail());
         }
         return user;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -131,13 +131,9 @@ public abstract class Action {
         String googleId = userInfo == null ? null : userInfo.getId();
 
         user.setGoogleId(googleId);
-        if (unregisteredStudent == null && unregisteredInstructor == null) {
-            user.setRegkey(getRequestParamValue(Const.ParamsNames.REGKEY));
-        } else if (unregisteredStudent != null) {
-            user.setRegkey(unregisteredStudent.getRegKey());
+        if (unregisteredStudent != null) {
             user.setEmail(unregisteredStudent.getEmail());
         } else {
-            user.setRegkey(unregisteredInstructor.getRegKey());
             user.setEmail(unregisteredInstructor.getEmail());
         }
         return user;

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -541,7 +541,6 @@ export interface RequestLogDetails extends LogDetails {
 }
 
 export interface RequestLogUser {
-  regkey: string;
   email: string;
   googleId: string;
 }


### PR DESCRIPTION
Fixes : #13924 

This pull request removes the usage and tracking of the `regkey` field from the logging system, including both backend Java code and related TypeScript definitions. The main impact is that `regkey` will no longer be stored, filtered, or processed in request logs, simplifying user information handling in logs.

**Removal of `regkey` from logging:**

* Removed the `regkey` field, along with its getter and setter, from the `RequestLogUser` class (`RequestLogUser.java`, `RequestLogUser` interface in `api-output.ts`). [[1]](diffhunk://#diff-6a43afd85db0e1a3a84eee2db633de9eaeadef723075e51647061779e9c7b2c1L8-L19) [[2]](diffhunk://#diff-c71c73b9c365f409e118f095acde1346bf90320212a62a258598958744116606L544)
* Eliminated logic that set or filtered by `regkey` in log creation and querying, including in `Logger.java`, `GoogleCloudLoggingService.java`, and `LocalLoggingService.java`. [[1]](diffhunk://#diff-254220f9ac90bc1df79fade490de998a66222bdeb656873dcc2835316bb1b1f5L128-L130) [[2]](diffhunk://#diff-e99f5eac8bba5a69361f09d468e6d6f716fb7cdc2d2cfb6826c3e3c497af2039L152-L154) [[3]](diffhunk://#diff-e2cee109e354235e31a9822984eafc1dfc89f93f3e66cf6551638c9363a85911L108-R112) [[4]](diffhunk://#diff-e2cee109e354235e31a9822984eafc1dfc89f93f3e66cf6551638c9363a85911L128-R127) [[5]](diffhunk://#diff-e2cee109e354235e31a9822984eafc1dfc89f93f3e66cf6551638c9363a85911L143-R144) [[6]](diffhunk://#diff-e2cee109e354235e31a9822984eafc1dfc89f93f3e66cf6551638c9363a85911L188-L190)
* Updated the logic for populating `RequestLogUser` in `Action.java` to no longer set or check the `regkey` field.