### PR TITLE
[#13979] Migrate delete user actions to use userId

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -101,7 +101,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
-        assertEquals(logic.getInstructorsByCourse(instructor.getCourseId()).size(), 1);
+        assertEquals(1, logic.getInstructorsByCourse(instructor.getCourseId()).size());
 
         InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
@@ -144,7 +144,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 Const.ParamsNames.USER_ID, instructorToDelete.getId().toString(),
         };
 
-        assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
+        assertEquals(1, logic.getInstructorsByCourse(courseId).size());
 
         InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
@@ -165,7 +165,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
                 Const.ParamsNames.USER_ID, instructorToDelete.getId().toString(),
         };
 
-        assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
+        assertEquals(1, logic.getInstructorsByCourse(courseId).size());
 
         InvalidOperationException ioe = verifyInvalidOperation(
                 addUserToParams(instructorToDelete.getGoogleId(), submissionParams));

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -15,7 +15,6 @@ import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.MessageOutput;
 import teammates.ui.webapi.DeleteInstructorAction;
@@ -275,7 +274,6 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     @Override
     protected void testAccessControl() throws Exception {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        Student student = typicalBundle.students.get("student1InCourse1");
         Course course = typicalBundle.courses.get("course1");
 
         String[] params = new String[] {

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -239,12 +239,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         };
 
         assertNull(logic.getInstructor(nonExistentInstructorId));
-
-        DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
-        JsonResult response = getJsonResult(deleteInstructorAction);
-
-        MessageOutput msg = (MessageOutput) response.getOutput();
-        assertEquals("Instructor is successfully deleted.", msg.getMessage());
+        verifyEntityNotFoundAcl(submissionParams);
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -204,10 +204,6 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         String instructorId = instructor1OfCourse1.getGoogleId();
 
-        String[] legacyInstructorParameter = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructorId,
-        };
-
         String[] onlyCourseParameter = new String[] {
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
         };
@@ -215,13 +211,11 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         loginAsAdmin();
 
         verifyHttpParameterFailure();
-        verifyHttpParameterFailure(legacyInstructorParameter);
         verifyHttpParameterFailure(onlyCourseParameter);
 
         loginAsInstructor(instructorId);
 
         verifyHttpParameterFailure();
-        verifyHttpParameterFailure(legacyInstructorParameter);
         verifyHttpParameterFailure(onlyCourseParameter);
     }
 
@@ -251,23 +245,6 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
 
         MessageOutput msg = (MessageOutput) response.getOutput();
         assertEquals("Instructor is successfully deleted.", msg.getMessage());
