### PR TITLE
[#13738] Remove feedbackSessionName from links

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
@@ -34,27 +34,21 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
 
     InstructorFeedbackEditPage loginToFeedbackEditPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withCourseId(course.getId())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
 
         return loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
     }
 
     FeedbackSubmitPage loginToFeedbackSubmitPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withCourseId(student.getCourseId())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
 
         return loginToPage(url, FeedbackSubmitPage.class, student.getGoogleId());
     }
 
     FeedbackSubmitPage getFeedbackSubmitPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withCourseId(student.getCourseId())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
 
         return getNewPageInstance(url, FeedbackSubmitPage.class);
     }

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -51,10 +51,8 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         ______TS("unregistered student: can access results");
         Student unregistered = testData.students.get("Unregistered");
         AppUrl url = createFrontendUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                .withCourseId(unregistered.getCourseId())
                 .withStudentEmail(unregistered.getEmail())
                 .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName())
                 .withRegistrationKey(unregistered.getRegKey());
         resultsPage = getNewPageInstance(url, FeedbackResultsPage.class);
 
@@ -66,9 +64,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         ______TS("registered student: can access results");
         Student student = testData.students.get("Alice");
         url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
-                .withCourseId(openSession.getCourseId())
-                .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName());
+                .withFeedbackSessionId(openSession.getId().toString());
         resultsPage = loginToPage(url, FeedbackResultsPage.class, student.getGoogleId());
 
         resultsPage.verifyFeedbackSessionDetails(openSession, course);
@@ -110,9 +106,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         logout();
         Instructor instructor = testData.instructors.get("FRes.instr");
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
-                .withCourseId(openSession.getCourseId())
-                .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName());
+                .withFeedbackSessionId(openSession.getId().toString());
         resultsPage = loginToPage(url, FeedbackResultsPage.class, instructor.getGoogleId());
 
         resultsPage.verifyFeedbackSessionDetails(openSession, course);
@@ -125,9 +119,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("preview results as student: can access results");
         url = createFrontendUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                .withCourseId(openSession.getCourseId())
                 .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName())
                 .withParam("previewas", student.getEmail());
         resultsPage = getNewPageInstance(url, FeedbackResultsPage.class);
 
@@ -153,9 +145,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
 
         ______TS("preview results as instructor: can access results");
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
-                .withCourseId(openSession.getCourseId())
                 .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName())
                 .withParam("previewas", instructor.getEmail());
         resultsPage = getNewPageInstance(url, FeedbackResultsPage.class);
 

--- a/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
@@ -56,9 +56,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
-                .withCourseId(openSession.getCourseId())
-                .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName());
+                .withFeedbackSessionId(openSession.getId().toString());
         FeedbackSubmitPage submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getGoogleId());
 
         ______TS("verify loaded session data");
@@ -70,7 +68,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
 
         ______TS("questions with giver type students");
         logout();
-        submitPage = loginToPage(getStudentSubmitPageUrl(student, openSession), FeedbackSubmitPage.class,
+        submitPage = loginToPage(getStudentSubmitPageUrl(openSession), FeedbackSubmitPage.class,
                 student.getGoogleId());
 
         submitPage.verifyNumQuestions(4);
@@ -96,12 +94,12 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         submitPage.verifyWarningMessageForPartialResponse(unansweredQuestions);
 
         ______TS("cannot submit in closed session");
-        AppUrl closedSessionUrl = getStudentSubmitPageUrl(student, closedSession);
+        AppUrl closedSessionUrl = getStudentSubmitPageUrl(closedSession);
         submitPage = getNewPageInstance(closedSessionUrl, FeedbackSubmitPage.class);
         submitPage.verifyCannotSubmit();
 
         ______TS("can submit in grace period");
-        AppUrl gracePeriodSessionUrl = getStudentSubmitPageUrl(student, gracePeriodSession);
+        AppUrl gracePeriodSessionUrl = getStudentSubmitPageUrl(gracePeriodSession);
         submitPage = getNewPageInstance(gracePeriodSessionUrl, FeedbackSubmitPage.class);
         FeedbackQuestion question = testData.feedbackQuestions.get("qn1InGracePeriodSession");
         Team recipient = team2;
@@ -156,9 +154,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         ______TS("preview as instructor");
         logout();
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
-                .withCourseId(openSession.getCourseId())
                 .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName())
                 .withParam("previewas", instructor.getEmail());
         submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getGoogleId());
 
@@ -169,9 +165,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
 
         ______TS("preview as student");
         url = createFrontendUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                .withCourseId(openSession.getCourseId())
                 .withFeedbackSessionId(openSession.getId().toString())
-                .withSessionName(openSession.getName())
                 .withParam("previewas", student.getEmail());
         submitPage = getNewPageInstance(url, FeedbackSubmitPage.class);
 
@@ -185,9 +179,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
 
         ______TS("moderating instructor cannot see questions without instructor visibility");
         url = createFrontendUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                .withCourseId(gracePeriodSession.getCourseId())
                 .withFeedbackSessionId(gracePeriodSession.getId().toString())
-                .withSessionName(gracePeriodSession.getName())
                 .withParam("moderatedperson", student.getEmail())
                 .withParam("moderatedquestionId", question.getId().toString());
         submitPage = getNewPageInstance(url, FeedbackSubmitPage.class);
@@ -205,11 +197,9 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         verifyPresentInDatabase(response);
     }
 
-    private AppUrl getStudentSubmitPageUrl(Student student, FeedbackSession session) {
+    private AppUrl getStudentSubmitPageUrl(FeedbackSession session) {
         return createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withCourseId(student.getCourseId())
-                .withFeedbackSessionId(session.getId().toString())
-                .withSessionName(session.getName());
+                .withFeedbackSessionId(session.getId().toString());
     }
 
     private List<String> getOtherStudents(Student currentStudent) {

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
@@ -44,9 +44,7 @@ public class InstructorFeedbackEditPageE2ETest extends BaseE2ETestCase {
     @Override
     protected void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
-                .withCourseId(course.getId())
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
         InstructorFeedbackEditPage feedbackEditPage =
                 loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -92,9 +92,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         FeedbackSession feedbackSession = testData.feedbackSessions.get("Open Session");
 
         resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
-                .withCourseId(course.getId())
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
 
         organiseResponses(course.getId());
 
@@ -337,9 +335,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         FeedbackSession feedbackSession = testData.feedbackSessions.get("Open Session 2");
 
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
-                .withCourseId(course.getId())
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
         resultsPage = loginToPage(url, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
 
         ______TS("verify loaded session details");

--- a/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
@@ -12,7 +12,6 @@ import org.testng.annotations.Test;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.InstructorSessionIndividualExtensionPage;
-import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -24,7 +23,6 @@ import teammates.ui.output.DeadlineExtensionsData;
  */
 public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETestCase {
     private Instructor instructor;
-    private Course course;
     private FeedbackSession feedbackSession;
     private Map<String, User> users;
     private Collection<Student> students;
@@ -36,7 +34,6 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
                 loadDataBundle("/InstructorSessionIndividualExtensionPageE2ETest.json"));
 
         instructor = testData.instructors.get("ISesIe.instructor1");
-        course = testData.courses.get("course");
         feedbackSession = testData.feedbackSessions.get("firstSession");
         students = testData.students.values();
         instructors = testData.instructors.values();
@@ -154,9 +151,7 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
 
     private InstructorSessionIndividualExtensionPage loginToInstructorSessionIndividualExtensionPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_INDIVIDUAL_EXTENSION_PAGE)
-                .withCourseId(course.getId())
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
 
         return loginToPage(url, InstructorSessionIndividualExtensionPage.class, instructor.getGoogleId());
     }

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
@@ -11,7 +11,6 @@ import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.FeedbackSubmitPage;
 import teammates.e2e.pageobjects.InstructorStudentActivityLogsPage;
-import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
@@ -25,7 +24,6 @@ import teammates.storage.entity.Student;
  */
 public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
     private Instructor instructor;
-    private Course course;
     private FeedbackSession feedbackSession;
     private FeedbackQuestion feedbackQuestion;
     private Student student;
@@ -36,7 +34,6 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
                 loadDataBundle("/InstructorStudentActivityLogsPageE2ETest.json"));
 
         instructor = testData.instructors.get("instructor");
-        course = testData.courses.get("course");
         student = testData.students.get("alice.tmms@ISActLogs.CS2104");
         feedbackQuestion = testData.feedbackQuestions.get("qn1");
         feedbackSession = testData.feedbackSessions.get("openSession");
@@ -69,9 +66,7 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
         ______TS("verify logs output");
         logout();
         AppUrl studentSubmissionPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withCourseId(course.getId())
-                .withFeedbackSessionId(feedbackSession.getId().toString())
-                .withSessionName(feedbackSession.getName());
+                .withFeedbackSessionId(feedbackSession.getId().toString());
         FeedbackSubmitPage studentSubmissionPage = loginToPage(studentSubmissionPageUrl,
                 FeedbackSubmitPage.class, student.getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
@@ -22,9 +22,7 @@ public class FeedbackResultsPageAxeTest extends BaseAxeTestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
-                .withCourseId(testData.courses.get("FRes.CS2104").getId())
-                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString())
-                .withSessionName(testData.feedbackSessions.get("Open Session").getName());
+                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString());
         FeedbackResultsPage resultsPage = loginToPage(url, FeedbackResultsPage.class,
                 testData.students.get("Alice").getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
@@ -22,9 +22,7 @@ public class FeedbackSubmitPageAxeTest extends BaseAxeTestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
-                .withCourseId(testData.courses.get("FSubmit.CS2104").getId())
-                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString())
-                .withSessionName(testData.feedbackSessions.get("Open Session").getName());
+                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString());
 
         FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class,
                 testData.students.get("alice.tmms@FSubmit.CS2104").getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
