### PR TITLE
[#13721] Pass user instead of separate instructor and student objects to session results related methods

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
@@ -122,8 +122,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         output = (SessionResultsData) r.getOutput();
         expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
-                        student.getEmail(),
-                        false, null, true),
+                        student, null, true),
                 student);
 
         assertTrue(isSessionResultsDataEqual(expectedResults, output));
@@ -143,8 +142,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         output = (SessionResultsData) r.getOutput();
         expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
-                        student.getEmail(),
-                        false, null, false),
+                        student, null, false),
                 student);
 
         assertTrue(isSessionResultsDataEqual(expectedResults, output));
@@ -167,8 +165,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         output = (SessionResultsData) r.getOutput();
         expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
-                        student.getEmail(),
-                        false, question.getId(), false),
+                        student, question.getId(), false),
                 student);
 
         assertTrue(isSessionResultsDataEqual(expectedResults, output));

--- a/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetSessionResultsActionIT.java
@@ -68,7 +68,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
 
         SessionResultsData output = (SessionResultsData) r.getOutput();
 
-        SessionResultsData expectedResults = SessionResultsData.initForInstructor(
+        SessionResultsData expectedResults = SessionResultsData.init(
                 logic.getSessionResults(accessibleFeedbackSession,
                         instructor.getEmail(),
                         null, null, FeedbackResultFetchType.BOTH));
@@ -97,7 +97,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
 
                 output = (SessionResultsData) r.getOutput();
 
-                expectedResults = SessionResultsData.initForInstructor(
+                expectedResults = SessionResultsData.init(
                         logic.getSessionResults(accessibleFeedbackSession,
                                 instructor.getEmail(),
                                 null, section.getName(), fetchType));
@@ -120,7 +120,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         r = getJsonResult(a);
 
         output = (SessionResultsData) r.getOutput();
-        expectedResults = SessionResultsData.initForStudent(
+        expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
                         student.getEmail(),
                         false, null, true),
@@ -141,7 +141,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         r = getJsonResult(a);
 
         output = (SessionResultsData) r.getOutput();
-        expectedResults = SessionResultsData.initForStudent(
+        expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
                         student.getEmail(),
                         false, null, false),
@@ -165,7 +165,7 @@ public class GetSessionResultsActionIT extends BaseActionIT<GetSessionResultsAct
         r = getJsonResult(a);
 
         output = (SessionResultsData) r.getOutput();
-        expectedResults = SessionResultsData.initForStudent(
+        expectedResults = SessionResultsData.initForUser(
                 logic.getSessionResultsForUser(accessibleFeedbackSession,
                         student.getEmail(),
                         false, question.getId(), false),

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1273,8 +1273,11 @@ public class Logic {
     /**
      * Gets the session result for a feedback session for the given user.
      *
-     * @see FeedbackResponsesLogic#getSessionResultsForUser(FeedbackSession, String,
-     *      String, boolean, String)
+     * @param feedbackSession the feedback session
+     * @param user the user viewing the feedback session
+     * @param questionId if not null, will only return partial bundle for the question
+     * @param isPreviewResults true if getting session results for preview purpose
+     * @return the session result bundle
      */
     public SessionResultsBundle getSessionResultsForUser(
             FeedbackSession feedbackSession, User user,

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1277,10 +1277,10 @@ public class Logic {
      *      String, boolean, String)
      */
     public SessionResultsBundle getSessionResultsForUser(
-            FeedbackSession feedbackSession, String userEmail, boolean isInstructor,
+            FeedbackSession feedbackSession, User user,
             @Nullable UUID questionId, boolean isPreviewResults) {
         return feedbackResponsesLogic.getSessionResultsForUser(
-                feedbackSession, userEmail, isInstructor, questionId, isPreviewResults);
+                feedbackSession, user, questionId, isPreviewResults);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -17,7 +17,9 @@ import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackResponseComment;
+import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 import teammates.ui.request.FeedbackResponseCommentUpdateRequest;
 
 /**
@@ -144,8 +146,8 @@ public final class FeedbackResponseCommentsLogic {
      * Verifies whether the comment is visible to certain user.
      * @return true/false
      */
-    public boolean checkIsResponseCommentVisibleForUser(String userEmail, boolean isInstructor,
-            Student student, Set<String> studentsEmailInTeam, FeedbackResponse response,
+    public boolean checkIsResponseCommentVisibleForUser(User user,
+            Set<String> studentsEmailInTeam, FeedbackResponse response,
             FeedbackQuestion relatedQuestion, FeedbackResponseComment relatedComment) {
 
         if (response == null || relatedQuestion == null) {
@@ -156,22 +158,23 @@ public final class FeedbackResponseCommentsLogic {
         boolean isVisibleToGiver = isVisibilityFollowingFeedbackQuestion
                                  || relatedComment.checkIsVisibleTo(ViewerType.GIVER);
 
-        boolean isVisibleToUser = checkIsVisibleToUser(userEmail, response, relatedQuestion, relatedComment,
-                isVisibleToGiver, isInstructor, !isInstructor);
+        boolean isVisibleToUser = checkIsVisibleToUser(user, response, relatedQuestion, relatedComment, isVisibleToGiver);
 
-        boolean isVisibleToUserTeam = checkIsVisibleToUserTeam(student, studentsEmailInTeam, response,
-                relatedQuestion, relatedComment, !isInstructor);
+        boolean isVisibleToUserTeam = false;
+        if (user instanceof Student student) {
+            isVisibleToUserTeam = checkIsVisibleToUserTeam(student, studentsEmailInTeam, response,
+                    relatedQuestion, relatedComment);
+        }
 
         return isVisibleToUser || isVisibleToUserTeam;
     }
 
     private boolean checkIsVisibleToUserTeam(Student student, Set<String> studentsEmailInTeam,
             FeedbackResponse response, FeedbackQuestion relatedQuestion,
-            FeedbackResponseComment relatedComment, boolean isUserStudent) {
+            FeedbackResponseComment relatedComment) {
 
         boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipients =
-                isUserStudent
-                && relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS
+                relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS
                 && checkIsResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               ViewerType.RECEIVER)
                 && response.getRecipient().equals(student.getTeamName());
@@ -181,7 +184,7 @@ public final class FeedbackResponseCommentsLogic {
                 || checkIsResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               ViewerType.OWN_TEAM_MEMBERS))
                 && (studentsEmailInTeam.contains(response.getGiver())
-                        || isUserStudent && student.getTeamName().equals(response.getGiver()));
+                        || student.getTeamName().equals(response.getGiver()));
 
         boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers =
                 checkIsResponseCommentVisibleTo(relatedQuestion, relatedComment,
@@ -193,27 +196,28 @@ public final class FeedbackResponseCommentsLogic {
                 || isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers;
     }
 
-    private boolean checkIsVisibleToUser(String userEmail, FeedbackResponse response,
+    private boolean checkIsVisibleToUser(User user, FeedbackResponse response,
             FeedbackQuestion relatedQuestion, FeedbackResponseComment relatedComment,
-            boolean isVisibleToGiver, boolean isUserInstructor, boolean isUserStudent) {
+            boolean isVisibleToGiver) {
+        boolean isUserInstructor = user instanceof Instructor;
 
         boolean isUserInstructorAndRelatedResponseCommentVisibleToInstructors =
                 isUserInstructor && checkIsResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                                                ViewerType.INSTRUCTORS);
 
         boolean isUserResponseRecipientAndRelatedResponseCommentVisibleToRecipients =
-                SanitizationHelper.areEmailsEqual(response.getRecipient(), userEmail)
+                SanitizationHelper.areEmailsEqual(response.getRecipient(), user.getEmail())
                         && checkIsResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, ViewerType.RECEIVER);
 
         boolean isUserResponseGiverAndRelatedResponseCommentVisibleToGivers =
-                SanitizationHelper.areEmailsEqual(response.getGiver(), userEmail) && isVisibleToGiver;
+                SanitizationHelper.areEmailsEqual(response.getGiver(), user.getEmail()) && isVisibleToGiver;
 
         boolean isUserRelatedResponseCommentGiver = SanitizationHelper.areEmailsEqual(relatedComment.getGiver(),
-                userEmail);
+                user.getEmail());
 
         boolean isUserStudentAndRelatedResponseCommentVisibleToStudents =
-                isUserStudent && checkIsResponseCommentVisibleTo(relatedQuestion,
+                !isUserInstructor && checkIsResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, ViewerType.STUDENTS);
 
         return isUserInstructorAndRelatedResponseCommentVisibleToInstructors

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -37,6 +37,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.Team;
+import teammates.storage.entity.User;
 import teammates.storage.entity.responses.FeedbackRankRecipientsResponse;
 
 /**
@@ -554,8 +555,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private SessionResultsBundle buildResultsBundle(
-            boolean isCourseWide, String sectionName,
-            boolean isInstructor, String userEmail, Instructor instructor, Student student,
+            boolean isCourseWide, String sectionName, User user,
             CourseRoster roster, List<FeedbackQuestion> allQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
 
@@ -582,7 +582,7 @@ public final class FeedbackResponsesLogic {
         }
 
         Set<String> studentsEmailInTeam = new HashSet<>();
-        if (student != null) {
+        if (user instanceof Student student) {
             for (Student studentInTeam
                     : roster.getTeamToMembersTable().getOrDefault(student.getTeamName(), Collections.emptyList())) {
                 studentsEmailInTeam.add(studentInTeam.getEmail());
@@ -608,7 +608,7 @@ public final class FeedbackResponsesLogic {
             }
             // check visibility of response
             boolean isVisibleResponse = isResponseVisibleForUser(
-                    userEmail, student, instructor, studentsEmailInTeam,
+                    user, studentsEmailInTeam,
                     response.getGiver(), response.getRecipient(),
                     response.getGiverSectionName(), response.getRecipientSectionName(),
                     correspondingQuestion);
@@ -630,10 +630,10 @@ public final class FeedbackResponsesLogic {
             // generate giver/recipient name visibility table
             responseGiverVisibilityTable.put(response.getId(),
                     isNameVisibleToUser(correspondingQuestion, response.getGiver(), response.getRecipient(),
-                        userEmail, isInstructor, true, roster));
+                        user.getEmail(), user instanceof Instructor, true, roster));
             responseRecipientVisibilityTable.put(response.getId(),
                     isNameVisibleToUser(correspondingQuestion, response.getGiver(), response.getRecipient(),
-                        userEmail, isInstructor, false, roster));
+                        user.getEmail(), user instanceof Instructor, false, roster));
         }
         RequestTracer.checkRemainingTime();
 
@@ -658,7 +658,7 @@ public final class FeedbackResponsesLogic {
             }
             // check visibility of comment
             boolean isVisibleResponseComment = frcLogic.checkIsResponseCommentVisibleForUser(
-                    userEmail, isInstructor, student, studentsEmailInTeam, relatedResponse, relatedQuestion, frc);
+                    user, studentsEmailInTeam, relatedResponse, relatedQuestion, frc);
             if (!isVisibleResponseComment) {
                 continue;
             }
@@ -673,13 +673,13 @@ public final class FeedbackResponsesLogic {
             relatedCommentsMap.computeIfAbsent(relatedResponse, key -> new ArrayList<>()).add(frc);
             // generate comment giver name visibility table
             commentVisibilityTable.put(frc.getId(),
-                    frcLogic.checkIsNameVisibleToUser(frc, relatedResponse, userEmail, roster));
+                    frcLogic.checkIsNameVisibleToUser(frc, relatedResponse, user.getEmail(), roster));
         }
         RequestTracer.checkRemainingTime();
 
         List<FeedbackResponse> existingResponses = new ArrayList<>(relatedResponses);
         List<FeedbackMissingResponse> missingResponses = Collections.emptyList();
-        if (isCourseWide) {
+        if (isCourseWide && user instanceof Instructor instructor) {
             missingResponses = buildMissingResponses(
                     instructor, responseGiverVisibilityTable, responseRecipientVisibilityTable, relatedQuestions,
                     existingResponses, roster, sectionName);
@@ -728,22 +728,20 @@ public final class FeedbackResponsesLogic {
         // consider the current viewing user
         Instructor instructor = usersLogic.getInstructorForEmail(courseId, instructorEmail);
 
-        return buildResultsBundle(true, sectionName, true, instructorEmail,
-                instructor, null, roster, allQuestions, allResponses, false);
+        return buildResultsBundle(true, sectionName, instructor, roster, allQuestions, allResponses, false);
     }
 
     /**
      * Gets the session result for a feedback session for the given user.
      *
      * @param feedbackSession the feedback session
-     * @param userEmail the user viewing the feedback session
-     * @param isInstructor true if the user is an instructor
+     * @param user the user viewing the feedback session
      * @param questionId if not null, will only return partial bundle for the question
      * @param isPreviewResults true if getting session results for preview purpose
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResultsForUser(
-            FeedbackSession feedbackSession, String userEmail, boolean isInstructor,
+            FeedbackSession feedbackSession, User user,
             @Nullable UUID questionId, boolean isPreviewResults) {
         String courseId = feedbackSession.getCourseId();
         CourseRoster roster = new CourseRoster(
@@ -755,21 +753,22 @@ public final class FeedbackResponsesLogic {
         RequestTracer.checkRemainingTime();
 
         // load response(s)
-        Student student = isInstructor ? null : usersLogic.getStudentForEmail(courseId, userEmail);
-        Instructor instructor = isInstructor ? usersLogic.getInstructorForEmail(courseId, userEmail) : null;
         List<FeedbackResponse> allResponses = new ArrayList<>();
         for (FeedbackQuestion question : allQuestions) {
             // load viewable responses for students/instructors proactively
             // this is cost-effective as in most of time responses for the whole session will not be viewable to individuals
-            List<FeedbackResponse> viewableResponses = isInstructor
-                    ? getFeedbackResponsesToOrFromInstructorForQuestion(question, instructor)
-                    : getViewableFeedbackResponsesForStudentForQuestion(question, student, roster);
+            List<FeedbackResponse> viewableResponses = Collections.emptyList();
+            if (user instanceof Instructor instructor) {
+                viewableResponses = getFeedbackResponsesToOrFromInstructorForQuestion(question, instructor);
+            } else if (user instanceof Student student) {
+                viewableResponses = getViewableFeedbackResponsesForStudentForQuestion(question, student, roster);
+            }
+
             allResponses.addAll(viewableResponses);
         }
         RequestTracer.checkRemainingTime();
 
-        return buildResultsBundle(false, null, isInstructor, userEmail,
-                instructor, student, roster, allQuestions, allResponses, isPreviewResults);
+        return buildResultsBundle(false, null, user, roster, allQuestions, allResponses, isPreviewResults);
     }
 
     /**
@@ -841,7 +840,7 @@ public final class FeedbackResponsesLogic {
                             recipientIdentifier, recipientInfo.getSectionName());
 
                     boolean isVisibleResponse = isResponseVisibleForUser(
-                            instructor.getEmail(), null, instructor, Collections.emptySet(),
+                            instructor, Collections.emptySet(),
                             missingResponse.giver(), missingResponse.recipient(),
                             missingResponse.giverSectionName(), missingResponse.recipientSectionName(),
                             correspondingQuestion);
@@ -954,9 +953,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private boolean isResponseVisibleForUser(
-            String userEmail,
-            Student student,
-            Instructor instructor,
+            User user,
             Set<String> studentsEmailInTeam,
             String giver,
             String recipient,
@@ -964,45 +961,57 @@ public final class FeedbackResponsesLogic {
             String recipientSectionName,
             FeedbackQuestion relatedQuestion
     ) {
-        boolean isInstructor = instructor != null;
+        boolean isVisibleToRecipient = SanitizationHelper.areEmailsEqual(recipient, user.getEmail())
+                && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER);
+        boolean isVisibleToGiver = SanitizationHelper.areEmailsEqual(giver, user.getEmail());
 
-        boolean isGiverSectionRestrictedForInstructor = isInstructor && !instructor.isAllowedForPrivilege(
+        boolean isGiverSectionRestrictedForInstructor = false;
+        boolean isRecipientSectionRestrictedForInstructor = false;
+        boolean isVisibleToInstructor = false;
+        if (user instanceof Instructor instructor) {
+            isGiverSectionRestrictedForInstructor = !instructor.isAllowedForPrivilege(
                         giverSectionName,
                         relatedQuestion.getFeedbackSessionName(),
                         Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS
                 );
 
-        boolean isRecipientSectionRestrictedForInstructor = isInstructor
-                && relatedQuestion.getRecipientType() != QuestionRecipientType.NONE
-                && !instructor.isAllowedForPrivilege(
-                        recipientSectionName,
-                        relatedQuestion.getFeedbackSessionName(),
-                        Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS
-                );
+            isRecipientSectionRestrictedForInstructor =
+                    relatedQuestion.getRecipientType() != QuestionRecipientType.NONE
+                    && !instructor.isAllowedForPrivilege(
+                            recipientSectionName,
+                            relatedQuestion.getFeedbackSessionName(),
+                            Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS
+                    );
 
-        boolean isVisibleToInstructor = isInstructor
-                && relatedQuestion.isResponseVisibleTo(ViewerType.INSTRUCTORS)
-                && !isGiverSectionRestrictedForInstructor
-                && !isRecipientSectionRestrictedForInstructor;
-        boolean isVisibleToRecipient = SanitizationHelper.areEmailsEqual(recipient, userEmail)
-                && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER);
-        boolean isVisibleToGiver = SanitizationHelper.areEmailsEqual(giver, userEmail);
-        boolean isVisibleToStudents = !isInstructor && relatedQuestion.isResponseVisibleTo(ViewerType.STUDENTS);
-        boolean isVisibleToTeamRecipient = studentsEmailInTeam != null && !isInstructor
-                && (relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS
-                    || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION
-                    || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_EXCLUDING_SELF)
-                && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER)
-                && recipient.equals(student.getTeamName());
-        boolean isVisibleToTeamGiver = studentsEmailInTeam != null && !isInstructor
-                && relatedQuestion.getGiverType() == QuestionGiverType.TEAMS
-                && giver.equals(student.getTeamName());
-        boolean isVisibleToOwnTeamMembers = studentsEmailInTeam != null && !isInstructor
-                && relatedQuestion.isResponseVisibleTo(ViewerType.OWN_TEAM_MEMBERS)
-                && studentsEmailInTeam.contains(giver);
-        boolean isVisibleToReceiverTeamMembers = studentsEmailInTeam != null && !isInstructor
-                && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER_TEAM_MEMBERS)
-                && studentsEmailInTeam.contains(recipient);
+            isVisibleToInstructor =
+                    relatedQuestion.isResponseVisibleTo(ViewerType.INSTRUCTORS)
+                    && !isGiverSectionRestrictedForInstructor
+                    && !isRecipientSectionRestrictedForInstructor;
+        }
+
+        boolean isVisibleToStudents = false;
+        boolean isVisibleToTeamRecipient = false;
+        boolean isVisibleToTeamGiver = false;
+        boolean isVisibleToOwnTeamMembers = false;
+        boolean isVisibleToReceiverTeamMembers = false;
+        if (user instanceof Student student) {
+            isVisibleToStudents = relatedQuestion.isResponseVisibleTo(ViewerType.STUDENTS);
+            isVisibleToTeamRecipient = studentsEmailInTeam != null
+                    && (relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS
+                        || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION
+                        || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_EXCLUDING_SELF)
+                    && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER)
+                    && recipient.equals(student.getTeamName());
+            isVisibleToTeamGiver = studentsEmailInTeam != null
+                    && relatedQuestion.getGiverType() == QuestionGiverType.TEAMS
+                    && giver.equals(student.getTeamName());
+            isVisibleToOwnTeamMembers = studentsEmailInTeam != null
+                    && relatedQuestion.isResponseVisibleTo(ViewerType.OWN_TEAM_MEMBERS)
+                    && studentsEmailInTeam.contains(giver);
+            isVisibleToReceiverTeamMembers = studentsEmailInTeam != null
+                    && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER_TEAM_MEMBERS)
+                    && studentsEmailInTeam.contains(recipient);
+        }
 
         return isVisibleToInstructor || isVisibleToRecipient || isVisibleToGiver
                 || isVisibleToStudents || isVisibleToTeamRecipient || isVisibleToTeamGiver

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -28,6 +28,7 @@ import teammates.storage.entity.FeedbackResponseComment;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 
 /**
  * API output format for session results, including statistics.
@@ -72,7 +73,7 @@ public class SessionResultsData extends ApiOutput {
     /**
      * Factory method to construct API output for user.
      */
-    public static SessionResultsData initForUser(SessionResultsBundle bundle, Student student) {
+    public static SessionResultsData initForUser(SessionResultsBundle bundle, User user) {
         SessionResultsData sessionResultsData = new SessionResultsData();
 
         Map<FeedbackQuestion, List<FeedbackResponse>> questionsWithResponses =
@@ -84,7 +85,7 @@ public class SessionResultsData extends ApiOutput {
             boolean hasCommentNotVisibleForPreview = bundle.getQuestionsWithCommentNotVisibleForPreviewSet()
                     .contains(question);
             QuestionOutput qnOutput = new QuestionOutput(question,
-                    questionDetails.getQuestionResultStatisticsJson(question, student.getEmail(), bundle),
+                    questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle),
                     false, hasCommentNotVisibleForPreview);
             Map<String, List<ResponseOutput>> otherResponsesMap = new HashMap<>();
 
@@ -92,15 +93,15 @@ public class SessionResultsData extends ApiOutput {
 
             if (questionDetails.isIndividualResponsesShownToStudents()) {
                 for (FeedbackResponse response : responses) {
-                    boolean isUserInstructor = Const.USER_TEAM_FOR_INSTRUCTOR.equals(student.getTeamName());
+                    boolean isUserInstructor = user instanceof Instructor;
 
-                    boolean isUserGiver = SanitizationHelper.areEmailsEqual(student.getEmail(), response.getGiver())
+                    boolean isUserGiver = SanitizationHelper.areEmailsEqual(user.getEmail(), response.getGiver())
                             && (isUserInstructor && question.getGiverType() == QuestionGiverType.INSTRUCTORS
                             || !isUserInstructor && question.getGiverType() != QuestionGiverType.INSTRUCTORS);
-                    boolean isUserRecipient = SanitizationHelper.areEmailsEqual(student.getEmail(), response.getRecipient())
+                    boolean isUserRecipient = SanitizationHelper.areEmailsEqual(user.getEmail(), response.getRecipient())
                             && (isUserInstructor && question.getRecipientType() == QuestionRecipientType.INSTRUCTORS
                             || !isUserInstructor && question.getRecipientType() != QuestionRecipientType.INSTRUCTORS);
-                    ResponseOutput responseOutput = buildSingleResponseForUser(response, bundle, student);
+                    ResponseOutput responseOutput = buildSingleResponseForUser(response, bundle, user);
 
                     if (isUserRecipient) {
                         qnOutput.responsesToSelf.add(responseOutput);
@@ -136,16 +137,20 @@ public class SessionResultsData extends ApiOutput {
     }
 
     private static ResponseOutput buildSingleResponseForUser(
-            FeedbackResponse response, SessionResultsBundle bundle, Student student) {
+            FeedbackResponse response, SessionResultsBundle bundle, User user) {
         FeedbackQuestion question = response.getFeedbackQuestion();
-        boolean isUserInstructor = Const.USER_TEAM_FOR_INSTRUCTOR.equals(student.getTeamName());
+        boolean isUserInstructor = user instanceof Instructor;
 
         // process giver
-        boolean isUserGiver = SanitizationHelper.areEmailsEqual(student.getEmail(), response.getGiver())
+        boolean isUserGiver = SanitizationHelper.areEmailsEqual(user.getEmail(), response.getGiver())
                 && (isUserInstructor && question.getGiverType() == QuestionGiverType.INSTRUCTORS
                 || !isUserInstructor && question.getGiverType() != QuestionGiverType.INSTRUCTORS);
-        boolean isUserTeamGiver = question.getGiverType() == QuestionGiverType.TEAMS
-                && student.getTeamName().equals(response.getGiver());
+        boolean isUserTeamGiver = false;
+        if (user instanceof Student student) {
+            isUserTeamGiver = question.getGiverType() == QuestionGiverType.TEAMS
+                    && student.getTeamName().equals(response.getGiver());
+        }
+
         String giverName;
         String giverTeam = "";
         if (isUserTeamGiver) {
@@ -153,24 +158,34 @@ public class SessionResultsData extends ApiOutput {
             giverTeam = response.getGiver();
         } else if (isUserGiver) {
             giverName = "You";
-            giverTeam = student.getTeamName();
+            giverTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
+            if (user instanceof Student student) {
+                giverTeam = student.getTeamName();
+            }
         } else {
             // we don't want student to figure out who is who by using the hash
             giverName = removeAnonymousHash(getGiverNameOfResponse(response.getId(), response.getGiver(), question, bundle));
         }
 
         // process recipient
-        boolean isUserRecipient = SanitizationHelper.areEmailsEqual(student.getEmail(), response.getRecipient())
+        boolean isUserRecipient = SanitizationHelper.areEmailsEqual(user.getEmail(), response.getRecipient())
                 && (isUserInstructor && question.getRecipientType() == QuestionRecipientType.INSTRUCTORS
                 || !isUserInstructor && question.getRecipientType() != QuestionRecipientType.INSTRUCTORS);
-        boolean isUserTeamRecipient = (question.getRecipientType() == QuestionRecipientType.TEAMS
-                || question.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION)
-                && student.getTeamName().equals(response.getRecipient());
+        boolean isUserTeamRecipient = false;
+        if (user instanceof Student student) {
+             isUserTeamRecipient = (question.getRecipientType() == QuestionRecipientType.TEAMS
+                    || question.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION)
+                    && student.getTeamName().equals(response.getRecipient());
+        }
+
         String recipientName;
         String recipientTeam = "";
         if (isUserRecipient) {
             recipientName = "You";
-            recipientTeam = student.getTeamName();
+            recipientTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
+            if (user instanceof Student student) {
+                recipientTeam = student.getTeamName();
+            }
         } else if (isUserTeamRecipient) {
             recipientName = String.format("Your Team (%s)", response.getRecipient());
             recipientTeam = response.getRecipient();

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -173,7 +173,7 @@ public class SessionResultsData extends ApiOutput {
                 || !isUserInstructor && question.getRecipientType() != QuestionRecipientType.INSTRUCTORS);
         boolean isUserTeamRecipient = false;
         if (user instanceof Student student) {
-             isUserTeamRecipient = (question.getRecipientType() == QuestionRecipientType.TEAMS
+            isUserTeamRecipient = (question.getRecipientType() == QuestionRecipientType.TEAMS
                     || question.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION)
                     && student.getTeamName().equals(response.getRecipient());
         }

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -43,9 +43,9 @@ public class SessionResultsData extends ApiOutput {
     }
 
     /**
-     * Factory method to construct API output for instructor.
+     * Factory method to construct API output for course-wide results.
      */
-    public static SessionResultsData initForInstructor(SessionResultsBundle bundle) {
+    public static SessionResultsData init(SessionResultsBundle bundle) {
         SessionResultsData sessionResultsData = new SessionResultsData();
 
         Map<FeedbackQuestion, List<FeedbackResponse>> questionsWithResponses =
@@ -56,12 +56,12 @@ public class SessionResultsData extends ApiOutput {
             QuestionOutput qnOutput = new QuestionOutput(question,
                     questionDetails.getQuestionResultStatisticsJson(question, null, bundle), false, false);
             // put normal responses
-            List<ResponseOutput> allResponses = buildResponsesForInstructor(responses, bundle);
+            List<ResponseOutput> allResponses = buildResponses(responses, bundle);
             qnOutput.allResponses.addAll(allResponses);
 
             // put missing responses
             List<FeedbackMissingResponse> missingResponses = bundle.getQuestionMissingResponseMap().get(question);
-            qnOutput.allResponses.addAll(buildMissingResponsesForInstructor(missingResponses, bundle));
+            qnOutput.allResponses.addAll(buildMissingResponses(missingResponses, bundle));
 
             sessionResultsData.questions.add(qnOutput);
         });
@@ -70,9 +70,9 @@ public class SessionResultsData extends ApiOutput {
     }
 
     /**
-     * Factory method to construct API output for student.
+     * Factory method to construct API output for user.
      */
-    public static SessionResultsData initForStudent(SessionResultsBundle bundle, Student student) {
+    public static SessionResultsData initForUser(SessionResultsBundle bundle, Student student) {
         SessionResultsData sessionResultsData = new SessionResultsData();
 
         Map<FeedbackQuestion, List<FeedbackResponse>> questionsWithResponses =
@@ -100,7 +100,7 @@ public class SessionResultsData extends ApiOutput {
                     boolean isUserRecipient = SanitizationHelper.areEmailsEqual(student.getEmail(), response.getRecipient())
                             && (isUserInstructor && question.getRecipientType() == QuestionRecipientType.INSTRUCTORS
                             || !isUserInstructor && question.getRecipientType() != QuestionRecipientType.INSTRUCTORS);
-                    ResponseOutput responseOutput = buildSingleResponseForStudent(response, bundle, student);
+                    ResponseOutput responseOutput = buildSingleResponseForUser(response, bundle, student);
 
                     if (isUserRecipient) {
                         qnOutput.responsesToSelf.add(responseOutput);
@@ -135,7 +135,7 @@ public class SessionResultsData extends ApiOutput {
         return sessionResultsData;
     }
 
-    private static ResponseOutput buildSingleResponseForStudent(
+    private static ResponseOutput buildSingleResponseForUser(
             FeedbackResponse response, SessionResultsBundle bundle, Student student) {
         FeedbackQuestion question = response.getFeedbackQuestion();
         boolean isUserInstructor = Const.USER_TEAM_FOR_INSTRUCTOR.equals(student.getTeamName());
@@ -210,18 +210,18 @@ public class SessionResultsData extends ApiOutput {
                 + REGEX_ANONYMOUS_PARTICIPANT_HASH, Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT + " $1");
     }
 
-    private static List<ResponseOutput> buildResponsesForInstructor(
+    private static List<ResponseOutput> buildResponses(
             List<FeedbackResponse> responses, SessionResultsBundle bundle) {
         List<ResponseOutput> output = new ArrayList<>();
 
         for (FeedbackResponse response : responses) {
-            output.add(buildSingleResponseForInstructor(response, bundle));
+            output.add(buildSingleResponse(response, bundle));
         }
 
         return output;
     }
 
-    private static ResponseOutput buildSingleResponseForInstructor(
+    private static ResponseOutput buildSingleResponse(
             FeedbackResponse response, SessionResultsBundle bundle) {
         FeedbackQuestion question = response.getFeedbackQuestion();
         // process giver
@@ -293,18 +293,18 @@ public class SessionResultsData extends ApiOutput {
                 .build();
     }
 
-    private static List<ResponseOutput> buildMissingResponsesForInstructor(
+    private static List<ResponseOutput> buildMissingResponses(
             List<FeedbackMissingResponse> responses, SessionResultsBundle bundle) {
         List<ResponseOutput> output = new ArrayList<>();
 
         for (FeedbackMissingResponse response : responses) {
-            output.add(buildSingleMissingResponseForInstructor(response, bundle));
+            output.add(buildSingleMissingResponse(response, bundle));
         }
 
         return output;
     }
 
-    private static ResponseOutput buildSingleMissingResponseForInstructor(
+    private static ResponseOutput buildSingleMissingResponse(
             FeedbackMissingResponse response, SessionResultsBundle bundle) {
         // process giver
         String giverEmail = null;

--- a/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
@@ -9,7 +9,6 @@ import teammates.common.util.StringHelper;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.Team;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -110,16 +109,14 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
             // Section name filter is not applicable here
             instructor = getInstructorOfCourseFromRequest(courseId);
 
-            bundle = logic.getSessionResultsForUser(feedbackSession, instructor.getEmail(),
-                    true, questionUuid, isPreviewResults);
+            bundle = logic.getSessionResultsForUser(feedbackSession, instructor, questionUuid, isPreviewResults);
 
             return new JsonResult(SessionResultsData.initForUser(bundle, instructor));
         case STUDENT_RESULT:
             // Section name filter is not applicable here
             Student student = getStudentOfCourseFromRequest(courseId);
 
-            bundle = logic.getSessionResultsForUser(feedbackSession, student.getEmail(),
-                    false, questionUuid, isPreviewResults);
+            bundle = logic.getSessionResultsForUser(feedbackSession, student, questionUuid, isPreviewResults);
 
             return new JsonResult(SessionResultsData.initForUser(bundle, student));
         case INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:

--- a/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
@@ -97,7 +97,6 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
 
         String courseId = feedbackSession.getCourseId();
         Instructor instructor;
-        Student student;
         SessionResultsBundle bundle;
 
         switch (intent) {
@@ -114,15 +113,10 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
             bundle = logic.getSessionResultsForUser(feedbackSession, instructor.getEmail(),
                     true, questionUuid, isPreviewResults);
 
-            // Build a fake student object, as the results will be displayed as if they are displayed to a student
-            student = new Student(instructor.getCourse(), instructor.getName(), instructor.getEmail(), "");
-            Team team = new Team(Const.USER_TEAM_FOR_INSTRUCTOR);
-            student.setTeam(team);
-
-            return new JsonResult(SessionResultsData.initForUser(bundle, student));
+            return new JsonResult(SessionResultsData.initForUser(bundle, instructor));
         case STUDENT_RESULT:
             // Section name filter is not applicable here
-            student = getStudentOfCourseFromRequest(courseId);
+            Student student = getStudentOfCourseFromRequest(courseId);
 
             bundle = logic.getSessionResultsForUser(feedbackSession, student.getEmail(),
                     false, questionUuid, isPreviewResults);

--- a/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
@@ -106,7 +106,7 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
 
             bundle = logic.getSessionResults(feedbackSession, instructor.getEmail(),
                     questionUuid, selectedSection, fetchType);
-            return new JsonResult(SessionResultsData.initForInstructor(bundle));
+            return new JsonResult(SessionResultsData.init(bundle));
         case INSTRUCTOR_RESULT:
             // Section name filter is not applicable here
             instructor = getInstructorOfCourseFromRequest(courseId);
@@ -119,7 +119,7 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
             Team team = new Team(Const.USER_TEAM_FOR_INSTRUCTOR);
             student.setTeam(team);
 
-            return new JsonResult(SessionResultsData.initForStudent(bundle, student));
+            return new JsonResult(SessionResultsData.initForUser(bundle, student));
         case STUDENT_RESULT:
             // Section name filter is not applicable here
             student = getStudentOfCourseFromRequest(courseId);
@@ -127,7 +127,7 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
             bundle = logic.getSessionResultsForUser(feedbackSession, student.getEmail(),
                     false, questionUuid, isPreviewResults);
 
-            return new JsonResult(SessionResultsData.initForStudent(bundle, student));
+            return new JsonResult(SessionResultsData.initForUser(bundle, student));
         case INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:
             throw new InvalidHttpParameterException("Invalid intent for this action");
         default:

--- a/src/test/java/teammates/ui/webapi/GetSessionResultsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionResultsActionTest.java
@@ -91,7 +91,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
             when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
-                            eq(instructorStub.getEmail()), eq(true), isNull(), eq(false)))
+                            eq(instructorStub), isNull(), eq(false)))
                     .thenReturn(resultsStub);
             break;
         case STUDENT_RESULT:
@@ -99,7 +99,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
             when(mockLogic.getStudentByGoogleId(session.getCourseId(), googleId)).thenReturn(studentStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
-                            eq(studentStub.getEmail()), eq(false), isNull(), eq(false)))
+                            eq(studentStub), isNull(), eq(false)))
                     .thenReturn(resultsStub);
             break;
         case INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:
@@ -221,8 +221,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
         when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
         when(mockLogic.getSessionResultsForUser(argThat(
                         argument -> Objects.equals(argument.getName(), session.getName())),
-                eq(instructorStub.getEmail()),
-                eq(true), eq(questionStub.getId()), eq(true))).thenReturn(resultsStub);
+                eq(instructorStub), eq(questionStub.getId()), eq(true))).thenReturn(resultsStub);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, session.getId().toString(),
@@ -247,8 +246,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
         when(mockLogic.getStudentByGoogleId(session.getCourseId(), googleId)).thenReturn(studentStub);
         when(mockLogic.getSessionResultsForUser(argThat(
                         argument -> Objects.equals(argument.getName(), session.getName())),
-                eq(studentStub.getEmail()),
-                eq(false), eq(questionStub.getId()), eq(true))).thenReturn(resultsStub);
+                eq(studentStub), eq(questionStub.getId()), eq(true))).thenReturn(resultsStub);
 
         String[] params = {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, session.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/GetSessionResultsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionResultsActionTest.java
@@ -67,7 +67,7 @@ public class GetSessionResultsActionTest extends BaseActionTest<GetSessionResult
                 new HashSet<>(), new HashSet<>(), new ArrayList<>(),
                 new ArrayList<>(), new HashMap<>(), new HashMap<>(),
                 new HashMap<>(), new HashMap<>(), new CourseRoster(new ArrayList<>(), new ArrayList<>()));
-        expectedResults = SessionResultsData.initForInstructor(resultsStub);
+        expectedResults = SessionResultsData.init(resultsStub);
         reset(mockLogic);
     }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Separate instructor and student objects are passed to some session results related methods. In addition, we create a dummy student so instructors can utilise methods originally designed for students.

This PR updates the methods to accept user instead of instructor/student, using `instanceof` to differentiate between instructor and student.

This is also required to unblock #13934.