-    }
-
-    @Test
-    protected void testExecute_adminDeletesInstructorWithLegacyCourseParam_shouldFail() {
-        loginAsAdmin();
-
-        Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        String instructorId = instructor1OfCourse1.getGoogleId();
-
-        String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructorId,
-                Const.ParamsNames.COURSE_ID, "fake-course",
-        };
-
-        assertNull(logic.getCourse("fake-course"));
-
-        verifyHttpParameterFailure(submissionParams);
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteInstructorActionIT.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -50,15 +52,13 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_typicalCaseByGoogleId_shouldPass() {
+    protected void testExecute_typicalCaseByUserId_shouldPass() {
         loginAsAdmin();
 
         Instructor instructor = typicalBundle.instructors.get("instructor2OfCourse1");
-        String instructorId = instructor.getGoogleId();
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructorId,
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
@@ -71,14 +71,13 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    public void testExecute_deleteInstructorByEmail_shouldPass() {
+    public void testExecute_deleteInstructorByUserId_shouldPass() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor instructor2OfCourse1 = typicalBundle.instructors.get("instructor2OfCourse1");
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor2OfCourse1.getEmail(),
-                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
+                Const.ParamsNames.USER_ID, instructor2OfCourse1.getId().toString(),
         };
 
         assertTrue(logic.getInstructorsByCourse(instructor1OfCourse1.getCourseId()).size() > 1);
@@ -94,15 +93,13 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_adminDeletesLastInstructorByGoogleId_shouldFail() {
+    protected void testExecute_adminDeletesLastInstructorByUserId_shouldFail() {
         loginAsAdmin();
 
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse3");
-        String instructorId = instructor.getGoogleId();
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructorId,
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         assertEquals(logic.getInstructorsByCourse(instructor.getCourseId()).size(), 1);
@@ -116,14 +113,13 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_instructorDeleteOwnRoleByGoogleId_shouldPass() {
+    protected void testExecute_instructorDeleteOwnRoleByUserId_shouldPass() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor instructor2OfCourse1 = typicalBundle.instructors.get("instructor2OfCourse1");
         loginAsInstructor(instructor2OfCourse1.getGoogleId());
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, instructor2OfCourse1.getGoogleId(),
-                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
+                Const.ParamsNames.USER_ID, instructor2OfCourse1.getId().toString(),
         };
 
         assertTrue(logic.getInstructorsByCourse(instructor1OfCourse1.getCourseId()).size() > 1);
@@ -139,15 +135,14 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_deleteLastInstructorByGoogleId_shouldFail() {
+    protected void testExecute_deleteLastInstructorByUserId_shouldFail() {
         Instructor instructorToDelete = typicalBundle.instructors.get("instructor1OfCourse3");
         String courseId = instructorToDelete.getCourseId();
 
         loginAsInstructor(instructorToDelete.getGoogleId());
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructorToDelete.getId().toString(),
         };
 
         assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
@@ -161,15 +156,14 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_deleteLastInstructorInMasqueradeByGoogleId_shouldFail() {
+    protected void testExecute_deleteLastInstructorInMasqueradeByUserId_shouldFail() {
         Instructor instructorToDelete = typicalBundle.instructors.get("instructor1OfCourse3");
         String courseId = instructorToDelete.getCourseId();
 
         loginAsAdmin();
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructorToDelete.getId().toString(),
         };
 
         assertEquals(logic.getInstructorsByCourse(courseId).size(), 1);
@@ -184,13 +178,12 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_deleteInstructorInMasqueradeByGoogleId_shouldPass() {
+    protected void testExecute_deleteInstructorInMasqueradeByUserId_shouldPass() {
         Instructor instructorToDelete = typicalBundle.instructors.get("instructor2OfCourse1");
         String courseId = instructorToDelete.getCourseId();
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructorToDelete.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructorToDelete.getId().toString(),
         };
 
         loginAsAdmin();
@@ -212,7 +205,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         String instructorId = instructor1OfCourse1.getGoogleId();
 
-        String[] onlyInstructorParameter = new String[] {
+        String[] legacyInstructorParameter = new String[] {
                 Const.ParamsNames.INSTRUCTOR_ID, instructorId,
         };
 
@@ -223,13 +216,13 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         loginAsAdmin();
 
         verifyHttpParameterFailure();
-        verifyHttpParameterFailure(onlyInstructorParameter);
+        verifyHttpParameterFailure(legacyInstructorParameter);
         verifyHttpParameterFailure(onlyCourseParameter);
 
         loginAsInstructor(instructorId);
 
         verifyHttpParameterFailure();
-        verifyHttpParameterFailure(onlyInstructorParameter);
+        verifyHttpParameterFailure(legacyInstructorParameter);
         verifyHttpParameterFailure(onlyCourseParameter);
     }
 
@@ -237,42 +230,22 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     protected void testExecute_noSuchInstructor_shouldFail() {
         loginAsAdmin();
 
-        attemptToDeleteFakeInstructorByGoogleId();
-        attemptToDeleteFakeInstructorByEmail();
+        attemptToDeleteFakeInstructorByUserId();
 
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
 
-        attemptToDeleteFakeInstructorByGoogleId();
-        attemptToDeleteFakeInstructorByEmail();
+        attemptToDeleteFakeInstructorByUserId();
     }
 
-    private void attemptToDeleteFakeInstructorByGoogleId() {
-        Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+    private void attemptToDeleteFakeInstructorByUserId() {
+        UUID nonExistentInstructorId = UUID.randomUUID();
 
         String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_ID, "fake-googleId",
-                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
+                Const.ParamsNames.USER_ID, nonExistentInstructorId.toString(),
         };
 
-        assertNull(logic.getInstructorByGoogleId(instructor1OfCourse1.getCourseId(), "fake-googleId"));
-
-        DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
-        JsonResult response = getJsonResult(deleteInstructorAction);
-
-        MessageOutput msg = (MessageOutput) response.getOutput();
-        assertEquals("Instructor is successfully deleted.", msg.getMessage());
-    }
-
-    private void attemptToDeleteFakeInstructorByEmail() {
-        Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-
-        String[] submissionParams = new String[] {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, "fake-instructor@fake-email",
-                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.getCourseId(),
-        };
-
-        assertNull(logic.getInstructorForEmail(instructor1OfCourse1.getCourseId(), "fake-instructor@fake-email"));
+        assertNull(logic.getInstructor(nonExistentInstructorId));
 
         DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
         JsonResult response = getJsonResult(deleteInstructorAction);
@@ -282,7 +255,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
     }
 
     @Test
-    protected void testExecute_adminDeletesInstructorInFakeCourse_shouldFail() {
+    protected void testExecute_adminDeletesInstructorWithLegacyCourseParam_shouldFail() {
         loginAsAdmin();
 
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
@@ -295,11 +268,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
 
         assertNull(logic.getCourse("fake-course"));
 
-        DeleteInstructorAction deleteInstructorAction = getAction(submissionParams);
-        JsonResult response = getJsonResult(deleteInstructorAction);
-
-        MessageOutput msg = (MessageOutput) response.getOutput();
-        assertEquals("Instructor is successfully deleted.", msg.getMessage());
+        verifyHttpParameterFailure(submissionParams);
     }
 
     @Test
@@ -310,8 +279,7 @@ public class DeleteInstructorActionIT extends BaseActionIT<DeleteInstructorActio
         Course course = typicalBundle.courses.get("course1");
 
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         verifyAccessibleForAdmin(params);

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -71,14 +71,13 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
 
         assertNull(logic.getStudent(student2InCourse1.getId()));
 
-        ______TS("Student does not exist, fails silently");
+        ______TS("Student does not exist, access control fails");
         UUID nonExistentStudentId = UUID.randomUUID();
         params = new String[] {
                 Const.ParamsNames.USER_ID, nonExistentStudentId.toString(),
         };
 
-        deleteStudentAction = getAction(params);
-        getJsonResult(deleteStudentAction);
+        verifyEntityNotFoundAcl(params);
         assertNotNull(logic.getStudent(student3InCourse1.getId()));
 
         ______TS("Incomplete params given");

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -3,6 +3,8 @@ package teammates.it.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -47,49 +49,37 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         Student student3InCourse1 = typicalBundle.students.get("student3InCourse1");
         String courseId = instructor.getCourseId();
 
-        ______TS("Typical Success Case delete a student by email");
+        ______TS("Typical Success Case delete a student by user id");
         loginAsInstructor(instructor.getGoogleId());
 
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getEmail(),
+                Const.ParamsNames.USER_ID, student1InCourse1.getId().toString(),
         };
 
         DeleteStudentAction deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNull(logic.getStudentForEmail(courseId, student1InCourse1.getEmail()));
+        assertNull(logic.getStudent(student1InCourse1.getId()));
 
-        ______TS("Typical Success Case delete a student by id");
+        ______TS("Typical Success Case delete another student by user id");
         params = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_ID, student2InCourse1.getGoogleId(),
+                Const.ParamsNames.USER_ID, student2InCourse1.getId().toString(),
         };
 
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
 
-        assertNull(logic.getStudentByGoogleId(courseId, student2InCourse1.getGoogleId()));
-
-        ______TS("Course does not exist, fails silently");
-        params = new String[] {
-                Const.ParamsNames.COURSE_ID, "non-existent-course",
-                Const.ParamsNames.STUDENT_ID, student3InCourse1.getGoogleId(),
-        };
-
-        deleteStudentAction = getAction(params);
-        getJsonResult(deleteStudentAction);
-
-        assertNotNull(logic.getStudentByGoogleId(student3InCourse1.getCourseId(), student3InCourse1.getGoogleId()));
+        assertNull(logic.getStudent(student2InCourse1.getId()));
 
         ______TS("Student does not exist, fails silently");
+        UUID nonExistentStudentId = UUID.randomUUID();
         params = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_ID, "non-existent-id",
+                Const.ParamsNames.USER_ID, nonExistentStudentId.toString(),
         };
 
         deleteStudentAction = getAction(params);
         getJsonResult(deleteStudentAction);
+        assertNotNull(logic.getStudent(student3InCourse1.getId()));
 
         ______TS("Incomplete params given");
         verifyHttpParameterFailure();
@@ -110,16 +100,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
                 Const.ParamsNames.STUDENT_ID, student1InCourse1.getGoogleId(),
         };
 
-        verifyAccessibleForAdmin(params);
-
-        ______TS("Random email given, fails silently");
-        params = new String[] {
-                Const.ParamsNames.COURSE_ID, courseId,
-                Const.ParamsNames.STUDENT_EMAIL, "random-email",
-        };
-
-        deleteStudentAction = getAction(params);
-        getJsonResult(deleteStudentAction);
+        verifyHttpParameterFailure(params);
     }
 
     @Test
@@ -130,8 +111,7 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         Course course = typicalBundle.courses.get("course1");
 
         String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         verifyAccessibleForAdmin(params);

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -88,18 +88,6 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
         };
 
         verifyHttpParameterFailure(params);
-
-        params = new String[] {
-                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getEmail(),
-        };
-
-        verifyHttpParameterFailure(params);
-
-        params = new String[] {
-                Const.ParamsNames.STUDENT_ID, student1InCourse1.getGoogleId(),
-        };
-
-        verifyHttpParameterFailure(params);
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/DeleteStudentActionIT.java
@@ -106,7 +106,6 @@ public class DeleteStudentActionIT extends BaseActionIT<DeleteStudentAction> {
     @Test
     @Override
     protected void testAccessControl() throws Exception {
-        Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         Student student = typicalBundle.students.get("student1InCourse1");
         Course course = typicalBundle.courses.get("course1");
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -114,7 +114,6 @@ public final class Const {
         public static final String COURSE_ID = "courseid";
         public static final String COURSE_STATUS = "coursestatus";
         public static final String INSTRUCTOR_ID = "instructorid";
-        public static final String INSTRUCTOR_EMAIL = "instructoremail";
         public static final String INSTRUCTOR_INSTITUTION = "instructorinstitution";
         public static final String IS_CREATING_ACCOUNT = "iscreatingaccount";
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1077,13 +1077,12 @@ public class Logic {
      *
      * <br/>
      * Preconditions: <br/>
-     * * All parameters are non-null.
+     * * User ID is non-null.
      */
-    public void deleteStudentCascade(String courseId, String studentEmail) {
-        assert courseId != null;
-        assert studentEmail != null;
+    public void deleteStudentCascade(UUID userId) {
+        assert userId != null;
 
-        usersLogic.deleteStudentCascade(courseId, studentEmail);
+        usersLogic.deleteStudentCascade(userId);
     }
 
     /**
@@ -1123,13 +1122,12 @@ public class Logic {
      *
      * <br/>
      * Preconditions: <br/>
-     * * All parameters are non-null.
+     * * User ID is non-null.
      */
-    public void deleteInstructorCascade(String courseId, String email) {
-        assert courseId != null;
-        assert email != null;
+    public void deleteInstructorCascade(UUID userId) {
+        assert userId != null;
 
-        usersLogic.deleteInstructorCascade(courseId, email);
+        usersLogic.deleteInstructorCascade(userId);
     }
 
     public List<Notification> getAllNotifications() {

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -59,6 +59,7 @@ import teammates.storage.entity.Student;
 import teammates.storage.entity.Team;
 import teammates.storage.entity.UsageStatistics;
 import teammates.storage.entity.User;
+import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.request.FeedbackQuestionUpdateRequest;
 import teammates.ui.request.FeedbackResponseCommentUpdateRequest;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
@@ -1124,7 +1125,7 @@ public class Logic {
      * Preconditions: <br/>
      * * User ID is non-null.
      */
-    public void deleteInstructorCascade(UUID userId) {
+    public void deleteInstructorCascade(UUID userId) throws InvalidOperationException {
         assert userId != null;
 
         usersLogic.deleteInstructorCascade(userId);

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -293,13 +293,13 @@ public final class UsersLogic {
     }
 
     /**
-     * Deletes an instructor and cascades deletion to
+     * Deletes an instructor by user ID and cascades deletion to
      * associated feedback responses, deadline extensions and comments.
      *
      * <p>Fails silently if the instructor does not exist.
      */
-    public void deleteInstructorCascade(String courseId, String email) {
-        Instructor instructor = getInstructorForEmail(courseId, email);
+    public void deleteInstructorCascade(UUID userId) {
+        Instructor instructor = getInstructor(userId);
         if (instructor == null) {
             return;
         }
@@ -677,17 +677,18 @@ public final class UsersLogic {
     }
 
     /**
-     * Deletes a student along with its associated feedback responses, deadline extensions and comments.
+     * Deletes a student by user ID along with its associated feedback responses, deadline extensions and comments.
      *
      * <p>Fails silently if the student does not exist.
      */
-    public void deleteStudentCascade(String courseId, String studentEmail) {
-        Student student = getStudentForEmail(courseId, studentEmail);
+    public void deleteStudentCascade(UUID userId) {
+        Student student = getStudent(userId);
 
         if (student == null) {
             return;
         }
 
+        String courseId = student.getCourseId();
         deleteUser(student);
         HibernateUtil.flushSession();
         feedbackResponsesLogic.updateRankRecipientQuestionResponsesAfterDeletingStudent(courseId);

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -37,6 +37,7 @@ import teammates.storage.entity.Section;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.Team;
 import teammates.storage.entity.User;
+import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.request.InstructorCreateRequest;
 import teammates.ui.request.StudentEnrollRequest;
 import teammates.ui.request.StudentUpdateRequest;
@@ -298,13 +299,44 @@ public final class UsersLogic {
      *
      * <p>Fails silently if the instructor does not exist.
      */
-    public void deleteInstructorCascade(UUID userId) {
+    public void deleteInstructorCascade(UUID userId) throws InvalidOperationException {
         Instructor instructor = getInstructor(userId);
         if (instructor == null) {
             return;
         }
 
+        if (!hasAlternativeInstructor(instructor)) {
+            throw new InvalidOperationException(
+                    "The instructor you are trying to delete is the last instructor in the course. "
+                            + "Deleting the last instructor from the course is not allowed.");
+        }
+
         deleteUser(instructor);
+    }
+
+    /**
+     * Returns true if there is at least one joined instructor (other than the instructor to delete)
+     * with the privilege of modifying instructors and at least one instructor visible to the students.
+     */
+    private boolean hasAlternativeInstructor(Instructor instructorToDelete) {
+        List<Instructor> instructors = getInstructorsForCourse(instructorToDelete.getCourseId());
+        boolean hasAlternativeModifyInstructor = false;
+        boolean hasAlternativeVisibleInstructor = false;
+
+        for (Instructor instr : instructors) {
+            hasAlternativeModifyInstructor = hasAlternativeModifyInstructor || instr.isRegistered()
+                    && !instr.equals(instructorToDelete)
+                    && instr.isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+
+            hasAlternativeVisibleInstructor = hasAlternativeVisibleInstructor
+                    || instr.isDisplayedToStudents()
+                    && !instr.equals(instructorToDelete);
+
+            if (hasAlternativeModifyInstructor && hasAlternativeVisibleInstructor) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -1,10 +1,8 @@
 package teammates.ui.webapi;
 
-import java.util.List;
 import java.util.UUID;
 
 import teammates.common.util.Const;
-import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.Instructor;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -41,49 +39,8 @@ public class DeleteInstructorAction extends Action {
     @Override
     public JsonResult execute() throws InvalidOperationException {
         UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
-        Instructor instructor = logic.getInstructor(userId);
-
-        if (instructor == null) {
-            return new JsonResult("Instructor is successfully deleted.");
-        }
-
-        // Deleting last instructor from the course is not allowed (even by admins)
-        if (!hasAlternativeInstructor(instructor.getCourseId(), instructor.getEmail())) {
-            throw new InvalidOperationException(
-                    "The instructor you are trying to delete is the last instructor in the course. "
-                            + "Deleting the last instructor from the course is not allowed.");
-        }
-
         logic.deleteInstructorCascade(userId);
 
         return new JsonResult("Instructor is successfully deleted.");
-    }
-
-    /**
-     * Returns true if there is at least one joined instructor (other than the instructor to delete)
-     * with the privilege of modifying instructors and at least one instructor visible to the students.
-     *
-     * @param courseId                Id of the course
-     * @param instructorToDeleteEmail Email of the instructor who is being deleted
-     */
-    private boolean hasAlternativeInstructor(String courseId, String instructorToDeleteEmail) {
-        List<Instructor> instructors = logic.getInstructorsByCourse(courseId);
-        boolean hasAlternativeModifyInstructor = false;
-        boolean hasAlternativeVisibleInstructor = false;
-
-        for (Instructor instr : instructors) {
-            hasAlternativeModifyInstructor = hasAlternativeModifyInstructor || instr.isRegistered()
-                    && !SanitizationHelper.areEmailsEqual(instr.getEmail(), instructorToDeleteEmail)
-                    && instr.isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
-
-            hasAlternativeVisibleInstructor = hasAlternativeVisibleInstructor
-                    || instr.isDisplayedToStudents()
-                    && !SanitizationHelper.areEmailsEqual(instr.getEmail(), instructorToDeleteEmail);
-
-            if (hasAlternativeModifyInstructor && hasAlternativeVisibleInstructor) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.Instructor;
+import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -19,14 +20,14 @@ public class DeleteInstructorAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        //allow access to admins or instructor with modify permission
-        if (authContext.isAdmin()) {
-            return;
-        }
-
         UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
         Instructor instructorToDelete = logic.getInstructor(userId);
         if (instructorToDelete == null) {
+            throw new EntityNotFoundException("Instructor with user ID " + userId + " does not exist.");
+        }
+
+        //allow access to admins or instructor with modify permission
+        if (authContext.isAdmin()) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -1,11 +1,11 @@
 package teammates.ui.webapi;
 
 import java.util.List;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.Instructor;
-import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -26,39 +26,35 @@ public class DeleteInstructorAction extends Action {
             return;
         }
 
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
+        UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        Instructor instructorToDelete = logic.getInstructor(userId);
+        if (instructorToDelete == null) {
+            return;
+        }
+
+        Instructor instructor = logic.getInstructorByGoogleId(instructorToDelete.getCourseId(), getCurrentUserGoogleId());
         gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+                instructor, logic.getCourse(instructorToDelete.getCourseId()),
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override
     public JsonResult execute() throws InvalidOperationException {
-        String instructorId = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_ID);
-        String instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-
-        Instructor instructor;
-        if (instructorId != null) {
-            instructor = logic.getInstructorByGoogleId(courseId, instructorId);
-        } else if (instructorEmail != null) {
-            instructor = logic.getInstructorForEmail(courseId, instructorEmail);
-        } else {
-            throw new InvalidHttpParameterException("Instructor to delete not specified");
-        }
+        UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        Instructor instructor = logic.getInstructor(userId);
 
         if (instructor == null) {
             return new JsonResult("Instructor is successfully deleted.");
         }
 
         // Deleting last instructor from the course is not allowed (even by admins)
-        if (!hasAlternativeInstructor(courseId, instructor.getEmail())) {
+        if (!hasAlternativeInstructor(instructor.getCourseId(), instructor.getEmail())) {
             throw new InvalidOperationException(
                     "The instructor you are trying to delete is the last instructor in the course. "
                             + "Deleting the last instructor from the course is not allowed.");
         }
 
-        logic.deleteInstructorCascade(courseId, instructor.getEmail());
+        logic.deleteInstructorCascade(userId);
 
         return new JsonResult("Instructor is successfully deleted.");
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -37,12 +37,8 @@ public class DeleteStudentAction extends Action {
     @Override
     public JsonResult execute() {
         UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
-        Student student = logic.getStudent(userId);
 
-        // if student is not found, fail silently
-        if (student != null) {
-            logic.deleteStudentCascade(userId);
-        }
+        logic.deleteStudentCascade(userId);
 
         return new JsonResult("Student is successfully deleted.");
     }

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import java.util.UUID;
+
 import teammates.common.util.Const;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -21,32 +23,25 @@ public class DeleteStudentAction extends Action {
             return;
         }
 
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        Student student = logic.getStudent(userId);
+        if (student == null) {
+            return;
+        }
 
-        Instructor instructor = logic.getInstructorByGoogleId(courseId, getCurrentUserGoogleId());
+        Instructor instructor = logic.getInstructorByGoogleId(student.getCourseId(), getCurrentUserGoogleId());
         gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+                instructor, logic.getCourse(student.getCourseId()), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override
     public JsonResult execute() {
-        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        String studentId = getRequestParamValue(Const.ParamsNames.STUDENT_ID);
-
-        String studentEmail = null;
-
-        if (studentId == null) {
-            studentEmail = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
-        } else {
-            Student student = logic.getStudentByGoogleId(courseId, studentId);
-            if (student != null) {
-                studentEmail = student.getEmail();
-            }
-        }
+        UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
+        Student student = logic.getStudent(userId);
 
         // if student is not found, fail silently
-        if (studentEmail != null) {
-            logic.deleteStudentCascade(courseId, studentEmail);
+        if (student != null) {
+            logic.deleteStudentCascade(userId);
         }
 
         return new JsonResult("Student is successfully deleted.");

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import teammates.common.util.Const;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -19,13 +20,13 @@ public class DeleteStudentAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
-            return;
-        }
-
         UUID userId = getUuidRequestParamValue(Const.ParamsNames.USER_ID);
         Student student = logic.getStudent(userId);
         if (student == null) {
+            throw new EntityNotFoundException("Student with user ID " + userId + " does not exist.");
+        }
+
+        if (authContext.isAdmin()) {
             return;
         }
 

--- a/src/test/java/teammates/logic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsersLogicTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +29,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.User;
 import teammates.test.BaseTestCase;
+import teammates.ui.exception.InvalidOperationException;
 
 /**
  * SUT: {@link UsersLogic}.
@@ -135,6 +137,64 @@ public class UsersLogicTest extends BaseTestCase {
     }
 
     @Test
+    public void testDeleteInstructorCascade_hasAlternativeInstructor_success() throws InvalidOperationException {
+        Instructor instructorToDelete = createRegisteredInstructor("to-delete@teammates.tmt", true);
+        Instructor alternativeInstructor = createRegisteredInstructor("alternative@teammates.tmt", true);
+
+        when(usersDb.getInstructor(instructorToDelete.getId())).thenReturn(instructorToDelete);
+        when(usersDb.getInstructorsForCourse(course.getId()))
+                .thenReturn(new ArrayList<>(List.of(instructorToDelete, alternativeInstructor)));
+
+        usersLogic.deleteInstructorCascade(instructorToDelete.getId());
+
+        verify(usersDb, times(1)).deleteUser(instructorToDelete);
+    }
+
+    @Test
+    public void testDeleteInstructorCascade_instructorDoesNotExist_failSilently() throws InvalidOperationException {
+        UUID userId = UUID.randomUUID();
+        when(usersDb.getInstructor(userId)).thenReturn(null);
+
+        usersLogic.deleteInstructorCascade(userId);
+
+        verify(usersDb, times(0)).deleteUser(instructor);
+    }
+
+    @Test
+    public void testDeleteInstructorCascade_noAlternativeModifyInstructor_throwsInvalidOperationException() {
+        Instructor instructorToDelete = createRegisteredInstructor("to-delete@teammates.tmt", true);
+        Instructor alternativeInstructor = createUnregisteredInstructor("alternative@teammates.tmt", true);
+
+        when(usersDb.getInstructor(instructorToDelete.getId())).thenReturn(instructorToDelete);
+        when(usersDb.getInstructorsForCourse(course.getId()))
+                .thenReturn(new ArrayList<>(List.of(instructorToDelete, alternativeInstructor)));
+
+        InvalidOperationException ioe = assertThrows(InvalidOperationException.class,
+                () -> usersLogic.deleteInstructorCascade(instructorToDelete.getId()));
+
+        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
+                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
+        verify(usersDb, times(0)).deleteUser(instructorToDelete);
+    }
+
+    @Test
+    public void testDeleteInstructorCascade_noAlternativeVisibleInstructor_throwsInvalidOperationException() {
+        Instructor instructorToDelete = createRegisteredInstructor("to-delete@teammates.tmt", true);
+        Instructor alternativeInstructor = createRegisteredInstructor("alternative@teammates.tmt", false);
+
+        when(usersDb.getInstructor(instructorToDelete.getId())).thenReturn(instructorToDelete);
+        when(usersDb.getInstructorsForCourse(course.getId()))
+                .thenReturn(new ArrayList<>(List.of(instructorToDelete, alternativeInstructor)));
+
+        InvalidOperationException ioe = assertThrows(InvalidOperationException.class,
+                () -> usersLogic.deleteInstructorCascade(instructorToDelete.getId()));
+
+        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
+                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
+        verify(usersDb, times(0)).deleteUser(instructorToDelete);
+    }
+
+    @Test
     public void testUpdateToEnsureValidityOfInstructorsForTheCourse_lastModifyInstructorPrivilege_shouldPreserve() {
         InstructorPrivileges privileges = instructor.getPrivileges();
         privileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
@@ -143,6 +203,26 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
                 Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
+    }
+
+    private Instructor createRegisteredInstructor(String email, boolean isDisplayedToStudents) {
+        Instructor instructor = createInstructor(email, isDisplayedToStudents);
+        instructor.setAccount(getTypicalAccount());
+        return instructor;
+    }
+
+    private Instructor createUnregisteredInstructor(String email, boolean isDisplayedToStudents) {
+        Instructor instructor = createInstructor(email, isDisplayedToStudents);
+        instructor.setAccount(null);
+        return instructor;
+    }
+
+    private Instructor createInstructor(String email, boolean isDisplayedToStudents) {
+        Instructor instructor = getTypicalInstructor();
+        instructor.setCourse(course);
+        instructor.setEmail(email);
+        instructor.setDisplayedToStudents(isDisplayedToStudents);
+        return instructor;
     }
 
 }

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -69,6 +69,8 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        when(mockLogic.getInstructor(instructor.getId())).thenReturn(instructor);
+        when(mockLogic.getInstructor(instructor2.getId())).thenReturn(instructor2);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructor2.getGoogleId())).thenReturn(instructor2);
         when(mockLogic.getStudentByGoogleId(course.getId(), studentId)).thenReturn(student);
@@ -79,34 +81,16 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_deleteInstructorByGoogleId_success() {
+    void testExecute_deleteInstructorByUserId_success() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor2.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor2.getId().toString(),
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor2.getGoogleId());
-        verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor2.getEmail());
-        verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
-        assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_deleteInstructorByEmail_success() {
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor2.getEmail(),
-        };
-
-        DeleteInstructorAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, times(1)).getInstructorForEmail(course.getId(), instructor2.getEmail());
-        verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor2.getEmail());
-        verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(instructor2.getId());
+        verify(mockLogic, times(1)).deleteInstructorCascade(instructor2.getId());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 
@@ -116,8 +100,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         when(mockLogic.getInstructorsByCourse(course.getId())).thenReturn(List.of(instructor));
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         assertEquals(mockLogic.getInstructorsByCourse(course.getId()).size(), 1);
@@ -126,8 +109,8 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(instructor.getId());
+        verify(mockLogic, never()).deleteInstructorCascade(any());
     }
 
     @Test
@@ -135,16 +118,15 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         instructor2.setAccount(null);
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         InvalidOperationException ioe = verifyInvalidOperation(params);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(instructor.getId());
+        verify(mockLogic, never()).deleteInstructorCascade(any());
     }
 
     @Test
@@ -152,16 +134,15 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         instructor2.setDisplayedToStudents(false);
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         InvalidOperationException ioe = verifyInvalidOperation(params);
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(instructor.getId());
+        verify(mockLogic, never()).deleteInstructorCascade(any());
     }
 
     @Test
@@ -169,69 +150,30 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         loginAsInstructor(instructor.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), instructor.getGoogleId());
-        verify(mockLogic, times(1)).deleteInstructorCascade(course.getId(), instructor.getEmail());
-        verify(mockLogic, times(1)).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(instructor.getId());
+        verify(mockLogic, times(1)).deleteInstructorCascade(instructor.getId());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
-    void testExecute_deleteNonExistentInstructorByGoogleId_failSilently() {
-        when(mockLogic.getInstructorByGoogleId(course.getId(), "fake-googleId")).thenReturn(null);
+    void testExecute_deleteNonExistentInstructorByUserId_failSilently() {
+        String fakeInstructorId = "00000000-0000-4000-8000-000000000001";
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, "fake-googleId",
+                Const.ParamsNames.USER_ID, fakeInstructorId,
         };
 
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructorByGoogleId(course.getId(), "fake-googleId");
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
-        assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_deleteNonExistentInstructorByEmail_failSilently() {
-        String fakeInstructorEmail = "fake-instructoremail@teammates.tmt";
-        when(mockLogic.getInstructorForEmail(course.getId(), fakeInstructorEmail)).thenReturn(null);
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_EMAIL, fakeInstructorEmail,
-        };
-
-        DeleteInstructorAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, times(1)).getInstructorForEmail(course.getId(), fakeInstructorEmail);
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
-        assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_nonExistentCourse_failSilently() {
-        String nonExistentCourseId = "non-existent-course-id";
-        when(mockLogic.getCourse(nonExistentCourseId)).thenReturn(null);
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, nonExistentCourseId,
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
-        };
-
-        DeleteInstructorAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, times(1)).getInstructorByGoogleId(nonExistentCourseId, instructor.getGoogleId());
-        verify(mockLogic, never()).deleteInstructorCascade(any(), any());
+        verify(mockLogic, times(1)).getInstructor(java.util.UUID.fromString(fakeInstructorId));
+        verify(mockLogic, never()).deleteInstructorCascade(any());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 
@@ -241,7 +183,16 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_missingCourseIdWithInstructorId_throwsInvalidHttpParameterException() {
+    void testExecute_invalidUserId_throwsInvalidHttpParameterException() {
+        String[] params = {
+                Const.ParamsNames.USER_ID, "invalid-user-id",
+        };
+
+        verifyHttpParameterFailure(params);
+    }
+
+    @Test
+    void testExecute_legacyInstructorIdWithoutUserId_throwsInvalidHttpParameterException() {
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
         };
@@ -250,7 +201,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_missingCourseIdWithInstructorEmail_throwsInvalidHttpParameterException() {
+    void testExecute_legacyInstructorEmailWithoutUserId_throwsInvalidHttpParameterException() {
         String[] params = {
                 Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
         };
@@ -259,19 +210,9 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_onlyCourseId_throwsInvalidHttpParameterException() {
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
     void testAccessControl() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
+                Const.ParamsNames.USER_ID, instructor.getId().toString(),
         };
 
         verifyOnlyInstructorsOfTheSameCourseCanAccess(course, params);

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -155,6 +155,18 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
+    void testAccessControl_nonExistentInstructor_throwsEntityNotFoundException() {
+        String fakeInstructorId = "00000000-0000-4000-8000-000000000001";
+        String[] params = {
+                Const.ParamsNames.USER_ID, fakeInstructorId,
+        };
+
+        loginAsAdmin();
+        verifyEntityNotFoundAcl(params);
+        logoutUser();
+    }
+
+    @Test
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.USER_ID, instructor.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -1,8 +1,7 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,7 +80,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_deleteInstructorByUserId_success() {
+    void testExecute_deleteInstructorByUserId_success() throws InvalidOperationException {
         String[] params = {
                 Const.ParamsNames.USER_ID, instructor2.getId().toString(),
         };
@@ -89,33 +88,16 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructor(instructor2.getId());
         verify(mockLogic, times(1)).deleteInstructorCascade(instructor2.getId());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
-    void testExecute_onlyOneInstructorInCourse_throwsInvalidOperationException() {
-        // Override the mock logic for the course to have only one instructor
-        when(mockLogic.getInstructorsByCourse(course.getId())).thenReturn(List.of(instructor));
-
-        String[] params = {
-                Const.ParamsNames.USER_ID, instructor.getId().toString(),
-        };
-
-        assertEquals(mockLogic.getInstructorsByCourse(course.getId()).size(), 1);
-
-        InvalidOperationException ioe = verifyInvalidOperation(params);
-        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
-                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
-
-        verify(mockLogic, times(1)).getInstructor(instructor.getId());
-        verify(mockLogic, never()).deleteInstructorCascade(any());
-    }
-
-    @Test
-    void testExecute_onlyOneRegisteredInstructor_throwsInvalidOperationException() {
-        instructor2.setAccount(null);
+    void testExecute_onlyOneInstructorInCourse_throwsInvalidOperationException() throws InvalidOperationException {
+        doThrow(new InvalidOperationException(
+                "The instructor you are trying to delete is the last instructor in the course. "
+                        + "Deleting the last instructor from the course is not allowed."))
+                        .when(mockLogic).deleteInstructorCascade(instructor.getId());
 
         String[] params = {
                 Const.ParamsNames.USER_ID, instructor.getId().toString(),
@@ -125,28 +107,11 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
 
-        verify(mockLogic, times(1)).getInstructor(instructor.getId());
-        verify(mockLogic, never()).deleteInstructorCascade(any());
+        verify(mockLogic, times(1)).deleteInstructorCascade(instructor.getId());
     }
 
     @Test
-    void testExecute_onlyOneInstructorDisplayedToStudents_throwsInvalidOperationException() {
-        instructor2.setDisplayedToStudents(false);
-
-        String[] params = {
-                Const.ParamsNames.USER_ID, instructor.getId().toString(),
-        };
-
-        InvalidOperationException ioe = verifyInvalidOperation(params);
-        assertEquals("The instructor you are trying to delete is the last instructor in the course. "
-                + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
-
-        verify(mockLogic, times(1)).getInstructor(instructor.getId());
-        verify(mockLogic, never()).deleteInstructorCascade(any());
-    }
-
-    @Test
-    void testExecute_instructorDeleteOwnRoleByGoogleId_success() {
+    void testExecute_instructorDeleteOwnRoleByGoogleId_success() throws InvalidOperationException {
         loginAsInstructor(instructor.getGoogleId());
 
         String[] params = {
@@ -156,13 +121,12 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructor(instructor.getId());
         verify(mockLogic, times(1)).deleteInstructorCascade(instructor.getId());
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
-    void testExecute_deleteNonExistentInstructorByUserId_failSilently() {
+    void testExecute_deleteNonExistentInstructorByUserId_failSilently() throws InvalidOperationException {
         String fakeInstructorId = "00000000-0000-4000-8000-000000000001";
 
         String[] params = {
@@ -172,8 +136,7 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
         DeleteInstructorAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getInstructor(java.util.UUID.fromString(fakeInstructorId));
-        verify(mockLogic, never()).deleteInstructorCascade(any());
+        verify(mockLogic, times(1)).deleteInstructorCascade(java.util.UUID.fromString(fakeInstructorId));
         assertEquals("Instructor is successfully deleted.", actionOutput.getMessage());
     }
 

--- a/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteInstructorActionTest.java
@@ -155,24 +155,6 @@ public class DeleteInstructorActionTest extends BaseActionTest<DeleteInstructorA
     }
 
     @Test
-    void testExecute_legacyInstructorIdWithoutUserId_throwsInvalidHttpParameterException() {
-        String[] params = {
-                Const.ParamsNames.INSTRUCTOR_ID, instructor.getGoogleId(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_legacyInstructorEmailWithoutUserId_throwsInvalidHttpParameterException() {
-        String[] params = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, instructor.getEmail(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.USER_ID, instructor.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
@@ -25,7 +25,6 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     private Course course;
     private Student student;
     private Instructor instructor;
-    private String studentId = "student-googleId";
     private String instructorId = "instructor-googleId";
 
     @Override
@@ -51,91 +50,36 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
 
     private void setupMockLogic() {
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
-        when(mockLogic.getStudentByGoogleId(course.getId(), studentId)).thenReturn(student);
-        when(mockLogic.getStudentForEmail(course.getId(), student.getEmail())).thenReturn(student);
+        when(mockLogic.getStudent(student.getId())).thenReturn(student);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);
     }
 
     @Test
-    void testExecute_deleteStudentByEmail_success() {
+    void testExecute_deleteStudentByUserId_success() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
-        verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
-        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_deleteStudentById_success() {
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, studentId,
-        };
-
-        DeleteStudentAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), studentId);
-        verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), student.getEmail());
-        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_nonExistentCourse_failSilently() {
-        when(mockLogic.getCourse("RANDOM_COURSE")).thenReturn(null);
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, "RANDOM_COURSE",
-                Const.ParamsNames.STUDENT_ID, studentId,
-        };
-
-        DeleteStudentAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, times(1)).getStudentByGoogleId("RANDOM_COURSE", studentId);
-        verify(mockLogic, never()).deleteStudentCascade(any(), any());
+        verify(mockLogic, times(1)).deleteStudentCascade(student.getId());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
     @Test
     void testExecute_nonExistentStudentId_failSilently() {
-        when(mockLogic.getStudentByGoogleId(course.getId(), "RANDOM_STUDENT")).thenReturn(null);
+        String randomUserId = "00000000-0000-4000-8000-000000000001";
 
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, "RANDOM_STUDENT",
+                Const.ParamsNames.USER_ID, randomUserId,
         };
 
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getStudentByGoogleId(course.getId(), "RANDOM_STUDENT");
-        verify(mockLogic, never()).deleteStudentCascade(any(), any());
-        assertEquals("Student is successfully deleted.", actionOutput.getMessage());
-    }
-
-    @Test
-    void testExecute_nonExistentStudentEmail_failSilently() {
-        when(mockLogic.getStudentForEmail(course.getId(), "RANDOM_EMAIL")).thenReturn(null);
-
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_EMAIL, "RANDOM_EMAIL",
-        };
-
-        DeleteStudentAction action = getAction(params);
-        MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
-
-        verify(mockLogic, never()).getStudentByGoogleId(any(), any());
-        verify(mockLogic, times(1)).deleteStudentCascade(course.getId(), "RANDOM_EMAIL");
-        verify(mockLogic, times(1)).deleteStudentCascade(any(), any());
-        verify(mockLogic, never()).deleteStudentCascade(course.getId(), student.getEmail());
+        verify(mockLogic, times(1)).getStudent(java.util.UUID.fromString(randomUserId));
+        verify(mockLogic, never()).deleteStudentCascade(any());
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 
@@ -145,27 +89,9 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     }
 
     @Test
-    void testExecute_missingStudentIdOrEmail_throwsInvalidHttpParameterException() {
+    void testExecute_invalidUserId_throwsInvalidHttpParameterException() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_missingCourseIdWithStudentId_throwsInvalidHttpParameterException() {
-        String[] params = {
-                Const.ParamsNames.STUDENT_ID, studentId,
-        };
-
-        verifyHttpParameterFailure(params);
-    }
-
-    @Test
-    void testExecute_missingCourseIdWithStudentEmail_throwsInvalidHttpParameterException() {
-        String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, student.getEmail(),
+                Const.ParamsNames.USER_ID, "invalid-user-id",
         };
 
         verifyHttpParameterFailure(params);
@@ -174,8 +100,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     @Test
     void testAccessControl() {
         String[] params = {
-                Const.ParamsNames.COURSE_ID, course.getId(),
-                Const.ParamsNames.STUDENT_ID, studentId,
+                Const.ParamsNames.USER_ID, student.getId().toString(),
         };
 
         verifyAdminsCanAccess(params);

--- a/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
@@ -1,11 +1,11 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.UUID;
 
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -78,8 +78,7 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
         DeleteStudentAction action = getAction(params);
         MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-        verify(mockLogic, times(1)).getStudent(java.util.UUID.fromString(randomUserId));
-        verify(mockLogic, never()).deleteStudentCascade(any());
+        verify(mockLogic, times(1)).deleteStudentCascade(UUID.fromString(randomUserId));
         assertEquals("Student is successfully deleted.", actionOutput.getMessage());
     }
 

--- a/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteStudentActionTest.java
@@ -97,6 +97,18 @@ public class DeleteStudentActionTest extends BaseActionTest<DeleteStudentAction>
     }
 
     @Test
+    void testAccessControl_nonExistentStudent_throwsEntityNotFoundException() {
+        String randomUserId = "00000000-0000-4000-8000-000000000001";
+        String[] params = {
+                Const.ParamsNames.USER_ID, randomUserId,
+        };
+
+        loginAsAdmin();
+        verifyEntityNotFoundAcl(params);
+        logoutUser();
+    }
+
+    @Test
     void testAccessControl() {
         String[] params = {
                 Const.ParamsNames.USER_ID, student.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
+++ b/src/test/java/teammates/ui/webapi/ResetAccountActionTest.java
@@ -57,30 +57,14 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         verifyHttpParameterFailure(params1);
 
         String[] params2 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
+                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
         };
         verifyHttpParameterFailure(params2);
 
         String[] params3 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        verifyHttpParameterFailure(params3);
-
-        String[] params4 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        verifyHttpParameterFailure(params4);
-
-        String[] params5 = {
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
-        };
-        verifyHttpParameterFailure(params5);
-
-        String[] params6 = {
                 Const.ParamsNames.USER_ID, "invalid-user-id",
         };
-        verifyHttpParameterFailure(params6);
+        verifyHttpParameterFailure(params3);
     }
 
     @Test
@@ -208,26 +192,9 @@ public class ResetAccountActionTest extends BaseActionTest<ResetAccountAction> {
         String[] params3 = {
                 Const.ParamsNames.USER_ID, stubInstructor.getId().toString(),
         };
-        String[] params4 = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        String[] params5 = {
-                Const.ParamsNames.INSTRUCTOR_EMAIL, stubInstructor.getEmail(),
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-        };
-        String[] params6 = {
-                Const.ParamsNames.COURSE_ID, stubInstructor.getCourseId(),
-        };
-        String[] params7 = {
-                "random-params", "random-value",
-        };
 
         verifyOnlyAdminsCanAccess(params1);
         verifyOnlyAdminsCanAccess(params2);
         verifyOnlyAdminsCanAccess(params3);
-        verifyOnlyAdminsCanAccess(params4);
-        verifyOnlyAdminsCanAccess(params5);
-        verifyOnlyAdminsCanAccess(params6);
-        verifyOnlyAdminsCanAccess(params7);
     }
 }

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -557,8 +557,8 @@ describe('StudentListComponent', () => {
     expect(modalSpy).toHaveBeenCalledTimes(1);
     expect(modalSpy).toHaveBeenLastCalledWith(expectedModalHeader, SimpleModalType.DANGER, expectedModalContent);
 
-    expect(removeStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.email);
-    expect(component.students).not.toContain(studentModel.student.email);
+    expect(removeStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.userId);
+    expect(component.students).not.toContain(studentModel);
   });
 
   it(

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -557,7 +557,7 @@ describe('StudentListComponent', () => {
     expect(modalSpy).toHaveBeenCalledTimes(1);
     expect(modalSpy).toHaveBeenLastCalledWith(expectedModalHeader, SimpleModalType.DANGER, expectedModalContent);
 
-    expect(removeStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.userId);
+    expect(removeStudentFromCourseSpy).toHaveBeenCalledWith(studentModel);
     expect(component.students).not.toContain(studentModel);
   });
 

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -247,9 +247,9 @@ export class StudentListComponent implements OnInit {
     );
     modalRef.result.then(
       () => {
-        this.removeStudentFromCourse(studentModel.student.email);
+        this.removeStudentFromCourse(studentModel.student.userId);
         this.students = this.students.filter(
-          (student: StudentListRowModel) => student.student.email !== studentModel.student.email,
+          (student: StudentListRowModel) => student.student.userId !== studentModel.student.userId,
         );
         this.setRowData();
       },
@@ -274,8 +274,8 @@ export class StudentListComponent implements OnInit {
   /**
    * Removes the student from course.
    */
-  removeStudentFromCourse(studentEmail: string): void {
-    this.removeStudentFromCourseEvent.emit(studentEmail);
+  removeStudentFromCourse(studentUserId: string): void {
+    this.removeStudentFromCourseEvent.emit(studentUserId);
   }
 
   /**

--- a/src/web/app/components/student-list/student-list.component.ts
+++ b/src/web/app/components/student-list/student-list.component.ts
@@ -66,7 +66,7 @@ export class StudentListComponent implements OnInit {
     this.setRowData();
   }
 
-  @Output() removeStudentFromCourseEvent: EventEmitter<string> = new EventEmitter();
+  @Output() removeStudentFromCourseEvent: EventEmitter<StudentListRowModel> = new EventEmitter();
   @Output() sortStudentListEvent: EventEmitter<SortableEvent> = new EventEmitter();
 
   rowsData: SortableTableCellData[][] = [];
@@ -247,7 +247,7 @@ export class StudentListComponent implements OnInit {
     );
     modalRef.result.then(
       () => {
-        this.removeStudentFromCourse(studentModel.student.userId);
+        this.removeStudentFromCourse(studentModel);
         this.students = this.students.filter(
           (student: StudentListRowModel) => student.student.userId !== studentModel.student.userId,
         );
@@ -274,8 +274,8 @@ export class StudentListComponent implements OnInit {
   /**
    * Removes the student from course.
    */
-  removeStudentFromCourse(studentUserId: string): void {
-    this.removeStudentFromCourseEvent.emit(studentUserId);
+  removeStudentFromCourse(studentModel: StudentListRowModel): void {
+    this.removeStudentFromCourseEvent.emit(studentModel);
   }
 
   /**

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.html
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.html
@@ -41,7 +41,7 @@
               <td class="text-break">[{{ instructor.courseId }}] {{ instructor.courseName }}</td>
               <td class="text-break">{{ instructor.institute }}</td>
               <td>
-                <button class="btn btn-sm btn-danger" (click)="removeInstructorFromCourse(instructor.courseId)">
+                <button class="btn btn-sm btn-danger" (click)="removeInstructorFromCourse(instructor)">
                   <i class="fas fa-trash-alt"></i> Remove From Course
                 </button>
               </td>
@@ -81,7 +81,7 @@
               <td class="text-break">[{{ student.courseId }}] {{ student.courseName }}</td>
               <td class="text-break">{{ student.institute }}</td>
               <td>
-                <button class="btn btn-sm btn-danger" (click)="removeStudentFromCourse(student.courseId)">
+                <button class="btn btn-sm btn-danger" (click)="removeStudentFromCourse(student)">
                   <i class="fas fa-trash-alt"></i> Remove From Course
                 </button>
               </td>

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
@@ -6,7 +6,7 @@ import { InstructorService } from '../../../services/instructor.service';
 import { NavigationService } from '../../../services/navigation.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
-import { Account } from '../../../types/api-output';
+import { Account, Instructor, Student } from '../../../types/api-output';
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { ErrorMessageOutput } from '../../error-message-output';
 
@@ -87,16 +87,19 @@ export class AdminAccountsPageComponent implements OnInit {
   /**
    * Removes the student from course.
    */
-  removeStudentFromCourse(courseId: string): void {
+  removeStudentFromCourse(studentToDelete: Student): void {
     this.studentService
       .deleteStudent({
-        courseId,
-        googleId: this.accountInfo.googleId,
+        userId: studentToDelete.userId,
       })
       .subscribe({
         next: () => {
-          this.accountInfo.students = this.accountInfo.students.filter((student) => student.courseId !== courseId);
-          this.statusMessageService.showSuccessToast(`Student is successfully deleted from course "${courseId}"`);
+          this.accountInfo.students = this.accountInfo.students.filter(
+            (student) => student.userId !== studentToDelete.userId,
+          );
+          this.statusMessageService.showSuccessToast(
+            `Student is successfully deleted from course "${studentToDelete.courseId}"`,
+          );
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
@@ -107,18 +110,19 @@ export class AdminAccountsPageComponent implements OnInit {
   /**
    * Removes the instructor from course.
    */
-  removeInstructorFromCourse(courseId: string): void {
+  removeInstructorFromCourse(instructorToDelete: Instructor): void {
     this.instructorService
       .deleteInstructor({
-        courseId,
-        instructorId: this.accountInfo.googleId,
+        userId: instructorToDelete.userId,
       })
       .subscribe({
         next: () => {
           this.accountInfo.instructors = this.accountInfo.instructors.filter(
-            (instructor) => instructor.courseId !== courseId,
+            (instructor) => instructor.userId !== instructorToDelete.userId,
           );
-          this.statusMessageService.showSuccessToast(`Instructor is successfully deleted from course "${courseId}"`);
+          this.statusMessageService.showSuccessToast(
+            `Instructor is successfully deleted from course "${instructorToDelete.courseId}"`,
+          );
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -347,7 +347,7 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
    * Removes the student from course and update the course statistics
    */
   removeStudentFromCourse(studentUserId: string): void {
-    this.courseService.removeStudentFromCourse(studentUserId).subscribe({
+    this.studentService.deleteStudent({ userId: studentUserId }).subscribe({
       next: () => {
         this.students = this.students.filter(
           (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -346,11 +346,11 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
   /**
    * Removes the student from course and update the course statistics
    */
-  removeStudentFromCourse(studentUserId: string): void {
-    this.studentService.deleteStudent({ userId: studentUserId }).subscribe({
+  removeStudentFromCourse(studentRow: StudentListRowModel): void {
+    this.studentService.deleteStudent({ userId: studentRow.student.userId }).subscribe({
       next: () => {
         this.students = this.students.filter(
-          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,
+          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentRow.student.userId,
         );
 
         const students: Student[] = this.students.map((studentModel: StudentListRowModel) => studentModel.student);

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -346,11 +346,11 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
   /**
    * Removes the student from course and update the course statistics
    */
-  removeStudentFromCourse(studentEmail: string): void {
-    this.courseService.removeStudentFromCourse(this.courseDetails.course.courseId, studentEmail).subscribe({
+  removeStudentFromCourse(studentUserId: string): void {
+    this.courseService.removeStudentFromCourse(studentUserId).subscribe({
       next: () => {
         this.students = this.students.filter(
-          (studentModel: StudentListRowModel) => studentModel.student.email !== studentEmail,
+          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,
         );
 
         const students: Student[] = this.students.map((studentModel: StudentListRowModel) => studentModel.student);

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -479,8 +479,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
       () => {
         this.instructorService
           .deleteInstructor({
-            courseId: panelDetail.originalInstructor.courseId,
-            instructorEmail: panelDetail.originalInstructor.email,
+            userId: panelDetail.originalInstructor.userId,
           })
           .subscribe({
             next: () => {

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -2,13 +2,13 @@
 
 exports[`InstructorSearchPageComponent > should snap with a search key 1`] = `
 <tm-instructor-search-page
-  courseService={[Function _CourseService]}
   instructorService={[Function _InstructorService]}
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function _SearchService]}
   searchString=""
   statusMessageService={[Function _StatusMessageService]}
+  studentService={[Function _StudentService]}
   studentsListRowTables={[Function Array]}
 >
   <tm-instructor-search-bar>
@@ -56,13 +56,13 @@ exports[`InstructorSearchPageComponent > should snap with a search key 1`] = `
 
 exports[`InstructorSearchPageComponent > should snap with a student table 1`] = `
 <tm-instructor-search-page
-  courseService={[Function _CourseService]}
   instructorService={[Function _InstructorService]}
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function _SearchService]}
   searchString=""
   statusMessageService={[Function _StatusMessageService]}
+  studentService={[Function _StudentService]}
   studentsListRowTables={[Function Array]}
 >
   <tm-instructor-search-bar>
@@ -537,13 +537,13 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
 
 exports[`InstructorSearchPageComponent > should snap with default fields 1`] = `
 <tm-instructor-search-page
-  courseService={[Function _CourseService]}
   instructorService={[Function _InstructorService]}
   isSearching="false"
   searchParams={[Function Object]}
   searchService={[Function _SearchService]}
   searchString=""
   statusMessageService={[Function _StatusMessageService]}
+  studentService={[Function _StudentService]}
   studentsListRowTables={[Function Array]}
 >
   <tm-instructor-search-bar>

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -6,10 +6,10 @@ import {
   SearchStudentsListRowTable,
   StudentResultTableComponent,
 } from './student-result-table/student-result-table.component';
-import { CourseService } from '../../../services/course.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { InstructorSearchResult, SearchService } from '../../../services/search.service';
 import { StatusMessageService } from '../../../services/status-message.service';
+import { StudentService } from '../../../services/student.service';
 import { ApiConst } from '../../../types/api-const';
 import { InstructorPermissionSet, InstructorPrivilege, Student } from '../../../types/api-output';
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
@@ -27,8 +27,8 @@ import { ErrorMessageOutput } from '../../error-message-output';
 export class InstructorSearchPageComponent {
   private statusMessageService = inject(StatusMessageService);
   private searchService = inject(SearchService);
-  private courseService = inject(CourseService);
   private instructorService = inject(InstructorService);
+  private studentService = inject(StudentService);
 
   searchParams: SearchParams = {
     searchKey: '',
@@ -153,7 +153,7 @@ export class InstructorSearchPageComponent {
   removeStudentFromCourse(studentRow: StudentListRowModel): void {
     const courseId: string = studentRow.student.courseId;
 
-    this.courseService.removeStudentFromCourse(studentRow.student.userId).subscribe({
+    this.studentService.deleteStudent({ userId: studentRow.student.userId }).subscribe({
       next: () => {
         const affectedTable: SearchStudentsListRowTable | undefined = this.studentsListRowTables.find(
           (table: SearchStudentsListRowTable) => table.courseId === courseId,

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -152,16 +152,15 @@ export class InstructorSearchPageComponent {
    */
   removeStudentFromCourse(studentRow: StudentListRowModel): void {
     const courseId: string = studentRow.student.courseId;
-    const studentEmail: string = studentRow.student.email;
 
-    this.courseService.removeStudentFromCourse(courseId, studentEmail).subscribe({
+    this.courseService.removeStudentFromCourse(studentRow.student.userId).subscribe({
       next: () => {
         const affectedTable: SearchStudentsListRowTable | undefined = this.studentsListRowTables.find(
           (table: SearchStudentsListRowTable) => table.courseId === courseId,
         );
         if (affectedTable) {
           affectedTable.students = affectedTable.students.filter(
-            (student: StudentListRowModel) => student.student.email !== studentEmail,
+            (student: StudentListRowModel) => student.student.userId !== studentRow.student.userId,
           );
         }
 

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.html
@@ -15,7 +15,7 @@
         [tableSortBy]="studentSortBy"
         [tableSortOrder]="studentSortOrder"
         [searchString]="searchString"
-        (removeStudentFromCourseEvent)="removeStudent(course.students, $event)"
+        (removeStudentFromCourseEvent)="removeStudentFromCourseEvent.emit($event)"
       >
       </tm-student-list>
     </div>

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
@@ -96,5 +96,4 @@ export class StudentResultTableComponent {
       return this.tableComparatorService.compare(by, order, strA, strB);
     };
   }
-
 }

--- a/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/student-result-table/student-result-table.component.ts
@@ -3,7 +3,6 @@ import { TableComparatorService } from '../../../../services/table-comparator.se
 import { SortBy, SortOrder } from '../../../../types/sort-properties';
 import { JoinStatePipe } from '../../../components/student-list/join-state.pipe';
 import { StudentListRowModel, StudentListComponent } from '../../../components/student-list/student-list.component';
-import { areEmailsEqual } from '../../../components/teammates-common/email-utils';
 import { SearchTermsHighlighterPipe } from '../../../pipes/search-terms-highlighter.pipe';
 
 /**
@@ -98,12 +97,4 @@ export class StudentResultTableComponent {
     };
   }
 
-  removeStudent(students: StudentListRowModel[], studentEmail: string): void {
-    const studentToRemove: StudentListRowModel | undefined = students.find((student: StudentListRowModel) =>
-      areEmailsEqual(student.student.email, studentEmail),
-    );
-    if (studentToRemove) {
-      this.removeStudentFromCourseEvent.emit(studentToRemove);
-    }
-  }
 }

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -205,7 +205,7 @@ export class InstructorStudentListPageComponent implements OnInit {
    * Removes the student from course and update the course statistics.
    */
   removeStudentFromCourse(courseTab: CourseTab, studentUserId: string): void {
-    this.courseService.removeStudentFromCourse(studentUserId).subscribe({
+    this.studentService.deleteStudent({ userId: studentUserId }).subscribe({
       next: () => {
         courseTab.studentList = courseTab.studentList.filter(
           (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -204,11 +204,11 @@ export class InstructorStudentListPageComponent implements OnInit {
   /**
    * Removes the student from course and update the course statistics.
    */
-  removeStudentFromCourse(courseTab: CourseTab, studentUserId: string): void {
-    this.studentService.deleteStudent({ userId: studentUserId }).subscribe({
+  removeStudentFromCourse(courseTab: CourseTab, studentRow: StudentListRowModel): void {
+    this.studentService.deleteStudent({ userId: studentRow.student.userId }).subscribe({
       next: () => {
         courseTab.studentList = courseTab.studentList.filter(
-          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,
+          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentRow.student.userId,
         );
 
         const students: Student[] = courseTab.studentList.map(

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -204,11 +204,11 @@ export class InstructorStudentListPageComponent implements OnInit {
   /**
    * Removes the student from course and update the course statistics.
    */
-  removeStudentFromCourse(courseTab: CourseTab, studentEmail: string): void {
-    this.courseService.removeStudentFromCourse(courseTab.course.courseId, studentEmail).subscribe({
+  removeStudentFromCourse(courseTab: CourseTab, studentUserId: string): void {
+    this.courseService.removeStudentFromCourse(studentUserId).subscribe({
       next: () => {
         courseTab.studentList = courseTab.studentList.filter(
-          (studentModel: StudentListRowModel) => studentModel.student.email !== studentEmail,
+          (studentModel: StudentListRowModel) => studentModel.student.userId !== studentUserId,
         );
 
         const students: Student[] = courseTab.studentList.map(

--- a/src/web/services/course.service.spec.ts
+++ b/src/web/services/course.service.spec.ts
@@ -160,13 +160,11 @@ describe('CourseService', () => {
   });
 
   it('should execute DELETE to remove student from course', () => {
-    const courseId = 'test-id';
-    const studentEmail = 'test@example.com';
+    const userId = '00000000-0000-4000-8000-000000000001';
     const paramsMap: { [key: string]: string } = {
-      courseid: courseId,
-      studentemail: studentEmail,
+      userid: userId,
     };
-    service.removeStudentFromCourse(courseId, studentEmail);
+    service.removeStudentFromCourse(userId);
     expect(spyHttpRequestService.delete).toHaveBeenCalledWith(ResourceEndpoints.STUDENT, paramsMap);
   });
 

--- a/src/web/services/course.service.spec.ts
+++ b/src/web/services/course.service.spec.ts
@@ -159,15 +159,6 @@ describe('CourseService', () => {
     expect(spyHttpRequestService.post).toHaveBeenCalledWith(ResourceEndpoints.JOIN_REMIND, paramMap);
   });
 
-  it('should execute DELETE to remove student from course', () => {
-    const userId = '00000000-0000-4000-8000-000000000001';
-    const paramsMap: { [key: string]: string } = {
-      userid: userId,
-    };
-    service.removeStudentFromCourse(userId);
-    expect(spyHttpRequestService.delete).toHaveBeenCalledWith(ResourceEndpoints.STUDENT, paramsMap);
-  });
-
   it('should execute GET when getting course section names', () => {
     const paramMap: Record<string, string> = {
       courseid: 'CS3281',

--- a/src/web/services/course.service.ts
+++ b/src/web/services/course.service.ts
@@ -174,10 +174,9 @@ export class CourseService {
   /**
    * Removes student from course.
    */
-  removeStudentFromCourse(courseId: string, studentEmail: string): Observable<any> {
+  removeStudentFromCourse(userId: string): Observable<any> {
     const paramsMap: Record<string, string> = {
-      courseid: courseId,
-      studentemail: studentEmail,
+      userid: userId,
     };
     return this.httpRequestService.delete(ResourceEndpoints.STUDENT, paramsMap);
   }

--- a/src/web/services/course.service.ts
+++ b/src/web/services/course.service.ts
@@ -172,16 +172,6 @@ export class CourseService {
   }
 
   /**
-   * Removes student from course.
-   */
-  removeStudentFromCourse(userId: string): Observable<any> {
-    const paramsMap: Record<string, string> = {
-      userid: userId,
-    };
-    return this.httpRequestService.delete(ResourceEndpoints.STUDENT, paramsMap);
-  }
-
-  /**
    * Gets a list of course section names.
    */
   getCourseSectionNames(courseId: string): Observable<any> {

--- a/src/web/services/instructor.service.spec.ts
+++ b/src/web/services/instructor.service.spec.ts
@@ -98,10 +98,9 @@ describe('InstructorService', () => {
   });
 
   it('should execute DELETE when deleting an instructor for a course', () => {
-    service.deleteInstructor({ courseId: 'CS3281', instructorEmail: 'John Doe' });
+    service.deleteInstructor({ userId: '00000000-0000-4000-8000-000000000001' });
     const paramMap: Record<string, string> = {
-      courseid: 'CS3281',
-      instructoremail: 'John Doe',
+      userid: '00000000-0000-4000-8000-000000000001',
     };
     expect(spyHttpRequestService.delete).toHaveBeenCalledWith(ResourceEndpoints.INSTRUCTOR, paramMap);
   });

--- a/src/web/services/instructor.service.ts
+++ b/src/web/services/instructor.service.ts
@@ -78,22 +78,10 @@ export class InstructorService {
   /**
    * Deletes an instructor from a course by calling API.
    */
-  deleteInstructor(queryParams: {
-    courseId: string;
-    instructorEmail?: string;
-    instructorId?: string;
-  }): Observable<any> {
+  deleteInstructor(queryParams: { userId: string }): Observable<any> {
     const paramMap: Record<string, string> = {
-      courseid: queryParams.courseId,
+      userid: queryParams.userId,
     };
-
-    if (queryParams.instructorEmail) {
-      paramMap['instructoremail'] = queryParams.instructorEmail;
-    }
-
-    if (queryParams.instructorId) {
-      paramMap['instructorid'] = queryParams.instructorId;
-    }
 
     return this.httpRequestService.delete(ResourceEndpoints.INSTRUCTOR, paramMap);
   }

--- a/src/web/services/instructor.service.ts
+++ b/src/web/services/instructor.service.ts
@@ -76,7 +76,7 @@ export class InstructorService {
   }
 
   /**
-   * Deletes an instructor from a course by calling API.
+   * Deletes an instructor by calling API.
    */
   deleteInstructor(queryParams: { userId: string }): Observable<any> {
     const paramMap: Record<string, string> = {

--- a/src/web/services/student.service.ts
+++ b/src/web/services/student.service.ts
@@ -77,7 +77,7 @@ export class StudentService {
   }
 
   /**
-   * Deletes a student in a course by calling API.
+   * Deletes a student by calling API.
    */
   deleteStudent(queryParams: { userId: string }): Observable<any> {
     const paramsMap: Record<string, string> = {

--- a/src/web/services/student.service.ts
+++ b/src/web/services/student.service.ts
@@ -79,10 +79,9 @@ export class StudentService {
   /**
    * Deletes a student in a course by calling API.
    */
-  deleteStudent(queryParams: { googleId: string; courseId: string }): Observable<any> {
+  deleteStudent(queryParams: { userId: string }): Observable<any> {
     const paramsMap: Record<string, string> = {
-      googleid: queryParams.googleId,
-      courseid: queryParams.courseId,
+      userid: queryParams.userId,
     };
     return this.httpRequestService.delete(ResourceEndpoints.STUDENT, paramsMap);
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13979

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Migrate actions to use userId. Deletion by both course+email and course+googleId natural keys are removed.
2. Moved logic from action to logic layer.