### PR TITLE
[#13918] Add auth type for automated worker/cron services

### DIFF
--- a/src/main/java/teammates/common/datatransfer/UserInfo.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfo.java
@@ -39,12 +39,6 @@ public class UserInfo {
      */
     public boolean isMaintainer;
 
-    /**
-     * True only for verified cron/worker automated callers (bearer + path), not for human app admins.
-     * See {@link teammates.common.util.AutomatedRequestAuth#isTrustedCronOrWorkerRequest}.
-     */
-    public boolean isAutomatedService;
-
     public UserInfo(String googleId, UUID accountId) {
         this.id = googleId;
         this.accountId = accountId;

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -372,14 +372,6 @@ public final class Const {
     }
 
     /**
-     * User principal identifiers for verified automated cron/worker API callers.
-     */
-    public static class AutomatedService {
-        public static final String CRON_SERVICE_USER_ID = "Cron-Service";
-        public static final String WORKER_SERVICE_USER_ID = "Worker-Service";
-    }
-
-    /**
      * Represents URIs of endpoints used by cron jobs.
      */
     public static class CronJobURIs {

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -78,13 +78,4 @@ public class UserProvision {
         return userInfo;
     }
 
-    /**
-     * User principal for verified cron/worker requests: not a human app admin; {@link UserInfo#isAutomatedService} only.
-     */
-    public UserInfo getAutomatedServiceUser(String serviceId) {
-        UserInfo userInfo = new UserInfo(serviceId, null);
-        userInfo.isAutomatedService = true;
-        return userInfo;
-    }
-
 }

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -150,15 +150,13 @@ public abstract class Action {
 
         boolean trustedAutomatedCronOrWorker = AutomatedRequestAuth.isTrustedCronOrWorkerRequest(req);
         if (trustedAutomatedCronOrWorker) {
-            userInfo = userProvision.getAutomatedServiceUser(
-                    AutomatedRequestAuth.isCronRequestPath(req)
-                            ? Const.AutomatedService.CRON_SERVICE_USER_ID
-                            : Const.AutomatedService.WORKER_SERVICE_USER_ID);
-        } else {
-            String cookie = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.AUTH_COOKIE_NAME);
-            UserInfoCookie uic = UserInfoCookie.fromCookie(cookie);
-            userInfo = userProvision.getCurrentUser(uic);
+            authType = AuthType.AUTOMATED_SERVICE;
+            return;
         }
+
+        String cookie = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.AUTH_COOKIE_NAME);
+        UserInfoCookie uic = UserInfoCookie.fromCookie(cookie);
+        userInfo = userProvision.getCurrentUser(uic);
 
         String regKey = getRequestParamValue(Const.ParamsNames.REGKEY);
         String userParam = getRequestParamValue(Const.ParamsNames.USER_ID);

--- a/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
@@ -14,7 +14,7 @@ abstract class AdminOnlyAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isAdmin) {
+        if (userInfo == null || !userInfo.isAdmin) {
             throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/AuthType.java
+++ b/src/main/java/teammates/ui/webapi/AuthType.java
@@ -26,6 +26,11 @@ public enum AuthType {
     MASQUERADE(2),
 
     /**
+     * Verified automated service (cron/worker).
+     */
+    AUTOMATED_SERVICE(2),
+
+    /**
      * All-access pass via secret key.
      */
     ALL_ACCESS(3);

--- a/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
+++ b/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
@@ -13,18 +13,21 @@ abstract class AutomatedServiceAction extends Action {
 
     @Override
     AuthType getMinAuthLevel() {
-        return AuthType.LOGGED_IN;
+        return AuthType.AUTOMATED_SERVICE;
     }
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         if (!canAccessAsAdminOrAutomatedService()) {
-            throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
+            throw new UnauthorizedAccessException(
+                    "Admin or automated service privilege is required to access this resource."
+            );
         }
     }
 
     boolean canAccessAsAdminOrAutomatedService() {
-        return userInfo.isAdmin || userInfo.isAutomatedService;
+        return authType == AuthType.AUTOMATED_SERVICE
+                || userInfo != null && userInfo.isAdmin;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
+++ b/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
@@ -7,7 +7,7 @@ import teammates.ui.exception.UnauthorizedAccessException;
  *
  * <p>Application administrators using {@code /webapi} routes are included: authorization is
  * {@link teammates.common.datatransfer.UserInfo#isAdmin} or
- * {@link teammates.common.datatransfer.UserInfo#isAutomatedService}.
+ * {@link teammates.ui.webapi.AuthType#AUTOMATED_SERVICE}.
  */
 abstract class AutomatedServiceAction extends Action {
 

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -92,7 +92,6 @@ public class MockUserProvision extends UserProvision {
      */
     public void loginAsAutomatedService() {
         isAutomatedServiceMode = true;
-        mockUser.isAdmin = false;
     }
 
     public boolean isAutomatedServiceMode() {

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -15,20 +15,20 @@ public class MockUserProvision extends UserProvision {
     private static final UUID MOCK_ACCOUNT_ID = UUID.randomUUID();
     private UserInfo mockUser = new UserInfo("user.id", MOCK_ACCOUNT_ID);
     private boolean isLoggedIn;
+    private boolean isAutomatedServiceMode;
     private boolean isMaintainer;
     private boolean isAdmin;
     private boolean isInstructor;
     private boolean isStudent;
 
     private UserInfo loginUser(String userId, boolean isAdmin, boolean isInstructor, boolean isStudent,
-            boolean isMaintainer, boolean isAutomatedService) {
+            boolean isMaintainer) {
         isLoggedIn = true;
         mockUser.id = userId;
         mockUser.isAdmin = isAdmin;
         mockUser.isInstructor = isInstructor;
         mockUser.isStudent = isStudent;
         mockUser.isMaintainer = isMaintainer;
-        mockUser.isAutomatedService = isAutomatedService;
         return mockUser;
     }
 
@@ -38,7 +38,7 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginUser(String userId) {
-        return loginUser(userId, false, false, false, false, false);
+        return loginUser(userId, false, false, false, false);
     }
 
     /**
@@ -47,7 +47,7 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginAsAdmin(String userId) {
-        return loginUser(userId, true, false, false, false, false);
+        return loginUser(userId, true, false, false, false);
     }
 
     /**
@@ -56,7 +56,7 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginAsInstructor(String userId) {
-        return loginUser(userId, false, true, false, false, false);
+        return loginUser(userId, false, true, false, false);
     }
 
     /**
@@ -65,7 +65,7 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginAsStudent(String userId) {
-        return loginUser(userId, false, false, true, false, false);
+        return loginUser(userId, false, false, true, false);
     }
 
     /**
@@ -74,7 +74,7 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginAsStudentInstructor(String userId) {
-        return loginUser(userId, false, true, true, false, false);
+        return loginUser(userId, false, true, true, false);
     }
 
     /**
@@ -83,14 +83,20 @@ public class MockUserProvision extends UserProvision {
      * @return The user info after login process
      */
     public UserInfo loginAsMaintainer(String userId) {
-        return loginUser(userId, false, false, false, true, false);
+        return loginUser(userId, false, false, false, true);
     }
 
     /**
-     * Models a verified cron/worker principal ({@link UserInfo#isAutomatedService}), not a human app admin.
+     * Models a verified cron/worker principal ({@link AuthType#AUTOMATED_SERVICE}), not a human app admin.
+     * Does not log in a user; sets a flag that {@code BaseActionTest} uses to override {@code action.authType}.
      */
-    public UserInfo loginAsAutomatedService(String userId) {
-        return loginUser(userId, false, false, false, false, true);
+    public void loginAsAutomatedService() {
+        isAutomatedServiceMode = true;
+        mockUser.isAdmin = false;
+    }
+
+    public boolean isAutomatedServiceMode() {
+        return isAutomatedServiceMode;
     }
 
     /**
@@ -98,6 +104,7 @@ public class MockUserProvision extends UserProvision {
      */
     public void logoutUser() {
         isLoggedIn = false;
+        isAutomatedServiceMode = false;
     }
 
     @Override
@@ -117,7 +124,6 @@ public class MockUserProvision extends UserProvision {
         userInfo.isInstructor = isInstructor;
         userInfo.isStudent = isStudent;
         userInfo.isMaintainer = isMaintainer;
-        userInfo.isAutomatedService = mockUser.isAutomatedService;
 
         return userInfo;
     }

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -324,11 +324,10 @@ public class UserProvisionTest extends BaseTestCase {
         assertEquals(expected.contains(Role.INSTRUCTOR), user.isInstructor);
         assertEquals(expected.contains(Role.STUDENT), user.isStudent);
         assertEquals(expected.contains(Role.MAINTAINER), user.isMaintainer);
-        assertEquals(expected.contains(Role.AUTOMATED_SERVICE), user.isAutomatedService);
     }
 
     private enum Role {
-        ADMIN, INSTRUCTOR, STUDENT, MAINTAINER, AUTOMATED_SERVICE
+        ADMIN, INSTRUCTOR, STUDENT, MAINTAINER
     }
 
 }

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.util.Config;
-import teammates.common.util.Const;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.UsersLogic;
 import teammates.storage.entity.Account;
@@ -297,17 +296,6 @@ public class UserProvisionTest extends BaseTestCase {
 
         assertEquals(userId, user.id);
         assertHasRoles(user, Role.ADMIN);
-        verifyNoInteractions(mockUsersLogic);
-    }
-
-    @Test
-    public void testGetAutomatedServiceUser_returnsUserInfoWithOnlyIsAutomatedServiceTrue() {
-        String serviceId = Const.AutomatedService.CRON_SERVICE_USER_ID;
-
-        UserInfo user = userProvision.getAutomatedServiceUser(serviceId);
-
-        assertEquals(serviceId, user.id);
-        assertHasRoles(user, Role.AUTOMATED_SERVICE);
         verifyNoInteractions(mockUsersLogic);
     }
 

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -112,6 +112,10 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             action.setRecaptchaVerifier(mockRecaptchaVerifier);
             action.setEmailGenerator(mockEmailGenerator);
             action.init(req);
+            if (mockUserProvision.isAutomatedServiceMode()) {
+                action.authType = AuthType.AUTOMATED_SERVICE;
+                action.userInfo = null;
+            }
             return action;
         } catch (ActionMappingException e) {
             throw new RuntimeException(e);
@@ -200,13 +204,11 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     }
 
     /**
-     * Models a verified cron/worker principal ({@link UserInfo#isAutomatedService}), for actions that allow
+     * Models a verified cron/worker principal ({@link AuthType#AUTOMATED_SERVICE}), for actions that allow
      * automated services as well as human admins.
      */
     protected void loginAsAutomatedService() {
-        UserInfo user = mockUserProvision.loginAsAutomatedService(Const.AutomatedService.CRON_SERVICE_USER_ID);
-        assertTrue(user.isAutomatedService);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsAutomatedService();
     }
 
     /**

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -209,6 +209,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      */
     protected void loginAsAutomatedService() {
         mockUserProvision.loginAsAutomatedService();
+        assertTrue(mockUserProvision.isAutomatedServiceMode());
     }
 
     /**

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -625,7 +625,6 @@ export interface UserInfo {
   isInstructor: boolean;
   isStudent: boolean;
   isMaintainer: boolean;
-  isAutomatedService: boolean;
 }
 
 export enum AccountRequestStatus {


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Add a new auth type for automated services to remove the need for providing a `UserInfo` for external workers.
* Remove `isAutomatedService` boolean from `UserInfo`.
* Update related tests.
