### PR TITLE
[#13979] Migrate reset account action to user userId

### DIFF
--- a/src/it/java/teammates/it/logic/core/UsersLogicIT.java
+++ b/src/it/java/teammates/it/logic/core/UsersLogicIT.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -14,7 +16,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.InstructorPermissions;
-import teammates.common.util.HibernateUtil;
 import teammates.it.test.BaseTestCaseWithDatabaseAccess;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.CoursesLogic;
@@ -25,6 +26,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.Team;
+import teammates.storage.entity.User;
 
 /**
  * SUT: {@link UsersLogic}.
@@ -59,80 +61,49 @@ public class UsersLogicIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testResetInstructorGoogleId()
+    public void testResetAccount_instructor()
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         Instructor instructor = getTypicalInstructor();
         instructor.setCourse(course);
         instructor.setAccount(account);
 
-        String email = instructor.getEmail();
-        String courseId = instructor.getCourseId();
         String googleId = instructor.getGoogleId();
 
-        ______TS("success: reset instructor that does not exist");
+        ______TS("failure: reset instructor that does not exist");
         assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetInstructorGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetAccount(instructor.getId()));
 
         ______TS("success: reset instructor that exists");
         usersLogic.createInstructor(instructor);
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
+        User resetUser = usersLogic.resetAccount(instructor.getId());
 
+        assertEquals(instructor, resetUser);
         assertNull(instructor.getAccount());
-        assertEquals(0, accountsLogic.getAccountsForEmail(email).size());
+        assertEquals(account, accountsLogic.getAccountForGoogleId(googleId));
 
-        ______TS("found at least one other user with same googleId, should not delete account");
-        Account anotherAccount = getTypicalAccount();
-        accountsLogic.createAccount(anotherAccount);
-
-        instructor.setCourse(course);
-        instructor.setAccount(anotherAccount);
-
-        Student anotherUser = usersLogic.createStudent(course, team, "name", "student-email@gmail.tmt", "comments");
-        anotherUser.setAccount(anotherAccount);
-        HibernateUtil.flushSession();
-
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
-
-        assertNull(instructor.getAccount());
-        assertEquals(anotherAccount, accountsLogic.getAccountForGoogleId(googleId));
     }
 
     @Test
-    public void testResetStudentGoogleId()
+    public void testResetAccount_student()
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         String email = "email@gmail.tmt";
-        String courseId = course.getId();
         String googleId = account.getGoogleId();
 
-        ______TS("success: reset student that does not exist");
+        ______TS("failure: reset student that does not exist");
+        UUID missingStudentId = UUID.randomUUID();
         assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetStudentGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetAccount(missingStudentId));
 
         ______TS("success: reset student that exists");
         Student student = usersLogic.createStudent(course, team, "name", email, "comments");
         student.setAccount(account);
 
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+        User resetUser = usersLogic.resetAccount(student.getId());
 
+        assertEquals(student, resetUser);
         assertNull(student.getAccount());
-        assertEquals(0, accountsLogic.getAccountsForEmail(email).size());
+        assertEquals(account, accountsLogic.getAccountForGoogleId(googleId));
 
-        ______TS("found at least one other user with same googleId, should not delete account");
-        Account anotherAccount = getTypicalAccount();
-        accountsLogic.createAccount(anotherAccount);
-
-        student.setCourse(course);
-        student.setAccount(anotherAccount);
-
-        Instructor anotherUser = getTypicalInstructor();
-        anotherUser.setCourse(course);
-        anotherUser.setAccount(anotherAccount);
-
-        usersLogic.createInstructor(anotherUser);
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
-
-        assertNull(student.getAccount());
-        assertEquals(anotherAccount, accountsLogic.getAccountForGoogleId(googleId));
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetRegKeyValidityActionIT.java
@@ -132,8 +132,8 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         ______TS("Normal case: No logged in user for an unused regkey; should be valid/unused/allowed");
 
         try {
-            logic.resetStudentGoogleId(student1.getEmail(), student1.getCourseId(), student1.getGoogleId());
-            logic.resetInstructorGoogleId(instructor1.getEmail(), instructor1.getCourseId(), instructor1.getGoogleId());
+            logic.resetAccount(student1.getId());
+            logic.resetAccount(instructor1.getId());
         } catch (EntityDoesNotExistException e) {
             e.printStackTrace();
         }

--- a/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -50,10 +52,9 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
 
         loginAsAdmin();
 
-        ______TS("Typical Success Case with Student Email param given and Student exists");
+        ______TS("Typical Success Case with Student user ID param given and Student exists");
         String[] params = new String[] {
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-                Const.ParamsNames.COURSE_ID, student.getCourseId(),
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         ResetAccountAction resetAccountAction = getAction(params);
@@ -65,20 +66,18 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
         assertNull(student.getAccount());
         assertNull(student.getGoogleId());
 
-        ______TS("Student Email param given but Student is non existent");
-        String invalidEmail = "does-not-exist-email@teammates.tmt";
+        ______TS("User ID param given but user is non existent");
+        UUID invalidUserId = UUID.randomUUID();
         String[] invalidParams = new String[] {
-                Const.ParamsNames.STUDENT_EMAIL, invalidEmail,
-                Const.ParamsNames.COURSE_ID, student.getCourseId(),
+                Const.ParamsNames.USER_ID, invalidUserId.toString(),
         };
 
         EntityNotFoundException enfe = verifyEntityNotFound(invalidParams);
-        assertEquals("Student does not exist.", enfe.getMessage());
+        assertEquals("User does not exist.", enfe.getMessage());
 
-        ______TS("Typical Success Case with Instructor Email param given and Instructor exists");
+        ______TS("Typical Success Case with Instructor user ID param given and Instructor exists");
         params = new String[] {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         resetAccountAction = getAction(params);
@@ -90,14 +89,6 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
         assertNull(instructor.getAccount());
         assertNull(instructor.getGoogleId());
 
-        ______TS("Instructor Email param given but Instructor is non existent");
-        invalidParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, invalidEmail,
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-        };
-
-        enfe = verifyEntityNotFound(invalidParams);
-        assertEquals("Instructor does not exist.", enfe.getMessage());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/ResetAccountActionIT.java
@@ -73,7 +73,7 @@ public class ResetAccountActionIT extends BaseActionIT<ResetAccountAction> {
         };
 
         EntityNotFoundException enfe = verifyEntityNotFound(invalidParams);
-        assertEquals("User does not exist.", enfe.getMessage());
+        assertEquals(Const.ERROR_UPDATE_NON_EXISTENT + "User [id=" + invalidUserId + "]", enfe.getMessage());
 
         ______TS("Typical Success Case with Instructor user ID param given and Instructor exists");
         params = new String[] {

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1130,33 +1130,13 @@ public class Logic {
     }
 
     /**
-     * Resets the googleId associated with the instructor.
+     * Resets the account associated with the user.
      *
-     * <br/>
-     * Preconditions: <br/>
-     * * All parameters are non-null.
-     *
-     * @throws EntityDoesNotExistException If instructor cannot be found with given
-     *                                     email and courseId.
+     * @return the user whose account was reset.
+     * @throws EntityDoesNotExistException If user cannot be found with given id.
      */
-    public void resetInstructorGoogleId(String email, String courseId, String googleId)
-            throws EntityDoesNotExistException {
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
-    }
-
-    /**
-     * Resets the googleId associated with the student.
-     *
-     * <br/>
-     * Preconditions: <br/>
-     * * All parameters are non-null.
-     *
-     * @throws EntityDoesNotExistException If student cannot be found with given
-     *                                     email and courseId.
-     */
-    public void resetStudentGoogleId(String email, String courseId, String googleId)
-            throws EntityDoesNotExistException {
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+    public User resetAccount(UUID userId) throws EntityDoesNotExistException {
+        return usersLogic.resetAccount(userId);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -747,29 +747,6 @@ public final class UsersLogic {
     }
 
     /**
-     * Resets the googleId associated with the instructor.
-     */
-    public void resetInstructorGoogleId(String email, String courseId, String googleId)
-            throws EntityDoesNotExistException {
-        assert email != null;
-        assert courseId != null;
-        assert googleId != null;
-
-        Instructor instructor = getInstructorForEmail(courseId, email);
-
-        if (instructor == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT
-                    + "Instructor [courseId=" + courseId + ", email=" + email + "]");
-        }
-
-        instructor.setAccount(null);
-
-        if (usersDb.getAllUsersByGoogleId(googleId).isEmpty()) {
-            accountsLogic.deleteAccount(googleId);
-        }
-    }
-
-    /**
      * Updates a student by student id and update request, and cascades to responses and comments if needed.
      */
     public Student updateStudent(UUID studentId, StudentUpdateRequest updateRequest)
@@ -991,26 +968,19 @@ public final class UsersLogic {
     }
 
     /**
-     * Resets the googleId associated with the student.
+     * Resets the account associated with the user.
      */
-    public void resetStudentGoogleId(String email, String courseId, String googleId)
-            throws EntityDoesNotExistException {
-        assert email != null;
-        assert courseId != null;
-        assert googleId != null;
+    public User resetAccount(UUID userId) throws EntityDoesNotExistException {
+        assert userId != null;
 
-        Student student = getStudentForEmail(courseId, email);
+        User user = getUser(userId);
 
-        if (student == null) {
-            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT
-                    + "Student [courseId=" + courseId + ", email=" + email + "]");
+        if (user == null) {
+            throw new EntityDoesNotExistException(ERROR_UPDATE_NON_EXISTENT + "User [id=" + userId + "]");
         }
 
-        student.setAccount(null);
-
-        if (usersDb.getAllUsersByGoogleId(googleId).isEmpty()) {
-            accountsLogic.deleteAccount(googleId);
-        }
+        user.setAccount(null);
+        return user;
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/ResetAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/ResetAccountAction.java
@@ -21,44 +21,30 @@ public class ResetAccountAction extends AdminOnlyAction {
     @Override
     public JsonResult execute() {
         UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
-        User existingUser = logic.getUser(userId);
+        User existingUser;
 
-        if (existingUser == null) {
-            throw new EntityNotFoundException("User does not exist.");
+        try {
+            existingUser = logic.resetAccount(userId);
+        } catch (EntityDoesNotExistException e) {
+            throw new EntityNotFoundException(e);
         }
 
         Course course = existingUser.getCourse();
 
         if (existingUser instanceof Student existingStudent) {
-            try {
-                if (existingStudent.getGoogleId() != null) {
-                    logic.resetStudentGoogleId(existingStudent.getEmail(), existingStudent.getCourseId(),
-                            existingStudent.getGoogleId());
-                }
-                // Generate and queue rejoin email to priority queue
-                EmailWrapper email = emailGenerator
-                        .generateStudentCourseRejoinEmailAfterGoogleIdReset(course, existingStudent);
-                List<EmailWrapper> emails = new ArrayList<>();
-                emails.add(email);
-                taskQueuer.scheduleEmailsForPrioritySending(emails);
-            } catch (EntityDoesNotExistException e) {
-                throw new EntityNotFoundException(e);
-            }
+            // Generate and queue rejoin email to priority queue
+            EmailWrapper email = emailGenerator
+                    .generateStudentCourseRejoinEmailAfterGoogleIdReset(course, existingStudent);
+            List<EmailWrapper> emails = new ArrayList<>();
+            emails.add(email);
+            taskQueuer.scheduleEmailsForPrioritySending(emails);
         } else if (existingUser instanceof Instructor existingInstructor) {
-            try {
-                if (existingInstructor.getGoogleId() != null) {
-                    logic.resetInstructorGoogleId(existingInstructor.getEmail(), existingInstructor.getCourseId(),
-                            existingInstructor.getGoogleId());
-                }
-                // Generate and queue rejoin email to priority queue
-                EmailWrapper email = emailGenerator
-                        .generateInstructorCourseRejoinEmailAfterGoogleIdReset(existingInstructor, course);
-                List<EmailWrapper> emails = new ArrayList<>();
-                emails.add(email);
-                taskQueuer.scheduleEmailsForPrioritySending(emails);
-            } catch (EntityDoesNotExistException e) {
-                throw new EntityNotFoundException(e);
-            }
+            // Generate and queue rejoin email to priority queue
+            EmailWrapper email = emailGenerator
+                    .generateInstructorCourseRejoinEmailAfterGoogleIdReset(existingInstructor, course);
+            List<EmailWrapper> emails = new ArrayList<>();
+            emails.add(email);
+            taskQueuer.scheduleEmailsForPrioritySending(emails);
         }
 
         return new JsonResult("Account is successfully reset.");

--- a/src/main/java/teammates/ui/webapi/ResetAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/ResetAccountAction.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
@@ -9,8 +10,8 @@ import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
-import teammates.ui.exception.InvalidHttpParameterException;
 
 /**
  * Action: resets an account ID.
@@ -19,29 +20,20 @@ public class ResetAccountAction extends AdminOnlyAction {
 
     @Override
     public JsonResult execute() {
-        String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+        UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        User existingUser = logic.getUser(userId);
 
-        if (studentEmail == null && instructorEmail == null) {
-            throw new InvalidHttpParameterException("Either student email or instructor email has to be specified.");
+        if (existingUser == null) {
+            throw new EntityNotFoundException("User does not exist.");
         }
 
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(courseId);
-        if (course == null) {
-            throw new EntityNotFoundException("Course does not exist");
-        }
+        Course course = existingUser.getCourse();
 
-        if (studentEmail != null) {
-            Student existingStudent = logic.getStudentForEmail(courseId, studentEmail);
-
-            if (existingStudent == null) {
-                throw new EntityNotFoundException("Student does not exist.");
-            }
-
+        if (existingUser instanceof Student existingStudent) {
             try {
                 if (existingStudent.getGoogleId() != null) {
-                    logic.resetStudentGoogleId(studentEmail, courseId, existingStudent.getGoogleId());
+                    logic.resetStudentGoogleId(existingStudent.getEmail(), existingStudent.getCourseId(),
+                            existingStudent.getGoogleId());
                 }
                 // Generate and queue rejoin email to priority queue
                 EmailWrapper email = emailGenerator
@@ -52,16 +44,11 @@ public class ResetAccountAction extends AdminOnlyAction {
             } catch (EntityDoesNotExistException e) {
                 throw new EntityNotFoundException(e);
             }
-        } else if (instructorEmail != null) {
-            Instructor existingInstructor = logic.getInstructorForEmail(courseId, instructorEmail);
-
-            if (existingInstructor == null) {
-                throw new EntityNotFoundException("Instructor does not exist.");
-            }
-
+        } else if (existingUser instanceof Instructor existingInstructor) {
             try {
                 if (existingInstructor.getGoogleId() != null) {
-                    logic.resetInstructorGoogleId(instructorEmail, courseId, existingInstructor.getGoogleId());
+                    logic.resetInstructorGoogleId(existingInstructor.getEmail(), existingInstructor.getCourseId(),
+                            existingInstructor.getGoogleId());
                 }
                 // Generate and queue rejoin email to priority queue
                 EmailWrapper email = emailGenerator

--- a/src/test/java/teammates/logic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsersLogicTest.java
@@ -10,10 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -27,6 +26,7 @@ import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 import teammates.test.BaseTestCase;
 
 /**
@@ -66,71 +66,43 @@ public class UsersLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testResetInstructorGoogleId_instructorExistsWithEmptyUsersListFromGoogleId_success()
+    public void testResetAccount_instructorExists_success()
             throws EntityDoesNotExistException {
-        String courseId = instructor.getCourseId();
-        String email = instructor.getEmail();
         String googleId = account.getGoogleId();
 
-        when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(instructor);
-        when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(usersDb.getUser(instructor.getId())).thenReturn(instructor);
 
-        List<Instructor> instructorsList = new ArrayList<>();
-        instructorsList.add(instructor);
-        when(usersLogic.getInstructorsForCourse(courseId)).thenReturn(instructorsList);
+        User resetUser = usersLogic.resetAccount(instructor.getId());
 
-        usersLogic.resetInstructorGoogleId(email, courseId, googleId);
-
-        assertEquals(null, instructor.getAccount());
-        verify(accountsLogic, times(1)).deleteAccount(googleId);
+        assertEquals(instructor, resetUser);
+        assertNull(instructor.getAccount());
+        verify(accountsLogic, times(0)).deleteAccount(googleId);
     }
 
     @Test
-    public void testResetInstructorGoogleId_instructorDoesNotExists_throwsEntityDoesNotExistException() {
-        String courseId = instructor.getCourseId();
-        String email = instructor.getEmail();
-        String googleId = account.getGoogleId();
+    public void testResetAccount_userDoesNotExist_throwsEntityDoesNotExistException() {
+        UUID userId = UUID.randomUUID();
 
-        when(usersLogic.getInstructorForEmail(courseId, email)).thenReturn(null);
+        when(usersDb.getUser(userId)).thenReturn(null);
 
         EntityDoesNotExistException exception = assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetInstructorGoogleId(email, courseId, googleId));
+                () -> usersLogic.resetAccount(userId));
 
-        assertEquals(ERROR_UPDATE_NON_EXISTENT
-                + "Instructor [courseId=" + courseId + ", email=" + email + "]", exception.getMessage());
+        assertEquals(ERROR_UPDATE_NON_EXISTENT + "User [id=" + userId + "]", exception.getMessage());
     }
 
     @Test
-    public void testResetStudentGoogleId_studentExistsWithEmptyUsersListFromGoogleId_success()
+    public void testResetAccount_studentExists_success()
             throws EntityDoesNotExistException {
-        String courseId = student.getCourseId();
-        String email = student.getEmail();
         String googleId = account.getGoogleId();
 
-        when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(student);
-        when(usersDb.getAllUsersByGoogleId(googleId)).thenReturn(Collections.emptyList());
-        when(accountsLogic.getAccountForGoogleId(googleId)).thenReturn(account);
+        when(usersDb.getUser(student.getId())).thenReturn(student);
 
-        usersLogic.resetStudentGoogleId(email, courseId, googleId);
+        User resetUser = usersLogic.resetAccount(student.getId());
 
+        assertEquals(student, resetUser);
         assertNull(student.getAccount());
-        verify(accountsLogic, times(1)).deleteAccount(googleId);
-    }
-
-    @Test
-    public void testResetStudentGoogleId_entityDoesNotExists_throwsEntityDoesNotExistException() {
-        String courseId = student.getCourseId();
-        String email = student.getEmail();
-        String googleId = account.getGoogleId();
-
-        when(usersLogic.getStudentForEmail(courseId, email)).thenReturn(null);
-
-        EntityDoesNotExistException exception = assertThrows(EntityDoesNotExistException.class,
-                () -> usersLogic.resetStudentGoogleId(email, courseId, googleId));
-
-        assertEquals(ERROR_UPDATE_NON_EXISTENT
-                + "Student [courseId=" + courseId + ", email=" + email + "]", exception.getMessage());
+        verify(accountsLogic, times(0)).deleteAccount(googleId);
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -47,10 +49,6 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         stubInstructorAfterReset = getTypicalInstructor();
         reset(mockLogic, mockEmailGenerator);
         logoutUser();
-
-        // Mock getCourse to avoid NPE
-        when(mockLogic.getCourse(stubStudent.getCourseId())).thenReturn(stubStudent.getCourse());
-        when(mockLogic.getCourse(stubInstructor.getCourseId())).thenReturn(stubInstructor.getCourse());
     }
 
     @Test
@@ -78,56 +76,23 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
                 Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
         };
         verifyHttpParameterFailure(params5);
+
+        String[] params6 = {
+                Const.ParamsNames.USER_ID, "invalid-user-id",
+        };
+        verifyHttpParameterFailure(params6);
     }
 
     @Test
-    void testExecute_invalidStudentEmail_throwsEntityNotFoundException() {
+    void testExecute_invalidUserId_throwsEntityNotFoundException() {
         loginAsAdmin();
 
+        UUID invalidUserId = UUID.randomUUID();
         String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, "invalid-student-email",
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+                Const.ParamsNames.USER_ID, invalidUserId.toString(),
         };
-        when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), "invalid-student-email"))
-                .thenReturn(null);
+        when(mockLogic.getUser(invalidUserId)).thenReturn(null);
         verifyEntityNotFound(params);
-        assertEquals(0, mockTaskQueuer.getTasksAdded().size());
-    }
-
-    @Test
-    void testExecute_invalidInstructorEmail_throwsEntityNotFoundException() {
-        loginAsAdmin();
-
-        String[] params = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, "invalid-instructor-email",
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
-        };
-        when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), "invalid-instructor-email"))
-                .thenReturn(null);
-        verifyEntityNotFound(params);
-        assertEquals(0, mockTaskQueuer.getTasksAdded().size());
-    }
-
-    @Test
-    void testExecute_invalidCourseId_throwsEntityNotFoundException() {
-        loginAsAdmin();
-
-        String[] params1 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, "invalid-course-id",
-        };
-        when(mockLogic.getStudentForEmail("invalid-course-id", stubStudent.getEmail()))
-                .thenReturn(null);
-        verifyEntityNotFound(params1);
-        assertEquals(0, mockTaskQueuer.getTasksAdded().size());
-
-        String[] params2 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.COURSE_ID, "invalid-course-id",
-        };
-        when(mockLogic.getInstructorForEmail("invalid-course-id", stubInstructor.getEmail()))
-                .thenReturn(null);
-        verifyEntityNotFound(params2);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
     }
 
@@ -136,11 +101,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
+                Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
-        when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), stubInstructor.getEmail()))
-                .thenReturn(stubInstructor);
+        when(mockLogic.getUser(stubInstructor.getId())).thenReturn(stubInstructor);
         when(mockEmailGenerator.generateInstructorCourseRejoinEmailAfterGoogleIdReset(
                 stubInstructor, stubInstructor.getCourse())).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -158,11 +121,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
         };
-        when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
-                .thenReturn(stubStudent);
+        when(mockLogic.getUser(stubStudent.getId())).thenReturn(stubStudent);
         when(mockEmailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(
                 stubStudent.getCourse(), stubStudent)).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -180,11 +141,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudentAfterReset.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudentAfterReset.getCourseId(),
+                Const.ParamsNames.USER_ID, stubStudentAfterReset.getId().toString(),
         };
-        when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
-                .thenReturn(stubStudentAfterReset);
+        when(mockLogic.getUser(stubStudentAfterReset.getId())).thenReturn(stubStudentAfterReset);
         when(mockEmailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(
                 stubStudent.getCourse(), stubStudentAfterReset)).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -202,11 +161,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructorAfterReset.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubInstructorAfterReset.getCourseId(),
+                Const.ParamsNames.USER_ID, stubInstructorAfterReset.getId().toString(),
         };
-        when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), stubInstructor.getEmail()))
-                .thenReturn(stubInstructorAfterReset);
+        when(mockLogic.getUser(stubInstructorAfterReset.getId())).thenReturn(stubInstructorAfterReset);
         when(mockEmailGenerator.generateInstructorCourseRejoinEmailAfterGoogleIdReset(
                 stubInstructorAfterReset, stubInstructor.getCourse())).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -225,11 +182,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
         };
-        when(mockLogic.getStudentForEmail(stubStudent.getCourseId(), stubStudent.getEmail()))
-                .thenReturn(stubStudent);
+        when(mockLogic.getUser(stubStudent.getId())).thenReturn(stubStudent);
         doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentGoogleId(stubStudent.getEmail(),
                 stubStudent.getCourseId(), stubStudent.getGoogleId());
         verifyEntityNotFound(params);
@@ -243,11 +198,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         loginAsAdmin();
 
         String[] params = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
+                Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
-        when(mockLogic.getInstructorForEmail(stubInstructor.getCourseId(), stubInstructor.getEmail()))
-                .thenReturn(stubInstructor);
+        when(mockLogic.getUser(stubInstructor.getId())).thenReturn(stubInstructor);
         doThrow(EntityDoesNotExistException.class).when(mockLogic).resetInstructorGoogleId(stubInstructor.getEmail(),
                 stubInstructor.getCourseId(), stubInstructor.getGoogleId());
         verifyEntityNotFound(params);
@@ -258,11 +211,10 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
     void testAccessControl() {
         String[] params1 = {};
         String[] params2 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.COURSE_ID, stubStudent.getCourseId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
         };
         String[] params3 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
+                Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
         String[] params4 = {
                 Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),

--- a/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
@@ -84,14 +84,14 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
     }
 
     @Test
-    void testExecute_invalidUserId_throwsEntityNotFoundException() {
+    void testExecute_invalidUserId_throwsEntityNotFoundException() throws EntityDoesNotExistException {
         loginAsAdmin();
 
         UUID invalidUserId = UUID.randomUUID();
         String[] params = {
                 Const.ParamsNames.USER_ID, invalidUserId.toString(),
         };
-        when(mockLogic.getUser(invalidUserId)).thenReturn(null);
+        when(mockLogic.resetAccount(invalidUserId)).thenThrow(EntityDoesNotExistException.class);
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
     }
@@ -103,7 +103,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
-        when(mockLogic.getUser(stubInstructor.getId())).thenReturn(stubInstructor);
+        when(mockLogic.resetAccount(stubInstructor.getId())).thenReturn(stubInstructor);
         when(mockEmailGenerator.generateInstructorCourseRejoinEmailAfterGoogleIdReset(
                 stubInstructor, stubInstructor.getCourse())).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -112,8 +112,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(1)).resetInstructorGoogleId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+        verify(mockLogic, times(1)).resetAccount(stubInstructor.getId());
     }
 
     @Test
@@ -123,7 +122,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
         };
-        when(mockLogic.getUser(stubStudent.getId())).thenReturn(stubStudent);
+        when(mockLogic.resetAccount(stubStudent.getId())).thenReturn(stubStudent);
         when(mockEmailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(
                 stubStudent.getCourse(), stubStudent)).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -132,8 +131,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(1))
-                .resetStudentGoogleId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+        verify(mockLogic, times(1)).resetAccount(stubStudent.getId());
     }
 
     @Test
@@ -143,7 +141,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubStudentAfterReset.getId().toString(),
         };
-        when(mockLogic.getUser(stubStudentAfterReset.getId())).thenReturn(stubStudentAfterReset);
+        when(mockLogic.resetAccount(stubStudentAfterReset.getId())).thenReturn(stubStudentAfterReset);
         when(mockEmailGenerator.generateStudentCourseRejoinEmailAfterGoogleIdReset(
                 stubStudent.getCourse(), stubStudentAfterReset)).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -152,8 +150,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(0))
-                .resetStudentGoogleId(stubStudent.getEmail(), stubStudent.getCourseId(), stubStudent.getGoogleId());
+        verify(mockLogic, times(1)).resetAccount(stubStudentAfterReset.getId());
     }
 
     @Test
@@ -163,7 +160,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubInstructorAfterReset.getId().toString(),
         };
-        when(mockLogic.getUser(stubInstructorAfterReset.getId())).thenReturn(stubInstructorAfterReset);
+        when(mockLogic.resetAccount(stubInstructorAfterReset.getId())).thenReturn(stubInstructorAfterReset);
         when(mockEmailGenerator.generateInstructorCourseRejoinEmailAfterGoogleIdReset(
                 stubInstructorAfterReset, stubInstructor.getCourse())).thenReturn(mock(EmailWrapper.class));
         ResetAccountAction action = getAction(params);
@@ -172,8 +169,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
 
         assertEquals("Account is successfully reset.", output.getMessage());
         verifySpecifiedTasksAdded(Const.TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
-        verify(mockLogic, times(0)).resetInstructorGoogleId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+        verify(mockLogic, times(1)).resetAccount(stubInstructorAfterReset.getId());
     }
 
     @Test
@@ -184,9 +180,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
         };
-        when(mockLogic.getUser(stubStudent.getId())).thenReturn(stubStudent);
-        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetStudentGoogleId(stubStudent.getEmail(),
-                stubStudent.getCourseId(), stubStudent.getGoogleId());
+        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetAccount(stubStudent.getId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
 
@@ -200,9 +194,7 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params = {
                 Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
-        when(mockLogic.getUser(stubInstructor.getId())).thenReturn(stubInstructor);
-        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetInstructorGoogleId(stubInstructor.getEmail(),
-                stubInstructor.getCourseId(), stubInstructor.getGoogleId());
+        doThrow(EntityDoesNotExistException.class).when(mockLogic).resetAccount(stubInstructor.getId());
         verifyEntityNotFound(params);
         assertEquals(0, mockTaskQueuer.getTasksAdded().size());
     }

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.spec.ts
@@ -173,7 +173,7 @@ describe('AdminInstructorSearchTableComponent', () => {
       });
     });
 
-    vi.spyOn(accountService, 'resetInstructorAccount').mockReturnValue(
+    vi.spyOn(accountService, 'resetAccount').mockReturnValue(
       of({
         message: 'Success',
       }),
@@ -219,7 +219,7 @@ describe('AdminInstructorSearchTableComponent', () => {
       });
     });
 
-    vi.spyOn(accountService, 'resetInstructorAccount').mockReturnValue(
+    vi.spyOn(accountService, 'resetAccount').mockReturnValue(
       throwError(() => ({
         error: {
           message: 'This is the error message',

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.ts
@@ -70,7 +70,7 @@ export class AdminInstructorSearchTableComponent implements OnChanges {
 
     modalRef.result.then(
       () => {
-        this.accountService.resetInstructorAccount(instructor.courseId, instructor.email).subscribe({
+        this.accountService.resetAccount(instructor.userId).subscribe({
           next: () => {
             this.instructorReset.emit();
             this.statusMessageService.showSuccessToast("The instructor's Google ID has been reset.");

--- a/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.spec.ts
@@ -154,7 +154,7 @@ describe('AdminStudentSearchTableComponent', () => {
       });
     });
 
-    vi.spyOn(accountService, 'resetStudentAccount').mockReturnValue(
+    vi.spyOn(accountService, 'resetAccount').mockReturnValue(
       of({
         message: 'success',
       }),
@@ -205,7 +205,7 @@ describe('AdminStudentSearchTableComponent', () => {
       });
     });
 
-    vi.spyOn(accountService, 'resetStudentAccount').mockReturnValue(
+    vi.spyOn(accountService, 'resetAccount').mockReturnValue(
       throwError(() => ({
         error: {
           message: 'This is the error message.',

--- a/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.ts
@@ -72,7 +72,7 @@ export class AdminStudentSearchTableComponent implements OnChanges {
 
     modalRef.result.then(
       () => {
-        this.accountService.resetStudentAccount(student.courseId, student.email).subscribe({
+        this.accountService.resetAccount(student.userId).subscribe({
           next: () => {
             student.googleId = '';
             this.studentReset.emit();

--- a/src/web/services/account.service.spec.ts
+++ b/src/web/services/account.service.spec.ts
@@ -91,20 +91,10 @@ describe('AccountService', () => {
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.ACCOUNT_REQUEST_RESET, paramMap);
   });
 
-  it('should execute PUT on account/reset endpoint for student', () => {
-    service.resetStudentAccount(id, 'testStudentEmail');
+  it('should execute PUT on account/reset endpoint', () => {
+    service.resetAccount('testUserId');
     const paramMap: Record<string, string> = {
-      courseid: id,
-      studentemail: 'testStudentEmail',
-    };
-    expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.ACCOUNT_RESET, paramMap);
-  });
-
-  it('should execute PUT on account/reset endpoint for instructor', () => {
-    service.resetInstructorAccount(id, 'testInstructorEmail');
-    const paramMap: Record<string, string> = {
-      courseid: id,
-      instructoremail: 'testInstructorEmail',
+      userid: 'testUserId',
     };
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.ACCOUNT_RESET, paramMap);
   });

--- a/src/web/services/account.service.ts
+++ b/src/web/services/account.service.ts
@@ -74,23 +74,11 @@ export class AccountService {
   }
 
   /**
-   * Resets a student account by calling API.
+   * Resets a user account by calling API.
    */
-  resetStudentAccount(courseId: string, studentEmail: string): Observable<MessageOutput> {
+  resetAccount(userId: string): Observable<MessageOutput> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      studentemail: studentEmail,
-    };
-    return this.httpRequestService.put(ResourceEndpoints.ACCOUNT_RESET, paramMap);
-  }
-
-  /**
-   * Resets an instructor account by calling API.
-   */
-  resetInstructorAccount(courseId: string, instructorEmail: string): Observable<MessageOutput> {
-    const paramMap: Record<string, string> = {
-      courseid: courseId,
-      instructoremail: instructorEmail,
+      userid: userId,
     };
     return this.httpRequestService.put(ResourceEndpoints.ACCOUNT_RESET, paramMap);
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13979

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Migrates reset account action to use userId instead of student/instructor email. Of note, account is no longer deleted if orphaned.