@@ -23,9 +23,7 @@ public class InstructorFeedbackEditPageAxeTest extends BaseAxeTestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
-                .withCourseId(testData.courses.get("InstFEP.CS2104").getId())
-                .withFeedbackSessionId(testData.feedbackSessions.get("openSession").getId().toString())
-                .withSessionName(testData.feedbackSessions.get("openSession").getName());
+                .withFeedbackSessionId(testData.feedbackSessions.get("openSession").getId().toString());
 
         InstructorFeedbackEditPage feedbackEditPage = loginToPage(url, InstructorFeedbackEditPage.class,
                 testData.instructors.get("InstFEP.instr").getGoogleId());

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
@@ -23,9 +23,7 @@ public class InstructorFeedbackReportPageAxeTest extends BaseAxeTestCase {
     @Override
     public void testAll() {
         AppUrl resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
-                .withCourseId(testData.courses.get("tm.e2e.IFRep.CS2104").getId())
-                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString())
-                .withSessionName(testData.feedbackSessions.get("Open Session").getName());
+                .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId().toString());
         InstructorFeedbackResultsPage resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class,
                 testData.instructors.get("IFRep.instr.CS2104").getGoogleId());
 

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
@@ -23,9 +23,7 @@ public class InstructorSessionIndividualExtensionPageAxeTest extends BaseAxeTest
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_INDIVIDUAL_EXTENSION_PAGE)
-                .withCourseId(testData.courses.get("course").getId())
-                .withFeedbackSessionId(testData.feedbackSessions.get("firstSession").getId().toString())
-                .withSessionName(testData.feedbackSessions.get("firstSession").getName());
+                .withFeedbackSessionId(testData.feedbackSessions.get("firstSession").getId().toString());
 
         InstructorSessionIndividualExtensionPage individualExtensionPage =
                 loginToPage(url, InstructorSessionIndividualExtensionPage.class,

--- a/src/main/java/teammates/common/util/AppUrl.java
+++ b/src/main/java/teammates/common/util/AppUrl.java
@@ -26,10 +26,6 @@ public class AppUrl extends Url {
         return withParam(Const.ParamsNames.COURSE_ID, courseId);
     }
 
-    public AppUrl withSessionName(String feedbackSessionName) {
-        return withParam(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
-    }
-
     public AppUrl withFeedbackSessionId(String feedbackSessionId) {
         return withParam(Const.ParamsNames.FEEDBACK_SESSION_ID, feedbackSessionId);
     }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -127,7 +127,6 @@ public final class Const {
         public static final String ACCOUNT_REQUEST_ID = "id";
         public static final String ACCOUNT_REQUEST_STATUS = "status";
 
-        public static final String FEEDBACK_SESSION_NAME = "fsname";
         public static final String FEEDBACK_SESSION_STARTTIME = "starttime";
         public static final String FEEDBACK_SESSION_ENDTIME = "endtime";
         public static final String FEEDBACK_SESSION_MODERATED_PERSON = "moderatedperson";

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -152,8 +152,6 @@ public final class EmailGenerator {
         String status;
         if (emailType == EmailType.FEEDBACK_OPENING_SOON) {
             String editUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
-                    .withCourseId(course.getId())
-                    .withSessionName(session.getName())
                     .withFeedbackSessionId(session.getId().toString())
                     .toAbsoluteString();
             // If instructor has not joined the course, populate additional notes with information to join course.
@@ -166,8 +164,6 @@ public final class EmailGenerator {
             status = FEEDBACK_STATUS_SESSION_OPENING_SOON;
         } else {
             String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
-                    .withCourseId(course.getId())
-                    .withSessionName(session.getName())
                     .withFeedbackSessionId(session.getId().toString())
                     .toAbsoluteString();
             additionalNotes = fillUpViewResponsesDetailsFragment(reportUrl);
@@ -300,8 +296,6 @@ public final class EmailGenerator {
 
             if (fs.isOpened() || fs.isClosed()) {
                 String submitUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                        .withCourseId(course.getId())
-                        .withSessionName(fs.getName())
                         .withFeedbackSessionId(fs.getId().toString())
                         .withRegistrationKey(userKey)
                         .withEntityType(isInstructor ? Const.EntityType.INSTRUCTOR : "")
@@ -311,8 +305,6 @@ public final class EmailGenerator {
 
             if (fs.isPublished()) {
                 String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                        .withCourseId(course.getId())
-                        .withSessionName(fs.getName())
                         .withFeedbackSessionId(fs.getId().toString())
                         .withRegistrationKey(userKey)
                         .withEntityType(isInstructor ? Const.EntityType.INSTRUCTOR : "")
@@ -456,8 +448,6 @@ public final class EmailGenerator {
 
                 if (session.isOpened() || session.isClosed()) {
                     var submitUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                            .withCourseId(course.getId())
-                            .withSessionName(session.getName())
                             .withFeedbackSessionId(session.getId().toString())
                             .withRegistrationKey(student.getRegKey())
                             .toAbsoluteString();
@@ -466,8 +456,6 @@ public final class EmailGenerator {
 
                 if (session.isPublished()) {
                     var reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                            .withCourseId(course.getId())
-                            .withSessionName(session.getName())
                             .withFeedbackSessionId(session.getId().toString())
                             .withRegistrationKey(student.getRegKey())
                             .toAbsoluteString();
@@ -716,15 +704,11 @@ public final class EmailGenerator {
             Course course, FeedbackSession session, Student student, String template,
             EmailType type, String feedbackAction, String additionalContactInformation) {
         String submitUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                .withCourseId(course.getId())
-                .withSessionName(session.getName())
                 .withFeedbackSessionId(session.getId().toString())
                 .withRegistrationKey(student.getRegKey())
                 .toAbsoluteString();
 
         String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                .withCourseId(course.getId())
-                .withSessionName(session.getName())
                 .withFeedbackSessionId(session.getId().toString())
                 .withRegistrationKey(student.getRegKey())
                 .toAbsoluteString();
@@ -759,16 +743,12 @@ public final class EmailGenerator {
             Course course, FeedbackSession session, Instructor instructor,
             String template, EmailType type, String feedbackAction, String additionalContactInformation) {
         String submitUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
-                .withCourseId(course.getId())
-                .withSessionName(session.getName())
                 .withFeedbackSessionId(session.getId().toString())
                 .withRegistrationKey(instructor.getRegKey())
                 .withEntityType(Const.EntityType.INSTRUCTOR)
                 .toAbsoluteString();
 
         String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
-                .withCourseId(course.getId())
-                .withSessionName(session.getName())
                 .withFeedbackSessionId(session.getId().toString())
                 .withRegistrationKey(instructor.getRegKey())
                 .withEntityType(Const.EntityType.INSTRUCTOR)

--- a/src/test/resources/emails/sessionLinksRecoveryOpenedOrClosedAndpublishedSessions.html
+++ b/src/test/resources/emails/sessionLinksRecoveryOpenedOrClosedAndpublishedSessions.html
@@ -17,10 +17,10 @@
     </tr>
     <tr>
     <td style="border: 1px solid black; padding: 5px; vertical-align: top;">First feedback session</td>
-    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse4&fsname=First%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">submission link</a>][<a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse4&fsname=First%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">result link</a>]</td>
+    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?fsid=${fsid}&key=${regkey.enc}">submission link</a>][<a href="${app.url}/web/sessions/result?fsid=${fsid}&key=${regkey.enc}">result link</a>]</td>
 </tr><tr>
     <td style="border: 1px solid black; padding: 5px; vertical-align: top;">Second feedback session</td>
-    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse4&fsname=Second%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">submission link</a>][<a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse4&fsname=Second%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">result link</a>]</td>
+    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?fsid=${fsid}&key=${regkey.enc}">submission link</a>][<a href="${app.url}/web/sessions/result?fsid=${fsid}&key=${regkey.enc}">result link</a>]</td>
 </tr>
     </tbody>
 </table>

--- a/src/test/resources/emails/sessionLinksRecoveryOpenedOrClosedButUnpublishedSessions.html
+++ b/src/test/resources/emails/sessionLinksRecoveryOpenedOrClosedButUnpublishedSessions.html
@@ -17,10 +17,10 @@
     </tr>
     <tr>
     <td style="border: 1px solid black; padding: 5px; vertical-align: top;">First feedback session</td>
-    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse3&fsname=First%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">submission link</a>]</td>
+    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?fsid=${fsid}&key=${regkey.enc}">submission link</a>]</td>
 </tr><tr>
     <td style="border: 1px solid black; padding: 5px; vertical-align: top;">Second feedback session</td>
-    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse3&fsname=Second%20feedback%20session&fsid=${fsid}&key=${regkey.enc}">submission link</a>]</td>
+    <td style="border: 1px solid black; padding: 5px; vertical-align: top;">[<a href="${app.url}/web/sessions/submission?fsid=${fsid}&key=${regkey.enc}">submission link</a>]</td>
 </tr>
     </tbody>
 </table>

--- a/src/web/app/components/preview-session-panel/preview-session-panel.component.html
+++ b/src/web/app/components/preview-session-panel/preview-session-panel.component.html
@@ -24,8 +24,6 @@
             <a
               tmRouterLink="/web/sessions/submission"
               [queryParams]="{
-                courseid: courseId,
-                fsname: feedbackSessionName,
                 fsid: feedbackSessionId,
                 previewas: emailOfStudentToPreview,
               }"
@@ -80,8 +78,6 @@
             <a
               tmRouterLink="/web/instructor/sessions/submission"
               [queryParams]="{
-                courseid: courseId,
-                fsname: feedbackSessionName,
                 fsid: feedbackSessionId,
                 previewas: emailOfInstructorToPreview,
               }"

--- a/src/web/app/components/preview-session-result-panel/preview-session-result-panel.component.html
+++ b/src/web/app/components/preview-session-result-panel/preview-session-result-panel.component.html
@@ -20,8 +20,6 @@
             <a
               tmRouterLink="/web/sessions/result"
               [queryParams]="{
-                courseid: courseId,
-                fsname: feedbackSessionName,
                 fsid: feedbackSessionId,
                 previewas: emailOfStudentToPreview,
               }"
@@ -75,8 +73,6 @@
             <a
               tmRouterLink="/web/instructor/sessions/result"
               [queryParams]="{
-                courseid: courseId,
-                fsname: feedbackSessionName,
                 fsid: feedbackSessionId,
                 previewas: emailOfInstructorToPreview,
               }"

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -366,8 +366,6 @@
                   class="ps-3 pt-2"
                   tmRouterLink="/web/instructor/sessions/individual-extension"
                   [queryParams]="{
-                    courseid: model.courseId,
-                    fsname: model.feedbackSessionName,
                     fsid: model.feedbackSessionId,
                     preselectnonsubmitters: false,
                   }"

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -252,14 +252,14 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                     >
                       <a
                         class="btn dropdown-item clickable disabled"
-                        href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%207%20Review"
+                        href="/web/instructor/sessions/result?fsid=second-session-id"
                         tmrouterlink="/web/instructor/sessions/result"
                       >
                         View Results (from/to me)
                       </a>
                       <a
                         class="btn dropdown-item clickable disabled"
-                        href="/web/instructor/sessions/report?courseid=GOT&fsname=Season%207%20Review"
+                        href="/web/instructor/sessions/report?fsid=second-session-id"
                         tmrouterlink="/web/instructor/sessions/report"
                       >
                         View Results (course-wide)
@@ -391,7 +391,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                   class="d-flex gap-1"
                 >
                   <a
-                    href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
+                    href="/web/instructor/sessions/edit?fsid=first-session-id&editingMode=true"
                     tmrouterlink="/web/instructor/sessions/edit"
                   >
                     <button
@@ -415,7 +415,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                      Copy 
                   </button>
                   <a
-                    href="/web/instructor/sessions/submission?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
+                    href="/web/instructor/sessions/submission?fsid=first-session-id&editingMode=true"
                     tmrouterlink="/web/instructor/sessions/submission"
                   >
                     <button
@@ -444,14 +444,14 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
                     >
                       <a
                         class="btn dropdown-item clickable"
-                        href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%208%20Review"
+                        href="/web/instructor/sessions/result?fsid=first-session-id"
                         tmrouterlink="/web/instructor/sessions/result"
                       >
                         View Results (from/to me)
                       </a>
                       <a
                         class="btn dropdown-item clickable"
-                        href="/web/instructor/sessions/report?courseid=GOT&fsname=Season%208%20Review"
+                        href="/web/instructor/sessions/report?fsid=first-session-id"
                         tmrouterlink="/web/instructor/sessions/report"
                       >
                         View Results (course-wide)
@@ -705,7 +705,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                   class="d-flex gap-1"
                 >
                   <a
-                    href="/web/instructor/sessions/edit?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
+                    href="/web/instructor/sessions/edit?fsid=first-session-id&editingMode=true"
                     tmrouterlink="/web/instructor/sessions/edit"
                   >
                     <button
@@ -729,7 +729,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                      Copy 
                   </button>
                   <a
-                    href="/web/instructor/sessions/submission?courseid=GOT&fsname=Season%208%20Review&editingMode=true"
+                    href="/web/instructor/sessions/submission?fsid=first-session-id&editingMode=true"
                     tmrouterlink="/web/instructor/sessions/submission"
                   >
                     <button
@@ -758,14 +758,14 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                     >
                       <a
                         class="btn dropdown-item clickable"
-                        href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%208%20Review"
+                        href="/web/instructor/sessions/result?fsid=first-session-id"
                         tmrouterlink="/web/instructor/sessions/result"
                       >
                         View Results (from/to me)
                       </a>
                       <a
                         class="btn dropdown-item clickable"
-                        href="/web/instructor/sessions/report?courseid=GOT&fsname=Season%208%20Review"
+                        href="/web/instructor/sessions/report?fsid=first-session-id"
                         tmrouterlink="/web/instructor/sessions/report"
                       >
                         View Results (course-wide)
@@ -923,14 +923,14 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
                     >
                       <a
                         class="btn dropdown-item clickable disabled"
-                        href="/web/instructor/sessions/result?courseid=GOT&fsname=Season%207%20Review"
+                        href="/web/instructor/sessions/result?fsid=second-session-id"
                         tmrouterlink="/web/instructor/sessions/result"
                       >
                         View Results (from/to me)
                       </a>
                       <a
                         class="btn dropdown-item clickable disabled"
-                        href="/web/instructor/sessions/report?courseid=GOT&fsname=Season%207%20Review"
+                        href="/web/instructor/sessions/report?fsid=second-session-id"
                         tmrouterlink="/web/instructor/sessions/report"
                       >
                         View Results (course-wide)

--- a/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
+++ b/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
@@ -3,8 +3,6 @@
     <a
       tmRouterLink="/web/instructor/sessions/edit"
       [queryParams]="{
-        courseid: courseId,
-        fsname: fsName,
         fsid: fsId,
         editingMode: true,
       }"
@@ -38,8 +36,6 @@
     <a
       tmRouterLink="/web/instructor/sessions/submission"
       [queryParams]="{
-        courseid: courseId,
-        fsname: fsName,
         fsid: fsId,
         editingMode: true,
       }"
@@ -82,8 +78,6 @@
         }"
         tmRouterLink="/web/instructor/sessions/result"
         [queryParams]="{
-          courseid: courseId,
-          fsname: fsName,
           fsid: fsId,
         }"
         >View Results (from/to me)</a
@@ -95,8 +89,6 @@
         }"
         tmRouterLink="/web/instructor/sessions/report"
         [queryParams]="{
-          courseid: courseId,
-          fsname: fsName,
           fsid: fsId,
         }"
         >View Results (course-wide)</a

--- a/src/web/app/components/sessions-table/cell-with-group-buttons.component.ts
+++ b/src/web/app/components/sessions-table/cell-with-group-buttons.component.ts
@@ -16,9 +16,7 @@ import { TeammatesRouterDirective } from '../teammates-router/teammates-router.d
 })
 export class GroupButtonsComponent {
   @Input() idx = 0;
-  @Input() fsName = '';
   @Input() fsId = '';
-  @Input() courseId = '';
   @Input() rowClicked = 0;
   @Input() isSendReminderLoading = false;
 

--- a/src/web/app/components/sessions-table/sessions-table.component.spec.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.spec.ts
@@ -39,6 +39,7 @@ describe('SessionsTableComponent', () => {
   });
 
   const feedbackSession1: FeedbackSession = {
+    feedbackSessionId: 'first-session-id',
     courseId: 'GOT',
     timeZone: 'Asia/Singapore',
     feedbackSessionName: 'Season 8 Review',
@@ -56,6 +57,7 @@ describe('SessionsTableComponent', () => {
   };
 
   const feedbackSession2: FeedbackSession = {
+    feedbackSessionId: 'second-session-id',
     courseId: 'GOT',
     timeZone: 'Asia/Singapore',
     feedbackSessionName: 'Season 7 Review',

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -761,7 +761,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                 class="d-flex gap-1"
                               >
                                 <a
-                                  href="/web/instructor/sessions/edit?courseid=CS1231&fsname=First%20Session&editingMode=true"
+                                  href="/web/instructor/sessions/edit?fsid=first-session-id&editingMode=true"
                                   tmrouterlink="/web/instructor/sessions/edit"
                                 >
                                   <button
@@ -785,7 +785,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                    Copy 
                                 </button>
                                 <a
-                                  href="/web/instructor/sessions/submission?courseid=CS1231&fsname=First%20Session&editingMode=true"
+                                  href="/web/instructor/sessions/submission?fsid=first-session-id&editingMode=true"
                                   tmrouterlink="/web/instructor/sessions/submission"
                                 >
                                   <button
@@ -814,14 +814,14 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
                                   >
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/result?courseid=CS1231&fsname=First%20Session"
+                                      href="/web/instructor/sessions/result?fsid=first-session-id"
                                       tmrouterlink="/web/instructor/sessions/result"
                                     >
                                       View Results (from/to me)
                                     </a>
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/report?courseid=CS1231&fsname=First%20Session"
+                                      href="/web/instructor/sessions/report?fsid=first-session-id"
                                       tmrouterlink="/web/instructor/sessions/report"
                                     >
                                       View Results (course-wide)
@@ -1381,14 +1381,14 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                   >
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/result?courseid=CS1231&fsname=Second%20Session"
+                                      href="/web/instructor/sessions/result?fsid=second-session-id"
                                       tmrouterlink="/web/instructor/sessions/result"
                                     >
                                       View Results (from/to me)
                                     </a>
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/report?courseid=CS1231&fsname=Second%20Session"
+                                      href="/web/instructor/sessions/report?fsid=second-session-id"
                                       tmrouterlink="/web/instructor/sessions/report"
                                     >
                                       View Results (course-wide)
@@ -1566,14 +1566,14 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
                                   >
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/result?courseid=CS1231&fsname=First%20Session"
+                                      href="/web/instructor/sessions/result?fsid=first-session-id"
                                       tmrouterlink="/web/instructor/sessions/result"
                                     >
                                       View Results (from/to me)
                                     </a>
                                     <a
                                       class="btn dropdown-item clickable disabled"
-                                      href="/web/instructor/sessions/report?courseid=CS1231&fsname=First%20Session"
+                                      href="/web/instructor/sessions/report?fsid=first-session-id"
                                       tmrouterlink="/web/instructor/sessions/report"
                                     >
                                       View Results (course-wide)

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -62,6 +62,7 @@ const testCourse3: Course = {
 };
 
 const testFeedbackSession1: FeedbackSession = {
+  feedbackSessionId: 'first-session-id',
   feedbackSessionName: 'First Session',
   courseId: 'CS1231',
   timeZone: 'Asia/Singapore',
@@ -79,6 +80,7 @@ const testFeedbackSession1: FeedbackSession = {
 };
 
 const testFeedbackSession2: FeedbackSession = {
+  feedbackSessionId: 'second-session-id',
   feedbackSessionName: 'Second Session',
   courseId: 'CS1231',
   timeZone: 'Asia/Singapore',

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -441,8 +441,6 @@ export abstract class InstructorSessionBasePageComponent {
             {
               onClosed: () =>
                 this.navigationService.navigateByURLWithParamEncoding('/web/instructor/sessions/edit', {
-                  courseid: createdSession.courseId,
-                  fsname: createdSession.feedbackSessionName,
                   fsid: createdSession.feedbackSessionId,
                 }),
             },
@@ -452,8 +450,6 @@ export abstract class InstructorSessionBasePageComponent {
             '/web/instructor/sessions/edit',
             'The feedback session has been copied. Please modify settings/questions as necessary.',
             {
-              courseid: createdSession.courseId,
-              fsname: createdSession.feedbackSessionName,
               fsid: createdSession.feedbackSessionId,
             },
           );
@@ -494,8 +490,6 @@ export abstract class InstructorSessionBasePageComponent {
    */
   submitSessionAsInstructor(model: SessionsTableRowModel): void {
     this.navigationService.navigateByURLWithParamEncoding('/web/instructor/sessions/submission', {
-      courseid: model.feedbackSession.courseId,
-      fsname: model.feedbackSession.feedbackSessionName,
       fsid: model.feedbackSession.feedbackSessionId,
     });
   }

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -1230,7 +1230,7 @@ exports[`InstructorSessionEditPageComponent should snap with feedback session qu
                   >
                     <a
                       class="ps-3 pt-2"
-                      href="/web/instructor/sessions/individual-extension?courseid=testId&fsname=test%20session&fsid=ee47e471-fbd8-478e-a350-51152802215b&preselectnonsubmitters=false"
+                      href="/web/instructor/sessions/individual-extension?fsid=ee47e471-fbd8-478e-a350-51152802215b&preselectnonsubmitters=false"
                       tmrouterlink="/web/instructor/sessions/individual-extension"
                     >
                        Individual Deadline Extensions 
@@ -4493,7 +4493,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
                   >
                     <a
                       class="ps-3 pt-2"
-                      href="/web/instructor/sessions/individual-extension?courseid=&fsname=&fsid=&preselectnonsubmitters=false"
+                      href="/web/instructor/sessions/individual-extension?fsid=&preselectnonsubmitters=false"
                       tmrouterlink="/web/instructor/sessions/individual-extension"
                     >
                        Individual Deadline Extensions 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback question f
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -20,7 +20,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback question f
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed={[Function Boolean]}
   hasLoadingFeedbackSessionFailed="false"
@@ -104,7 +104,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback questions 
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -117,7 +117,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback questions 
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed="false"
   hasLoadingFeedbackSessionFailed="false"
@@ -201,7 +201,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session fa
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -214,7 +214,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session fa
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed="false"
   hasLoadingFeedbackSessionFailed={[Function Boolean]}
@@ -301,7 +301,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session is
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -314,7 +314,7 @@ exports[`InstructorSessionEditPageComponent should snap when feedback session is
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed="false"
   hasLoadingFeedbackSessionFailed="false"
@@ -398,7 +398,7 @@ exports[`InstructorSessionEditPageComponent should snap with default fields 1`] 
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -411,7 +411,7 @@ exports[`InstructorSessionEditPageComponent should snap with default fields 1`] 
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed="false"
   hasLoadingFeedbackSessionFailed="false"
@@ -3761,7 +3761,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
   QuestionEditFormMode={[Function Object]}
   SessionEditFormMode={[Function Object]}
   changeDetectorRef={[Function ViewRef]}
-  courseId="undefined"
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   coursesOfModifiedSession={[Function Array]}
@@ -3774,7 +3774,7 @@ exports[`InstructorSessionEditPageComponent should snap with new question added 
   feedbackSessionActionsService={[Function FeedbackSessionActionsService]}
   feedbackSessionId="undefined"
   feedbackSessionModelBeforeEditing={[Function Object]}
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadingFeedbackQuestionsFailed="false"
   hasLoadingFeedbackSessionFailed="false"

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -735,7 +735,7 @@ describe('InstructorSessionEditPageComponent', () => {
     expect(navSpy).toHaveBeenLastCalledWith(
       '/web/instructor/sessions/edit',
       'The feedback session has been copied. Please modify settings/questions as necessary.',
-      { courseid: 'testId2', fsid: 'fbd91470-8378-4b43-9f82-0b81fb2e9f1b', fsname: 'Test Session' },
+      { fsid: 'fbd91470-8378-4b43-9f82-0b81fb2e9f1b' },
     );
   });
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -357,6 +357,8 @@ describe('InstructorSessionEditPageComponent', () => {
     jest
       .spyOn(feedbackSessionsService, 'getFeedbackSessionDeadlineExtensions')
       .mockReturnValue(of(testDeadlineExtensions));
+    jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(of({ students: [] }));
+    jest.spyOn(instructorService, 'loadInstructors').mockReturnValue(of({ instructors: [] }));
 
     component.loadFeedbackSession();
 
@@ -445,14 +447,14 @@ describe('InstructorSessionEditPageComponent', () => {
     };
     jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(of(students));
 
-    component.getAllStudentsOfCourse();
+    component.getAllStudentsOfCourse().subscribe();
 
     expect(component.studentsOfCourse.length).toBe(2);
     expect(component.studentsOfCourse[0].name).toBe(testStudent1.name);
     expect(component.emailOfStudentToPreview).toBe(testStudent1.email);
   });
 
-  it('should display error message when failed to get student', () => {
+  it('should emit error when failed to get student', () => {
     jest.spyOn(studentService, 'getStudentsFromCourse').mockReturnValue(
       throwError(() => ({
         error: {
@@ -460,13 +462,14 @@ describe('InstructorSessionEditPageComponent', () => {
         },
       })),
     );
-    const spy: SpyInstance = jest.spyOn(statusMessageService, 'showErrorToast').mockImplementation((args: string) => {
-      expect(args).toEqual('This is the error message.');
+    let hasError = false;
+    component.getAllStudentsOfCourse().subscribe({
+      error: () => {
+        hasError = true;
+      },
     });
 
-    component.getAllStudentsOfCourse();
-
-    expect(spy).toHaveBeenCalled();
+    expect(hasError).toBeTruthy();
   });
 
   it('should get all instructors of the course', () => {
@@ -489,13 +492,13 @@ describe('InstructorSessionEditPageComponent', () => {
     };
     jest.spyOn(instructorService, 'loadInstructors').mockReturnValue(of(instructors));
 
-    component.getAllInstructors();
+    component.getAllInstructors().subscribe();
     expect(component.instructorsOfCourse.length).toBe(2);
     expect(component.instructorsOfCourse[0].name).toBe(testInstructor1.name);
     expect(component.emailOfInstructorToPreview).toBe(testInstructor1.email);
   });
 
-  it('should display error message when failed to get instructor', () => {
+  it('should emit error when failed to get instructor', () => {
     jest.spyOn(instructorService, 'loadInstructors').mockReturnValue(
       throwError(() => ({
         error: {
@@ -503,13 +506,14 @@ describe('InstructorSessionEditPageComponent', () => {
         },
       })),
     );
-    const spy: SpyInstance = jest.spyOn(statusMessageService, 'showErrorToast').mockImplementation((args: string) => {
-      expect(args).toEqual('This is the error message.');
+    let hasError = false;
+    component.getAllInstructors().subscribe({
+      error: () => {
+        hasError = true;
+      },
     });
 
-    component.getAllInstructors();
-
-    expect(spy).toHaveBeenCalled();
+    expect(hasError).toBeTruthy();
   });
 
   it('should collapse all questions', () => {

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, inject, OnInit, TemplateRef, ViewChild } 
 import { ActivatedRoute } from '@angular/router';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { forkJoin, Observable, of } from 'rxjs';
-import { concatMap, finalize } from 'rxjs/operators';
+import { concatMap, finalize, map, switchMap } from 'rxjs/operators';
 import { FeedbackSessionTabModel } from './copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal-model';
 import { CopyQuestionsFromOtherSessionsModalComponent } from './copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component';
 import { TemplateQuestionModalComponent } from './template-question-modal/template-question-modal.component';
@@ -170,15 +170,11 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
-      this.courseId = queryParams.courseid;
-      this.feedbackSessionName = queryParams.fsname;
       this.feedbackSessionId = queryParams.fsid;
       this.isEditingMode = queryParams.editingMode === 'true';
 
       this.loadFeedbackSession();
       this.loadFeedbackQuestions();
-      this.getAllStudentsOfCourse();
-      this.getAllInstructors();
     });
   }
 
@@ -188,41 +184,50 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   loadFeedbackSession(): void {
     this.hasLoadingFeedbackSessionFailed = false;
     this.isLoadingFeedbackSession = true;
-    // load the course of the feedback session first
-    this.courseService.getCourseAsInstructor(this.courseId).subscribe({
-      next: (course: Course) => {
-        this.courseName = course.courseName;
+    this.feedbackSessionsService
+      .getFeedbackSession({
+        feedbackSessionId: this.feedbackSessionId,
+        intent: Intent.FULL_DETAIL,
+      })
+      .pipe(
+        switchMap((feedbackSession: FeedbackSession) => {
+          this.courseId = feedbackSession.courseId;
+          this.feedbackSessionName = feedbackSession.feedbackSessionName;
 
-        forkJoin([
-          this.feedbackSessionsService.getFeedbackSession({
-            feedbackSessionId: this.feedbackSessionId,
-            intent: Intent.FULL_DETAIL,
-          }),
-          this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
-        ])
-          .pipe(
-            finalize(() => {
-              this.isLoadingFeedbackSession = false;
-            }),
-          )
-          .subscribe({
-            next: ([feedbackSession, deadlineExtensions]: [FeedbackSession, DeadlineExtensions]) => {
-              this.sessionEditFormModel = this.getSessionEditFormModel(feedbackSession, this.isEditingMode);
-              this.feedbackSessionModelBeforeEditing = this.getSessionEditFormModel(feedbackSession);
-              this.userDeadlines = deadlineExtensions.userDeadlines;
-            },
-            error: (resp: ErrorMessageOutput) => {
-              this.hasLoadingFeedbackSessionFailed = true;
-              this.statusMessageService.showErrorToast(resp.error.message);
-            },
-          });
-      },
-      error: (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorToast(resp.error.message);
-        this.isLoadingFeedbackSession = false;
-        this.hasLoadingFeedbackSessionFailed = true;
-      },
-    });
+          return forkJoin([
+            this.courseService.getCourseAsInstructor(this.courseId),
+            this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
+            this.getAllStudentsOfCourse(),
+            this.getAllInstructors(),
+          ]).pipe(
+            map(([course, deadlineExtensions]: [Course, DeadlineExtensions, Student[], Instructor[]]) => ({
+              feedbackSession,
+              course,
+              deadlineExtensions,
+            })),
+          );
+        }),
+        finalize(() => {
+          this.isLoadingFeedbackSession = false;
+        }),
+      )
+      .subscribe({
+        next: (result: {
+          feedbackSession: FeedbackSession;
+          course: Course;
+          deadlineExtensions: DeadlineExtensions;
+        }) => {
+          const { feedbackSession, course, deadlineExtensions } = result;
+          this.courseName = course.courseName;
+          this.sessionEditFormModel = this.getSessionEditFormModel(feedbackSession, this.isEditingMode);
+          this.feedbackSessionModelBeforeEditing = this.getSessionEditFormModel(feedbackSession);
+          this.userDeadlines = deadlineExtensions.userDeadlines;
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.hasLoadingFeedbackSessionFailed = true;
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
   }
 
   /**
@@ -1183,9 +1188,9 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   /**
    * Gets all students of a course.
    */
-  getAllStudentsOfCourse(): void {
-    this.studentService.getStudentsFromCourse({ courseId: this.courseId }).subscribe({
-      next: (students: Students) => {
+  getAllStudentsOfCourse(): Observable<Student[]> {
+    return this.studentService.getStudentsFromCourse({ courseId: this.courseId }).pipe(
+      map((students: Students) => {
         this.studentsOfCourse = students.students;
 
         // sort the student list based on team name and student name
@@ -1201,24 +1206,23 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
         if (this.studentsOfCourse.length >= 1) {
           this.emailOfStudentToPreview = this.studentsOfCourse[0].email;
         }
-      },
-      error: (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorToast(resp.error.message);
-      },
-    });
+
+        return this.studentsOfCourse;
+      }),
+    );
   }
 
   /**
    * Gets all instructors of a course.
    */
-  getAllInstructors(): void {
-    this.instructorService
+  getAllInstructors(): Observable<Instructor[]> {
+    return this.instructorService
       .loadInstructors({
         courseId: this.courseId,
         intent: Intent.FULL_DETAIL,
       })
-      .subscribe({
-        next: (instructors: Instructors) => {
+      .pipe(
+        map((instructors: Instructors) => {
           this.instructorsOfCourse = instructors.instructors;
           // TODO use privilege API to filter instructors who has INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS
           // in the feedback session
@@ -1232,11 +1236,10 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
           if (this.instructorsOfCourse.length >= 1) {
             this.emailOfInstructorToPreview = this.instructorsOfCourse[0].email;
           }
-        },
-        error: (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorToast(resp.error.message);
-        },
-      });
+
+          return this.instructorsOfCourse;
+        }),
+      );
   }
 
   expandAll(): void {

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/__snapshots__/instructor-session-individual-extension-page.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -61,7 +61,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -106,6 +106,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select student
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -503,7 +504,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -554,7 +555,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -599,6 +600,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should select those t
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -1062,7 +1064,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -1113,7 +1115,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -1158,6 +1160,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -1621,7 +1624,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -1672,7 +1675,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -1717,6 +1720,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when clic
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -2174,13 +2178,13 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when feed
 <tm-instructor-session-individual-extension-page
   SortBy={[Function Object]}
   SortOrder={[Function Object]}
-  courseId={[Function String]}
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp="0"
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -2495,7 +2499,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -2546,7 +2550,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -2591,6 +2595,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -2990,7 +2995,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -3041,7 +3046,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -3086,6 +3091,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap when ther
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -3451,7 +3457,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -3502,7 +3508,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -3547,6 +3553,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with deta
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -4006,13 +4013,13 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
 <tm-instructor-session-individual-extension-page
   SortBy={[Function Object]}
   SortOrder={[Function Object]}
-  courseId={[Function String]}
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp="0"
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -4063,7 +4070,6 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with inst
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
             </div>
           </div>
           <div
@@ -4330,13 +4336,13 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
 <tm-instructor-session-individual-extension-page
   SortBy={[Function Object]}
   SortOrder={[Function Object]}
-  courseId={[Function String]}
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp="0"
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -4387,7 +4393,6 @@ exports[`InstructorSessionIndividualExtensionPageComponent should snap with stud
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
             </div>
           </div>
           <div
@@ -4643,9 +4648,9 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   courseName=""
   courseService={[Function CourseService]}
   feedbackSessionDetails={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -4963,7 +4968,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed={[Function Boolean]}
@@ -5014,7 +5019,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -5059,6 +5064,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -5209,13 +5215,13 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
 <tm-instructor-session-individual-extension-page
   SortBy={[Function Object]}
   SortOrder={[Function Object]}
-  courseId={[Function String]}
+  courseId=""
   courseName=""
   courseService={[Function CourseService]}
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp="0"
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName=""
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -5533,7 +5539,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed={[Function Boolean]}
@@ -5584,7 +5590,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -5629,6 +5635,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -5964,7 +5971,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -6015,7 +6022,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -6060,6 +6067,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should stop loading i
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -6346,7 +6354,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -6397,7 +6405,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -6442,6 +6450,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect instr
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div
@@ -6806,7 +6815,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
   feedbackSessionDetails={[Function Object]}
   feedbackSessionEndingTimestamp={[Function Number]}
   feedbackSessionId="undefined"
-  feedbackSessionName="undefined"
+  feedbackSessionName={[Function String]}
   feedbackSessionTimeZone={[Function String]}
   feedbackSessionsService={[Function FeedbackSessionsService]}
   hasLoadedAllInstructorsFailed="false"
@@ -6857,7 +6866,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
               class="col-md-3 text-md-start"
               id="course-id"
             >
-               exampleId 
+               testId1 
             </div>
           </div>
           <div
@@ -6902,6 +6911,7 @@ exports[`InstructorSessionIndividualExtensionPageComponent should unselect only 
               class="col-md-10 text-md-start"
               id="session-name"
             >
+               Test Session 
             </div>
           </div>
           <div

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { forkJoin } from 'rxjs';
-import { finalize, map } from 'rxjs/operators';
+import { finalize, map, switchMap } from 'rxjs/operators';
 import { InstructorExtensionTableColumnModel, StudentExtensionTableColumnModel } from './extension-table-column-model';
 import { IndividualExtensionDateModalComponent } from './individual-extension-date-modal/individual-extension-date-modal.component';
 import { CourseService } from '../../../services/course.service';
@@ -113,8 +113,6 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
-      this.courseId = queryParams.courseid;
-      this.feedbackSessionName = queryParams.fsname;
       this.feedbackSessionId = queryParams.fsid;
       this.isAllYetToSubmitInstructorsSelected = queryParams.preselectnonsubmitters === 'true';
       this.isAllYetToSubmitStudentsSelected = queryParams.preselectnonsubmitters === 'true';
@@ -133,15 +131,22 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
     this.hasLoadingFeedbackSessionFailed = false;
     this.isLoadingAllInstructors = true;
     this.hasLoadedAllInstructorsFailed = false;
-    forkJoin([
-      this.courseService.getCourseAsInstructor(this.courseId),
-      this.feedbackSessionsService.getFeedbackSession({
+    this.feedbackSessionsService
+      .getFeedbackSession({
         feedbackSessionId: this.feedbackSessionId,
         intent: Intent.FULL_DETAIL,
-      }),
-      this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
-    ])
+      })
       .pipe(
+        switchMap((feedbackSession: FeedbackSession) => {
+          this.feedbackSessionName = feedbackSession.feedbackSessionName;
+          this.courseId = feedbackSession.courseId;
+          this.setFeedbackSessionDetails(feedbackSession);
+
+          return forkJoin([
+            this.courseService.getCourseAsInstructor(this.courseId),
+            this.feedbackSessionsService.getFeedbackSessionDeadlineExtensions(this.feedbackSessionId),
+          ]);
+        }),
         finalize(() => {
           this.isLoadingFeedbackSession = false;
           this.isLoadingAllStudents = false;
@@ -149,9 +154,8 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
         }),
       )
       .subscribe({
-        next: ([course, feedbackSession, deadlineExtensions]: [Course, FeedbackSession, DeadlineExtensions]) => {
+        next: ([course, deadlineExtensions]: [Course, DeadlineExtensions]) => {
           this.courseName = course.courseName;
-          this.setFeedbackSessionDetails(feedbackSession);
           this.userDeadlines = deadlineExtensions.userDeadlines;
           this.getAllStudentsOfCourse(); // Both students and instructors need feedback ending time.
           this.getAllInstructorsOfCourse();

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -7,8 +7,6 @@
           <a
             tmRouterLink="/web/instructor/sessions/individual-extension"
             [queryParams]="{
-              courseid: session.courseId,
-              fsname: session.feedbackSessionName,
               fsid: session.feedbackSessionId,
               preselectnonsubmitters: true,
             }"
@@ -79,8 +77,6 @@
                         rel="noopener noreferrer"
                         target="_blank"
                         [queryParams]="{
-                          courseid: session.courseId,
-                          fsname: session.feedbackSessionName,
                           fsid: session.feedbackSessionId,
                           moderatedperson: noResponseStudent.email,
                         }"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -23,8 +23,6 @@
                   <a
                     tmRouterLink="/web/instructor/sessions/edit"
                     [queryParams]="{
-                      courseid: session.courseId,
-                      fsname: session.feedbackSessionName,
                       fsid: session.feedbackSessionId,
                       editingMode: true,
                     }"

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -2,7 +2,7 @@
 <tm-loading-retry
   [shouldShowRetry]="hasFeedbackSessionLoadingFailed || hasSectionsLoadingFailed || hasQuestionsLoadingFailed"
   [message]="'Failed to load feedback session'"
-  (retryEvent)="loadFeedbackSessionResults(courseId, feedbackSessionId)"
+  (retryEvent)="loadFeedbackSessionResults(feedbackSessionId)"
 >
   <div *tmIsLoading="isFeedbackSessionLoading">
     @if (session) {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -766,8 +766,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
 
   navigateToIndividualSessionResultPage(): void {
     this.navigationService.navigateByURL('/web/instructor/sessions/result', {
-      courseid: this.courseId,
-      fsname: this.fsName,
       fsid: this.feedbackSessionId,
     });
   }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -171,14 +171,12 @@ export class InstructorSessionResultPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
-      this.courseId = queryParams.courseid;
-      this.fsName = queryParams.fsname;
       this.feedbackSessionId = queryParams.fsid;
-      this.loadFeedbackSessionResults(this.courseId, this.feedbackSessionId);
+      this.loadFeedbackSessionResults(this.feedbackSessionId);
     });
   }
 
-  loadFeedbackSessionResults(courseId: string, feedbackSessionId: string): void {
+  loadFeedbackSessionResults(feedbackSessionId: string): void {
     this.hasQuestionsLoadingFailed = false;
     this.hasSectionsLoadingFailed = false;
     this.hasFeedbackSessionLoadingFailed = false;
@@ -192,6 +190,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
         next: (feedbackSession: FeedbackSession) => {
           this.session = feedbackSession;
           this.feedbackSessionId = feedbackSession.feedbackSessionId!;
+          this.courseId = feedbackSession.courseId;
+          this.fsName = feedbackSession.feedbackSessionName;
           this.formattedSessionOpeningTime = this.timezoneService.formatToString(
             this.session.submissionStartTimestamp,
             this.session.timeZone,
@@ -228,7 +228,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
           this.isFeedbackSessionLoading = false;
 
           // load section tabs
-          this.courseService.getCourseSectionNames(courseId).subscribe({
+          this.courseService.getCourseSectionNames(this.courseId).subscribe({
             next: (courseSectionNames: CourseSectionNames) => {
               this.sectionsModel['None'] = {
                 questions: [],
@@ -278,7 +278,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
           // load all students in course
           this.studentService
             .getStudentsFromCourse({
-              courseId,
+              courseId: this.courseId,
             })
             .subscribe({
               next: (allStudents: Students) => {
@@ -333,7 +333,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
           // load current instructor name
           this.instructorService
             .getInstructor({
-              courseId,
+              courseId: this.courseId,
               intent: Intent.FULL_DETAIL,
             })
             .subscribe((instructor: Instructor) => {

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
@@ -1,8 +1,6 @@
 <a
   [tmRouterLink]="isGiverInstructor ? '/web/instructor/sessions/submission' : '/web/sessions/submission'"
   [queryParams]="{
-    courseid: session.courseId,
-    fsname: session.feedbackSessionName,
     fsid: session.feedbackSessionId,
     moderatedperson: relatedGiverEmail,
     moderatedquestionId: moderatedQuestionId,

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -165,8 +165,6 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
                   {
                     onClosed: () =>
                       this.navigationService.navigateByURLWithParamEncoding('/web/instructor/sessions/edit', {
-                        courseid: createdFeedbackSession.courseId,
-                        fsname: createdFeedbackSession.feedbackSessionName,
                         fsid: createdFeedbackSession.feedbackSessionId,
                       }),
                   },
@@ -176,8 +174,6 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
                   '/web/instructor/sessions/edit',
                   'The feedback session has been copied. Please modify settings/questions as necessary.',
                   {
-                    courseid: createdFeedbackSession.courseId,
-                    fsname: createdFeedbackSession.feedbackSessionName,
                     fsid: createdFeedbackSession.feedbackSessionId,
                   },
                 );
@@ -363,8 +359,6 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
               complete: () => {
                 this.navigationService
                   .navigateByURLWithParamEncoding('/web/instructor/sessions/edit', {
-                    courseid: feedbackSession.courseId,
-                    fsname: feedbackSession.feedbackSessionName,
                     fsid: feedbackSession.feedbackSessionId,
                   })
                   .then(() => {

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -5,14 +5,14 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -81,7 +81,6 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -96,7 +95,6 @@ exports[`SessionResultPageComponent should snap when previewing results 1`] = `
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -156,14 +154,14 @@ exports[`SessionResultPageComponent should snap when session results failed to l
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -233,7 +231,6 @@ exports[`SessionResultPageComponent should snap when session results failed to l
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -248,7 +245,6 @@ exports[`SessionResultPageComponent should snap when session results failed to l
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -311,14 +307,14 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -388,7 +384,6 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -403,7 +398,6 @@ exports[`SessionResultPageComponent should snap with an open feedback session wi
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -463,14 +457,14 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -540,7 +534,6 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -555,7 +548,6 @@ exports[`SessionResultPageComponent should snap with default fields 1`] = `
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -615,14 +607,14 @@ exports[`SessionResultPageComponent should snap with session details and results
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -697,14 +689,14 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -774,7 +766,6 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -789,7 +780,6 @@ exports[`SessionResultPageComponent should snap with session details loaded and 
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -849,14 +839,14 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -927,7 +917,6 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -942,7 +931,6 @@ exports[`SessionResultPageComponent should snap with user that is logged in and 
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div
@@ -1002,14 +990,14 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
   Intent={[Function Object]}
   authService={[Function AuthService]}
   backendUrl={[Function String]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
   entityType={[Function String]}
   feedbackQuestionsService={[Function FeedbackQuestionsService]}
-  feedbackSessionId="undefined"
-  feedbackSessionName={[Function String]}
+  feedbackSessionId={[Function String]}
+  feedbackSessionName=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
@@ -1079,7 +1067,6 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
           class="col-md-7 text-md-start"
           id="course-id"
         >
-          CS3281
         </div>
       </div>
       <div
@@ -1094,7 +1081,6 @@ exports[`SessionResultPageComponent should snap with user that is not logged in 
           class="col-md-7 text-md-start"
           id="session-name"
         >
-          Peer Feedback
         </div>
       </div>
       <div

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -33,6 +33,7 @@ import { Intent } from '../../../types/api-request';
 
 describe('SessionResultPageComponent', () => {
   const testFeedbackSession: FeedbackSession = {
+    feedbackSessionId: 'test-session-id',
     feedbackSessionName: 'First Session',
     courseId: 'CS1231',
     timeZone: 'Asia/Singapore',

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -96,8 +96,7 @@ describe('SessionResultPageComponent', () => {
   let logService: LogService;
 
   const testQueryParams: Record<string, string> = {
-    courseid: 'CS3281',
-    fsname: 'Peer Feedback',
+    fsid: 'test-session-id',
     key: 'reg-key',
     previewas: '',
   };
@@ -193,6 +192,7 @@ describe('SessionResultPageComponent', () => {
 
   it('should snap with an open feedback session with no questions', () => {
     component.session = {
+      feedbackSessionId: 'test-session-id',
       courseId: 'CS3281',
       timeZone: 'UTC',
       feedbackSessionName: 'Peer Review 1',
@@ -230,8 +230,7 @@ describe('SessionResultPageComponent', () => {
 
     component.ngOnInit();
 
-    expect(component.courseId).toEqual('CS3281');
-    expect(component.feedbackSessionName).toEqual('Peer Feedback');
+    expect(component.feedbackSessionId).toEqual('test-session-id');
     expect(component.regKey).toEqual('reg-key');
     expect(component.loggedInUser).toEqual('user-id');
   });
@@ -250,8 +249,7 @@ describe('SessionResultPageComponent', () => {
 
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith('/web/student/sessions/result', {
-      courseid: 'CS3281',
-      fsname: 'Peer Feedback',
+      fsid: 'test-session-id',
     });
   });
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -156,8 +156,6 @@ export class SessionResultPageComponent implements OnInit {
                       // The logged in user matches the registration key; redirect to the logged in URL
 
                       this.navigationService.navigateByURLWithParamEncoding(`/web/${this.entityType}/sessions/result`, {
-                        courseid: this.courseId,
-                        fsname: this.feedbackSessionName,
                         fsid: this.feedbackSessionId,
                       });
                     } else {
@@ -263,7 +261,6 @@ export class SessionResultPageComponent implements OnInit {
         this.instructorService
           .getInstructor({
             courseId: this.courseId,
-            feedbackSessionName: this.feedbackSessionName,
             intent: this.intent,
             key: this.regKey,
             previewAs: this.previewAsPerson,
@@ -366,8 +363,6 @@ export class SessionResultPageComponent implements OnInit {
 
   navigateToSessionReportPage(): void {
     this.navigationService.navigateByURL('/web/instructor/sessions/report', {
-      courseid: this.courseId,
-      fsname: this.feedbackSessionName,
       fsid: this.feedbackSessionId,
     });
   }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -125,8 +125,6 @@ export class SessionResultPageComponent implements OnInit {
         switchMap(() => this.route.queryParams),
       )
       .subscribe((queryParams: any) => {
-        this.courseId = queryParams.courseid;
-        this.feedbackSessionName = queryParams.fsname;
         this.feedbackSessionId = queryParams.fsid;
         this.regKey = queryParams.key || '';
         this.previewAsPerson = queryParams.previewas ? queryParams.previewas : '';
@@ -299,6 +297,8 @@ export class SessionResultPageComponent implements OnInit {
           const TIME_FORMAT = 'ddd, DD MMM, YYYY, hh:mm A zz';
           this.session = feedbackSession;
           this.feedbackSessionId = feedbackSession.feedbackSessionId;
+          this.courseId = feedbackSession.courseId;
+          this.feedbackSessionName = feedbackSession.feedbackSessionName;
           this.formattedSessionOpeningTime = this.timezoneService.formatToString(
             this.session.submissionStartTimestamp,
             this.session.timeZone,

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -160,8 +160,6 @@ export class SessionResultPageComponent implements OnInit {
                       });
                     } else {
                       // Valid, unused registration key; load information based on the key
-                      this.loadCourseInfo();
-                      this.loadPersonName();
                       this.loadFeedbackSession();
                     }
                   } else if (resp.isValid) {
@@ -198,8 +196,6 @@ export class SessionResultPageComponent implements OnInit {
             } else if (this.loggedInUser) {
               // Load information based on logged in user
               // This will also cover preview cases
-              this.loadCourseInfo();
-              this.loadPersonName();
               this.loadFeedbackSession();
             } else {
               this.navigationService.navigateWithErrorMessage(
@@ -308,6 +304,8 @@ export class SessionResultPageComponent implements OnInit {
           );
 
           this.logStudentView();
+          this.loadCourseInfo();
+          this.loadPersonName();
 
           this.feedbackQuestionsService
             .getFeedbackQuestions({

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -21,7 +21,7 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -171,7 +171,7 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -182,7 +182,7 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -329,7 +329,7 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -340,7 +340,7 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -778,7 +778,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -789,7 +789,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -910,7 +910,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             class="col-md-10 text-md-start"
             id="course-id"
           >
-            CS3281
           </div>
         </div>
         <div
@@ -925,7 +924,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             class="col-md-10 text-md-start"
             id="fs-name"
           >
-            Feedback Session Name
           </div>
         </div>
         <div
@@ -3816,7 +3814,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -3827,7 +3825,7 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -3948,7 +3946,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             class="col-md-10 text-md-start"
             id="course-id"
           >
-            CS3281
           </div>
         </div>
         <div
@@ -3963,7 +3960,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
             class="col-md-10 text-md-start"
             id="fs-name"
           >
-            Feedback Session Name
           </div>
         </div>
         <div
@@ -6890,7 +6886,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -6901,7 +6897,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}
@@ -7049,7 +7045,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
-  courseId={[Function String]}
+  courseId=""
   courseInstitute=""
   courseName=""
   courseService={[Function CourseService]}
@@ -7060,7 +7056,7 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
   feedbackResponsesService={[Function FeedbackResponsesService]}
   feedbackSessionId={[Function String]}
   feedbackSessionInstructions=""
-  feedbackSessionName={[Function String]}
+  feedbackSessionName=""
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function FeedbackSessionsService]}

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -596,19 +596,18 @@ describe('SessionSubmissionPageComponent', () => {
 
   const testInfo: AuthInfo = {
     masquerade: false,
+    loginUrl: 'http://localhost:8080/auth',
     user: {
       id: 'user-id',
+      accountId: 'account-id',
       isAdmin: false,
       isInstructor: false,
       isStudent: true,
       isMaintainer: false,
-      isAutomatedService: false,
     },
   };
 
   const testQueryParams: any = {
-    courseid: 'CS3281',
-    fsname: 'Feedback Session Name',
     fsid: '00000000-0000-4000-8000-000000000001',
     key: 'reg-key',
   };
@@ -782,8 +781,7 @@ describe('SessionSubmissionPageComponent', () => {
     jest.spyOn(authService, 'getAuthUser').mockReturnValue(of(testInfo));
     component.ngOnInit();
     expect(component.intent).toEqual(Intent.STUDENT_SUBMISSION);
-    expect(component.courseId).toEqual(testQueryParams.courseid);
-    expect(component.feedbackSessionName).toEqual(testQueryParams.fsname);
+    expect(component.feedbackSessionId).toEqual(testQueryParams.fsid);
     expect(component.regKey).toEqual(testQueryParams.key);
     expect(component.loggedInUser).toEqual(testInfo.user?.id);
   });
@@ -802,8 +800,6 @@ describe('SessionSubmissionPageComponent', () => {
 
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith('/web/student/sessions/submission', {
-      courseid: 'CS3281',
-      fsname: 'Feedback Session Name',
       fsid: '00000000-0000-4000-8000-000000000001',
     });
   });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -210,8 +210,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                       this.navigationService.navigateByURLWithParamEncoding(
                         `/web/${this.entityType}/sessions/submission`,
                         {
-                          courseid: this.courseId,
-                          fsname: this.feedbackSessionName,
                           fsid: this.feedbackSessionId,
                         },
                       );
@@ -363,7 +361,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         this.instructorService
           .getInstructor({
             courseId: this.courseId,
-            feedbackSessionName: this.feedbackSessionName,
             intent: this.intent,
             key: this.regKey,
             moderatedPerson: this.moderatedPerson,

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -179,8 +179,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         switchMap(() => this.route.queryParams),
       )
       .subscribe((queryParams: any) => {
-        this.courseId = queryParams.courseid;
-        this.feedbackSessionName = queryParams.fsname;
         this.feedbackSessionId = queryParams.fsid;
         this.regKey = queryParams.key ? queryParams.key : '';
         this.moderatedPerson = queryParams.moderatedperson ? queryParams.moderatedperson : '';
@@ -409,6 +407,8 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       .subscribe({
         next: (feedbackSession: FeedbackSession) => {
           this.feedbackSessionId = feedbackSession.feedbackSessionId;
+          this.courseId = feedbackSession.courseId;
+          this.feedbackSessionName = feedbackSession.feedbackSessionName;
           this.feedbackSessionInstructions = feedbackSession.instructions;
           this.formattedSessionOpeningTime = this.timezoneService.formatToString(
             feedbackSession.submissionStartTimestamp,

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -215,8 +215,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                       );
                     } else {
                       // Valid, unused registration key; load information based on the key
-                      this.loadCourseInfo();
-                      this.loadPersonName();
                       this.loadFeedbackSession(false, auth);
                     }
                   } else if (resp.isValid) {
@@ -252,8 +250,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             } else if (this.loggedInUser) {
               // Load information based on logged in user
               // This will also cover moderation/preview cases
-              this.loadCourseInfo();
-              this.loadPersonName();
               this.loadFeedbackSession(false, auth);
             } else {
               this.navigationService.navigateWithErrorMessage(
@@ -419,6 +415,8 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           this.feedbackSessionTimezone = feedbackSession.timeZone;
 
           this.logStudentAccess();
+          this.loadCourseInfo();
+          this.loadPersonName();
 
           // don't show alert modal in moderation
           if (!this.moderatedPerson) {

--- a/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
@@ -267,7 +267,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button disabled"
-                        href="/web/student/sessions/result?courseid=CS1231&fsname=First%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-0"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -275,7 +275,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=CS1231&fsname=First%20Session"
+                        href="/web/student/sessions/submission"
                         id="edit-submit-btn-0"
                         tmrouterlink="/web/student/sessions/submission"
                       >
@@ -313,7 +313,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button disabled"
-                        href="/web/student/sessions/result?courseid=CS1231&fsname=Second%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-1"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -321,7 +321,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=CS1231&fsname=Second%20Session"
+                        href="/web/student/sessions/submission"
                         id="view-submit-btn-1"
                         tmrouterlink="/web/student/sessions/submission"
                       >
@@ -435,7 +435,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button disabled"
-                        href="/web/student/sessions/result?courseid=LSM1306&fsname=Third%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-0"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -443,7 +443,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=LSM1306&fsname=Third%20Session"
+                        href="/web/student/sessions/submission"
                         id="edit-submit-btn-0"
                         tmrouterlink="/web/student/sessions/submission"
                       >
@@ -481,7 +481,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button disabled"
-                        href="/web/student/sessions/result?courseid=LSM1306&fsname=Fourth%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-1"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -489,7 +489,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=LSM1306&fsname=Fourth%20Session"
+                        href="/web/student/sessions/submission"
                         id="view-submit-btn-1"
                         tmrouterlink="/web/student/sessions/submission"
                       >
@@ -684,7 +684,7 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button"
-                        href="/web/student/sessions/result?courseid=CS2103&fsname=First%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-0"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -692,7 +692,7 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=CS2103&fsname=First%20Session"
+                        href="/web/student/sessions/submission"
                         id="edit-submit-btn-0"
                         tmrouterlink="/web/student/sessions/submission"
                       >
@@ -730,7 +730,7 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
                     >
                       <a
                         class="btn btn-light btn-sm btn-margin-right custom-button disabled"
-                        href="/web/student/sessions/result?courseid=CS2103&fsname=Second%20Session"
+                        href="/web/student/sessions/result"
                         id="view-responses-btn-1"
                         tmrouterlink="/web/student/sessions/result"
                       >
@@ -738,7 +738,7 @@ exports[`StudentHomePageComponent should snap with feedback sessions 1`] = `
                       </a>
                       <a
                         class="btn btn-light btn-sm custom-button"
-                        href="/web/student/sessions/submission?courseid=CS2103&fsname=Second%20Session"
+                        href="/web/student/sessions/submission"
                         id="start-submit-btn-1"
                         tmrouterlink="/web/student/sessions/submission"
                       >

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.html
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.html
@@ -122,8 +122,6 @@
                                   [ngClass]="{ disabled: !session.isPublished }"
                                   tmRouterLink="/web/student/sessions/result"
                                   [queryParams]="{
-                                    courseid: session.session.courseId,
-                                    fsname: session.session.feedbackSessionName,
                                     fsid: session.session.feedbackSessionId,
                                   }"
                                   id="view-responses-btn-{{ i }}"
@@ -140,8 +138,6 @@
                                   <a
                                     tmRouterLink="/web/student/sessions/submission"
                                     [queryParams]="{
-                                      courseid: session.session.courseId,
-                                      fsname: session.session.feedbackSessionName,
                                       fsid: session.session.feedbackSessionId,
                                     }"
                                     id="start-submit-btn-{{ i }}"
@@ -154,8 +150,6 @@
                                   <a
                                     tmRouterLink="/web/student/sessions/submission"
                                     [queryParams]="{
-                                      courseid: session.session.courseId,
-                                      fsname: session.session.feedbackSessionName,
                                       fsid: session.session.feedbackSessionId,
                                     }"
                                     id="edit-submit-btn-{{ i }}"
@@ -168,8 +162,6 @@
                                   <a
                                     tmRouterLink="/web/student/sessions/submission"
                                     [queryParams]="{
-                                      courseid: session.session.courseId,
-                                      fsname: session.session.feedbackSessionName,
                                       fsid: session.session.feedbackSessionId,
                                     }"
                                     id="view-submit-btn-{{ i }}"

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -780,12 +780,8 @@ describe('StudentHomePageComponent', () => {
 
     const href1: any = fixture.debugElement.nativeElement.querySelector('#view-responses-btn-0').getAttribute('href');
     const href2: any = fixture.debugElement.nativeElement.querySelector('#view-responses-btn-1').getAttribute('href');
-    expect(href1).toEqual(
-      '/web/student/sessions/result?courseid=CS1231&fsname=First%20Session&fsid=00000000-0000-4000-8000-000000000001',
-    );
-    expect(href2).toEqual(
-      '/web/student/sessions/result?courseid=CS1231&fsname=Second%20Session&fsid=00000000-0000-4000-8000-000000000002',
-    );
+    expect(href1).toEqual('/web/student/sessions/result?fsid=00000000-0000-4000-8000-000000000001');
+    expect(href2).toEqual('/web/student/sessions/result?fsid=00000000-0000-4000-8000-000000000002');
   });
 
   // start/edit/view submission button share the same router link and query params
@@ -859,12 +855,8 @@ describe('StudentHomePageComponent', () => {
 
     const href1: any = fixture.debugElement.nativeElement.querySelector('#view-submit-btn-0').getAttribute('href');
     const href2: any = fixture.debugElement.nativeElement.querySelector('#view-submit-btn-1').getAttribute('href');
-    expect(href1).toEqual(
-      '/web/student/sessions/submission?courseid=CS1231&fsname=First%20Session&fsid=00000000-0000-4000-8000-000000000001',
-    );
-    expect(href2).toEqual(
-      '/web/student/sessions/submission?courseid=CS1231&fsname=Second%20Session&fsid=00000000-0000-4000-8000-000000000002',
-    );
+    expect(href1).toEqual('/web/student/sessions/submission?fsid=00000000-0000-4000-8000-000000000001');
+    expect(href2).toEqual('/web/student/sessions/submission?fsid=00000000-0000-4000-8000-000000000002');
   });
 
   it('should sort courses by their IDs', () => {

--- a/src/web/services/instructor.service.ts
+++ b/src/web/services/instructor.service.ts
@@ -34,7 +34,6 @@ export class InstructorService {
    */
   getInstructor(queryParams: {
     courseId: string;
-    feedbackSessionName?: string;
     intent: Intent;
     key?: string;
     moderatedPerson?: string;
@@ -44,9 +43,6 @@ export class InstructorService {
       courseid: queryParams.courseId,
       intent: queryParams.intent,
     };
-    if (queryParams.feedbackSessionName) {
-      paramMap['fsname'] = queryParams.feedbackSessionName;
-    }
     if (queryParams.key) {
       paramMap['key'] = queryParams.key;
     }

--- a/src/web/services/link.service.spec.ts
+++ b/src/web/services/link.service.spec.ts
@@ -78,36 +78,32 @@ describe('Link Service', () => {
 
   it('should generate the submit url', () => {
     expect(
-      service.generateSubmitUrl(mockStudent, 'another happy landing', false, '00000000-0000-4000-8000-000000000001'),
+      service.generateSubmitUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001'),
     ).toBe(
       `${window.location.origin}/web/sessions/submission?key=keyheehee` +
-        '&fsname=another%20happy%20landing&courseid=dog.gma-demo' +
         '&fsid=00000000-0000-4000-8000-000000000001',
     );
 
     expect(
-      service.generateSubmitUrl(mockInstructor, 'another happy landing', true, '00000000-0000-4000-8000-000000000002'),
+      service.generateSubmitUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002'),
     ).toBe(
       `${window.location.origin}/web/sessions/submission?key=impicklerick` +
-        '&fsname=another%20happy%20landing&courseid=dog.gma-demo' +
         '&fsid=00000000-0000-4000-8000-000000000002&entitytype=instructor',
     );
   });
 
   it('should generate the result url', () => {
     expect(
-      service.generateResultUrl(mockStudent, 'another happy landing', false, '00000000-0000-4000-8000-000000000001'),
+      service.generateResultUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001'),
     ).toBe(
-      `${window.location.origin}/web/sessions/result?` +
-        'key=keyheehee&fsname=another%20happy%20landing&courseid=dog.gma-demo' +
+      `${window.location.origin}/web/sessions/result?key=keyheehee` +
         '&fsid=00000000-0000-4000-8000-000000000001',
     );
 
     expect(
-      service.generateResultUrl(mockInstructor, 'another happy landing', true, '00000000-0000-4000-8000-000000000002'),
+      service.generateResultUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002'),
     ).toBe(
-      `${window.location.origin}/web/sessions/result?` +
-        'key=impicklerick&fsname=another%20happy%20landing&courseid=dog.gma-demo' +
+      `${window.location.origin}/web/sessions/result?key=impicklerick` +
         '&fsid=00000000-0000-4000-8000-000000000002&entitytype=instructor',
     );
   });

--- a/src/web/services/link.service.spec.ts
+++ b/src/web/services/link.service.spec.ts
@@ -77,32 +77,22 @@ describe('Link Service', () => {
   });
 
   it('should generate the submit url', () => {
-    expect(
-      service.generateSubmitUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001'),
-    ).toBe(
-      `${window.location.origin}/web/sessions/submission?key=keyheehee` +
-        '&fsid=00000000-0000-4000-8000-000000000001',
+    expect(service.generateSubmitUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001')).toBe(
+      `${window.location.origin}/web/sessions/submission?key=keyheehee` + '&fsid=00000000-0000-4000-8000-000000000001',
     );
 
-    expect(
-      service.generateSubmitUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002'),
-    ).toBe(
+    expect(service.generateSubmitUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002')).toBe(
       `${window.location.origin}/web/sessions/submission?key=impicklerick` +
         '&fsid=00000000-0000-4000-8000-000000000002&entitytype=instructor',
     );
   });
 
   it('should generate the result url', () => {
-    expect(
-      service.generateResultUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001'),
-    ).toBe(
-      `${window.location.origin}/web/sessions/result?key=keyheehee` +
-        '&fsid=00000000-0000-4000-8000-000000000001',
+    expect(service.generateResultUrl(mockStudent, false, '00000000-0000-4000-8000-000000000001')).toBe(
+      `${window.location.origin}/web/sessions/result?key=keyheehee` + '&fsid=00000000-0000-4000-8000-000000000001',
     );
 
-    expect(
-      service.generateResultUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002'),
-    ).toBe(
+    expect(service.generateResultUrl(mockInstructor, true, '00000000-0000-4000-8000-000000000002')).toBe(
       `${window.location.origin}/web/sessions/result?key=impicklerick` +
         '&fsid=00000000-0000-4000-8000-000000000002&entitytype=instructor',
     );

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -106,19 +106,15 @@ export class LinkService {
    */
   generateSubmitUrl(
     entity: Student | Instructor,
-    fsname: string,
     isInstructor: boolean,
     feedbackSessionId: string,
   ): string {
     const frontendUrl: string = window.location.origin;
-    const courseId: string = entity.courseId;
     const key: string = entity.key || '';
     const params: {
       [key: string]: string;
     } = {
       key,
-      fsname,
-      courseid: courseId,
       fsid: feedbackSessionId,
     };
 
@@ -136,19 +132,15 @@ export class LinkService {
    */
   generateResultUrl(
     entity: Student | Instructor,
-    fsname: string,
     isInstructor: boolean,
     feedbackSessionId: string,
   ): string {
     const frontendUrl: string = window.location.origin;
-    const courseId: string = entity.courseId;
     const key: string = entity.key || '';
     const params: {
       [key: string]: string;
     } = {
       key,
-      fsname,
-      courseid: courseId,
       fsid: feedbackSessionId,
     };
 

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -104,11 +104,7 @@ export class LinkService {
   /**
    * Generates submit url for a feedback session.
    */
-  generateSubmitUrl(
-    entity: Student | Instructor,
-    isInstructor: boolean,
-    feedbackSessionId: string,
-  ): string {
+  generateSubmitUrl(entity: Student | Instructor, isInstructor: boolean, feedbackSessionId: string): string {
     const frontendUrl: string = window.location.origin;
     const key: string = entity.key || '';
     const params: {
@@ -130,11 +126,7 @@ export class LinkService {
   /**
    * Generates a result url for a feedback session.
    */
-  generateResultUrl(
-    entity: Student | Instructor,
-    isInstructor: boolean,
-    feedbackSessionId: string,
-  ): string {
+  generateResultUrl(entity: Student | Instructor, isInstructor: boolean, feedbackSessionId: string): string {
     const frontendUrl: string = window.location.origin;
     const key: string = entity.key || '';
     const params: {

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -280,7 +280,6 @@ export class SearchService {
           name: feedbackSession.feedbackSessionName,
           feedbackSessionUrl: this.linkService.generateSubmitUrl(
             entity,
-            feedbackSession.feedbackSessionName,
             isInstructor,
             feedbackSession.feedbackSessionId,
           ),
@@ -291,7 +290,6 @@ export class SearchService {
           name: feedbackSession.feedbackSessionName,
           feedbackSessionUrl: this.linkService.generateSubmitUrl(
             entity,
-            feedbackSession.feedbackSessionName,
             isInstructor,
             feedbackSession.feedbackSessionId,
           ),
@@ -302,7 +300,6 @@ export class SearchService {
           name: feedbackSession.feedbackSessionName,
           feedbackSessionUrl: this.linkService.generateSubmitUrl(
             entity,
-            feedbackSession.feedbackSessionName,
             isInstructor,
             feedbackSession.feedbackSessionId,
           ),
@@ -315,7 +312,6 @@ export class SearchService {
           name: feedbackSession.feedbackSessionName,
           feedbackSessionUrl: this.linkService.generateResultUrl(
             entity,
-            feedbackSession.feedbackSessionName,
             isInstructor,
             feedbackSession.feedbackSessionId,
           ),


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13738

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Remove feedbackSessionName from links. These are now unused after having successfully migrated APIs to use feedbackSessionId.