### PR TITLE
[#13936] Introduce AuthContext to decouple API UserInfo from authentication state

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
@@ -15,7 +15,6 @@ import org.apache.http.client.methods.HttpPut;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.UserInfo;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
@@ -165,8 +164,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * Logs in the user to the test environment as an admin.
      */
     protected void loginAsAdmin() {
-        UserInfo user = mockUserProvision.loginAsAdmin(Config.APP_ADMINS.get(0));
-        assertTrue(user.isAdmin);
+        mockUserProvision.loginAsAdmin(Config.APP_ADMINS.get(0));
     }
 
     /**
@@ -174,10 +172,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * (without any right).
      */
     protected void loginAsUnregistered(String userId) {
-        UserInfo user = mockUserProvision.loginUser(userId);
-        assertFalse(user.isStudent);
-        assertFalse(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginUser(userId);
     }
 
     /**
@@ -185,10 +180,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * (without admin rights or student rights).
      */
     protected void loginAsInstructor(String userId) {
-        UserInfo user = mockUserProvision.loginAsInstructor(userId);
-        assertFalse(user.isStudent);
-        assertTrue(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsInstructor(userId);
     }
 
     /**
@@ -196,10 +188,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * (without admin rights or instructor rights).
      */
     protected void loginAsStudent(String userId) {
-        UserInfo user = mockUserProvision.loginAsStudent(userId);
-        assertTrue(user.isStudent);
-        assertFalse(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsStudent(userId);
     }
 
     /**
@@ -207,18 +196,14 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * admin rights).
      */
     protected void loginAsStudentInstructor(String userId) {
-        UserInfo user = mockUserProvision.loginAsStudentInstructor(userId);
-        assertTrue(user.isStudent);
-        assertTrue(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsStudentInstructor(userId);
     }
 
     /**
      * Logs in the user to the test environment as a maintainer.
      */
     protected void loginAsMaintainer() {
-        UserInfo user = mockUserProvision.loginAsMaintainer(Config.APP_MAINTAINERS.get(0));
-        assertTrue(user.isMaintainer);
+        mockUserProvision.loginAsMaintainer(Config.APP_MAINTAINERS.get(0));
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/AuthContext.java
+++ b/src/main/java/teammates/common/datatransfer/AuthContext.java
@@ -4,66 +4,23 @@ import java.util.UUID;
 
 /**
  * Represents the authentication context of a user.
+ * 
+ * @param id           The user's Google ID.
+ * @param accountId    The user's account ID.
+ * @param isAdmin      Indicates whether the user has admin privilege.
+ * @param isInstructor Indicates whether the user has instructor privilege.
+ * @param isStudent    Indicates whether the user has student privilege.
+ * @param isMaintainer Indicates whether the user has maintainer privilege.
  */
-public class AuthContext {
-
-    /**
-     * The user's Google ID.
-     */
-    public String id;
-
-    /**
-     * The user's account ID.
-     */
-    public UUID accountId;
-
-    /**
-     * Indicates whether the user has admin privilege.
-     */
-    public boolean isAdmin;
-
-    /**
-     * Indicates whether the user has instructor privilege.
-     */
-    public boolean isInstructor;
-
-    /**
-     * Indicates whether the user has student privilege.
-     */
-    public boolean isStudent;
-
-    /**
-     * Indicates whether the user has maintainer privilege.
-     */
-    public boolean isMaintainer;
+public record AuthContext(
+        String id,
+        UUID accountId,
+        boolean isAdmin,
+        boolean isInstructor,
+        boolean isStudent,
+        boolean isMaintainer) {
 
     public AuthContext(String googleId, UUID accountId) {
-        this.id = googleId;
-        this.accountId = accountId;
+        this(googleId, accountId, false, false, false, false);
     }
-
-    public String getId() {
-        return id;
-    }
-
-    public UUID getAccountId() {
-        return accountId;
-    }
-
-    public boolean getIsAdmin() {
-        return isAdmin;
-    }
-
-    public boolean getIsInstructor() {
-        return isInstructor;
-    }
-
-    public boolean getIsStudent() {
-        return isStudent;
-    }
-
-    public boolean getIsMaintainer() {
-        return isMaintainer;
-    }
-
 }

--- a/src/main/java/teammates/common/datatransfer/AuthContext.java
+++ b/src/main/java/teammates/common/datatransfer/AuthContext.java
@@ -1,0 +1,69 @@
+package teammates.common.datatransfer;
+
+import java.util.UUID;
+
+/**
+ * Represents the authentication context of a user.
+ */
+public class AuthContext {
+
+    /**
+     * The user's Google ID.
+     */
+    public String id;
+
+    /**
+     * The user's account ID.
+     */
+    public UUID accountId;
+
+    /**
+     * Indicates whether the user has admin privilege.
+     */
+    public boolean isAdmin;
+
+    /**
+     * Indicates whether the user has instructor privilege.
+     */
+    public boolean isInstructor;
+
+    /**
+     * Indicates whether the user has student privilege.
+     */
+    public boolean isStudent;
+
+    /**
+     * Indicates whether the user has maintainer privilege.
+     */
+    public boolean isMaintainer;
+
+    public AuthContext(String googleId, UUID accountId) {
+        this.id = googleId;
+        this.accountId = accountId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public UUID getAccountId() {
+        return accountId;
+    }
+
+    public boolean getIsAdmin() {
+        return isAdmin;
+    }
+
+    public boolean getIsInstructor() {
+        return isInstructor;
+    }
+
+    public boolean getIsStudent() {
+        return isStudent;
+    }
+
+    public boolean getIsMaintainer() {
+        return isMaintainer;
+    }
+
+}

--- a/src/main/java/teammates/common/datatransfer/AuthContext.java
+++ b/src/main/java/teammates/common/datatransfer/AuthContext.java
@@ -19,8 +19,4 @@ public record AuthContext(
         boolean isInstructor,
         boolean isStudent,
         boolean isMaintainer) {
-
-    public AuthContext(String googleId, UUID accountId) {
-        this(googleId, accountId, false, false, false, false);
-    }
 }

--- a/src/main/java/teammates/common/datatransfer/AuthContext.java
+++ b/src/main/java/teammates/common/datatransfer/AuthContext.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 /**
  * Represents the authentication context of a user.
- * 
+ *
  * @param id           The user's Google ID.
  * @param accountId    The user's account ID.
  * @param isAdmin      Indicates whether the user has admin privilege.

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -77,8 +77,9 @@ public class UserProvision {
      * Gets the information of a user who has administrator role only.
      */
     public AuthContext getAdminOnlyUserContext(String userId) {
+        // Only used for testing. To be removed in the future.
         Account account = userId == null ? null : accountsLogic.getAccountForGoogleId(userId);
-        return new AuthContext(userId, account == null ? null : account.getId(), true, false, false, false);
+        return new AuthContext(userId, account == null ? null : account.getId(), true, true, true, true);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -1,5 +1,6 @@
 package teammates.logic.api;
 
+import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.UserInfo;
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.util.Config;
@@ -29,8 +30,8 @@ public class UserProvision {
     /**
      * Gets the information of the current logged in user.
      */
-    public UserInfo getCurrentUser(UserInfoCookie uic) {
-        UserInfo user = getCurrentLoggedInUser(uic);
+    public AuthContext getCurrentUserContext(UserInfoCookie uic) {
+        AuthContext user = getCurrentLoggedInUserContext(uic);
 
         if (user == null) {
             return null;
@@ -47,35 +48,50 @@ public class UserProvision {
     /**
      * Gets the current logged in user.
      */
-    UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
+    AuthContext getCurrentLoggedInUserContext(UserInfoCookie uic) {
         if (uic == null || !uic.isValid()) {
             return null;
         }
 
-        return new UserInfo(uic.getUserId(), uic.getAccountId());
+        return new AuthContext(uic.getUserId(), uic.getAccountId());
     }
 
     /**
      * Gets the information of the current masqueraded user.
      */
-    public UserInfo getMasqueradeUser(String googleId) {
+    public AuthContext getMasqueradeUserContext(String googleId) {
         Account account = accountsLogic.getAccountForGoogleId(googleId);
-        UserInfo userInfo = new UserInfo(googleId, account == null ? null : account.getId());
-        userInfo.isAdmin = false;
-        userInfo.isInstructor = usersLogic.isInstructorInAnyCourse(googleId);
-        userInfo.isStudent = usersLogic.isStudentInAnyCourse(googleId);
-        userInfo.isMaintainer = Config.getAppMaintainers().contains(googleId);
-        return userInfo;
+        AuthContext authContext = new AuthContext(googleId, account == null ? null : account.getId());
+        authContext.isAdmin = false;
+        authContext.isInstructor = usersLogic.isInstructorInAnyCourse(googleId);
+        authContext.isStudent = usersLogic.isStudentInAnyCourse(googleId);
+        authContext.isMaintainer = Config.getAppMaintainers().contains(googleId);
+        return authContext;
     }
 
     /**
      * Gets the information of a user who has administrator role only.
      */
-    public UserInfo getAdminOnlyUser(String userId) {
+    public AuthContext getAdminOnlyUserContext(String userId) {
         Account account = userId == null ? null : accountsLogic.getAccountForGoogleId(userId);
-        UserInfo userInfo = new UserInfo(userId, account == null ? null : account.getId());
-        userInfo.isAdmin = true;
-        return userInfo;
+        AuthContext authContext = new AuthContext(userId, account == null ? null : account.getId());
+        authContext.isAdmin = true;
+        return authContext;
     }
 
+    /**
+     * Gets the information of a user from an AuthContext.
+     */
+    public UserInfo getUserInfo(AuthContext authContext) {
+        if (authContext == null) {
+            return null;
+        }
+
+        UserInfo userInfo = new UserInfo(authContext.id, authContext.accountId);
+        userInfo.isAdmin = Config.getAppAdmins().contains(authContext.id);
+        userInfo.isInstructor = usersLogic.isInstructorInAnyCourse(authContext.id);
+        userInfo.isStudent = usersLogic.isStudentInAnyCourse(authContext.id);
+        userInfo.isMaintainer = Config.getAppMaintainers().contains(authContext.id);
+        return userInfo;
+    }
 }

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -55,7 +55,8 @@ public class UserProvision {
             return null;
         }
 
-        return new AuthContext(uic.getUserId(), uic.getAccountId());
+        return new AuthContext(uic.getUserId(), uic.getAccountId(),
+                false, false, false, false);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -37,12 +37,14 @@ public class UserProvision {
             return null;
         }
 
-        String userId = user.id;
-        user.isAdmin = Config.getAppAdmins().contains(userId);
-        user.isInstructor = usersLogic.isInstructorInAnyCourse(userId);
-        user.isStudent = usersLogic.isStudentInAnyCourse(userId);
-        user.isMaintainer = Config.getAppMaintainers().contains(userId);
-        return user;
+        String userId = user.id();
+        return new AuthContext(
+                userId,
+                user.accountId(),
+                Config.getAppAdmins().contains(userId),
+                usersLogic.isInstructorInAnyCourse(userId),
+                usersLogic.isStudentInAnyCourse(userId),
+                Config.getAppMaintainers().contains(userId));
     }
 
     /**
@@ -61,12 +63,13 @@ public class UserProvision {
      */
     public AuthContext getMasqueradeUserContext(String googleId) {
         Account account = accountsLogic.getAccountForGoogleId(googleId);
-        AuthContext authContext = new AuthContext(googleId, account == null ? null : account.getId());
-        authContext.isAdmin = false;
-        authContext.isInstructor = usersLogic.isInstructorInAnyCourse(googleId);
-        authContext.isStudent = usersLogic.isStudentInAnyCourse(googleId);
-        authContext.isMaintainer = Config.getAppMaintainers().contains(googleId);
-        return authContext;
+        return new AuthContext(
+                googleId,
+                account == null ? null : account.getId(),
+                false,
+                usersLogic.isInstructorInAnyCourse(googleId),
+                usersLogic.isStudentInAnyCourse(googleId),
+                Config.getAppMaintainers().contains(googleId));
     }
 
     /**
@@ -74,9 +77,7 @@ public class UserProvision {
      */
     public AuthContext getAdminOnlyUserContext(String userId) {
         Account account = userId == null ? null : accountsLogic.getAccountForGoogleId(userId);
-        AuthContext authContext = new AuthContext(userId, account == null ? null : account.getId());
-        authContext.isAdmin = true;
-        return authContext;
+        return new AuthContext(userId, account == null ? null : account.getId(), true, false, false, false);
     }
 
     /**
@@ -87,11 +88,11 @@ public class UserProvision {
             return null;
         }
 
-        UserInfo userInfo = new UserInfo(authContext.id, authContext.accountId);
-        userInfo.isAdmin = Config.getAppAdmins().contains(authContext.id);
-        userInfo.isInstructor = usersLogic.isInstructorInAnyCourse(authContext.id);
-        userInfo.isStudent = usersLogic.isStudentInAnyCourse(authContext.id);
-        userInfo.isMaintainer = Config.getAppMaintainers().contains(authContext.id);
+        UserInfo userInfo = new UserInfo(authContext.id(), authContext.accountId());
+        userInfo.isAdmin = authContext.isAdmin();
+        userInfo.isInstructor = authContext.isInstructor();
+        userInfo.isStudent = authContext.isStudent();
+        userInfo.isMaintainer = authContext.isMaintainer();
         return userInfo;
     }
 }

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.InstructorPermissionSet;
-import teammates.common.datatransfer.UserInfo;
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.datatransfer.logs.RequestLogUser;
 import teammates.common.util.AutomatedRequestAuth;
@@ -50,7 +50,7 @@ public abstract class Action {
     LogsProcessor logsProcessor = LogsProcessor.inst();
 
     HttpServletRequest req;
-    UserInfo userInfo;
+    AuthContext authContext;
     AuthType authType;
 
     private Student unregisteredStudent;
@@ -64,7 +64,7 @@ public abstract class Action {
      */
     public void init(HttpServletRequest req) {
         this.req = req;
-        initAuthInfo();
+        initAuthContext();
     }
 
     /**
@@ -103,8 +103,8 @@ public abstract class Action {
      */
     public void checkAccessControl() throws UnauthorizedAccessException {
         String userParam = getRequestParamValue(Const.ParamsNames.USER_ID);
-        if (userInfo != null && userParam != null && !userInfo.isAdmin && !userParam.equals(userInfo.id)) {
-            throw new UnauthorizedAccessException("User " + userInfo.id
+        if (authContext != null && userParam != null && !authContext.isAdmin && !userParam.equals(authContext.id)) {
+            throw new UnauthorizedAccessException("User " + authContext.id
                     + " is trying to masquerade as " + userParam + " without admin permission.");
         }
 
@@ -128,7 +128,7 @@ public abstract class Action {
     public RequestLogUser getUserInfoForLogging() {
         RequestLogUser user = new RequestLogUser();
 
-        String googleId = userInfo == null ? null : userInfo.getId();
+        String googleId = authContext == null ? null : authContext.getId();
 
         user.setGoogleId(googleId);
         if (unregisteredStudent != null) {
@@ -139,12 +139,12 @@ public abstract class Action {
         return user;
     }
 
-    private void initAuthInfo() {
+    private void initAuthContext() {
         if (Config.BACKDOOR_KEY.equals(req.getHeader(Const.HeaderNames.BACKDOOR_KEY))) {
             authType = AuthType.ALL_ACCESS;
-            userInfo = userProvision.getAdminOnlyUser(getRequestParamValue(Const.ParamsNames.USER_ID));
-            userInfo.isStudent = true;
-            userInfo.isInstructor = true;
+            authContext = userProvision.getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
+            authContext.isStudent = true;
+            authContext.isInstructor = true;
             return;
         }
 
@@ -156,15 +156,15 @@ public abstract class Action {
 
         String cookie = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.AUTH_COOKIE_NAME);
         UserInfoCookie uic = UserInfoCookie.fromCookie(cookie);
-        userInfo = userProvision.getCurrentUser(uic);
+        authContext = userProvision.getCurrentUserContext(uic);
 
         String regKey = getRequestParamValue(Const.ParamsNames.REGKEY);
         String userParam = getRequestParamValue(Const.ParamsNames.USER_ID);
 
-        if (userInfo == null) {
+        if (authContext == null) {
             authType = StringHelper.isEmpty(regKey) ? AuthType.PUBLIC : AuthType.REG_KEY;
-        } else if (userParam != null && userInfo.isAdmin) {
-            userInfo = userProvision.getMasqueradeUser(userParam);
+        } else if (userParam != null && authContext.isAdmin) {
+            authContext = userProvision.getMasqueradeUserContext(userParam);
             authType = AuthType.MASQUERADE;
         } else {
             authType = AuthType.LOGGED_IN;
@@ -325,19 +325,19 @@ public abstract class Action {
 
     Instructor getPossiblyUnregisteredInstructor(String courseId) {
         return getUnregisteredInstructor().orElseGet(() -> {
-            if (userInfo == null) {
+            if (authContext == null) {
                 return null;
             }
-            return logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            return logic.getInstructorByGoogleId(courseId, authContext.getId());
         });
     }
 
     Student getPossiblyUnregisteredStudent(String courseId) {
         return getUnregisteredStudent().orElseGet(() -> {
-            if (userInfo == null) {
+            if (authContext == null) {
                 return null;
             }
-            return logic.getStudentByGoogleId(courseId, userInfo.getId());
+            return logic.getStudentByGoogleId(courseId, authContext.getId());
         });
     }
 

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -142,15 +142,7 @@ public abstract class Action {
     private void initAuthContext() {
         if (Config.BACKDOOR_KEY.equals(req.getHeader(Const.HeaderNames.BACKDOOR_KEY))) {
             authType = AuthType.ALL_ACCESS;
-            AuthContext adminOnlyContext = userProvision
-                    .getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
-            authContext = new AuthContext(
-                    adminOnlyContext.id(),
-                    adminOnlyContext.accountId(),
-                    adminOnlyContext.isAdmin(),
-                    true,
-                    true,
-                    adminOnlyContext.isMaintainer());
+            authContext = userProvision.getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -142,7 +142,8 @@ public abstract class Action {
     private void initAuthContext() {
         if (Config.BACKDOOR_KEY.equals(req.getHeader(Const.HeaderNames.BACKDOOR_KEY))) {
             authType = AuthType.ALL_ACCESS;
-            AuthContext adminOnlyContext = userProvision.getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
+            AuthContext adminOnlyContext = userProvision
+                    .getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
             authContext = new AuthContext(
                     adminOnlyContext.id(),
                     adminOnlyContext.accountId(),

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -103,8 +103,8 @@ public abstract class Action {
      */
     public void checkAccessControl() throws UnauthorizedAccessException {
         String userParam = getRequestParamValue(Const.ParamsNames.USER_ID);
-        if (authContext != null && userParam != null && !authContext.isAdmin && !userParam.equals(authContext.id)) {
-            throw new UnauthorizedAccessException("User " + authContext.id
+        if (authContext != null && userParam != null && !authContext.isAdmin() && !userParam.equals(authContext.id())) {
+            throw new UnauthorizedAccessException("User " + authContext.id()
                     + " is trying to masquerade as " + userParam + " without admin permission.");
         }
 
@@ -128,7 +128,7 @@ public abstract class Action {
     public RequestLogUser getUserInfoForLogging() {
         RequestLogUser user = new RequestLogUser();
 
-        String googleId = authContext == null ? null : authContext.getId();
+        String googleId = authContext == null ? null : authContext.id();
 
         user.setGoogleId(googleId);
         if (unregisteredStudent != null) {
@@ -142,9 +142,14 @@ public abstract class Action {
     private void initAuthContext() {
         if (Config.BACKDOOR_KEY.equals(req.getHeader(Const.HeaderNames.BACKDOOR_KEY))) {
             authType = AuthType.ALL_ACCESS;
-            authContext = userProvision.getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
-            authContext.isStudent = true;
-            authContext.isInstructor = true;
+            AuthContext adminOnlyContext = userProvision.getAdminOnlyUserContext(getRequestParamValue(Const.ParamsNames.USER_ID));
+            authContext = new AuthContext(
+                    adminOnlyContext.id(),
+                    adminOnlyContext.accountId(),
+                    adminOnlyContext.isAdmin(),
+                    true,
+                    true,
+                    adminOnlyContext.isMaintainer());
             return;
         }
 
@@ -163,7 +168,7 @@ public abstract class Action {
 
         if (authContext == null) {
             authType = StringHelper.isEmpty(regKey) ? AuthType.PUBLIC : AuthType.REG_KEY;
-        } else if (userParam != null && authContext.isAdmin) {
+        } else if (userParam != null && authContext.isAdmin()) {
             authContext = userProvision.getMasqueradeUserContext(userParam);
             authType = AuthType.MASQUERADE;
         } else {
@@ -328,7 +333,7 @@ public abstract class Action {
             if (authContext == null) {
                 return null;
             }
-            return logic.getInstructorByGoogleId(courseId, authContext.getId());
+            return logic.getInstructorByGoogleId(courseId, authContext.id());
         });
     }
 
@@ -337,7 +342,7 @@ public abstract class Action {
             if (authContext == null) {
                 return null;
             }
-            return logic.getStudentByGoogleId(courseId, authContext.getId());
+            return logic.getStudentByGoogleId(courseId, authContext.id());
         });
     }
 

--- a/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
@@ -14,7 +14,7 @@ abstract class AdminOnlyAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext == null || !authContext.isAdmin) {
+        if (authContext == null || !authContext.isAdmin()) {
             throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
@@ -14,7 +14,7 @@ abstract class AdminOnlyAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo == null || !userInfo.isAdmin) {
+        if (authContext == null || !authContext.isAdmin) {
             throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
+++ b/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
@@ -27,7 +27,7 @@ abstract class AutomatedServiceAction extends Action {
 
     boolean canAccessAsAdminOrAutomatedService() {
         return authType == AuthType.AUTOMATED_SERVICE
-                || userInfo != null && userInfo.isAdmin;
+                || authContext != null && authContext.isAdmin;
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
+++ b/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
@@ -27,7 +27,7 @@ abstract class AutomatedServiceAction extends Action {
 
     boolean canAccessAsAdminOrAutomatedService() {
         return authType == AuthType.AUTOMATED_SERVICE
-                || authContext != null && authContext.isAdmin;
+                || authContext != null && authContext.isAdmin();
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -74,23 +74,23 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifyAccessible(student, feedbackSession);
             if (student.getAccount() != null) {
-                if (userInfo == null) {
+                if (authContext == null) {
                     // Student is associated with an account; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!userInfo.id.equals(student.getAccount().getGoogleId())) {
+                } else if (!authContext.id.equals(student.getAccount().getGoogleId())) {
                     // Logged in student is not the same as the student registered for the given key, do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
                 }
@@ -146,22 +146,22 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                     feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                     feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
             if (instructor.getAccount() != null) {
-                if (userInfo == null) {
+                if (authContext == null) {
                     // Instructor is associated to an account; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!userInfo.id.equals(instructor.getAccount().getGoogleId())) {
+                } else if (!authContext.id.equals(instructor.getAccount().getGoogleId())) {
                     // Logged in instructor is not the same as the instructor registered for the given key,
                     // do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
@@ -192,10 +192,10 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
     private void verifyMatchingGoogleId(String googleId) throws UnauthorizedAccessException {
         if (!StringHelper.isEmpty(googleId)) {
-            if (userInfo == null) {
+            if (authContext == null) {
                 // Student/Instructor is associated to a google ID; even if registration key is passed, do not allow access
                 throw new UnauthorizedAccessException("Login is required to access this feedback session");
-            } else if (!userInfo.id.equals(googleId)) {
+            } else if (!authContext.id.equals(googleId)) {
                 // Logged in student/instructor is not the same as the student/instructor registered for the given key,
                 // do not allow access
                 throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
@@ -206,14 +206,14 @@ abstract class BasicFeedbackSubmissionAction extends Action {
     @SuppressWarnings("PMD.IdenticalConditionalBranches") // TODO find out why!
     private void checkAccessControlForPreview(FeedbackSession feedbackSession, boolean isInstructor)
             throws UnauthorizedAccessException {
-        gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+        gateKeeper.verifyLoggedInUserPrivileges(authContext);
         if (isInstructor) {
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         }
     }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -76,13 +76,13 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()), feedbackSession,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifyAccessible(student, feedbackSession);
@@ -90,7 +90,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
                 if (authContext == null) {
                     // Student is associated with an account; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!authContext.id.equals(student.getAccount().getGoogleId())) {
+                } else if (!authContext.id().equals(student.getAccount().getGoogleId())) {
                     // Logged in student is not the same as the student registered for the given key, do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
                 }
@@ -148,12 +148,12 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                     feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                     feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
@@ -161,7 +161,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
                 if (authContext == null) {
                     // Instructor is associated to an account; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!authContext.id.equals(instructor.getAccount().getGoogleId())) {
+                } else if (!authContext.id().equals(instructor.getAccount().getGoogleId())) {
                     // Logged in instructor is not the same as the instructor registered for the given key,
                     // do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
@@ -195,7 +195,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
             if (authContext == null) {
                 // Student/Instructor is associated to a google ID; even if registration key is passed, do not allow access
                 throw new UnauthorizedAccessException("Login is required to access this feedback session");
-            } else if (!authContext.id.equals(googleId)) {
+            } else if (!authContext.id().equals(googleId)) {
                 // Logged in student/instructor is not the same as the student/instructor registered for the given key,
                 // do not allow access
                 throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
@@ -209,11 +209,11 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         gateKeeper.verifyLoggedInUserPrivileges(authContext);
         if (isInstructor) {
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()), feedbackSession,
+                    logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()), feedbackSession,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         }
     }

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -19,14 +19,14 @@ public class BinCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Course course = logic.getCourse(idOfCourseToBin);
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToBin, authContext.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToBin, authContext.id()),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -19,14 +19,14 @@ public class BinCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Course course = logic.getCourse(idOfCourseToBin);
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToBin, userInfo.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToBin, authContext.id),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -28,7 +28,7 @@ public class BinFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -28,7 +28,7 @@ public class BinFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -83,7 +83,7 @@ public class CreateAccountAction extends Action {
         assert !instructorList.isEmpty();
 
         try {
-            logic.joinCourseForInstructor(instructorList.get(0).getRegKey(), authContext.id);
+            logic.joinCourseForInstructor(instructorList.get(0).getRegKey(), authContext.id());
         } catch (EntityDoesNotExistException | EntityAlreadyExistsException | InvalidParametersException e) {
             // EntityDoesNotExistException should not be thrown as all entities should exist in demo course.
             // EntityAlreadyExistsException should not be thrown as updated entities should not have

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -83,7 +83,7 @@ public class CreateAccountAction extends Action {
         assert !instructorList.isEmpty();
 
         try {
-            logic.joinCourseForInstructor(instructorList.get(0).getRegKey(), userInfo.id);
+            logic.joinCourseForInstructor(instructorList.get(0).getRegKey(), authContext.id);
         } catch (EntityDoesNotExistException | EntityAlreadyExistsException | InvalidParametersException e) {
             // EntityDoesNotExistException should not be thrown as all entities should exist in demo course.
             // EntityAlreadyExistsException should not be thrown as updated entities should not have

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -19,7 +19,7 @@ public class CreateAccountRequestAction extends PublicAction {
             throws InvalidHttpRequestBodyException, InvalidOperationException {
         AccountCreateRequest createRequest = getAndValidateRequestBody(AccountCreateRequest.class);
 
-        if (userInfo == null || !userInfo.isAdmin) {
+        if (authContext == null || !authContext.isAdmin) {
             String userCaptchaResponse = createRequest.getCaptchaResponse();
             if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
                 throw new InvalidHttpRequestBodyException("Something went wrong with "
@@ -45,7 +45,7 @@ public class CreateAccountRequestAction extends PublicAction {
 
         assert accountRequest != null;
 
-        if (userInfo == null || !userInfo.isAdmin) {
+        if (authContext == null || !authContext.isAdmin) {
             EmailWrapper adminAlertEmail = emailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
             EmailWrapper userAcknowledgementEmail = emailGenerator
                     .generateNewAccountRequestAcknowledgementEmail(accountRequest);

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -19,7 +19,7 @@ public class CreateAccountRequestAction extends PublicAction {
             throws InvalidHttpRequestBodyException, InvalidOperationException {
         AccountCreateRequest createRequest = getAndValidateRequestBody(AccountCreateRequest.class);
 
-        if (authContext == null || !authContext.isAdmin) {
+        if (authContext == null || !authContext.isAdmin()) {
             String userCaptchaResponse = createRequest.getCaptchaResponse();
             if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
                 throw new InvalidHttpRequestBodyException("Something went wrong with "
@@ -45,7 +45,7 @@ public class CreateAccountRequestAction extends PublicAction {
 
         assert accountRequest != null;
 
-        if (authContext == null || !authContext.isAdmin) {
+        if (authContext == null || !authContext.isAdmin()) {
             EmailWrapper adminAlertEmail = emailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
             EmailWrapper userAcknowledgementEmail = emailGenerator
                     .generateNewAccountRequestAcknowledgementEmail(accountRequest);

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -28,12 +28,12 @@ public class CreateCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String institute = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
-        List<Instructor> existingInstructors = logic.getInstructorsForGoogleId(authContext.getId());
+        List<Instructor> existingInstructors = logic.getInstructorsForGoogleId(authContext.id());
         boolean canCreateCourse = existingInstructors.stream()
                 .filter(Instructor::hasCoownerPrivileges)
                 .map(instructor -> logic.getCourse(instructor.getCourseId()))
@@ -64,7 +64,7 @@ public class CreateCourseAction extends Action {
         course.setCreatedAt(Instant.now());
 
         try {
-            Course createdCourse = logic.createCourseAndInstructor(authContext.getId(), course);
+            Course createdCourse = logic.createCourseAndInstructor(authContext.id(), course);
             return new JsonResult(new CourseData(createdCourse));
 
         } catch (EntityAlreadyExistsException e) {

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -28,12 +28,12 @@ public class CreateCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String institute = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
-        List<Instructor> existingInstructors = logic.getInstructorsForGoogleId(userInfo.getId());
+        List<Instructor> existingInstructors = logic.getInstructorsForGoogleId(authContext.getId());
         boolean canCreateCourse = existingInstructors.stream()
                 .filter(Instructor::hasCoownerPrivileges)
                 .map(instructor -> logic.getCourse(instructor.getCourseId()))
@@ -64,7 +64,7 @@ public class CreateCourseAction extends Action {
         course.setCreatedAt(Instant.now());
 
         try {
-            Course createdCourse = logic.createCourseAndInstructor(userInfo.getId(), course);
+            Course createdCourse = logic.createCourseAndInstructor(authContext.getId(), course);
             return new JsonResult(new CourseData(createdCourse));
 
         } catch (EntityAlreadyExistsException e) {

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -36,7 +36,7 @@ public class CreateFeedbackQuestionAction extends Action {
         }
 
         Instructor instructorDetailForCourse =
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(instructorDetailForCourse,
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -36,7 +36,7 @@ public class CreateFeedbackQuestionAction extends Action {
         }
 
         Instructor instructorDetailForCourse =
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         gateKeeper.verifyAccessible(instructorDetailForCourse,
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
@@ -81,7 +81,7 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             break;
         case INSTRUCTOR_RESULT:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(instructor, session, feedbackResponse.getGiverSection().getName(),
                     Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
             gateKeeper.verifyAccessible(instructor, session, feedbackResponse.getRecipientSection().getName(),
@@ -150,7 +150,7 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             giver = instructorAsFeedbackParticipant.getEmail();
             break;
         case INSTRUCTOR_RESULT:
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             giverRg = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructor.getId());
             isFromParticipant = false;
             isFollowingQuestionVisibility = false;

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackResponseCommentAction.java
@@ -80,8 +80,8 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             verifyResponseOwnerShipForInstructor(instructorAsFeedbackParticipant, feedbackResponse);
             break;
         case INSTRUCTOR_RESULT:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             gateKeeper.verifyAccessible(instructor, session, feedbackResponse.getGiverSection().getName(),
                     Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
             gateKeeper.verifyAccessible(instructor, session, feedbackResponse.getRecipientSection().getName(),
@@ -150,7 +150,7 @@ public class CreateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             giver = instructorAsFeedbackParticipant.getEmail();
             break;
         case INSTRUCTOR_RESULT:
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             giverRg = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructor.getId());
             isFromParticipant = false;
             isFollowingQuestionVisibility = false;

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -37,7 +37,7 @@ public class CreateFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
         Course course = logic.getCourse(courseId);
 
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
@@ -54,7 +54,7 @@ public class CreateFeedbackSessionAction extends Action {
         if (course == null) {
             throw new InvalidHttpParameterException("Failed to find course with the given course id.");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
         if (instructor == null) {
             throw new InvalidHttpParameterException("Failed to find instructor with the given courseId and googleId.");
         }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -37,7 +37,7 @@ public class CreateFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         Course course = logic.getCourse(courseId);
 
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
@@ -54,7 +54,7 @@ public class CreateFeedbackSessionAction extends Action {
         if (course == null) {
             throw new InvalidHttpParameterException("Failed to find course with the given course id.");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         if (instructor == null) {
             throw new InvalidHttpParameterException("Failed to find instructor with the given courseId and googleId.");
         }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -38,7 +38,7 @@ public class CreateFeedbackSessionLogAction extends Action {
         }
 
         if (authenticatedStudent.getAccount() != null
-                && (authContext == null || !authContext.getId().equals(authenticatedStudent.getAccount().getGoogleId()))) {
+                && (authContext == null || !authContext.id().equals(authenticatedStudent.getAccount().getGoogleId()))) {
             throw new UnauthorizedAccessException(
                     "Login is required to create a feedback session log for a student with an associated account.");
         }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionLogAction.java
@@ -38,7 +38,7 @@ public class CreateFeedbackSessionLogAction extends Action {
         }
 
         if (authenticatedStudent.getAccount() != null
-                && (userInfo == null || !userInfo.getId().equals(authenticatedStudent.getAccount().getGoogleId()))) {
+                && (authContext == null || !authContext.getId().equals(authenticatedStudent.getAccount().getGoogleId()))) {
             throw new UnauthorizedAccessException(
                     "Login is required to create a feedback session log for a student with an associated account.");
         }

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -32,17 +32,17 @@ public class CreateInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
@@ -64,7 +64,7 @@ public class CreateInstructorAction extends Action {
             Instructor createdInstructor = logic.createInstructor(instructorToAdd);
 
             // Generate and queue invitation email to priority queue (user-triggered)
-            Account inviter = logic.getAccountForGoogleId(userInfo.id);
+            Account inviter = logic.getAccountForGoogleId(authContext.id);
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter account does not exist.");
             }

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -32,17 +32,17 @@ public class CreateInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
@@ -64,7 +64,7 @@ public class CreateInstructorAction extends Action {
             Instructor createdInstructor = logic.createInstructor(instructorToAdd);
 
             // Generate and queue invitation email to priority queue (user-triggered)
-            Account inviter = logic.getAccountForGoogleId(authContext.id);
+            Account inviter = logic.getAccountForGoogleId(authContext.id());
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter account does not exist.");
             }

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -17,14 +17,14 @@ public class DeleteCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToDelete);
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToDelete, authContext.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToDelete, authContext.id()),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -17,14 +17,14 @@ public class DeleteCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToDelete);
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToDelete, userInfo.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToDelete, authContext.id),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -29,7 +29,7 @@ public class DeleteFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(question.getCourseId(), userInfo.getId()),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(question.getCourseId(), authContext.getId()),
                 getNonNullFeedbackSession(question.getFeedbackSession().getName(), question.getCourseId()),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -29,7 +29,7 @@ public class DeleteFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(question.getCourseId(), authContext.getId()),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(question.getCourseId(), authContext.id()),
                 getNonNullFeedbackSession(question.getFeedbackSession().getName(), question.getCourseId()),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -71,7 +71,7 @@ public class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionA
             break;
         case INSTRUCTOR_RESULT:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseCommentAction.java
@@ -70,8 +70,8 @@ public class DeleteFeedbackResponseCommentAction extends BasicCommentSubmissionA
                     new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructorAsFeedbackParticipant.getId()));
             break;
         case INSTRUCTOR_RESULT:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -25,7 +25,7 @@ public class DeleteFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -25,7 +25,7 @@ public class DeleteFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -22,16 +22,16 @@ public class DeleteInstructorAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         //allow access to admins or instructor with modify permission
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Admin or Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -22,16 +22,16 @@ public class DeleteInstructorAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         //allow access to admins or instructor with modify permission
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Admin or Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -17,17 +17,17 @@ public class DeleteStudentAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -17,17 +17,17 @@ public class DeleteStudentAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -16,13 +16,13 @@ public class DeleteStudentsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to delete students from course.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                     instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -16,13 +16,13 @@ public class DeleteStudentsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to delete students from course.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         gateKeeper.verifyAccessible(
                     instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -33,12 +33,12 @@ public class EnrollStudentsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         gateKeeper.verifyAccessible(
                     instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -33,12 +33,12 @@ public class EnrollStudentsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                     instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -1,6 +1,6 @@
 package teammates.ui.webapi;
 
-import teammates.common.datatransfer.UserInfo;
+import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
@@ -30,8 +30,8 @@ final class GateKeeper {
     /**
      * Verifies the user is logged in.
      */
-    void verifyLoggedInUserPrivileges(UserInfo userInfo) throws UnauthorizedAccessException {
-        if (userInfo != null) {
+    void verifyLoggedInUserPrivileges(AuthContext authContext) throws UnauthorizedAccessException {
+        if (authContext != null) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
@@ -17,7 +17,7 @@ public class GetActionClassesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isMaintainer && !userInfo.isAdmin) {
+        if (!authContext.isMaintainer && !authContext.isAdmin) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
@@ -17,7 +17,7 @@ public class GetActionClassesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer && !authContext.isAdmin) {
+        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jakarta.servlet.http.Cookie;
 
+import teammates.common.datatransfer.UserInfo;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
@@ -29,6 +30,7 @@ public class GetAuthInfoAction extends PublicAction {
             nextUrl = "";
         }
 
+        UserInfo userInfo = userProvision.getUserInfo(authContext);
         AuthInfo output = new AuthInfo(createLoginUrl(frontendUrl, nextUrl), userInfo, authType == AuthType.MASQUERADE);
         String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
         if (existingCsrfToken != null && isMatchingCsrfToken(existingCsrfToken, req.getSession().getId())) {

--- a/src/main/java/teammates/ui/webapi/GetCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseAction.java
@@ -20,7 +20,7 @@ public class GetCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext != null && authContext.isAdmin) {
+        if (authContext != null && authContext.isAdmin()) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseAction.java
@@ -20,7 +20,7 @@ public class GetCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo != null && userInfo.isAdmin) {
+        if (authContext != null && authContext.isAdmin) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetCourseSectionNamesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSectionNamesAction.java
@@ -24,7 +24,7 @@ public class GetCourseSectionNamesAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(courseId);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
 
         gateKeeper.verifyAccessible(instructor, course);
     }

--- a/src/main/java/teammates/ui/webapi/GetCourseSectionNamesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSectionNamesAction.java
@@ -24,7 +24,7 @@ public class GetCourseSectionNamesAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(courseId);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
 
         gateKeeper.verifyAccessible(instructor, course);
     }

--- a/src/main/java/teammates/ui/webapi/GetCoursesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCoursesAction.java
@@ -30,8 +30,8 @@ public class GetCoursesAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String entityType = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
 
-        if (!(Const.EntityType.STUDENT.equals(entityType) && userInfo.isStudent)
-                && !(Const.EntityType.INSTRUCTOR.equals(entityType) && userInfo.isInstructor)) {
+        if (!(Const.EntityType.STUDENT.equals(entityType) && authContext.isStudent)
+                && !(Const.EntityType.INSTRUCTOR.equals(entityType) && authContext.isInstructor)) {
             throw new UnauthorizedAccessException("Current account cannot access to courses of request entity type");
         }
     }
@@ -50,7 +50,7 @@ public class GetCoursesAction extends Action {
     }
 
     private JsonResult getStudentCourses() {
-        List<Course> courses = logic.getCoursesForStudentAccount(userInfo.id);
+        List<Course> courses = logic.getCoursesForStudentAccount(authContext.id);
         CoursesData coursesData = new CoursesData(courses);
         List<CourseData> courseDataList = coursesData.getCourses();
 
@@ -62,7 +62,7 @@ public class GetCoursesAction extends Action {
     private JsonResult getInstructorCourses() {
         String courseStatus = getNonNullRequestParamValue(Const.ParamsNames.COURSE_STATUS);
 
-        List<Instructor> instructors = logic.getInstructorsForGoogleId(userInfo.id);
+        List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id);
         List<Course> courses;
 
         switch (courseStatus) {

--- a/src/main/java/teammates/ui/webapi/GetCoursesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCoursesAction.java
@@ -30,8 +30,8 @@ public class GetCoursesAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String entityType = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
 
-        if (!(Const.EntityType.STUDENT.equals(entityType) && authContext.isStudent)
-                && !(Const.EntityType.INSTRUCTOR.equals(entityType) && authContext.isInstructor)) {
+        if (!(Const.EntityType.STUDENT.equals(entityType) && authContext.isStudent())
+                && !(Const.EntityType.INSTRUCTOR.equals(entityType) && authContext.isInstructor())) {
             throw new UnauthorizedAccessException("Current account cannot access to courses of request entity type");
         }
     }
@@ -50,7 +50,7 @@ public class GetCoursesAction extends Action {
     }
 
     private JsonResult getStudentCourses() {
-        List<Course> courses = logic.getCoursesForStudentAccount(authContext.id);
+        List<Course> courses = logic.getCoursesForStudentAccount(authContext.id());
         CoursesData coursesData = new CoursesData(courses);
         List<CourseData> courseDataList = coursesData.getCourses();
 
@@ -62,7 +62,7 @@ public class GetCoursesAction extends Action {
     private JsonResult getInstructorCourses() {
         String courseStatus = getNonNullRequestParamValue(Const.ParamsNames.COURSE_STATUS);
 
-        List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id);
+        List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id());
         List<Course> courses;
 
         switch (courseStatus) {

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -31,7 +31,7 @@ public class GetDeadlineExtensionsAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -31,7 +31,7 @@ public class GetDeadlineExtensionsAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -47,7 +47,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()),
+            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.id()),
                     feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -46,8 +46,8 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, userInfo.getId()),
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()),
                     feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -44,8 +44,8 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, userInfo.getId()),
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()),
                     feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -45,7 +45,7 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()),
+            gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.id()),
                     feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -32,7 +32,7 @@ public class GetFeedbackSessionLogsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
@@ -51,7 +51,7 @@ public class GetFeedbackSessionLogsAction extends Action {
             }
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -32,7 +32,7 @@ public class GetFeedbackSessionLogsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
@@ -51,7 +51,7 @@ public class GetFeedbackSessionLogsAction extends Action {
             }
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -30,7 +30,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession);
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -30,7 +30,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession);
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -30,7 +30,7 @@ public class GetFeedbackSessionsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
@@ -43,24 +43,24 @@ public class GetFeedbackSessionsAction extends Action {
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
-            if (!authContext.isStudent) {
-                throw new UnauthorizedAccessException("User " + authContext.getId()
+            if (!authContext.isStudent()) {
+                throw new UnauthorizedAccessException("User " + authContext.id()
                         + " does not have student privileges");
             }
 
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(logic.getStudentByGoogleId(courseId, authContext.getId()), course);
+                gateKeeper.verifyAccessible(logic.getStudentByGoogleId(courseId, authContext.id()), course);
             }
         } else {
-            if (!authContext.isInstructor) {
-                throw new UnauthorizedAccessException("User " + authContext.getId()
+            if (!authContext.isInstructor()) {
+                throw new UnauthorizedAccessException("User " + authContext.id()
                         + " does not have instructor privileges");
             }
 
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()), course);
+                gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.id()), course);
             }
         }
     }
@@ -76,7 +76,7 @@ public class GetFeedbackSessionsAction extends Action {
 
         if (courseId == null) {
             if (Const.EntityType.STUDENT.equals(entityType)) {
-                List<Student> students = logic.getStudentsByGoogleId(authContext.getId());
+                List<Student> students = logic.getStudentsByGoogleId(authContext.id());
                 for (Student student : students) {
                     String studentCourseId = student.getCourseId();
                     List<FeedbackSession> sessions = logic.getFeedbackSessionsForCourse(studentCourseId);
@@ -87,7 +87,7 @@ public class GetFeedbackSessionsAction extends Action {
             } else if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
                 boolean isInRecycleBin = getBooleanRequestParamValue(Const.ParamsNames.IS_IN_RECYCLE_BIN);
 
-                instructors = logic.getInstructorsForGoogleId(authContext.getId());
+                instructors = logic.getInstructorsForGoogleId(authContext.id());
 
                 if (isInRecycleBin) {
                     feedbackSessions = logic.getSoftDeletedFeedbackSessionsForInstructors(instructors);
@@ -98,14 +98,14 @@ public class GetFeedbackSessionsAction extends Action {
         } else {
             feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
             if (Const.EntityType.STUDENT.equals(entityType) && !feedbackSessions.isEmpty()) {
-                Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
+                Student student = logic.getStudentByGoogleId(courseId, authContext.id());
                 assert student != null;
                 for (FeedbackSession session : feedbackSessions) {
                     sessionToDeadline.put(session, logic.getDeadlineForUser(session, student));
                 }
             } else if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
                 instructors = Collections.singletonList(
-                        logic.getInstructorByGoogleId(courseId, authContext.getId()));
+                        logic.getInstructorByGoogleId(courseId, authContext.id()));
             }
         }
 

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -30,7 +30,7 @@ public class GetFeedbackSessionsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
@@ -43,24 +43,24 @@ public class GetFeedbackSessionsAction extends Action {
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
-            if (!userInfo.isStudent) {
-                throw new UnauthorizedAccessException("User " + userInfo.getId()
+            if (!authContext.isStudent) {
+                throw new UnauthorizedAccessException("User " + authContext.getId()
                         + " does not have student privileges");
             }
 
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(logic.getStudentByGoogleId(courseId, userInfo.getId()), course);
+                gateKeeper.verifyAccessible(logic.getStudentByGoogleId(courseId, authContext.getId()), course);
             }
         } else {
-            if (!userInfo.isInstructor) {
-                throw new UnauthorizedAccessException("User " + userInfo.getId()
+            if (!authContext.isInstructor) {
+                throw new UnauthorizedAccessException("User " + authContext.getId()
                         + " does not have instructor privileges");
             }
 
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, userInfo.getId()), course);
+                gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(courseId, authContext.getId()), course);
             }
         }
     }
@@ -76,7 +76,7 @@ public class GetFeedbackSessionsAction extends Action {
 
         if (courseId == null) {
             if (Const.EntityType.STUDENT.equals(entityType)) {
-                List<Student> students = logic.getStudentsByGoogleId(userInfo.getId());
+                List<Student> students = logic.getStudentsByGoogleId(authContext.getId());
                 for (Student student : students) {
                     String studentCourseId = student.getCourseId();
                     List<FeedbackSession> sessions = logic.getFeedbackSessionsForCourse(studentCourseId);
@@ -87,7 +87,7 @@ public class GetFeedbackSessionsAction extends Action {
             } else if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
                 boolean isInRecycleBin = getBooleanRequestParamValue(Const.ParamsNames.IS_IN_RECYCLE_BIN);
 
-                instructors = logic.getInstructorsForGoogleId(userInfo.getId());
+                instructors = logic.getInstructorsForGoogleId(authContext.getId());
 
                 if (isInRecycleBin) {
                     feedbackSessions = logic.getSoftDeletedFeedbackSessionsForInstructors(instructors);
@@ -98,14 +98,14 @@ public class GetFeedbackSessionsAction extends Action {
         } else {
             feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
             if (Const.EntityType.STUDENT.equals(entityType) && !feedbackSessions.isEmpty()) {
-                Student student = logic.getStudentByGoogleId(courseId, userInfo.getId());
+                Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
                 assert student != null;
                 for (FeedbackSession session : feedbackSessions) {
                     sessionToDeadline.put(session, logic.getDeadlineForUser(session, student));
                 }
             } else if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
                 instructors = Collections.singletonList(
-                        logic.getInstructorByGoogleId(courseId, userInfo.getId()));
+                        logic.getInstructorByGoogleId(courseId, authContext.getId()));
             }
         }
 

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -44,7 +44,7 @@ public class GetHasResponsesAction extends Action {
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(courseId, userInfo.getId()),
+                    logic.getInstructorByGoogleId(courseId, authContext.getId()),
                     logic.getCourse(courseId));
 
             return;
@@ -62,7 +62,7 @@ public class GetHasResponsesAction extends Action {
             }
 
             gateKeeper.verifyAccessible(
-                    logic.getStudentByGoogleId(courseId, userInfo.getId()),
+                    logic.getStudentByGoogleId(courseId, authContext.getId()),
                     feedbackSession);
         }
     }
@@ -82,7 +82,7 @@ public class GetHasResponsesAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         List<FeedbackSession> feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
-        Student student = logic.getStudentByGoogleId(courseId, userInfo.getId());
+        Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
 
         Map<String, Boolean> sessionsHasResponses = new HashMap<>();
         for (FeedbackSession feedbackSession : feedbackSessions) {
@@ -129,7 +129,7 @@ public class GetHasResponsesAction extends Action {
         String courseId = feedbackQuestion.getCourseId();
         FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(courseId, userInfo.getId()),
+                logic.getInstructorByGoogleId(courseId, authContext.getId()),
                 feedbackSession);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -44,7 +44,7 @@ public class GetHasResponsesAction extends Action {
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
             gateKeeper.verifyAccessible(
-                    logic.getInstructorByGoogleId(courseId, authContext.getId()),
+                    logic.getInstructorByGoogleId(courseId, authContext.id()),
                     logic.getCourse(courseId));
 
             return;
@@ -62,7 +62,7 @@ public class GetHasResponsesAction extends Action {
             }
 
             gateKeeper.verifyAccessible(
-                    logic.getStudentByGoogleId(courseId, authContext.getId()),
+                    logic.getStudentByGoogleId(courseId, authContext.id()),
                     feedbackSession);
         }
     }
@@ -82,7 +82,7 @@ public class GetHasResponsesAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         List<FeedbackSession> feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
-        Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
+        Student student = logic.getStudentByGoogleId(courseId, authContext.id());
 
         Map<String, Boolean> sessionsHasResponses = new HashMap<>();
         for (FeedbackSession feedbackSession : feedbackSessions) {
@@ -129,7 +129,7 @@ public class GetHasResponsesAction extends Action {
         String courseId = feedbackQuestion.getCourseId();
         FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(courseId, authContext.getId()),
+                logic.getInstructorByGoogleId(courseId, authContext.id()),
                 feedbackSession);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorAction.java
@@ -60,7 +60,7 @@ public class GetInstructorAction extends BasicFeedbackSubmissionAction {
             instructor = getInstructorOfCourseFromRequest(courseId);
             break;
         case FULL_DETAIL:
-            instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorAction.java
@@ -33,7 +33,7 @@ public class GetInstructorAction extends BasicFeedbackSubmissionAction {
             }
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
@@ -60,7 +60,7 @@ public class GetInstructorAction extends BasicFeedbackSubmissionAction {
             instructor = getInstructorOfCourseFromRequest(courseId);
             break;
         case FULL_DETAIL:
-            instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
@@ -18,13 +18,13 @@ public class GetInstructorPrivilegeAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
 
         if (instructor == null) {
             throw new UnauthorizedAccessException("Not instructor of the course");
@@ -41,7 +41,7 @@ public class GetInstructorPrivilegeAction extends Action {
 
         if (instructorId == null) {
             if (instructorEmail == null) {
-                instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+                instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             } else {
                 instructor = logic.getInstructorForEmail(courseId, instructorEmail);
 

--- a/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
@@ -18,13 +18,13 @@ public class GetInstructorPrivilegeAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
 
         if (instructor == null) {
             throw new UnauthorizedAccessException("Not instructor of the course");
@@ -41,7 +41,7 @@ public class GetInstructorPrivilegeAction extends Action {
 
         if (instructorId == null) {
             if (instructorEmail == null) {
-                instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+                instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             } else {
                 instructor = logic.getInstructorForEmail(courseId, instructorEmail);
 

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -26,7 +26,7 @@ public class GetInstructorsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
@@ -43,12 +43,12 @@ public class GetInstructorsAction extends Action {
         if (intentStr == null) {
             // get partial details of instructors with information hiding
             // student should belong to the course
-            Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
+            Student student = logic.getStudentByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(student, course);
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // this need instructor privileges
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(instructor, course);
         } else {
             throw new InvalidHttpParameterException("unknown intent");
@@ -80,14 +80,14 @@ public class GetInstructorsAction extends Action {
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // adds googleId if caller is admin or has the appropriate privilege to modify instructor
-            if (authContext.isAdmin || logic.getInstructorByGoogleId(courseId, authContext.getId()).getPrivileges()
+            if (authContext.isAdmin() || logic.getInstructorByGoogleId(courseId, authContext.id()).getPrivileges()
                     .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
                 data = new InstructorsData();
 
                 for (Instructor instructor : instructorsOfCourse) {
                     InstructorData instructorData = new InstructorData(instructor);
                     instructorData.setGoogleId(instructor.getGoogleId());
-                    if (authContext.isAdmin) {
+                    if (authContext.isAdmin()) {
                         instructorData.setKey(instructor.getRegKey());
                     }
                     data.getInstructors().add(instructorData);

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -26,7 +26,7 @@ public class GetInstructorsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
@@ -43,12 +43,12 @@ public class GetInstructorsAction extends Action {
         if (intentStr == null) {
             // get partial details of instructors with information hiding
             // student should belong to the course
-            Student student = logic.getStudentByGoogleId(courseId, userInfo.getId());
+            Student student = logic.getStudentByGoogleId(courseId, authContext.getId());
             gateKeeper.verifyAccessible(student, course);
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // this need instructor privileges
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             gateKeeper.verifyAccessible(instructor, course);
         } else {
             throw new InvalidHttpParameterException("unknown intent");
@@ -80,14 +80,14 @@ public class GetInstructorsAction extends Action {
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // adds googleId if caller is admin or has the appropriate privilege to modify instructor
-            if (userInfo.isAdmin || logic.getInstructorByGoogleId(courseId, userInfo.getId()).getPrivileges()
+            if (authContext.isAdmin || logic.getInstructorByGoogleId(courseId, authContext.getId()).getPrivileges()
                     .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
                 data = new InstructorsData();
 
                 for (Instructor instructor : instructorsOfCourse) {
                     InstructorData instructorData = new InstructorData(instructor);
                     instructorData.setGoogleId(instructor.getGoogleId());
-                    if (userInfo.isAdmin) {
+                    if (authContext.isAdmin) {
                         instructorData.setKey(instructor.getRegKey());
                     }
                     data.getInstructors().add(instructorData);

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -29,7 +29,7 @@ public class GetNotificationsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
         String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
@@ -38,8 +38,8 @@ public class GetNotificationsAction extends Action {
             throw new InvalidHttpParameterException(targetUserErrorMessage);
         }
         NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-        if (targetUser == NotificationTargetUser.INSTRUCTOR && !authContext.isInstructor
-                || targetUser == NotificationTargetUser.STUDENT && !authContext.isStudent) {
+        if (targetUser == NotificationTargetUser.INSTRUCTOR && !authContext.isInstructor()
+                || targetUser == NotificationTargetUser.STUDENT && !authContext.isStudent()) {
             throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
         }
     }
@@ -49,7 +49,7 @@ public class GetNotificationsAction extends Action {
         String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
         List<Notification> notifications;
 
-        if (targetUserString == null && authContext.isAdmin) {
+        if (targetUserString == null && authContext.isAdmin()) {
             // if request is from admin and targetUser is not specified, retrieve all notifications
             notifications = logic.getAllNotifications();
             return new JsonResult(new NotificationsData(notifications));
@@ -75,7 +75,7 @@ public class GetNotificationsAction extends Action {
             return new JsonResult(new NotificationsData(notifications));
         }
 
-        Account account = logic.getAccountForGoogleId(authContext.getId());
+        Account account = logic.getAccountForGoogleId(authContext.id());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -83,7 +83,7 @@ public class GetNotificationsAction extends Action {
         notifications = logic.getUnreadActiveNotificationsByTargetUser(
                 List.of(targetUser, NotificationTargetUser.GENERAL), account.getId(), Instant.now());
 
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return new JsonResult(new NotificationsData(notifications));
         }
 

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -29,7 +29,7 @@ public class GetNotificationsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
         String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
@@ -38,8 +38,8 @@ public class GetNotificationsAction extends Action {
             throw new InvalidHttpParameterException(targetUserErrorMessage);
         }
         NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-        if (targetUser == NotificationTargetUser.INSTRUCTOR && !userInfo.isInstructor
-                || targetUser == NotificationTargetUser.STUDENT && !userInfo.isStudent) {
+        if (targetUser == NotificationTargetUser.INSTRUCTOR && !authContext.isInstructor
+                || targetUser == NotificationTargetUser.STUDENT && !authContext.isStudent) {
             throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
         }
     }
@@ -49,7 +49,7 @@ public class GetNotificationsAction extends Action {
         String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
         List<Notification> notifications;
 
-        if (targetUserString == null && userInfo.isAdmin) {
+        if (targetUserString == null && authContext.isAdmin) {
             // if request is from admin and targetUser is not specified, retrieve all notifications
             notifications = logic.getAllNotifications();
             return new JsonResult(new NotificationsData(notifications));
@@ -75,7 +75,7 @@ public class GetNotificationsAction extends Action {
             return new JsonResult(new NotificationsData(notifications));
         }
 
-        Account account = logic.getAccountForGoogleId(userInfo.getId());
+        Account account = logic.getAccountForGoogleId(authContext.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -83,7 +83,7 @@ public class GetNotificationsAction extends Action {
         notifications = logic.getUnreadActiveNotificationsByTargetUser(
                 List.of(targetUser, NotificationTargetUser.GENERAL), account.getId(), Instant.now());
 
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return new JsonResult(new NotificationsData(notifications));
         }
 

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -25,7 +25,7 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     public ActionResult execute() {
-        Account account = logic.getAccountForGoogleId(userInfo.getId());
+        Account account = logic.getAccountForGoogleId(authContext.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -25,7 +25,7 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     public ActionResult execute() {
-        Account account = logic.getAccountForGoogleId(authContext.getId());
+        Account account = logic.getAccountForGoogleId(authContext.id());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
@@ -47,7 +47,7 @@ public class GetRegkeyValidityAction extends PublicAction {
                 isUsed = true;
                 // If the registration key has been used to register, the logged in user needs to match
                 // Block access to not logged in user and mismatched user
-                isAllowedAccess = userInfo != null && googleId.equals(userInfo.id);
+                isAllowedAccess = authContext != null && googleId.equals(authContext.id);
             }
         }
 

--- a/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
@@ -47,7 +47,7 @@ public class GetRegkeyValidityAction extends PublicAction {
                 isUsed = true;
                 // If the registration key has been used to register, the logged in user needs to match
                 // Block access to not logged in user and mismatched user
-                isAllowedAccess = authContext != null && googleId.equals(authContext.id);
+                isAllowedAccess = authContext != null && googleId.equals(authContext.id());
             }
         }
 

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -21,7 +21,7 @@ public class GetSessionResponseStatsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (userInfo.isAdmin) {
+        if (authContext.isAdmin) {
             return;
         }
 
@@ -31,7 +31,7 @@ public class GetSessionResponseStatsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         gateKeeper.verifyAccessible(instructor, feedbackSession);
     }
 

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -21,7 +21,7 @@ public class GetSessionResponseStatsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin) {
+        if (authContext.isAdmin()) {
             return;
         }
 
@@ -31,7 +31,7 @@ public class GetSessionResponseStatsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(instructor, feedbackSession);
     }
 

--- a/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
@@ -42,8 +42,8 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
 
         switch (intent) {
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             gateKeeper.verifyAccessible(instructor, feedbackSession);
             break;
         case INSTRUCTOR_RESULT:

--- a/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResultsAction.java
@@ -43,7 +43,7 @@ public class GetSessionResultsAction extends BasicFeedbackSubmissionAction {
         switch (intent) {
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(instructor, feedbackSession);
             break;
         case INSTRUCTOR_RESULT:

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -40,11 +40,11 @@ public class GetStudentAction extends Action {
         if (studentEmail != null) {
             student = logic.getStudentForEmail(courseId, studentEmail);
 
-            if (student == null || authContext == null || !authContext.isInstructor) {
+            if (student == null || authContext == null || !authContext.isInstructor()) {
                 throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
             }
 
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
 
             gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
                     student.getTeamName(),
@@ -52,11 +52,11 @@ public class GetStudentAction extends Action {
         } else if (regKey != null) {
             getUnregisteredStudent().orElseThrow(() -> new UnauthorizedAccessException(UNAUTHORIZED_ACCESS));
         } else {
-            if (authContext == null || !authContext.isStudent) {
+            if (authContext == null || !authContext.isStudent()) {
                 throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
             }
 
-            student = logic.getStudentByGoogleId(courseId, authContext.id);
+            student = logic.getStudentByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(student, course);
         }
     }
@@ -80,7 +80,7 @@ public class GetStudentAction extends Action {
         }
 
         StudentData studentData = new StudentData(student);
-        if (authContext != null && authContext.isAdmin) {
+        if (authContext != null && authContext.isAdmin()) {
             studentData.setKey(student.getRegKey());
             studentData.setGoogleId(
                     Optional.ofNullable(student.getAccount())

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -40,11 +40,11 @@ public class GetStudentAction extends Action {
         if (studentEmail != null) {
             student = logic.getStudentForEmail(courseId, studentEmail);
 
-            if (student == null || userInfo == null || !userInfo.isInstructor) {
+            if (student == null || authContext == null || !authContext.isInstructor) {
                 throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
             }
 
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
 
             gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
                     student.getTeamName(),
@@ -52,11 +52,11 @@ public class GetStudentAction extends Action {
         } else if (regKey != null) {
             getUnregisteredStudent().orElseThrow(() -> new UnauthorizedAccessException(UNAUTHORIZED_ACCESS));
         } else {
-            if (userInfo == null || !userInfo.isStudent) {
+            if (authContext == null || !authContext.isStudent) {
                 throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS);
             }
 
-            student = logic.getStudentByGoogleId(courseId, userInfo.id);
+            student = logic.getStudentByGoogleId(courseId, authContext.id);
             gateKeeper.verifyAccessible(student, course);
         }
     }
@@ -80,7 +80,7 @@ public class GetStudentAction extends Action {
         }
 
         StudentData studentData = new StudentData(student);
-        if (userInfo != null && userInfo.isAdmin) {
+        if (authContext != null && authContext.isAdmin) {
             studentData.setKey(student.getRegKey());
             studentData.setGoogleId(
                     Optional.ofNullable(student.getAccount())

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -28,12 +28,12 @@ public class GetStudentsAction extends Action {
 
         if (teamName == null) {
             // request to get all students of a course by instructor
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
             gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
-            Student student = logic.getStudentByGoogleId(courseId, userInfo.id);
+            Student student = logic.getStudentByGoogleId(courseId, authContext.id);
             if (student == null || !teamName.equals(student.getTeamName())) {
                 throw new UnauthorizedAccessException("You are not part of the team");
             }
@@ -45,7 +45,7 @@ public class GetStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String teamName = getRequestParamValue(Const.ParamsNames.TEAM_NAME);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
         String privilegeName = Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS;
         boolean hasCoursePrivilege = instructor != null
                 && instructor.isAllowedForPrivilege(privilegeName);

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -28,12 +28,12 @@ public class GetStudentsAction extends Action {
 
         if (teamName == null) {
             // request to get all students of a course by instructor
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
-            Student student = logic.getStudentByGoogleId(courseId, authContext.id);
+            Student student = logic.getStudentByGoogleId(courseId, authContext.id());
             if (student == null || !teamName.equals(student.getTeamName())) {
                 throw new UnauthorizedAccessException("You are not part of the team");
             }
@@ -45,7 +45,7 @@ public class GetStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String teamName = getRequestParamValue(Const.ParamsNames.TEAM_NAME);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         String privilegeName = Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS;
         boolean hasCoursePrivilege = instructor != null
                 && instructor.isAllowedForPrivilege(privilegeName);

--- a/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
@@ -21,7 +21,7 @@ public class GetTimeZonesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer && !authContext.isAdmin) {
+        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
@@ -21,7 +21,7 @@ public class GetTimeZonesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isMaintainer && !userInfo.isAdmin) {
+        if (!authContext.isMaintainer && !authContext.isAdmin) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
@@ -24,7 +24,7 @@ public class GetUsageStatisticsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isMaintainer && !userInfo.isAdmin) {
+        if (!authContext.isMaintainer && !authContext.isAdmin) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
@@ -24,7 +24,7 @@ public class GetUsageStatisticsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer && !authContext.isAdmin) {
+        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -51,7 +51,7 @@ public class JoinCourseAction extends Action {
         Student student;
 
         try {
-            student = logic.joinCourseForStudent(regkey, authContext.id);
+            student = logic.joinCourseForStudent(regkey, authContext.id());
         } catch (EntityDoesNotExistException ednee) {
             throw new EntityNotFoundException(ednee);
         } catch (EntityAlreadyExistsException eaee) {
@@ -71,7 +71,7 @@ public class JoinCourseAction extends Action {
         Instructor instructor;
 
         try {
-            instructor = logic.joinCourseForInstructor(regkey, authContext.id);
+            instructor = logic.joinCourseForInstructor(regkey, authContext.id());
         } catch (EntityDoesNotExistException ednee) {
             throw new EntityNotFoundException(ednee);
         } catch (EntityAlreadyExistsException eaee) {
@@ -90,7 +90,7 @@ public class JoinCourseAction extends Action {
     private void sendJoinEmail(String courseId, String userName, String userEmail, boolean isInstructor) {
         Course course = logic.getCourse(courseId);
         EmailWrapper email = emailGenerator.generateUserCourseRegisteredEmail(
-                userName, userEmail, authContext.id, isInstructor, course);
+                userName, userEmail, authContext.id(), isInstructor, course);
         emailSender.sendEmail(email);
     }
 }

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -51,7 +51,7 @@ public class JoinCourseAction extends Action {
         Student student;
 
         try {
-            student = logic.joinCourseForStudent(regkey, userInfo.id);
+            student = logic.joinCourseForStudent(regkey, authContext.id);
         } catch (EntityDoesNotExistException ednee) {
             throw new EntityNotFoundException(ednee);
         } catch (EntityAlreadyExistsException eaee) {
@@ -71,7 +71,7 @@ public class JoinCourseAction extends Action {
         Instructor instructor;
 
         try {
-            instructor = logic.joinCourseForInstructor(regkey, userInfo.id);
+            instructor = logic.joinCourseForInstructor(regkey, authContext.id);
         } catch (EntityDoesNotExistException ednee) {
             throw new EntityNotFoundException(ednee);
         } catch (EntityAlreadyExistsException eaee) {
@@ -90,7 +90,7 @@ public class JoinCourseAction extends Action {
     private void sendJoinEmail(String courseId, String userName, String userEmail, boolean isInstructor) {
         Course course = logic.getCourse(courseId);
         EmailWrapper email = emailGenerator.generateUserCourseRegisteredEmail(
-                userName, userEmail, userInfo.id, isInstructor, course);
+                userName, userEmail, authContext.id, isInstructor, course);
         emailSender.sendEmail(email);
     }
 }

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -35,7 +35,7 @@ public class MarkNotificationAsReadAction extends Action {
                 getAndValidateRequestBody(MarkNotificationAsReadRequest.class);
         UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
 
-        Account account = logic.getAccountForGoogleId(authContext.getId());
+        Account account = logic.getAccountForGoogleId(authContext.id());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -35,7 +35,7 @@ public class MarkNotificationAsReadAction extends Action {
                 getAndValidateRequestBody(MarkNotificationAsReadRequest.class);
         UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
 
-        Account account = logic.getAccountForGoogleId(userInfo.getId());
+        Account account = logic.getAccountForGoogleId(authContext.getId());
         if (account == null) {
             // This should not happen as the user is authenticated
             return new JsonResult("Account not found", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class PublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class PublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -36,7 +36,7 @@ public class RemindFeedbackSessionResultAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
@@ -61,7 +61,7 @@ public class RemindFeedbackSessionResultAction extends Action {
         // Generate reminder emails for specified users
         List<Student> studentsToRemindList = new ArrayList<>();
         List<Instructor> instructorsToRemindList = new ArrayList<>();
-        Instructor instructorToNotify = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructorToNotify = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
 
         for (UUID userId : usersToRemind) {
             User user = logic.getUser(userId);

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -36,7 +36,7 @@ public class RemindFeedbackSessionResultAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
@@ -61,7 +61,7 @@ public class RemindFeedbackSessionResultAction extends Action {
         // Generate reminder emails for specified users
         List<Student> studentsToRemindList = new ArrayList<>();
         List<Instructor> instructorsToRemindList = new ArrayList<>();
-        Instructor instructorToNotify = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructorToNotify = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
 
         for (UUID userId : usersToRemind) {
             User user = logic.getUser(userId);

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -36,7 +36,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(
                 instructor,
                 feedbackSession,
@@ -66,7 +66,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         List<Student> studentsToRemindList = new ArrayList<>();
         List<Instructor> instructorsToRemindList = new ArrayList<>();
         Instructor instructorToNotify = isSendingCopyToInstructor
-                ? logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId())
+                ? logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id())
                 : null;
 
         for (UUID userId : usersToRemind) {

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -36,7 +36,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         gateKeeper.verifyAccessible(
                 instructor,
                 feedbackSession,
@@ -66,7 +66,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         List<Student> studentsToRemindList = new ArrayList<>();
         List<Instructor> instructorsToRemindList = new ArrayList<>();
         Instructor instructorToNotify = isSendingCopyToInstructor
-                ? logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId())
+                ? logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId())
                 : null;
 
         for (UUID userId : usersToRemind) {

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -18,13 +18,13 @@ public class RestoreCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToRestore);
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToRestore, authContext.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToRestore, authContext.id()),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -18,13 +18,13 @@ public class RestoreCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToRestore);
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToRestore, userInfo.id),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(idOfCourseToRestore, authContext.id),
                 course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -31,7 +31,7 @@ public class RestoreFeedbackSessionAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
@@ -49,7 +49,7 @@ public class RestoreFeedbackSessionAction extends Action {
 
         FeedbackSessionData output = new FeedbackSessionData(feedbackSession);
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
         InstructorPermissionSet privilege = constructInstructorPrivileges(instructor, feedbackSession.getName());
         output.setPrivileges(privilege);
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -31,7 +31,7 @@ public class RestoreFeedbackSessionAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
@@ -49,7 +49,7 @@ public class RestoreFeedbackSessionAction extends Action {
 
         FeedbackSessionData output = new FeedbackSessionData(feedbackSession);
 
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
         InstructorPermissionSet privilege = constructInstructorPrivileges(instructor, feedbackSession.getName());
         output.setPrivileges(privilege);
 

--- a/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
@@ -24,7 +24,7 @@ public class SearchStudentsAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         // Only instructors and admins can search for student
-        if (!authContext.isInstructor && !authContext.isAdmin) {
+        if (!authContext.isInstructor() && !authContext.isAdmin()) {
             throw new UnauthorizedAccessException("Instructor or Admin privilege is required to access this resource.");
         }
     }
@@ -36,10 +36,10 @@ public class SearchStudentsAction extends Action {
 
         List<Student> students;
 
-        if (authContext.isInstructor && Const.EntityType.INSTRUCTOR.equals(entity)) {
-            List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id);
+        if (authContext.isInstructor() && Const.EntityType.INSTRUCTOR.equals(entity)) {
+            List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id());
             students = logic.searchStudents(searchKey, instructors);
-        } else if (authContext.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
+        } else if (authContext.isAdmin() && Const.EntityType.ADMIN.equals(entity)) {
             students = logic.searchStudentsInWholeSystem(searchKey);
         } else {
             throw new InvalidHttpParameterException("Invalid entity type for search");
@@ -49,7 +49,7 @@ public class SearchStudentsAction extends Action {
         for (Student s : students) {
             StudentData studentData = new StudentData(s);
 
-            if (authContext.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
+            if (authContext.isAdmin() && Const.EntityType.ADMIN.equals(entity)) {
                 studentData.addAdditionalInformationForAdminSearch(
                         s.getRegKey(),
                         s.getGoogleId()

--- a/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
@@ -24,7 +24,7 @@ public class SearchStudentsAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         // Only instructors and admins can search for student
-        if (!userInfo.isInstructor && !userInfo.isAdmin) {
+        if (!authContext.isInstructor && !authContext.isAdmin) {
             throw new UnauthorizedAccessException("Instructor or Admin privilege is required to access this resource.");
         }
     }
@@ -36,10 +36,10 @@ public class SearchStudentsAction extends Action {
 
         List<Student> students;
 
-        if (userInfo.isInstructor && Const.EntityType.INSTRUCTOR.equals(entity)) {
-            List<Instructor> instructors = logic.getInstructorsForGoogleId(userInfo.id);
+        if (authContext.isInstructor && Const.EntityType.INSTRUCTOR.equals(entity)) {
+            List<Instructor> instructors = logic.getInstructorsForGoogleId(authContext.id);
             students = logic.searchStudents(searchKey, instructors);
-        } else if (userInfo.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
+        } else if (authContext.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
             students = logic.searchStudentsInWholeSystem(searchKey);
         } else {
             throw new InvalidHttpParameterException("Invalid entity type for search");
@@ -49,7 +49,7 @@ public class SearchStudentsAction extends Action {
         for (Student s : students) {
             StudentData studentData = new StudentData(s);
 
-            if (userInfo.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
+            if (authContext.isAdmin && Const.EntityType.ADMIN.equals(entity)) {
                 studentData.addAdditionalInformationForAdminSearch(
                         s.getRegKey(),
                         s.getGoogleId()

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -24,7 +24,7 @@ public class SendErrorReportAction extends PublicAction {
      * Gets the user error report that will be sent to the system admin.
      */
     public String getUserErrorReportLogMessage(ErrorReportRequest report) {
-        String user = authContext == null ? "Non-logged in user" : authContext.id;
+        String user = authContext == null ? "Non-logged in user" : authContext.id();
         return "====== USER FEEDBACK ABOUT ERROR ======" + System.lineSeparator()
                 + "USER: " + user + System.lineSeparator()
                 + "REQUEST ID: " + report.getRequestId() + System.lineSeparator()

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -24,7 +24,7 @@ public class SendErrorReportAction extends PublicAction {
      * Gets the user error report that will be sent to the system admin.
      */
     public String getUserErrorReportLogMessage(ErrorReportRequest report) {
-        String user = userInfo == null ? "Non-logged in user" : userInfo.id;
+        String user = authContext == null ? "Non-logged in user" : authContext.id;
         return "====== USER FEEDBACK ABOUT ERROR ======" + System.lineSeparator()
                 + "USER: " + user + System.lineSeparator()
                 + "REQUEST ID: " + report.getRequestId() + System.lineSeparator()

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -32,7 +32,7 @@ public class SendJoinReminderEmailAction extends Action {
 
         String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
         String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
 
         boolean isSendingToStudent = studentEmail != null;
         boolean isSendingToInstructor = instructorEmail != null;
@@ -80,7 +80,7 @@ public class SendJoinReminderEmailAction extends Action {
                 throw new EntityNotFoundException(
                         "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
             }
-            Account inviter = logic.getAccountForGoogleId(authContext.id);
+            Account inviter = logic.getAccountForGoogleId(authContext.id());
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter account does not exist.");
             }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -32,7 +32,7 @@ public class SendJoinReminderEmailAction extends Action {
 
         String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
         String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
 
         boolean isSendingToStudent = studentEmail != null;
         boolean isSendingToInstructor = instructorEmail != null;
@@ -80,7 +80,7 @@ public class SendJoinReminderEmailAction extends Action {
                 throw new EntityNotFoundException(
                         "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
             }
-            Account inviter = logic.getAccountForGoogleId(userInfo.id);
+            Account inviter = logic.getAccountForGoogleId(authContext.id);
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter account does not exist.");
             }

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class UnpublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class UnpublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id());
 
         gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -24,13 +24,13 @@ public class UpdateCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(courseId);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
 
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -24,13 +24,13 @@ public class UpdateCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(courseId);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
 
         gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -36,7 +36,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -36,7 +36,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -31,7 +31,7 @@ public class UpdateFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(feedbackQuestion.getCourseId(), authContext.getId()),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(feedbackQuestion.getCourseId(), authContext.id()),
                 getNonNullFeedbackSession(feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId()),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -31,7 +31,7 @@ public class UpdateFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(feedbackQuestion.getCourseId(), userInfo.getId()),
+        gateKeeper.verifyAccessible(logic.getInstructorByGoogleId(feedbackQuestion.getCourseId(), authContext.getId()),
                 getNonNullFeedbackSession(feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId()),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -85,7 +85,7 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             break;
         case INSTRUCTOR_RESULT:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
@@ -134,7 +134,7 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             updater = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructorAsFeedbackParticipant.getId());
             break;
         case INSTRUCTOR_RESULT:
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
             updater = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructor.getId());
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackResponseCommentAction.java
@@ -84,8 +84,8 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
                     new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructorAsFeedbackParticipant.getId()));
             break;
         case INSTRUCTOR_RESULT:
-            gateKeeper.verifyLoggedInUserPrivileges(userInfo);
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
@@ -134,7 +134,7 @@ public class UpdateFeedbackResponseCommentAction extends BasicCommentSubmissionA
             updater = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructorAsFeedbackParticipant.getId());
             break;
         case INSTRUCTOR_RESULT:
-            Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.id);
+            Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id);
             updater = new ResponseGiver(ResponseGiverType.INSTRUCTOR, instructor.getId());
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class UpdateFeedbackSessionAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), userInfo.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class UpdateFeedbackSessionAction extends Action {
         }
 
         gateKeeper.verifyAccessible(
-                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.getId()),
+                logic.getInstructorByGoogleId(feedbackSession.getCourseId(), authContext.id()),
                 feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -24,13 +24,13 @@ public class UpdateInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -24,13 +24,13 @@ public class UpdateInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -24,7 +24,7 @@ public class UpdateInstructorPrivilegeAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -24,7 +24,7 @@ public class UpdateInstructorPrivilegeAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, userInfo.getId());
+        Instructor instructor = logic.getInstructorByGoogleId(courseId, authContext.getId());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -50,7 +50,7 @@ public class UpdateStudentAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!userInfo.isInstructor) {
+        if (!authContext.isInstructor) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         UUID studentId = getUuidRequestParamValue(Const.ParamsNames.STUDENT_SQL_ID);
@@ -59,7 +59,7 @@ public class UpdateStudentAction extends Action {
             throw new EntityNotFoundException(STUDENT_NOT_FOUND_FOR_EDIT);
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(existingStudent.getCourseId(), userInfo.id);
+        Instructor instructor = logic.getInstructorByGoogleId(existingStudent.getCourseId(), authContext.id);
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(existingStudent.getCourseId()), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -50,7 +50,7 @@ public class UpdateStudentAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isInstructor) {
+        if (!authContext.isInstructor()) {
             throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
         }
         UUID studentId = getUuidRequestParamValue(Const.ParamsNames.STUDENT_SQL_ID);
@@ -59,7 +59,7 @@ public class UpdateStudentAction extends Action {
             throw new EntityNotFoundException(STUDENT_NOT_FOUND_FOR_EDIT);
         }
 
-        Instructor instructor = logic.getInstructorByGoogleId(existingStudent.getCourseId(), authContext.id);
+        Instructor instructor = logic.getInstructorByGoogleId(existingStudent.getCourseId(), authContext.id());
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(existingStudent.getCourseId()), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -33,62 +33,61 @@ public class MockUserProvision extends UserProvision {
     }
 
     /**
-     * Adds a logged-in user without admin rights.
+     * Login as a user without admin rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginUser(String userId) {
         return loginUser(userId, false, false, false, false);
     }
 
     /**
-     * Adds a logged-in user as an admin.
+     * Login as a user with admin rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginAsAdmin(String userId) {
         return loginUser(userId, true, false, false, false);
     }
 
     /**
-     * Adds a logged-in user as an instructor.
+     * Login as a user with instructor rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginAsInstructor(String userId) {
         return loginUser(userId, false, true, false, false);
     }
 
     /**
-     * Adds a logged-in user as a student.
+     * Login as a user with student rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginAsStudent(String userId) {
         return loginUser(userId, false, false, true, false);
     }
 
     /**
-     * Adds a logged-in user as a student instructor.
+     * Login as a user with student and instructor rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginAsStudentInstructor(String userId) {
         return loginUser(userId, false, true, true, false);
     }
 
     /**
-     * Adds a logged-in user as a maintainer.
+     * Login as a user with maintainer rights.
      *
-     * @return The user info after login process
+     * @return The auth context after login process
      */
     public AuthContext loginAsMaintainer(String userId) {
         return loginUser(userId, false, false, false, true);
     }
 
     /**
-     * Models a verified cron/worker principal ({@link AuthType#AUTOMATED_SERVICE}), not a human app admin.
-     * Does not log in a user; sets a flag that {@code BaseActionTest} uses to override {@code action.authType}.
+     * Logs in as an automated service (cron/worker).
      */
     public void loginAsAutomatedService() {
         isAutomatedServiceMode = true;

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -13,7 +13,9 @@ import teammates.common.datatransfer.UserInfoCookie;
  */
 public class MockUserProvision extends UserProvision {
     private static final UUID MOCK_ACCOUNT_ID = UUID.randomUUID();
-    private AuthContext mockUser = new AuthContext("user.id", MOCK_ACCOUNT_ID);
+    private AuthContext mockUser = new AuthContext(
+            "user.id", MOCK_ACCOUNT_ID, false, false, false, false
+    );
     private boolean isLoggedIn;
     private boolean isAutomatedServiceMode;
     private boolean isMaintainer;

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -24,11 +24,7 @@ public class MockUserProvision extends UserProvision {
     private AuthContext loginUser(String userId, boolean isAdmin, boolean isInstructor, boolean isStudent,
             boolean isMaintainer) {
         isLoggedIn = true;
-        mockUser.id = userId;
-        mockUser.isAdmin = isAdmin;
-        mockUser.isInstructor = isInstructor;
-        mockUser.isStudent = isStudent;
-        mockUser.isMaintainer = isMaintainer;
+        mockUser = new AuthContext(userId, MOCK_ACCOUNT_ID, isAdmin, isInstructor, isStudent, isMaintainer);
         return mockUser;
     }
 
@@ -117,13 +113,7 @@ public class MockUserProvision extends UserProvision {
 
     @Override
     public AuthContext getMasqueradeUserContext(String googleId) {
-        AuthContext userInfo = new AuthContext(googleId, MOCK_ACCOUNT_ID);
-        userInfo.isAdmin = isAdmin;
-        userInfo.isInstructor = isInstructor;
-        userInfo.isStudent = isStudent;
-        userInfo.isMaintainer = isMaintainer;
-
-        return userInfo;
+        return new AuthContext(googleId, MOCK_ACCOUNT_ID, isAdmin, isInstructor, isStudent, isMaintainer);
     }
 
     public void setAdmin(boolean isAdmin) {

--- a/src/test/java/teammates/logic/api/MockUserProvision.java
+++ b/src/test/java/teammates/logic/api/MockUserProvision.java
@@ -2,7 +2,7 @@ package teammates.logic.api;
 
 import java.util.UUID;
 
-import teammates.common.datatransfer.UserInfo;
+import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.UserInfoCookie;
 
 /**
@@ -13,7 +13,7 @@ import teammates.common.datatransfer.UserInfoCookie;
  */
 public class MockUserProvision extends UserProvision {
     private static final UUID MOCK_ACCOUNT_ID = UUID.randomUUID();
-    private UserInfo mockUser = new UserInfo("user.id", MOCK_ACCOUNT_ID);
+    private AuthContext mockUser = new AuthContext("user.id", MOCK_ACCOUNT_ID);
     private boolean isLoggedIn;
     private boolean isAutomatedServiceMode;
     private boolean isMaintainer;
@@ -21,7 +21,7 @@ public class MockUserProvision extends UserProvision {
     private boolean isInstructor;
     private boolean isStudent;
 
-    private UserInfo loginUser(String userId, boolean isAdmin, boolean isInstructor, boolean isStudent,
+    private AuthContext loginUser(String userId, boolean isAdmin, boolean isInstructor, boolean isStudent,
             boolean isMaintainer) {
         isLoggedIn = true;
         mockUser.id = userId;
@@ -37,7 +37,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginUser(String userId) {
+    public AuthContext loginUser(String userId) {
         return loginUser(userId, false, false, false, false);
     }
 
@@ -46,7 +46,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginAsAdmin(String userId) {
+    public AuthContext loginAsAdmin(String userId) {
         return loginUser(userId, true, false, false, false);
     }
 
@@ -55,7 +55,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginAsInstructor(String userId) {
+    public AuthContext loginAsInstructor(String userId) {
         return loginUser(userId, false, true, false, false);
     }
 
@@ -64,7 +64,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginAsStudent(String userId) {
+    public AuthContext loginAsStudent(String userId) {
         return loginUser(userId, false, false, true, false);
     }
 
@@ -73,7 +73,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginAsStudentInstructor(String userId) {
+    public AuthContext loginAsStudentInstructor(String userId) {
         return loginUser(userId, false, true, true, false);
     }
 
@@ -82,7 +82,7 @@ public class MockUserProvision extends UserProvision {
      *
      * @return The user info after login process
      */
-    public UserInfo loginAsMaintainer(String userId) {
+    public AuthContext loginAsMaintainer(String userId) {
         return loginUser(userId, false, false, false, true);
     }
 
@@ -107,18 +107,18 @@ public class MockUserProvision extends UserProvision {
     }
 
     @Override
-    public UserInfo getCurrentUser(UserInfoCookie uic) {
-        return getCurrentLoggedInUser(uic);
+    public AuthContext getCurrentUserContext(UserInfoCookie uic) {
+        return getCurrentLoggedInUserContext(uic);
     }
 
     @Override
-    public UserInfo getCurrentLoggedInUser(UserInfoCookie uic) {
+    public AuthContext getCurrentLoggedInUserContext(UserInfoCookie uic) {
         return isLoggedIn ? mockUser : null;
     }
 
     @Override
-    public UserInfo getMasqueradeUser(String googleId) {
-        UserInfo userInfo = new UserInfo(googleId, MOCK_ACCOUNT_ID);
+    public AuthContext getMasqueradeUserContext(String googleId) {
+        AuthContext userInfo = new AuthContext(googleId, MOCK_ACCOUNT_ID);
         userInfo.isAdmin = isAdmin;
         userInfo.isInstructor = isInstructor;
         userInfo.isStudent = isStudent;

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -289,13 +289,13 @@ public class UserProvisionTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetAdminOnlyUser_returnsUserInfoWithOnlyIsAdminTrue() {
+    public void testGetAdminOnlyUser_returnsAuthContextWithAllRolesTrue() {
         String userId = "admin-user-id";
 
         AuthContext authContext = userProvision.getAdminOnlyUserContext(userId);
 
         assertEquals(userId, authContext.id());
-        assertHasRoles(authContext, Role.ADMIN);
+        assertHasRoles(authContext, Role.ADMIN, Role.INSTRUCTOR, Role.STUDENT);
         verifyNoInteractions(mockUsersLogic);
     }
 

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -295,7 +295,7 @@ public class UserProvisionTest extends BaseTestCase {
         AuthContext authContext = userProvision.getAdminOnlyUserContext(userId);
 
         assertEquals(userId, authContext.id());
-        assertHasRoles(authContext, Role.ADMIN, Role.INSTRUCTOR, Role.STUDENT);
+        assertHasRoles(authContext, Role.ADMIN, Role.MAINTAINER, Role.INSTRUCTOR, Role.STUDENT);
         verifyNoInteractions(mockUsersLogic);
     }
 

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.UserInfo;
+import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.UserInfoCookie;
 import teammates.common.util.Config;
 import teammates.logic.core.AccountsLogic;
@@ -76,12 +76,12 @@ public class UserProvisionTest extends BaseTestCase {
 
     @Test
     public void testGetCurrentUser_nullUic_returnsNull() {
-        assertNull(userProvision.getCurrentUser(null));
+        assertNull(userProvision.getCurrentUserContext(null));
     }
 
     @Test
     public void testGetCurrentUser_invalidCookie_returnsNull() {
-        assertNull(userProvision.getCurrentUser(createMockInvalidCookie()));
+        assertNull(userProvision.getCurrentUserContext(createMockInvalidCookie()));
     }
 
     @Test
@@ -89,10 +89,10 @@ public class UserProvisionTest extends BaseTestCase {
         String userId = "instructor-user-id";
         when(mockUsersLogic.isInstructorInAnyCourse(userId)).thenReturn(true);
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR);
     }
 
     @Test
@@ -100,10 +100,10 @@ public class UserProvisionTest extends BaseTestCase {
         String userId = "student-user-id";
         when(mockUsersLogic.isStudentInAnyCourse(userId)).thenReturn(true);
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.STUDENT);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.STUDENT);
     }
 
     @Test
@@ -111,10 +111,10 @@ public class UserProvisionTest extends BaseTestCase {
         String adminUserId = "admin-user-id";
         mockConfigStatic.when(Config::getAppAdmins).thenReturn(List.of(adminUserId));
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(adminUserId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(adminUserId));
 
-        assertEquals(adminUserId, user.id);
-        assertHasRoles(user, Role.ADMIN);
+        assertEquals(adminUserId, authContext.id);
+        assertHasRoles(authContext, Role.ADMIN);
     }
 
     @Test
@@ -122,20 +122,20 @@ public class UserProvisionTest extends BaseTestCase {
         String maintainerUserId = "maintainer-user-id";
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(maintainerUserId));
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(maintainerUserId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(maintainerUserId));
 
-        assertEquals(maintainerUserId, user.id);
-        assertHasRoles(user, Role.MAINTAINER);
+        assertEquals(maintainerUserId, authContext.id);
+        assertHasRoles(authContext, Role.MAINTAINER);
     }
 
     @Test
     public void testGetCurrentUser_unregistered_returnsUserInfoWithNoRoles() {
         String userId = "unregistered-user-id";
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasNoRoles(user);
+        assertEquals(userId, authContext.id);
+        assertHasNoRoles(authContext);
     }
 
     @Test
@@ -144,10 +144,10 @@ public class UserProvisionTest extends BaseTestCase {
         when(mockUsersLogic.isInstructorInAnyCourse(userId)).thenReturn(true);
         when(mockUsersLogic.isStudentInAnyCourse(userId)).thenReturn(true);
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR, Role.STUDENT);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT);
     }
 
     @Test
@@ -156,10 +156,10 @@ public class UserProvisionTest extends BaseTestCase {
         mockConfigStatic.when(Config::getAppAdmins).thenReturn(List.of(userId));
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(userId));
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.ADMIN, Role.MAINTAINER);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.ADMIN, Role.MAINTAINER);
     }
 
     @Test
@@ -169,10 +169,10 @@ public class UserProvisionTest extends BaseTestCase {
         when(mockUsersLogic.isStudentInAnyCourse(userId)).thenReturn(true);
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(userId));
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
     @Test
@@ -183,30 +183,30 @@ public class UserProvisionTest extends BaseTestCase {
         mockConfigStatic.when(Config::getAppAdmins).thenReturn(List.of(userId));
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(userId));
 
-        UserInfo user = userProvision.getCurrentUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.ADMIN, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.ADMIN, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
     @Test
     public void testGetCurrentLoggedInUser_nullUic_returnsNull() {
-        assertNull(userProvision.getCurrentLoggedInUser(null));
+        assertNull(userProvision.getCurrentLoggedInUserContext(null));
     }
 
     @Test
     public void testGetCurrentLoggedInUser_invalidCookie_returnsNull() {
-        assertNull(userProvision.getCurrentLoggedInUser(createMockInvalidCookie()));
+        assertNull(userProvision.getCurrentLoggedInUserContext(createMockInvalidCookie()));
     }
 
     @Test
     public void testGetCurrentLoggedInUser_validCookie_returnsUserInfoWithCorrectIdAndNoRoles() {
         String userId = "valid-user-id";
 
-        UserInfo user = userProvision.getCurrentLoggedInUser(createMockValidCookie(userId));
+        AuthContext authContext = userProvision.getCurrentLoggedInUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, user.id);
-        assertHasNoRoles(user);
+        assertEquals(userId, authContext.id);
+        assertHasNoRoles(authContext);
     }
 
     @Test
@@ -214,10 +214,10 @@ public class UserProvisionTest extends BaseTestCase {
         String googleId = "typical-instructor";
         when(mockUsersLogic.isInstructorInAnyCourse(googleId)).thenReturn(true);
 
-        UserInfo user = userProvision.getMasqueradeUser(googleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR);
+        assertEquals(googleId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR);
     }
 
     @Test
@@ -225,10 +225,10 @@ public class UserProvisionTest extends BaseTestCase {
         String googleId = "student-user-id";
         when(mockUsersLogic.isStudentInAnyCourse(googleId)).thenReturn(true);
 
-        UserInfo user = userProvision.getMasqueradeUser(googleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, user.id);
-        assertHasRoles(user, Role.STUDENT);
+        assertEquals(googleId, authContext.id);
+        assertHasRoles(authContext, Role.STUDENT);
     }
 
     @Test
@@ -236,10 +236,10 @@ public class UserProvisionTest extends BaseTestCase {
         String maintainerGoogleId = "maintainer-user-id";
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(maintainerGoogleId));
 
-        UserInfo user = userProvision.getMasqueradeUser(maintainerGoogleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(maintainerGoogleId);
 
-        assertEquals(maintainerGoogleId, user.id);
-        assertHasRoles(user, Role.MAINTAINER);
+        assertEquals(maintainerGoogleId, authContext.id);
+        assertHasRoles(authContext, Role.MAINTAINER);
     }
 
     @Test
@@ -247,20 +247,20 @@ public class UserProvisionTest extends BaseTestCase {
         String adminGoogleId = "admin-user-id";
         mockConfigStatic.when(Config::getAppAdmins).thenReturn(List.of(adminGoogleId));
 
-        UserInfo user = userProvision.getMasqueradeUser(adminGoogleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(adminGoogleId);
 
-        assertEquals(adminGoogleId, user.id);
-        assertHasNoRoles(user);
+        assertEquals(adminGoogleId, authContext.id);
+        assertHasNoRoles(authContext);
     }
 
     @Test
     public void testGetMasqueradeUser_unregistered_returnsUserInfoWithNoRoles() {
         String googleId = "unregistered-user-id";
 
-        UserInfo user = userProvision.getMasqueradeUser(googleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, user.id);
-        assertHasNoRoles(user);
+        assertEquals(googleId, authContext.id);
+        assertHasNoRoles(authContext);
     }
 
     @Test
@@ -269,10 +269,10 @@ public class UserProvisionTest extends BaseTestCase {
         when(mockUsersLogic.isInstructorInAnyCourse(googleId)).thenReturn(true);
         when(mockUsersLogic.isStudentInAnyCourse(googleId)).thenReturn(true);
 
-        UserInfo user = userProvision.getMasqueradeUser(googleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR, Role.STUDENT);
+        assertEquals(googleId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT);
     }
 
     @Test
@@ -282,20 +282,20 @@ public class UserProvisionTest extends BaseTestCase {
         when(mockUsersLogic.isStudentInAnyCourse(googleId)).thenReturn(true);
         mockConfigStatic.when(Config::getAppMaintainers).thenReturn(List.of(googleId));
 
-        UserInfo user = userProvision.getMasqueradeUser(googleId);
+        AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, user.id);
-        assertHasRoles(user, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
+        assertEquals(googleId, authContext.id);
+        assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
     @Test
     public void testGetAdminOnlyUser_returnsUserInfoWithOnlyIsAdminTrue() {
         String userId = "admin-user-id";
 
-        UserInfo user = userProvision.getAdminOnlyUser(userId);
+        AuthContext authContext = userProvision.getAdminOnlyUserContext(userId);
 
-        assertEquals(userId, user.id);
-        assertHasRoles(user, Role.ADMIN);
+        assertEquals(userId, authContext.id);
+        assertHasRoles(authContext, Role.ADMIN);
         verifyNoInteractions(mockUsersLogic);
     }
 
@@ -312,18 +312,16 @@ public class UserProvisionTest extends BaseTestCase {
         return cookie;
     }
 
-    private static void assertHasNoRoles(UserInfo user) {
-        // This method just calls assertHasRoles with an empty array to improve readability
-        assertHasRoles(user);
-
+    private static void assertHasNoRoles(AuthContext authContext) {
+        assertHasRoles(authContext);
     }
 
-    private static void assertHasRoles(UserInfo user, Role... expectedRoles) {
+    private static void assertHasRoles(AuthContext authContext, Role... expectedRoles) {
         Set<Role> expected = Set.of(expectedRoles);
-        assertEquals(expected.contains(Role.ADMIN), user.isAdmin);
-        assertEquals(expected.contains(Role.INSTRUCTOR), user.isInstructor);
-        assertEquals(expected.contains(Role.STUDENT), user.isStudent);
-        assertEquals(expected.contains(Role.MAINTAINER), user.isMaintainer);
+        assertEquals(expected.contains(Role.ADMIN), authContext.isAdmin);
+        assertEquals(expected.contains(Role.INSTRUCTOR), authContext.isInstructor);
+        assertEquals(expected.contains(Role.STUDENT), authContext.isStudent);
+        assertEquals(expected.contains(Role.MAINTAINER), authContext.isMaintainer);
     }
 
     private enum Role {

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -91,7 +91,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR);
     }
 
@@ -102,7 +102,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.STUDENT);
     }
 
@@ -113,7 +113,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(adminUserId));
 
-        assertEquals(adminUserId, authContext.id);
+        assertEquals(adminUserId, authContext.id());
         assertHasRoles(authContext, Role.ADMIN);
     }
 
@@ -124,7 +124,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(maintainerUserId));
 
-        assertEquals(maintainerUserId, authContext.id);
+        assertEquals(maintainerUserId, authContext.id());
         assertHasRoles(authContext, Role.MAINTAINER);
     }
 
@@ -134,7 +134,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasNoRoles(authContext);
     }
 
@@ -146,7 +146,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT);
     }
 
@@ -158,7 +158,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.ADMIN, Role.MAINTAINER);
     }
 
@@ -171,7 +171,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
@@ -185,7 +185,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.ADMIN, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
@@ -205,7 +205,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getCurrentLoggedInUserContext(createMockValidCookie(userId));
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasNoRoles(authContext);
     }
 
@@ -216,7 +216,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, authContext.id);
+        assertEquals(googleId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR);
     }
 
@@ -227,7 +227,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, authContext.id);
+        assertEquals(googleId, authContext.id());
         assertHasRoles(authContext, Role.STUDENT);
     }
 
@@ -238,7 +238,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(maintainerGoogleId);
 
-        assertEquals(maintainerGoogleId, authContext.id);
+        assertEquals(maintainerGoogleId, authContext.id());
         assertHasRoles(authContext, Role.MAINTAINER);
     }
 
@@ -249,7 +249,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(adminGoogleId);
 
-        assertEquals(adminGoogleId, authContext.id);
+        assertEquals(adminGoogleId, authContext.id());
         assertHasNoRoles(authContext);
     }
 
@@ -259,7 +259,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, authContext.id);
+        assertEquals(googleId, authContext.id());
         assertHasNoRoles(authContext);
     }
 
@@ -271,7 +271,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, authContext.id);
+        assertEquals(googleId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT);
     }
 
@@ -284,7 +284,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getMasqueradeUserContext(googleId);
 
-        assertEquals(googleId, authContext.id);
+        assertEquals(googleId, authContext.id());
         assertHasRoles(authContext, Role.INSTRUCTOR, Role.STUDENT, Role.MAINTAINER);
     }
 
@@ -294,7 +294,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         AuthContext authContext = userProvision.getAdminOnlyUserContext(userId);
 
-        assertEquals(userId, authContext.id);
+        assertEquals(userId, authContext.id());
         assertHasRoles(authContext, Role.ADMIN);
         verifyNoInteractions(mockUsersLogic);
     }
@@ -318,10 +318,10 @@ public class UserProvisionTest extends BaseTestCase {
 
     private static void assertHasRoles(AuthContext authContext, Role... expectedRoles) {
         Set<Role> expected = Set.of(expectedRoles);
-        assertEquals(expected.contains(Role.ADMIN), authContext.isAdmin);
-        assertEquals(expected.contains(Role.INSTRUCTOR), authContext.isInstructor);
-        assertEquals(expected.contains(Role.STUDENT), authContext.isStudent);
-        assertEquals(expected.contains(Role.MAINTAINER), authContext.isMaintainer);
+        assertEquals(expected.contains(Role.ADMIN), authContext.isAdmin());
+        assertEquals(expected.contains(Role.INSTRUCTOR), authContext.isInstructor());
+        assertEquals(expected.contains(Role.STUDENT), authContext.isStudent());
+        assertEquals(expected.contains(Role.MAINTAINER), authContext.isMaintainer());
     }
 
     private enum Role {

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -18,7 +18,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 
 import teammates.common.datatransfer.InstructorPrivileges;
-import teammates.common.datatransfer.UserInfo;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
@@ -114,7 +113,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             action.init(req);
             if (mockUserProvision.isAutomatedServiceMode()) {
                 action.authType = AuthType.AUTOMATED_SERVICE;
-                action.userInfo = null;
+                action.authContext = null;
             }
             return action;
         } catch (ActionMappingException e) {
@@ -147,8 +146,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      * Logs in the user to the test environment as an admin.
      */
     protected void loginAsAdmin() {
-        UserInfo user = mockUserProvision.loginAsAdmin(Config.APP_ADMINS.get(0));
-        assertTrue(user.isAdmin);
+        mockUserProvision.loginAsAdmin(Config.APP_ADMINS.get(0));
     }
 
     /**
@@ -156,10 +154,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      * (without any right).
      */
     protected void loginAsUnregistered(String userId) {
-        UserInfo user = mockUserProvision.loginUser(userId);
-        assertFalse(user.isStudent);
-        assertFalse(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginUser(userId);
     }
 
     /**
@@ -167,10 +162,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      * (without admin rights or student rights).
      */
     protected void loginAsInstructor(String userId) {
-        UserInfo user = mockUserProvision.loginAsInstructor(userId);
-        assertFalse(user.isStudent);
-        assertTrue(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsInstructor(userId);
     }
 
     /**
@@ -178,10 +170,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      * (without admin rights or instructor rights).
      */
     protected void loginAsStudent(String userId) {
-        UserInfo user = mockUserProvision.loginAsStudent(userId);
-        assertTrue(user.isStudent);
-        assertFalse(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsStudent(userId);
     }
 
     /**
@@ -189,18 +178,14 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      * (without admin rights).
      */
     protected void loginAsStudentInstructor(String userId) {
-        UserInfo user = mockUserProvision.loginAsStudentInstructor(userId);
-        assertTrue(user.isStudent);
-        assertTrue(user.isInstructor);
-        assertFalse(user.isAdmin);
+        mockUserProvision.loginAsStudentInstructor(userId);
     }
 
     /**
      * Logs in the user to the test environment as a maintainer.
      */
     protected void loginAsMaintainer() {
-        UserInfo user = mockUserProvision.loginAsMaintainer(Config.APP_MAINTAINERS.get(0));
-        assertTrue(user.isMaintainer);
+        mockUserProvision.loginAsMaintainer(Config.APP_MAINTAINERS.get(0));
     }
 
     /**
@@ -209,7 +194,6 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
      */
     protected void loginAsAutomatedService() {
         mockUserProvision.loginAsAutomatedService();
-        assertTrue(mockUserProvision.isAutomatedServiceMode());
     }
 
     /**


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13936

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Introduce AuthContext to decouple API UserInfo from authentication state. AuthContext will be updated in a future PR targeting the same issue to store context that is fit for purpose, it is a copy of UserInfo for now.

UserInfo is now only used as API output. AuthContext is is used when deriving authentication state within Actions. A new method, getUserInfo(AuthContext), was added to map auth context to UserInfo when required.