### PR TITLE
[#13918] Redirect dev login to OAuth2Callback for account creation

### DIFF
--- a/src/main/java/teammates/main/Application.java
+++ b/src/main/java/teammates/main/Application.java
@@ -10,6 +10,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
 
 import teammates.common.util.Config;
 import teammates.common.util.Logger;
+import teammates.ui.servlets.DevServerLoginServlet;
 
 /**
  * Entrypoint to the system.
@@ -40,13 +41,7 @@ public final class Application {
         if (Config.isDevServerLoginEnabled()) {
             // For dev server, we dynamically add servlet to serve the dev server login page.
 
-            ServletHolder devServerLoginServlet = new ServletHolder();
-            devServerLoginServlet.setName("DevServerLoginServlet");
-
-            // TODO: Revert to use constructor after modifying DevServerLoginServlet to redirect to
-            // Auth2CallbackServlet for account creation. HibernateUtil dependencies wouldn't be needed anymore.
-            // Register by class name so that Jetty's webapp classloader loads it and its dependencies correctly.
-            devServerLoginServlet.setClassName("teammates.ui.servlets.DevServerLoginServlet");
+            ServletHolder devServerLoginServlet = new ServletHolder("DevServerLoginServlet", new DevServerLoginServlet());
             webapp.addServlet(devServerLoginServlet, "/devServerLogin");
         }
 

--- a/src/main/java/teammates/ui/servlets/DevServerLoginServlet.java
+++ b/src/main/java/teammates/ui/servlets/DevServerLoginServlet.java
@@ -2,8 +2,9 @@ package teammates.ui.servlets;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -13,19 +14,12 @@ import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.FileHelper;
-import teammates.common.util.HibernateUtil;
 import teammates.common.util.HttpRequestHelper;
-import teammates.common.util.Logger;
-import teammates.logic.core.AccountsLogic;
-import teammates.storage.entity.Account;
 
 /**
  * Servlet that handles dev server login.
  */
 public class DevServerLoginServlet extends AuthServlet {
-
-    private static final Logger log = Logger.getLogger();
-    private final AccountsLogic accountsLogic = AccountsLogic.inst();
 
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -67,31 +61,17 @@ public class DevServerLoginServlet extends AuthServlet {
             return;
         }
 
-        // TODO: Redirect to OAuth2CallbackServlet for account creation,
-        // HibernateUtil shouldn't be used here
-        Account account;
-        try {
-            HibernateUtil.beginTransaction();
-            account = accountsLogic.createOrGetAccountForEmail(email);
-            HibernateUtil.commitTransaction();
-        } catch (Exception e) {
-            HibernateUtil.rollbackTransaction();
-            resp.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            log.severe("Error occurred while logging into dev server with email: " + email, e);
-            return;
-        }
-
-        UserInfoCookie uic = new UserInfoCookie(email, account.getId());
-        Cookie cookie = getLoginCookie(uic);
-        resp.addCookie(cookie);
-
         String nextUrl = req.getParameter("nextUrl");
         if (nextUrl == null) {
             nextUrl = "/";
         }
+
         // Prevent HTTP response splitting
-        nextUrl = resp.encodeRedirectURL(nextUrl.replace("\r\n", ""));
-        resp.sendRedirect(nextUrl);
+        nextUrl = nextUrl.replace("\r\n", "");
+        String encodedEmail = URLEncoder.encode(email, StandardCharsets.UTF_8);
+        String encodedNextUrl = URLEncoder.encode(nextUrl, StandardCharsets.UTF_8);
+        String redirectUrl = resp.encodeRedirectURL("/oauth2callback?email=" + encodedEmail + "&nextUrl=" + encodedNextUrl);
+        resp.sendRedirect(redirectUrl);
     }
 
 }

--- a/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
+++ b/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
@@ -16,6 +16,7 @@ import com.google.api.client.auth.oauth2.TokenResponse;
 
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Config;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.HttpRequest;
 import teammates.common.util.JsonUtils;
@@ -39,14 +40,19 @@ public class OAuth2CallbackServlet extends AuthServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         AuthResult authResult;
-        authResult = getGoogleOauth2AuthResult(req, resp);
+        if (Config.isDevServerLoginEnabled()) {
+            authResult = getDevServerAuthResult(req);
+        } else {
+            authResult = getGoogleOauth2AuthResult(req, resp);
+        }
+
         if (authResult == null) {
             return;
         }
-        Cookie cookie;
 
+        Cookie cookie;
         if (authResult.email == null) {
-            // invalid google ID
+            // invalid email
             req.getSession().invalidate();
 
             cookie = getLoginInvalidationCookie();
@@ -77,6 +83,13 @@ public class OAuth2CallbackServlet extends AuthServlet {
 
         resp.addCookie(cookie);
         resp.sendRedirect(authResult.nextUrl);
+    }
+
+    private AuthResult getDevServerAuthResult(HttpServletRequest req) {
+        String email = req.getParameter("email");
+        String nextUrl = req.getParameter("nextUrl");
+
+        return new AuthResult(email, nextUrl);
     }
 
     private AuthResult getGoogleOauth2AuthResult(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
+++ b/src/main/java/teammates/ui/servlets/OAuth2CallbackServlet.java
@@ -88,7 +88,9 @@ public class OAuth2CallbackServlet extends AuthServlet {
     private AuthResult getDevServerAuthResult(HttpServletRequest req) {
         String email = req.getParameter("email");
         String nextUrl = req.getParameter("nextUrl");
-
+        if (nextUrl == null) {
+            nextUrl = "/";
+        }
         return new AuthResult(email, nextUrl);
     }
 


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Modify `DevServerLoginServlet` to redirect to `OAuth2CallbackServlet` with the dev login params.
* Remove account creation logic in `DevServerLoginServlet` as it should be done during the callback instead.
* Revert registration of `DevServerLoginServlet` in `Application.java` to be as it was.
