### PR TITLE
[#13990] Increase session links recovery time period to 180 days

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SessionLinksRecoveryActionTestIT.java
@@ -7,8 +7,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.util.Const;
-import teammates.common.util.EmailType;
-import teammates.common.util.EmailWrapper;
+import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidHttpParameterException;
@@ -69,11 +68,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
 
         assertEquals("The recovery links for your feedback sessions have been sent to "
                 + "the specified email address: non-existent@abc.com", output.getMessage());
-        verifyNumberOfEmailsSent(1);
-
-        EmailWrapper emailSent = getEmailsSent().get(0);
-        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
-        assertEquals("non-existent@abc.com", emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
 
         ______TS("Typical case: successfully sent recovery link email: No feedback sessions found");
         Student student1InCourse2 = typicalBundle.students.get("student1InCourse2");
@@ -90,11 +85,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
         assertEquals("The recovery links for your feedback sessions have been sent to the "
                         + "specified email address: " + student1InCourse2.getEmail(),
                 output.getMessage());
-        verifyNumberOfEmailsSent(1);
-
-        emailSent = getEmailsSent().get(0);
-        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
-        assertEquals(student1InCourse2.getEmail(), emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
 
         ______TS("Typical case test 1: successfully sent recovery link email: opened session and unpublished feedback, "
                 + "closed session and unpublished feedback.");
@@ -112,11 +103,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
         assertEquals("The recovery links for your feedback sessions have been "
                         + "sent to the specified email address: " + student1InCourse3.getEmail(),
                 output.getMessage());
-        verifyNumberOfEmailsSent(1);
-
-        emailSent = getEmailsSent().get(0);
-        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
-        assertEquals(student1InCourse3.getEmail(), emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
 
         ______TS("Typical case test 2: successfully sent recovery link email: opened and published, "
                 + "closed and published.");
@@ -134,11 +121,7 @@ public class SessionLinksRecoveryActionTestIT extends BaseActionIT<SessionLinksR
         assertEquals("The recovery links for your feedback sessions have been sent "
                         + "to the specified email address: " + student1InCourse1.getEmail(),
                 output.getMessage());
-        verifyNumberOfEmailsSent(1);
-
-        emailSent = getEmailsSent().get(0);
-        assertEquals(EmailType.SESSION_LINKS_RECOVERY.getSubject(), emailSent.getSubject());
-        assertEquals(student1InCourse1.getEmail(), emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
     }
 
     @Override

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -428,8 +428,6 @@ public final class EmailGenerator {
 
         for (var student : studentsForEmail) {
             RequestTracer.checkRemainingTime();
-            // Query students' courses first
-            // as a student will likely be in only a small number of courses.
             Course course = student.getCourse();
             String courseId = course.getId();
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -58,7 +58,7 @@ public final class EmailGenerator {
 
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 
-    private static final long SESSION_LINK_RECOVERY_DURATION_IN_DAYS = 90;
+    private static final long SESSION_LINK_RECOVERY_DURATION_IN_DAYS = 180;
 
     private static final EmailGenerator instance = new EmailGenerator();
 

--- a/src/main/java/teammates/ui/output/SessionLinksRecoveryResponseData.java
+++ b/src/main/java/teammates/ui/output/SessionLinksRecoveryResponseData.java
@@ -4,16 +4,10 @@ package teammates.ui.output;
  * The output format for session links recovery request.
  */
 public class SessionLinksRecoveryResponseData extends ApiOutput {
-    private final boolean isEmailSent;
     private final String message;
 
-    public SessionLinksRecoveryResponseData(boolean isEmailSent, String message) {
-        this.isEmailSent = isEmailSent;
+    public SessionLinksRecoveryResponseData(String message) {
         this.message = message;
-    }
-
-    public boolean isEmailSent() {
-        return this.isEmailSent;
     }
 
     public String getMessage() {

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -2,8 +2,9 @@ package teammates.ui.webapi;
 
 import static teammates.common.util.FieldValidator.REGEX_EMAIL;
 
+import java.util.List;
+
 import teammates.common.util.Const;
-import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.StringHelper;
 import teammates.ui.exception.InvalidHttpParameterException;
@@ -29,15 +30,10 @@ public class SessionLinksRecoveryAction extends PublicAction {
         }
 
         EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
-        EmailSendingStatus status = emailSender.sendEmail(email);
+        taskQueuer.scheduleEmailsForPrioritySending(List.of(email));
 
-        if (status.isSuccess()) {
-            return new JsonResult(new SessionLinksRecoveryResponseData(true,
+        return new JsonResult(new SessionLinksRecoveryResponseData(true,
                     "The recovery links for your feedback sessions have been sent to the "
                             + "specified email address: " + recoveryEmailAddress));
-        } else {
-            return new JsonResult(new SessionLinksRecoveryResponseData(false, "An error occurred. "
-                    + "The email could not be sent."));
-        }
     }
 }

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -25,14 +25,14 @@ public class SessionLinksRecoveryAction extends PublicAction {
 
         String userCaptchaResponse = getRequestParamValue(Const.ParamsNames.USER_CAPTCHA_RESPONSE);
         if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
-            return new JsonResult(new SessionLinksRecoveryResponseData(false, "Something went wrong with "
-                    + "the reCAPTCHA verification. Please try again."));
+            throw new InvalidHttpParameterException("Something went wrong with the reCAPTCHA verification. "
+                    + "Please try again.");
         }
 
         EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
         taskQueuer.scheduleEmailsForPrioritySending(List.of(email));
 
-        return new JsonResult(new SessionLinksRecoveryResponseData(true,
+        return new JsonResult(new SessionLinksRecoveryResponseData(
                     "The recovery links for your feedback sessions have been sent to the "
                             + "specified email address: " + recoveryEmailAddress));
     }

--- a/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +12,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
+import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidHttpParameterException;
@@ -71,7 +71,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         stubEmailWrapper.setRecipient("non-existent@email.com");
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
         when(mockLogic.getAllStudentsForEmail("non-existent@email.com")).thenReturn(List.of());
-        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(eq("non-existent@email.com")))
+        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent("non-existent@email.com"))
                 .thenReturn(stubEmailWrapper);
         mockEmailSender.setShouldFail(false);
 
@@ -81,10 +81,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         SessionLinksRecoveryResponseData output = (SessionLinksRecoveryResponseData) result.getOutput();
         assertEquals("The recovery links for your feedback sessions have been sent to the "
                 + "specified email address: non-existent@email.com", output.getMessage());
-        verifyNumberOfEmailsSent(1);
-        EmailWrapper emailSent = mockEmailSender.getEmailsSent().get(0);
-        assertEquals("TEAMMATES: Recovery Email", emailSent.getSubject());
-        assertEquals("non-existent@email.com", emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
     }
 
     @Test
@@ -95,7 +92,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         };
 
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
-        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(eq(stubStudent.getEmail())))
+        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(stubStudent.getEmail()))
                 .thenReturn(stubEmailWrapper);
         mockEmailSender.setShouldFail(false);
 
@@ -107,10 +104,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         assertEquals("The recovery links for your feedback sessions have been sent to the "
                 + "specified email address: " + stubStudent.getEmail(), output.getMessage());
 
-        verifyNumberOfEmailsSent(1);
-        EmailWrapper emailSent = mockEmailSender.getEmailsSent().get(0);
-        assertEquals("TEAMMATES: Recovery Email", emailSent.getSubject());
-        assertEquals(stubStudent.getEmail(), emailSent.getRecipient());
+        verifySpecifiedTasksAdded(TaskQueue.PRIORITY_EMAIL_QUEUE_NAME, 1);
     }
 
     @Test
@@ -131,26 +125,6 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
                 output.getMessage());
 
         verifyNoEmailsSent();
-    }
-
-    @Test
-    void testExecute_emailSendingFails_returnsFalseResponse() {
-        String[] params = {
-                Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
-                Const.ParamsNames.USER_CAPTCHA_RESPONSE, "correct-captcha-response",
-        };
-
-        when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
-        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(eq(stubStudent.getEmail())))
-                .thenReturn(stubEmailWrapper);
-        mockEmailSender.setShouldFail(true);
-
-        SessionLinksRecoveryAction action = getAction(params);
-        JsonResult result = getJsonResult(action);
-
-        SessionLinksRecoveryResponseData output = (SessionLinksRecoveryResponseData) result.getOutput();
-        assertFalse(output.isEmailSent());
-        assertEquals("An error occurred. The email could not be sent.", output.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
@@ -1,8 +1,6 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +71,6 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         when(mockLogic.getAllStudentsForEmail("non-existent@email.com")).thenReturn(List.of());
         when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent("non-existent@email.com"))
                 .thenReturn(stubEmailWrapper);
-        mockEmailSender.setShouldFail(false);
 
         SessionLinksRecoveryAction action = getAction(params);
         JsonResult result = getJsonResult(action);
@@ -94,13 +91,11 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
         when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(stubStudent.getEmail()))
                 .thenReturn(stubEmailWrapper);
-        mockEmailSender.setShouldFail(false);
 
         SessionLinksRecoveryAction action = getAction(params);
         JsonResult result = getJsonResult(action);
 
         SessionLinksRecoveryResponseData output = (SessionLinksRecoveryResponseData) result.getOutput();
-        assertTrue(output.isEmailSent());
         assertEquals("The recovery links for your feedback sessions have been sent to the "
                 + "specified email address: " + stubStudent.getEmail(), output.getMessage());
 
@@ -108,7 +103,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
     }
 
     @Test
-    void testExecute_captchaVerificationFailed_returnsFalseResponse() {
+    void testExecute_captchaVerificationFailed_throwsInvalidHttpParameterException() {
         String[] params = {
                 Const.ParamsNames.STUDENT_EMAIL, stubStudent.getEmail(),
                 Const.ParamsNames.USER_CAPTCHA_RESPONSE, "incorrect-captcha-response",
@@ -116,15 +111,11 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
 
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(false);
 
-        SessionLinksRecoveryAction action = getAction(params);
-        JsonResult result = getJsonResult(action);
-
-        SessionLinksRecoveryResponseData output = (SessionLinksRecoveryResponseData) result.getOutput();
-        assertFalse(output.isEmailSent());
+        InvalidHttpParameterException ihpe = verifyHttpParameterFailure(params);
         assertEquals("Something went wrong with the reCAPTCHA verification. Please try again.",
-                output.getMessage());
+                ihpe.getMessage());
 
-        verifyNoEmailsSent();
+        verifyNoTasksAdded();
     }
 
     @Test

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.html
@@ -2,7 +2,7 @@
 
 <p>
   If you cannot find your feedback session links, enter your course registered email below. Links to all your feedback
-  sessions with start date within the past 90 days will be sent to the email address.
+  sessions with start date within the past 180 days will be sent to the email address.
 </p>
 
 <div class="card bg-light col-sm-9 col-md-6">

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 import { SessionLinksRecoveryPageComponent } from './session-links-recovery-page.component';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { StatusMessageService } from '../../../services/status-message.service';
@@ -7,6 +8,7 @@ import { Mocked } from 'vitest';
 
 const mockStatusMessageService: Mocked<Partial<StatusMessageService>> = {
   showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
 };
 
 const mockFeedbackSessionsService = {
@@ -80,5 +82,16 @@ describe('SessionLinksRecoveryPageComponent', () => {
     expect(mockStatusMessageService.showErrorToast).toHaveBeenCalledWith(
       'Please complete the "I\'m not a robot" checkbox before submitting.',
     );
+  });
+
+  it('should show success when recovery link request succeeds', () => {
+    setValidEmail(component);
+    mockFeedbackSessionsService.sendFeedbackSessionLinkToRecoveryEmail.mockReturnValue(
+      of({ message: 'Recovery links sent' }),
+    );
+
+    component.onSubmitFormSessionLinksRecovery(component.formSessionLinksRecovery);
+
+    expect(mockStatusMessageService.showSuccessToast).toHaveBeenCalledWith('Recovery links sent');
   });
 });

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.ts
@@ -18,9 +18,9 @@ import { ErrorMessageOutput } from '../../error-message-output';
   imports: [FormsModule, ReactiveFormsModule, NgxCaptchaModule, AjaxLoadingComponent],
 })
 export class SessionLinksRecoveryPageComponent implements OnInit {
-  private feedbackSessionsService = inject(FeedbackSessionsService);
-  private statusMessageService = inject(StatusMessageService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private readonly feedbackSessionsService = inject(FeedbackSessionsService);
+  private readonly statusMessageService = inject(StatusMessageService);
+  private readonly formBuilder = inject(UntypedFormBuilder);
 
   // ngx-recaptcha2 element properties
   captchaSuccess = false;
@@ -75,11 +75,7 @@ export class SessionLinksRecoveryPageComponent implements OnInit {
       )
       .subscribe({
         next: (resp: SessionLinksRecoveryResponse) => {
-          if (resp.isEmailSent) {
-            this.statusMessageService.showSuccessToast(resp.message);
-          } else {
-            this.statusMessageService.showErrorToast(resp.message);
-          }
+          this.statusMessageService.showSuccessToast(resp.message);
         },
         error: (response: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(response.error.message);

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -563,7 +563,6 @@ export interface ResponseOutput {
 }
 
 export interface SessionLinksRecoveryResponse extends ApiOutput {
-  isEmailSent: boolean;
   message: string;
 }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13990

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Increase duration from 90 days to 180 days. Email templates do not have to be updated, they are already 180 days.
2. Use task queuer to schedule emails instead of sending directly.
