### PR TITLE
[#13721] Remove DB-level cascade deletes in favor of Hibernate-managed cascade deletes

### DIFF
--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -15,8 +15,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.FieldValidator;
@@ -41,7 +39,6 @@ public class Account extends BaseEntity {
     private String email;
 
     @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<ReadNotification> readNotifications = new HashSet<>();
 
     @OneToMany(mappedBy = "account")

--- a/src/main/java/teammates/storage/entity/DeadlineExtension.java
+++ b/src/main/java/teammates/storage/entity/DeadlineExtension.java
@@ -13,8 +13,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.FieldValidator;
@@ -32,7 +30,6 @@ public class DeadlineExtension extends BaseEntity {
     private UUID userId;
 
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -16,8 +16,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.participanttypes.ViewerType;
@@ -34,7 +32,6 @@ public class FeedbackResponseComment extends BaseEntity {
     private UUID id;
 
     @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "responseId")
     private FeedbackResponse feedbackResponse;
 

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -21,8 +21,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import org.apache.commons.lang.StringUtils;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.Const;
@@ -92,11 +90,9 @@ public class FeedbackSession extends BaseEntity {
     private boolean isPublishedEmailSent;
 
     @OneToMany(mappedBy = "feedbackSession", cascade = CascadeType.REMOVE)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<DeadlineExtension> deadlineExtensions = new HashSet<>();
 
     @OneToMany(mappedBy = "feedbackSession", cascade = CascadeType.REMOVE)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<FeedbackQuestion> feedbackQuestions = new HashSet<>();
 
     @UpdateTimestamp

--- a/src/main/java/teammates/storage/entity/FeedbackSessionLog.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSessionLog.java
@@ -15,9 +15,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 
 /**
@@ -31,7 +28,6 @@ public class FeedbackSessionLog extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "studentId", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Student student;
 
     @Column(nullable = false, insertable = false, updatable = false)
@@ -39,7 +35,6 @@ public class FeedbackSessionLog extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "sessionId", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private FeedbackSession feedbackSession;
 
     @Column(nullable = false, insertable = false, updatable = false)

--- a/src/main/java/teammates/storage/entity/Notification.java
+++ b/src/main/java/teammates/storage/entity/Notification.java
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.datatransfer.NotificationStyle;
@@ -62,7 +60,6 @@ public class Notification extends BaseEntity {
     private Instant updatedAt;
 
     @OneToMany(mappedBy = "notification", cascade = CascadeType.REMOVE)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<ReadNotification> readNotifications = new HashSet<>();
 
     /**

--- a/src/main/java/teammates/storage/entity/Section.java
+++ b/src/main/java/teammates/storage/entity/Section.java
@@ -17,8 +17,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import teammates.common.util.FieldValidator;
@@ -46,7 +44,6 @@ public class Section extends BaseEntity {
     private String name;
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<Team> teams = new HashSet<>();
 
     @UpdateTimestamp

--- a/src/main/resources/db/changelog/migrations/20260516-remove-on-delete-cascade.xml
+++ b/src/main/resources/db/changelog/migrations/20260516-remove-on-delete-cascade.xml
@@ -1,0 +1,111 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="samuelfangjw" id="20260516-remove-on-delete-cascade-1">
+        <dropForeignKeyConstraint baseTableName="feedback_session_logs" constraintName="FK1m0hpecbnst5vj578k2mfwuy0" />
+        <addForeignKeyConstraint baseTableName="feedback_session_logs" baseColumnNames="session_id"
+                referencedTableName="feedback_sessions" referencedColumnNames="id"
+                constraintName="FK1m0hpecbnst5vj578k2mfwuy0" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="deadline_extensions" constraintName="FK41wmupob1x2gfup53prgathfg" />
+        <addForeignKeyConstraint baseTableName="deadline_extensions" baseColumnNames="user_id"
+                referencedTableName="users" referencedColumnNames="id"
+                constraintName="FK41wmupob1x2gfup53prgathfg" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="feedback_questions" constraintName="FK8ca7x73sh6f29r26sk226t65i" />
+        <addForeignKeyConstraint baseTableName="feedback_questions" baseColumnNames="session_id"
+                referencedTableName="feedback_sessions" referencedColumnNames="id"
+                constraintName="FK8ca7x73sh6f29r26sk226t65i" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="teams" constraintName="FKd1h70v57s3ehpquw083fa1ov" />
+        <addForeignKeyConstraint baseTableName="teams" baseColumnNames="section_id"
+                referencedTableName="sections" referencedColumnNames="id"
+                constraintName="FKd1h70v57s3ehpquw083fa1ov" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="feedback_response_comments" constraintName="FKh13gpp71ocp554jo4rfpoddny" />
+        <addForeignKeyConstraint baseTableName="feedback_response_comments" baseColumnNames="response_id"
+                referencedTableName="feedback_responses" referencedColumnNames="id"
+                constraintName="FKh13gpp71ocp554jo4rfpoddny" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="read_notifications" constraintName="FKixesv135gg19mb3ggagnbt417" />
+        <addForeignKeyConstraint baseTableName="read_notifications" baseColumnNames="notification_id"
+                referencedTableName="notifications" referencedColumnNames="id"
+                constraintName="FKixesv135gg19mb3ggagnbt417" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="feedback_session_logs" constraintName="FKmalqsiq2978c53gcdrrqmmcho" />
+        <addForeignKeyConstraint baseTableName="feedback_session_logs" baseColumnNames="student_id"
+                referencedTableName="students" referencedColumnNames="id"
+                constraintName="FKmalqsiq2978c53gcdrrqmmcho" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="read_notifications" constraintName="FKn2705bbw66x0oqvijwr67evld" />
+        <addForeignKeyConstraint baseTableName="read_notifications" baseColumnNames="account_id"
+                referencedTableName="accounts" referencedColumnNames="id"
+                constraintName="FKn2705bbw66x0oqvijwr67evld" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="deadline_extensions" constraintName="FKr994i0bv5oxepfcrs93lg4efd" />
+        <addForeignKeyConstraint baseTableName="deadline_extensions" baseColumnNames="session_id"
+                referencedTableName="feedback_sessions" referencedColumnNames="id"
+                constraintName="FKr994i0bv5oxepfcrs93lg4efd" deferrable="false" initiallyDeferred="false" validate="true"/>
+
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="feedback_session_logs" constraintName="FK1m0hpecbnst5vj578k2mfwuy0" />
+            <addForeignKeyConstraint baseTableName="feedback_session_logs" baseColumnNames="session_id"
+                    referencedTableName="feedback_sessions" referencedColumnNames="id"
+                    constraintName="FK1m0hpecbnst5vj578k2mfwuy0" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="deadline_extensions" constraintName="FK41wmupob1x2gfup53prgathfg" />
+            <addForeignKeyConstraint baseTableName="deadline_extensions" baseColumnNames="user_id"
+                    referencedTableName="users" referencedColumnNames="id"
+                    constraintName="FK41wmupob1x2gfup53prgathfg" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="feedback_questions" constraintName="FK8ca7x73sh6f29r26sk226t65i" />
+            <addForeignKeyConstraint baseTableName="feedback_questions" baseColumnNames="session_id"
+                    referencedTableName="feedback_sessions" referencedColumnNames="id"
+                    constraintName="FK8ca7x73sh6f29r26sk226t65i" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="teams" constraintName="FKd1h70v57s3ehpquw083fa1ov" />
+            <addForeignKeyConstraint baseTableName="teams" baseColumnNames="section_id"
+                    referencedTableName="sections" referencedColumnNames="id"
+                    constraintName="FKd1h70v57s3ehpquw083fa1ov" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="feedback_response_comments" constraintName="FKh13gpp71ocp554jo4rfpoddny" />
+            <addForeignKeyConstraint baseTableName="feedback_response_comments" baseColumnNames="response_id"
+                    referencedTableName="feedback_responses" referencedColumnNames="id"
+                    constraintName="FKh13gpp71ocp554jo4rfpoddny" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="read_notifications" constraintName="FKixesv135gg19mb3ggagnbt417" />
+            <addForeignKeyConstraint baseTableName="read_notifications" baseColumnNames="notification_id"
+                    referencedTableName="notifications" referencedColumnNames="id"
+                    constraintName="FKixesv135gg19mb3ggagnbt417" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="feedback_session_logs" constraintName="FKmalqsiq2978c53gcdrrqmmcho" />
+            <addForeignKeyConstraint baseTableName="feedback_session_logs" baseColumnNames="student_id"
+                    referencedTableName="students" referencedColumnNames="id"
+                    constraintName="FKmalqsiq2978c53gcdrrqmmcho" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="read_notifications" constraintName="FKn2705bbw66x0oqvijwr67evld" />
+            <addForeignKeyConstraint baseTableName="read_notifications" baseColumnNames="account_id"
+                    referencedTableName="accounts" referencedColumnNames="id"
+                    constraintName="FKn2705bbw66x0oqvijwr67evld" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+
+            <dropForeignKeyConstraint baseTableName="deadline_extensions" constraintName="FKr994i0bv5oxepfcrs93lg4efd" />
+            <addForeignKeyConstraint baseTableName="deadline_extensions" baseColumnNames="session_id"
+                    referencedTableName="feedback_sessions" referencedColumnNames="id"
+                    constraintName="FKr994i0bv5oxepfcrs93lg4efd" onDelete="CASCADE"
+                    deferrable="false" initiallyDeferred="false" validate="true"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

This PR removes all database-level ON DELETE CASCADE constraints and corresponding @OnDelete annotations from entity mappings. Cascade delete behavior is now consistently managed through Hibernate/JPA configuration (cascade = CascadeType.REMOVE / CascadeType.ALL) and application-level entity lifecycle handling.
