### PR TITLE
[#13979] Migrate join reminders email to use userId

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/CreateInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateInstructorActionIT.java
@@ -59,7 +59,7 @@ public class CreateInstructorActionIT extends BaseActionIT<CreateInstructorActio
 
     @Test
     protected void testExecute_typicalCase_shouldPass() throws Exception {
-        loginAsAdmin();
+        loginAsInstructor(typicalBundle.instructors.get("instructor1OfCourse1").getGoogleId());
 
         Course course1 = typicalBundle.courses.get("course1");
 
@@ -117,10 +117,6 @@ public class CreateInstructorActionIT extends BaseActionIT<CreateInstructorActio
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
         };
-
-        ______TS("Admins can access");
-
-        verifyAccessibleForAdmin(submissionParams);
 
         ______TS("only instructors of the same course can access");
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -24,7 +24,6 @@ import teammates.logic.core.CoursesLogic;
 import teammates.logic.core.DeadlineExtensionsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.logic.core.UsersLogic;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.DeadlineExtension;

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -877,7 +877,7 @@ public final class EmailGenerator {
      * Generates the course join email for the given {@code instructor} in {@code course}.
      * Also specifies contact information of {@code inviter}.
      */
-    public EmailWrapper generateInstructorCourseJoinEmail(Account inviter,
+    public EmailWrapper generateInstructorCourseJoinEmail(Instructor inviter,
             Instructor instructor, Course course) {
 
         String emailBody = Templates.populateTemplate(

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -10,7 +10,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.SanitizationHelper;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
@@ -32,10 +31,6 @@ public class CreateInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
-            return;
-        }
-
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
@@ -60,9 +55,9 @@ public class CreateInstructorAction extends Action {
             Instructor createdInstructor = logic.createInstructor(instructorToAdd);
 
             // Generate and queue invitation email to priority queue (user-triggered)
-            Account inviter = logic.getAccountForGoogleId(getCurrentUserGoogleId());
+            Instructor inviter = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
             if (inviter == null) {
-                throw new EntityNotFoundException("Inviter account does not exist.");
+                throw new EntityNotFoundException("Inviter does not exist.");
             }
             EmailWrapper email = emailGenerator.generateInstructorCourseJoinEmail(inviter, createdInstructor, course);
             List<EmailWrapper> emails = new ArrayList<>();

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -80,9 +79,9 @@ public class SendJoinReminderEmailAction extends Action {
                 throw new EntityNotFoundException(
                         "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
             }
-            Account inviter = logic.getAccountForGoogleId(getCurrentUserGoogleId());
+            Instructor inviter = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
             if (inviter == null) {
-                throw new EntityNotFoundException("Inviter account does not exist.");
+                throw new EntityNotFoundException("Inviter does not exist.");
             }
             EmailWrapper email = emailGenerator.generateInstructorCourseJoinEmail(inviter, instructorData, course);
             List<EmailWrapper> emails = new ArrayList<>();

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -2,12 +2,14 @@ package teammates.ui.webapi;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -23,63 +25,44 @@ public class SendJoinReminderEmailAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(courseId);
+        User user = getUserToRemind();
+        Course course = user == null ? getCourseForCourseWideReminder() : user.getCourse();
         if (course == null) {
-            throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
+            throw new EntityNotFoundException("Course does not exist!");
         }
 
-        String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
+        Instructor instructor = logic.getInstructorByGoogleId(course.getId(), getCurrentUserGoogleId());
 
-        boolean isSendingToStudent = studentEmail != null;
-        boolean isSendingToInstructor = instructorEmail != null;
-        if (isSendingToStudent) {
+        if (user == null || user instanceof Student) {
             gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
-        } else if (isSendingToInstructor) {
+        } else if (user instanceof Instructor) {
             gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
-        } else {
-            // this is sending registration emails to all students in the course and we will check if the instructor
-            // canmodifystudent for course level since for modifystudent privilege there is only course level setting for now
-            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         }
     }
 
     @Override
     public JsonResult execute() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(courseId);
-        if (course == null) {
-            throw new EntityNotFoundException("Course with ID " + courseId + " does not exist!");
-        }
-
-        String studentEmail = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        boolean isSendingToStudent = studentEmail != null;
-        boolean isSendingToInstructor = instructorEmail != null;
+        User user = getUserToRemind();
 
         JsonResult statusMsg;
 
-        if (isSendingToStudent) {
-            Student studentData = logic.getStudentForEmail(courseId, studentEmail);
-            if (studentData == null) {
-                throw new EntityNotFoundException(
-                        "Student with email " + studentEmail + " does not exist in course " + courseId + "!");
+        if (user instanceof Student student) {
+            Course course = student.getCourse();
+            if (course == null) {
+                throw new EntityNotFoundException("Course does not exist.");
             }
-            EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, studentData);
+            EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
             taskQueuer.scheduleEmailsForPrioritySending(emails);
-            statusMsg = new JsonResult("An email has been sent to " + studentEmail);
+            statusMsg = new JsonResult("An email has been sent to " + student.getEmail());
 
-        } else if (isSendingToInstructor) {
-            Instructor instructorData = logic.getInstructorForEmail(courseId, instructorEmail);
-            if (instructorData == null) {
-                throw new EntityNotFoundException(
-                        "Instructor with email " + instructorEmail + " does not exist in course " + courseId + "!");
+        } else if (user instanceof Instructor instructorData) {
+            Course course = instructorData.getCourse();
+            if (course == null) {
+                throw new EntityNotFoundException("Course does not exist.");
             }
-            Instructor inviter = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
+            Instructor inviter = logic.getInstructorByGoogleId(course.getId(), getCurrentUserGoogleId());
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter does not exist.");
             }
@@ -87,10 +70,11 @@ public class SendJoinReminderEmailAction extends Action {
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
             taskQueuer.scheduleEmailsForPrioritySending(emails);
-            statusMsg = new JsonResult("An email has been sent to " + instructorEmail);
+            statusMsg = new JsonResult("An email has been sent to " + instructorData.getEmail());
 
         } else {
-            List<Student> studentDataList = logic.getUnregisteredStudentsForCourse(courseId);
+            Course course = getCourseForCourseWideReminder();
+            List<Student> studentDataList = logic.getUnregisteredStudentsForCourse(course.getId());
             List<EmailWrapper> emails = new ArrayList<>();
             for (Student student : studentDataList) {
                 EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
@@ -101,5 +85,27 @@ public class SendJoinReminderEmailAction extends Action {
         }
 
         return statusMsg;
+    }
+
+    private User getUserToRemind() {
+        UUID userId = getNullableUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        if (userId == null) {
+            return null;
+        }
+
+        User user = logic.getUser(userId);
+        if (user == null) {
+            throw new EntityNotFoundException("User with ID " + userId + " does not exist.");
+        }
+        return user;
+    }
+
+    private Course getCourseForCourseWideReminder() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        Course course = logic.getCourse(courseId);
+        if (course == null) {
+            throw new EntityNotFoundException("Course with ID " + courseId + " does not exist.");
+        }
+        return course;
     }
 }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -48,9 +48,6 @@ public class SendJoinReminderEmailAction extends Action {
 
         if (user instanceof Student student) {
             Course course = student.getCourse();
-            if (course == null) {
-                throw new EntityNotFoundException("Course does not exist.");
-            }
             EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
@@ -59,9 +56,6 @@ public class SendJoinReminderEmailAction extends Action {
 
         } else if (user instanceof Instructor instructorData) {
             Course course = instructorData.getCourse();
-            if (course == null) {
-                throw new EntityNotFoundException("Course does not exist.");
-            }
             Instructor inviter = logic.getInstructorByGoogleId(course.getId(), getCurrentUserGoogleId());
             if (inviter == null) {
                 throw new EntityNotFoundException("Inviter does not exist.");

--- a/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
@@ -17,7 +17,6 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.ui.exception.InvalidOperationException;
@@ -31,7 +30,6 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
     private Instructor typicalInstructor;
     private Course typicalCourse;
-    private Account inviterAccount;
 
     @Override
     String getActionUri() {
@@ -49,7 +47,6 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         typicalInstructor = getTypicalInstructor();
         typicalCourse = getTypicalCourse();
-        inviterAccount = new Account(typicalInstructor.getGoogleId(), "Inviter Name", "inviter@teammates.tmt");
     }
 
     @Test
@@ -71,10 +68,11 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForGoogleId(typicalInstructor.getGoogleId())).thenReturn(inviterAccount);
+        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
+                .thenReturn(typicalInstructor);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
-        when(mockEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, newInstructor, typicalCourse))
+        when(mockEmailGenerator.generateInstructorCourseJoinEmail(typicalInstructor, newInstructor, typicalCourse))
                 .thenReturn(mockEmail);
 
         loginAsInstructor(typicalInstructor.getGoogleId());
@@ -167,11 +165,12 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.createInstructor(any(Instructor.class))).thenReturn(newInstructor);
-        when(mockLogic.getAccountForGoogleId(Mockito.anyString())).thenReturn(inviterAccount);
+        when(mockLogic.getInstructorByGoogleId(Mockito.eq(typicalCourse.getId()), Mockito.anyString()))
+                .thenReturn(typicalInstructor);
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockEmailGenerator.generateInstructorCourseJoinEmail(
-                any(Account.class), any(Instructor.class), any(Course.class)))
+                any(Instructor.class), any(Instructor.class), any(Course.class)))
                 .thenReturn(mockEmail);
 
         loginAsAdmin();

--- a/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
@@ -1,6 +1,8 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,7 +15,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -82,11 +83,10 @@ public class SendJoinReminderEmailActionTest
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
         };
 
-        Account inviterAccount = new Account(instructorGoogleId, "name", "email@tm.tmt");
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
-        when(mockLogic.getAccountForGoogleId(instructorGoogleId)).thenReturn(inviterAccount);
-        when(mockEmailGenerator.generateInstructorCourseJoinEmail(inviterAccount, instructor, course))
+        when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
+        when(mockEmailGenerator.generateInstructorCourseJoinEmail(any(Instructor.class), eq(instructor), eq(course)))
                 .thenReturn(mock(EmailWrapper.class));
 
         SendJoinReminderEmailAction action = getAction(params);

--- a/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
@@ -56,13 +56,10 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testExecute_sendToStudent_success() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, null,
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+        when(mockLogic.getUser(student.getId())).thenReturn(student);
         when(mockEmailGenerator.generateStudentCourseJoinEmail(course, student)).thenReturn(mock(EmailWrapper.class));
 
         SendJoinReminderEmailAction action = getAction(params);
@@ -78,13 +75,10 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testExecute_sendToInstructor_success() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, null,
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getInstructorForEmail(course.getId(), instructor.getEmail())).thenReturn(instructor);
+        when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
         when(mockEmailGenerator.generateInstructorCourseJoinEmail(any(Instructor.class), eq(instructor), eq(course)))
                 .thenReturn(mock(EmailWrapper.class));
@@ -103,8 +97,6 @@ public class SendJoinReminderEmailActionTest
     public void testExecute_sendToAllUnregisteredStudents_success() {
         String[] params = {
                 Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, null,
-                Const.ParamsNames.INSTRUCTOR_EMAIL, null,
         };
 
         List<Student> unregisteredStudents = List.of(student);
@@ -126,8 +118,7 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testSpecificAccessControl_sendToStudentInstructorCanModifyStudent_canAccess() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         InstructorPrivileges canModifyStudentPrivileges = new InstructorPrivileges();
@@ -135,7 +126,7 @@ public class SendJoinReminderEmailActionTest
 
         instructor.setPrivileges(canModifyStudentPrivileges);
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getUser(student.getId())).thenReturn(student);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
@@ -144,8 +135,7 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testSpecificAccessControl_sendToStudentInstructorCannotModifyStudent_cannotAccess() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         InstructorPrivileges cannotModifyStudentPrivileges = new InstructorPrivileges();
@@ -153,7 +143,7 @@ public class SendJoinReminderEmailActionTest
 
         instructor.setPrivileges(cannotModifyStudentPrivileges);
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getUser(student.getId())).thenReturn(student);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCannotAccess(params);
@@ -196,8 +186,7 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testSpecificAccessControl_sendToInstructorInstructorCanModifyInstructor_canAccess() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         InstructorPrivileges canModifyInstructorPrivileges = new InstructorPrivileges();
@@ -205,7 +194,7 @@ public class SendJoinReminderEmailActionTest
 
         instructor.setPrivileges(canModifyInstructorPrivileges);
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCanAccess(params);
@@ -214,8 +203,7 @@ public class SendJoinReminderEmailActionTest
     @Test
     public void testSpecificAccessControl_sendToInstructorInstructorCannotModifyInstructor_cannotAccess() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         InstructorPrivileges cannotModifyInstructorPrivileges = new InstructorPrivileges();
@@ -223,7 +211,7 @@ public class SendJoinReminderEmailActionTest
 
         instructor.setPrivileges(cannotModifyInstructorPrivileges);
 
-        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
 
         verifyCannotAccess(params);

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -527,7 +527,7 @@ describe('StudentListComponent', () => {
     expect(modalSpy).toHaveBeenCalledTimes(1);
     expect(modalSpy).toHaveBeenLastCalledWith('Send join request?', SimpleModalType.INFO, expectedModalContent);
 
-    expect(reminderStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.email);
+    expect(reminderStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.userId);
   });
 
   it('openDeleteModal: should display warning when deleting student from course', async () => {
@@ -565,12 +565,12 @@ describe('StudentListComponent', () => {
     'remindStudentFromCourse: should call statusMessageService.showSuccessToast with' + 'correct message upon success',
     () => {
       const successMessage = 'success';
-      vi.spyOn(courseService, 'remindStudentForJoin').mockReturnValue(of({ message: successMessage }));
-      const studentEmail = 'testemail@gmail.com';
+      vi.spyOn(courseService, 'remindUserForJoin').mockReturnValue(of({ message: successMessage }));
+      const studentId = 'test-user-id';
 
       const statusMessageServiceSpy = vi.spyOn(statusMessageService, 'showSuccessToast');
 
-      component.remindStudentFromCourse(studentEmail);
+      component.remindStudentFromCourse(studentId);
 
       expect(statusMessageServiceSpy).toHaveBeenLastCalledWith(successMessage);
     },
@@ -578,16 +578,16 @@ describe('StudentListComponent', () => {
 
   it('remindStudentFromCourse: should call statusMessageService.showErrorToast with correct message upon error', () => {
     const errorMessage = 'error';
-    vi.spyOn(courseService, 'remindStudentForJoin').mockReturnValue(
+    vi.spyOn(courseService, 'remindUserForJoin').mockReturnValue(
       throwError(() => ({
         error: { message: errorMessage },
       })),
     );
-    const studentEmail = 'testemail@gmail.com';
+    const studentId = 'test-user-id';
 
     const statusMessageServiceSpy = vi.spyOn(statusMessageService, 'showErrorToast');
 
-    component.remindStudentFromCourse(studentEmail);
+    component.remindStudentFromCourse(studentId);
 
     expect(statusMessageServiceSpy).toHaveBeenLastCalledWith(errorMessage);
   });

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -227,7 +227,7 @@ export class StudentListComponent implements OnInit {
     );
     modalRef.result.then(
       () => {
-        this.remindStudentFromCourse(studentModel.student.email);
+        this.remindStudentFromCourse(studentModel.student.userId);
       },
       () => {},
     );
@@ -260,8 +260,8 @@ export class StudentListComponent implements OnInit {
   /**
    * Remind the student from course.
    */
-  remindStudentFromCourse(studentEmail: string): void {
-    this.courseService.remindStudentForJoin(this.courseId, studentEmail).subscribe({
+  remindStudentFromCourse(studentId: string): void {
+    this.courseService.remindUserForJoin(studentId).subscribe({
       next: (resp: MessageOutput) => {
         this.statusMessageService.showSuccessToast(resp.message);
       },

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
@@ -300,12 +300,12 @@ describe('InstructorCourseEditPageComponent', () => {
   });
 
   it('should re-send reminder email for new instructors', () => {
-    const mockReminderFunction: MockedFunction<any> = vi.fn((_: string, email: string) =>
+    const mockReminderFunction: MockedFunction<any> = vi.fn(() =>
       of({
-        message: `An email has been sent to ${email}`,
+        message: `An email has been sent`,
       }),
     );
-    vi.spyOn(courseService, 'remindInstructorForJoin').mockImplementation(mockReminderFunction);
+    vi.spyOn(courseService, 'remindUserForJoin').mockImplementation(mockReminderFunction);
 
     vi.spyOn(simpleModalService, 'openConfirmationModal').mockReturnValue(createMockNgbModalRef());
 
@@ -330,7 +330,7 @@ describe('InstructorCourseEditPageComponent', () => {
     );
     button.click();
 
-    expect(mockReminderFunction).toHaveBeenCalledWith(testCourse.courseId, testInstructor2.email);
+    expect(mockReminderFunction).toHaveBeenCalledWith(testInstructor2.userId);
   });
 
   it('should snap with default fields', () => {

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -518,16 +518,14 @@ export class InstructorCourseEditPageComponent implements OnInit {
 
     modalRef.result.then(
       () => {
-        this.courseService
-          .remindInstructorForJoin(panelDetail.originalInstructor.courseId, panelDetail.originalInstructor.email)
-          .subscribe({
-            next: (resp: MessageOutput) => {
-              this.statusMessageService.showSuccessToast(resp.message);
-            },
-            error: (resp: ErrorMessageOutput) => {
-              this.statusMessageService.showErrorToast(resp.error.message);
-            },
-          });
+        this.courseService.remindUserForJoin(panelDetail.originalInstructor.userId).subscribe({
+          next: (resp: MessageOutput) => {
+            this.statusMessageService.showSuccessToast(resp.message);
+          },
+          error: (resp: ErrorMessageOutput) => {
+            this.statusMessageService.showErrorToast(resp.error.message);
+          },
+        });
       },
       () => {},
     );

--- a/src/web/services/course.service.spec.ts
+++ b/src/web/services/course.service.spec.ts
@@ -150,25 +150,12 @@ describe('CourseService', () => {
     expect(spyHttpRequestService.post).toHaveBeenCalledWith(ResourceEndpoints.JOIN_REMIND, paramMap);
   });
 
-  it('should execute POST to remind particular student', () => {
-    const courseId = 'test-id';
-    const studentEmail = 'test@example.com';
+  it('should execute POST to remind particular user', () => {
+    const userId = 'test-user-id';
     const paramMap: { [key: string]: string } = {
-      courseid: courseId,
-      studentemail: studentEmail,
+      userid: userId,
     };
-    service.remindStudentForJoin(courseId, studentEmail);
-    expect(spyHttpRequestService.post).toHaveBeenCalledWith(ResourceEndpoints.JOIN_REMIND, paramMap);
-  });
-
-  it('should execute POST to remind particular instructor', () => {
-    const courseId = 'test-id';
-    const instructorEmail = 'test@example.com';
-    const paramMap: { [key: string]: string } = {
-      courseid: courseId,
-      instructoremail: instructorEmail,
-    };
-    service.remindInstructorForJoin(courseId, instructorEmail);
+    service.remindUserForJoin(userId);
     expect(spyHttpRequestService.post).toHaveBeenCalledWith(ResourceEndpoints.JOIN_REMIND, paramMap);
   });
 

--- a/src/web/services/course.service.ts
+++ b/src/web/services/course.service.ts
@@ -162,23 +162,11 @@ export class CourseService {
   }
 
   /**
-   * Send join reminder email to a student.
+   * Send join reminder email to a user.
    */
-  remindStudentForJoin(courseId: string, studentEmail: string): Observable<MessageOutput> {
+  remindUserForJoin(userId: string): Observable<MessageOutput> {
     const paramMap: Record<string, string> = {
-      courseid: courseId,
-      studentemail: studentEmail,
-    };
-    return this.httpRequestService.post(ResourceEndpoints.JOIN_REMIND, paramMap);
-  }
-
-  /**
-   * Send join reminder email to an instructor.
-   */
-  remindInstructorForJoin(courseId: string, instructorEmail: string): Observable<MessageOutput> {
-    const paramMap: Record<string, string> = {
-      courseid: courseId,
-      instructoremail: instructorEmail,
+      userid: userId,
     };
     return this.httpRequestService.post(ResourceEndpoints.JOIN_REMIND, paramMap);
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13979

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Migrate Join reminders email to use userId.
2. Join Reminders action is now instructor only. Admins have no need to call this at the moment.
3. Also updated `generateInstructorCourseJoinEmail` to accept Instructor instead of Account. Account name and email should not be used as it may not be the official name/email of the instructor in the course. It is instead likely to be the personal email and name associated with google account.