### PR TITLE
[#13952] Make RecaptchaVerifier and LogsProcessor configuration explicitly config-driven 

### DIFF
--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -89,6 +89,12 @@ public final class Config {
     /** Value of {@code app.captcha.secretkey}. */
     public static final String CAPTCHA_SECRET_KEY;
 
+    /** Value of {@code app.recaptcha.service}. */
+    public static final String RECAPTCHA_SERVICE;
+
+    /** Value of {@code app.logging.service}. */
+    public static final String LOGGING_SERVICE;
+
     /** Value of {@code app.admins} (comma-separated in the property file). */
     public static final List<String> APP_ADMINS;
 
@@ -206,6 +212,10 @@ public final class Config {
         OAUTH2_CLIENT_ID = getProperty(properties, devProperties, "app.oauth2.client.id");
         OAUTH2_CLIENT_SECRET = getProperty(properties, devProperties, "app.oauth2.client.secret");
         CAPTCHA_SECRET_KEY = getProperty(properties, devProperties, "app.captcha.secretkey");
+        RECAPTCHA_SERVICE = getProperty(properties, devProperties, "app.recaptcha.service",
+                IS_DEV_SERVER ? "local" : "google");
+        LOGGING_SERVICE = getProperty(properties, devProperties, "app.logging.service",
+                IS_DEV_SERVER ? "local" : "google-cloud");
         APP_ADMINS = Collections.unmodifiableList(
                 Arrays.asList(getProperty(properties, devProperties, "app.admins", "").split(",")));
         APP_MAINTAINERS = Collections.unmodifiableList(
@@ -369,6 +379,14 @@ public final class Config {
      */
     public static boolean isAllowSendingEmailsToTestDomain() {
         return IS_DEV_SERVER && EMAIL_ALLOW_SENDING_TO_TEST_DOMAIN;
+    }
+
+    public static boolean isUsingLocalRecaptcha() {
+        return "local".equalsIgnoreCase(RECAPTCHA_SERVICE);
+    }
+
+    public static boolean isUsingLocalLogging() {
+        return "local".equalsIgnoreCase(LOGGING_SERVICE);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/LogsProcessor.java
+++ b/src/main/java/teammates/logic/api/LogsProcessor.java
@@ -24,7 +24,7 @@ public class LogsProcessor {
     private final LogService service;
 
     LogsProcessor() {
-        if (Config.IS_DEV_SERVER) {
+        if (Config.isUsingLocalLogging()) {
             service = new LocalLoggingService();
         } else {
             service = new GoogleCloudLoggingService();

--- a/src/main/java/teammates/logic/api/RecaptchaVerifier.java
+++ b/src/main/java/teammates/logic/api/RecaptchaVerifier.java
@@ -14,7 +14,7 @@ public class RecaptchaVerifier {
     private final RecaptchaService service;
 
     RecaptchaVerifier() {
-        if (Config.IS_DEV_SERVER) {
+        if (Config.isUsingLocalRecaptcha()) {
             service = new EmptyRecaptchaService();
         } else {
             service = new GoogleRecaptchaService(Config.CAPTCHA_SECRET_KEY);

--- a/src/main/resources/build-dev.template.properties
+++ b/src/main/resources/build-dev.template.properties
@@ -31,5 +31,13 @@ app.taskqueue.active = true
 # Override to "google-cloud-tasks" if you want to exercise the Cloud Tasks code path locally.
 app.taskqueue.service = local
 
+# Local development should default to local captcha verification.
+# Override to "google" if you want to test real Google reCAPTCHA on a dev server.
+app.recaptcha.service = local
+
+# Local development should default to local logging.
+# Override to "google-cloud" if you want to test cloud logging on a dev server.
+app.logging.service = local
+
 # Set to true to allow sending emails to test/demo domains (local dev only).
 app.email.allow.sending.to.test.domain = false

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -86,6 +86,16 @@ app.oauth2.client.secret=
 # e.g. "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" is a secret key for test environments.
 app.captcha.secretkey =
 
+# This is the service used for captcha verification.
+# Acceptable values are local, google.
+# Defaults to local in development, google in production.
+app.recaptcha.service =
+
+# This is the service used for logging.
+# Acceptable values are local, google-cloud.
+# Defaults to local in development, google-cloud in production.
+app.logging.service =
+
 # This is the list of emails of users who have access to admin features of the system.
 # Separate with commas for multiple values with no leading/trailing spaces.
 app.admins=app_admin@gmail.com


### PR DESCRIPTION
Fixes #13952 
**Outline of Solution**

Replaced environment-based selection in [RecaptchaVerifier] and [LogsProcessor]
Added explicit config-driven helpers in [Config.java]
Documented new config keys in [build.template.properties]and [build-dev.template.properties]
