### PR TITLE
[#13678] Remove masquerade user param from getAuthUser

### DIFF
--- a/src/web/app/pages-admin/admin-page.component.ts
+++ b/src/web/app/pages-admin/admin-page.component.ts
@@ -59,7 +59,7 @@ export class AdminPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isFetchingAuthDetails = true;
-    this.authService.getAuthUser(undefined, '/web/admin/home').subscribe({
+    this.authService.getAuthUser('/web/admin/home').subscribe({
       next: (res: AuthInfo) => {
         if (res.user) {
           this.user = res.user.id;

--- a/src/web/app/pages-instructor/instructor-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { AuthService } from '../../services/auth.service';
 import { AuthInfo, NotificationTargetUser } from '../../types/api-output';
@@ -14,7 +13,6 @@ import { PageComponent } from '../page.component';
   imports: [PageComponent],
 })
 export class InstructorPageComponent implements OnInit {
-  private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
 
   user = '';
@@ -68,31 +66,30 @@ export class InstructorPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isFetchingAuthDetails = true;
-    this.route.queryParams.subscribe((queryParams: any) => {
-      this.authService.getAuthUser(queryParams.user, '/web/instructor/home').subscribe({
-        next: (res: AuthInfo) => {
-          if (res.user) {
-            this.user = res.user.id;
-            if (res.masquerade) {
-              this.user += ' (M)';
-            }
-            this.isInstructor = res.user.isInstructor;
-            this.isStudent = res.user.isStudent;
-            this.isAdmin = res.user.isAdmin;
-            this.isMaintainer = res.user.isMaintainer;
-          } else {
-            window.location.href = `${this.backendUrl}${res.loginUrl}`;
+
+    this.authService.getAuthUser('/web/instructor/home').subscribe({
+      next: (res: AuthInfo) => {
+        if (res.user) {
+          this.user = res.user.id;
+          if (res.masquerade) {
+            this.user += ' (M)';
           }
-          this.isFetchingAuthDetails = false;
-        },
-        error: () => {
-          this.isInstructor = false;
-          this.isStudent = false;
-          this.isAdmin = false;
-          this.isMaintainer = false;
-          this.isFetchingAuthDetails = false;
-        },
-      });
+          this.isInstructor = res.user.isInstructor;
+          this.isStudent = res.user.isStudent;
+          this.isAdmin = res.user.isAdmin;
+          this.isMaintainer = res.user.isMaintainer;
+        } else {
+          window.location.href = `${this.backendUrl}${res.loginUrl}`;
+        }
+        this.isFetchingAuthDetails = false;
+      },
+      error: () => {
+        this.isInstructor = false;
+        this.isStudent = false;
+        this.isAdmin = false;
+        this.isMaintainer = false;
+        this.isFetchingAuthDetails = false;
+      },
     });
   }
 }

--- a/src/web/app/pages-maintainer/maintainer-page.component.ts
+++ b/src/web/app/pages-maintainer/maintainer-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { AuthService } from '../../services/auth.service';
 import { AuthInfo } from '../../types/api-output';
@@ -14,7 +13,6 @@ import { PageComponent } from '../page.component';
   imports: [PageComponent],
 })
 export class MaintainerPageComponent implements OnInit {
-  private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
 
   user = '';
@@ -42,31 +40,29 @@ export class MaintainerPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isFetchingAuthDetails = true;
-    this.route.queryParams.subscribe((queryParams: any) => {
-      this.authService.getAuthUser(queryParams.user, '/web/maintainer/home').subscribe({
-        next: (res: AuthInfo) => {
-          if (res.user) {
-            this.user = res.user.id;
-            if (res.masquerade) {
-              this.user += ' (M)';
-            }
-            this.isInstructor = res.user.isInstructor;
-            this.isStudent = res.user.isStudent;
-            this.isAdmin = res.user.isAdmin;
-            this.isMaintainer = res.user.isMaintainer;
-          } else {
-            window.location.href = `${this.backendUrl}${res.loginUrl}`;
+    this.authService.getAuthUser('/web/maintainer/home').subscribe({
+      next: (res: AuthInfo) => {
+        if (res.user) {
+          this.user = res.user.id;
+          if (res.masquerade) {
+            this.user += ' (M)';
           }
-          this.isFetchingAuthDetails = false;
-        },
-        error: () => {
-          this.isInstructor = false;
-          this.isStudent = false;
-          this.isAdmin = false;
-          this.isMaintainer = false;
-          this.isFetchingAuthDetails = false;
-        },
-      });
+          this.isInstructor = res.user.isInstructor;
+          this.isStudent = res.user.isStudent;
+          this.isAdmin = res.user.isAdmin;
+          this.isMaintainer = res.user.isMaintainer;
+        } else {
+          window.location.href = `${this.backendUrl}${res.loginUrl}`;
+        }
+        this.isFetchingAuthDetails = false;
+      },
+      error: () => {
+        this.isInstructor = false;
+        this.isStudent = false;
+        this.isAdmin = false;
+        this.isMaintainer = false;
+        this.isFetchingAuthDetails = false;
+      },
     });
   }
 }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -136,7 +136,7 @@ export class SessionResultPageComponent implements OnInit {
         }
 
         const nextUrl = `${window.location.pathname}${window.location.search.replace(/&/g, '%26')}`;
-        this.authService.getAuthUser(undefined, nextUrl).subscribe({
+        this.authService.getAuthUser(nextUrl).subscribe({
           next: (auth: AuthInfo) => {
             const isPreview = !!(auth.user && this.previewAsPerson);
             if (auth.user) {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -197,7 +197,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         }
 
         const nextUrl = `${window.location.pathname}${window.location.search.replace(/&/g, '%26')}`;
-        this.authService.getAuthUser(undefined, nextUrl).subscribe({
+        this.authService.getAuthUser(nextUrl).subscribe({
           next: (auth: AuthInfo) => {
             const isPreviewOrModeration = !!(auth.user && (this.moderatedPerson || this.previewAsPerson));
             if (auth.user) {

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { AuthService } from '../../services/auth.service';
 import { AuthInfo, NotificationTargetUser } from '../../types/api-output';
@@ -14,7 +13,6 @@ import { PageComponent } from '../page.component';
   imports: [PageComponent],
 })
 export class StudentPageComponent implements OnInit {
-  private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
 
   user = '';
@@ -43,31 +41,30 @@ export class StudentPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isFetchingAuthDetails = true;
-    this.route.queryParams.subscribe((queryParams: any) => {
-      this.authService.getAuthUser(queryParams.user, '/web/student/home').subscribe({
-        next: (res: AuthInfo) => {
-          if (res.user) {
-            this.user = res.user.id;
-            if (res.masquerade) {
-              this.user += ' (M)';
-            }
-            this.isInstructor = res.user.isInstructor;
-            this.isStudent = res.user.isStudent;
-            this.isAdmin = res.user.isAdmin;
-            this.isMaintainer = res.user.isMaintainer;
-          } else {
-            window.location.href = `${this.backendUrl}${res.loginUrl}`;
+
+    this.authService.getAuthUser('/web/student/home').subscribe({
+      next: (res: AuthInfo) => {
+        if (res.user) {
+          this.user = res.user.id;
+          if (res.masquerade) {
+            this.user += ' (M)';
           }
-          this.isFetchingAuthDetails = false;
-        },
-        error: () => {
-          this.isInstructor = false;
-          this.isStudent = false;
-          this.isAdmin = false;
-          this.isMaintainer = false;
-          this.isFetchingAuthDetails = false;
-        },
-      });
+          this.isInstructor = res.user.isInstructor;
+          this.isStudent = res.user.isStudent;
+          this.isAdmin = res.user.isAdmin;
+          this.isMaintainer = res.user.isMaintainer;
+        } else {
+          window.location.href = `${this.backendUrl}${res.loginUrl}`;
+        }
+        this.isFetchingAuthDetails = false;
+      },
+      error: () => {
+        this.isInstructor = false;
+        this.isStudent = false;
+        this.isAdmin = false;
+        this.isMaintainer = false;
+        this.isFetchingAuthDetails = false;
+      },
     });
   }
 }

--- a/src/web/app/public-page.component.ts
+++ b/src/web/app/public-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { PageComponent } from './page.component';
 import { environment } from '../environments/environment';
 import { AuthService } from '../services/auth.service';
@@ -13,17 +12,15 @@ import { AuthService } from '../services/auth.service';
   imports: [PageComponent],
 })
 export class PublicPageComponent {
-  private route = inject(ActivatedRoute);
   private authService = inject(AuthService);
 
   constructor() {
     if (environment.maintenance) {
       return;
     }
-    this.route.queryParams.subscribe((queryParams: any) => {
-      this.authService.getAuthUser(queryParams.user).subscribe(() => {
-        // No need to do anything with result; this is necessary to get CSRF token
-      });
+
+    this.authService.getAuthUser().subscribe(() => {
+      // No need to do anything with result; this is necessary to get CSRF token
     });
   }
 }

--- a/src/web/app/user-join-page.component.ts
+++ b/src/web/app/user-join-page.component.ts
@@ -55,7 +55,7 @@ export class UserJoinPageComponent implements OnInit {
       }
 
       const nextUrl = `${window.location.pathname}${window.location.search.replace(/&/g, '%26')}`;
-      this.authService.getAuthUser(undefined, nextUrl).subscribe((auth: AuthInfo) => {
+      this.authService.getAuthUser(nextUrl).subscribe((auth: AuthInfo) => {
         if (!auth.user) {
           this.isLoading = false;
           window.location.href = `${this.backendUrl}${auth.loginUrl}`;

--- a/src/web/services/auth.service.ts
+++ b/src/web/services/auth.service.ts
@@ -20,11 +20,8 @@ export class AuthService {
   /**
    * Gets the user authentication information.
    */
-  getAuthUser(user?: string, nextUrl?: string): Observable<AuthInfo> {
+  getAuthUser(nextUrl?: string): Observable<AuthInfo> {
     const params: Record<string, string> = { frontendUrl: this.frontendUrl };
-    if (user) {
-      params['user'] = user;
-    }
     if (nextUrl) {
       params['nextUrl'] = nextUrl;
     }

--- a/src/web/services/http-request.service.ts
+++ b/src/web/services/http-request.service.ts
@@ -64,9 +64,10 @@ export class HttpRequestService {
       }
     }
 
-    if (this.masqueradeModeService.isInMasqueradingMode() && !params.keys().includes('user')) {
-      params = params.append('user', this.masqueradeModeService.getMasqueradeUser());
+    if (this.masqueradeModeService.isInMasqueradingMode()) {
+      params = params.set('user', this.masqueradeModeService.getMasqueradeUser());
     }
+
     return params;
   }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13678

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Instead of relying on user parameter, we now rely solely on existing http request service to inject the user http param when appropriate. In http request service, user param is now always set if present. Previously, it was only set if existing parameters did not contain the user param.

This is part of a series of PRs to rethink masquerade mode for the new multi identity provider system. With this change, the frontend business logic is no longer coupled to the concept of masquerade mode. `user` param is now injected in a consistent way throughout the application.

Note on future plans: For masquerade mode, we will clean this up further by adding an `effectiveAccountId` field to the user cookie. An administrator will be able to call an endpoint to get a session cookie to impersonate a user. This is a slightly cleaner and safer pattern that we will be looking to adopt in the future.