### PR TITLE
[#13698] make pr.yml fail workflow and persist comment updates

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -1,4 +1,51 @@
 // PR checks for TEAMMATES contribution guidelines; used by .github/workflows/pr.yml.
+//
+// The script posts at most one persistent comment per PR (identified by the
+// COMMENT_SENTINEL below) and updates it on each run instead of stacking new
+// comments. When there are no outstanding issues the comment is rewritten to
+// reflect the all-clear state. When at least one violation is detected the
+// workflow exits non-zero so the check shows up as failed on the PR.
+const COMMENT_SENTINEL = '<!-- teammates-pr-checker:v1 -->';
+
+const buildComment = (login, problems) => {
+  const intro = `Hi @${login}, thank you for your interest in contributing to TEAMMATES!`;
+  if (problems.length === 0) {
+    return (
+      `${COMMENT_SENTINEL}\n` +
+      `${intro}\n\nNo outstanding [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html) issues remain on this PR.`
+    );
+  }
+  const items = problems.map((line) => `- ${line}`).join('\n');
+  return (
+    `${COMMENT_SENTINEL}\n` +
+    `${intro}\nHowever, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n` +
+    `${items}\n\nPlease address the above before we proceed to review your PR.`
+  );
+};
+
+const findExistingComment = async ({ github, owner, repo, issue_number }) => {
+  // Walk the comment list and look for our sentinel. The PR is usually small
+  // enough that the first page covers it, but iterate just in case.
+  let page = 1;
+  for (;;) {
+    const { data } = await github.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number,
+      per_page: 100,
+      page,
+    });
+    const match = data.find((c) => typeof c.body === 'string' && c.body.includes(COMMENT_SENTINEL));
+    if (match) {
+      return match;
+    }
+    if (data.length < 100) {
+      return null;
+    }
+    page += 1;
+  }
+};
+
 module.exports = async ({ github, context }) => {
   const pr = await github.rest.pulls.get({
     owner: context.repo.owner,
@@ -21,27 +68,51 @@ module.exports = async ({ github, context }) => {
       issue_number: issueNumber,
     });
     isIssueOpen = issue.data.state === 'open';
-    if (isTitleValid && isDescriptionValid && isIssueOpen) {
-      return;
-    }
   }
-  let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
-              However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+
+  const problems = [];
   if (!isTitleValid) {
-    body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
+    problems.push('Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`');
   }
   if (!isDescriptionValid) {
-    body +=
-      '- Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not address the issue fully)\n';
+    problems.push(
+      'Description must reference the issue number the PR is fixing, e.g. `Fixes #<issue-number>` (or `Part of #<issue-number>` if the PR does not address the issue fully)',
+    );
   }
   if (!isIssueOpen && issueNumber) {
-    body += `- The issue referenced in the description (#${issueNumber}) is not open.\n`;
+    problems.push(`The issue referenced in the description (#${issueNumber}) is not open.`);
   }
-  body += '\nPlease address the above before we proceed to review your PR.';
-  await github.rest.issues.createComment({
-    issue_number: context.issue.number,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    body,
-  });
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const issue_number = context.issue.number;
+  const existing = await findExistingComment({ github, owner, repo, issue_number });
+  const body = buildComment(pr.data.user.login, problems);
+
+  if (existing) {
+    if (existing.body !== body) {
+      await github.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existing.id,
+        body,
+      });
+    }
+  } else if (problems.length > 0) {
+    // Only post a fresh comment when there is something to flag; the all-clear
+    // path with no prior comment stays silent to avoid surprising contributors
+    // whose PRs were always compliant.
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number,
+      body,
+    });
+  }
+
+  if (problems.length > 0) {
+    // Fail the workflow so the check appears red on the PR until the
+    // contributor addresses the listed violations.
+    throw new Error(`PR template violations remain: ${problems.length}`);
+  }
 };

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - reopened
+      - edited
+      - synchronize
     branches:
       - master
 


### PR DESCRIPTION
## Summary

Fixes #13698. Rework `.github/scripts/check-pr.js` so the PR checker posts at most one comment per PR (a sentinel-tagged bot comment, updated in place) and fails the workflow when violations remain. Add `edited` and `synchronize` to the workflow triggers so subsequent title or body edits re-run the check.

## Why this matters

#13698 notes that the existing checker stays silent once the contributor fixes a violation, so the original warning comment lingers and the GitHub check passes without ever flagging that anything was wrong. The original spam-avoidance constraint (created instead of updated) addressed noise from the previous bot but left contributors without a clear all-clear signal and lets non-compliant PRs sit with a green check.

The change keeps the noise floor low - the bot posts one comment per PR identified by an HTML sentinel, and updates the body on every run rather than appending - while making both the all-clear and the still-failing states visible. The all-clear path silently does nothing if there is no prior comment, so PRs that were always compliant are not surprised by a new bot comment.

Throwing on violations makes the workflow exit non-zero, which causes the PR's Checks tab to show the `Pull Request Checker` job as failed until the contributor brings the title and description in line with the guidelines. The added `edited` and `synchronize` triggers re-run the script when the title or body changes or a new commit is pushed, so the comment and check status stay current as the contributor iterates.

## Testing

- `node -e "require('./.github/scripts/check-pr.js')"` loads the script without syntax errors.
- The diff touches only `.github/scripts/check-pr.js` (logic) and `.github/workflows/pr.yml` (triggers), both standard CI surfaces; no application code is affected. The behaviour change is observable in the workflow run log: violations now throw, all-clear runs no longer stack new comments.

Closes #13698
