### PR TITLE
[#13993] Instructor sample data: created student inaccessible to instructor

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,10 +143,9 @@ To test TEAMMATES locally, you will need an instructor and a student account.
 
 1. Visit [/web/admin/home](http://localhost:4200/web/admin/home) and log in as admin (`app_admin@gmail.com`).
 2. Add an instructor account.
-3. Use the admin search feature at [/web/admin/search](http://localhost:4200/web/admin/search) to find the account request, expand the row, and retrieve the account registration link to activate the instructor.
-4. From the instructor home page at [/web/instructor/home](http://localhost:4200/web/instructor/home), enroll a test student.
-5. Use the admin search feature to find the student, expand the row, and retrieve the course join link to activate the student account.
-6. You now have access to all TEAMMATES features.
+3. Use the admin search feature at [/web/admin/search](http://localhost:4200/web/admin/search) to find the account request, expand the row, and retrieve the account registration link.
+4. Use the registration link to activate the account.
+5. You now have access to all TEAMMATES features.
 
 ## Step 5: Next Steps
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -883,9 +883,7 @@ public class Logic {
     }
 
     /**
-     * Makes the user join the course, i.e. associate the account to the student or instructor.
-     * Preconditions: <br>
-     * * Parameters regkey and account are non-null.
+     * Makes the user join the course, i.e. associate the account to the user.
      */
     public User joinCourse(String regkey, Account account)
             throws EntityDoesNotExistException, EntityAlreadyExistsException {

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -3,6 +3,7 @@ package teammates.logic.core;
 import static teammates.common.util.Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -160,25 +161,16 @@ public final class AccountsLogic {
     }
 
     /**
-     * Makes the user join the course, i.e. associate the account to the student or instructor.
-     * Preconditions: <br>
-     * * Parameters regkey and account are non-null.
+     * Makes the user join the course, i.e. associate the account to the user.
      */
     public User joinCourse(String registrationKey, Account account)
             throws EntityDoesNotExistException, EntityAlreadyExistsException {
-        assert registrationKey != null;
-        assert account != null;
+        Objects.requireNonNull(account);
+        Objects.requireNonNull(registrationKey);
 
         User user = validateJoinRequest(registrationKey, account.getGoogleId());
         assert user.getAccount() == null;
         user.setAccount(account);
-        // Update the googleId of the student entity for the instructor which was created from sample data.
-        // TODO: The student entity from sample data must be joined separately as the email used here may be incorrect.
-        // i.e. the instructor email may be different from its corresponding student email.
-        // Student studentForInstructor = usersLogic.getStudentForEmail(instructor.getCourseId(), instructor.getEmail());
-        // if (studentForInstructor != null) {
-        //     studentForInstructor.setAccount(account);
-        // }
         return user;
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -85,7 +85,7 @@ public class CreateAccountAction extends Action {
         assert createdStudent != null : "Demo instructor student should have been created in data bundle";
 
         try {
-            logic.joinCourse(createdInstructor.getRegKey(), authContext.account());
+            logic.joinCourse(createdInstructor.getRegKey(), getCurrentAccount());
             logic.joinCourse(createdStudent.getRegKey(), getCurrentAccount());
         } catch (EntityDoesNotExistException | EntityAlreadyExistsException e) {
             // EntityDoesNotExistException should not be thrown as all entities should exist in demo course.

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.http.HttpStatus;
@@ -23,6 +22,7 @@ import teammates.common.util.TimeHelper;
 import teammates.logic.core.DataBundleLogic;
 import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Instructor;
+import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -68,22 +68,25 @@ public class CreateAccountAction extends Action {
         String instructorEmail = accountRequest.getEmail();
         String instructorName = accountRequest.getName();
         String instructorInstitution = accountRequest.getInstitute();
-        String courseId;
+        DataBundle dataBundle;
 
         try {
-            courseId = importDemoData(instructorEmail, instructorName, instructorInstitution, timezone);
+            dataBundle = importDemoData(instructorEmail, instructorName, instructorInstitution, timezone);
         } catch (InvalidParametersException e) {
             // There should not be any invalid parameter here
             log.severe("Unexpected error", e);
             return new JsonResult(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
 
-        List<Instructor> instructorList = logic.getInstructorsByCourse(courseId);
+        Instructor createdInstructor = dataBundle.instructors.get("demoInstructor");
+        Student createdStudent = dataBundle.students.get("demoInstructorStudent");
 
-        assert !instructorList.isEmpty();
+        assert createdInstructor != null : "Demo instructor should have been created in data bundle";
+        assert createdStudent != null : "Demo instructor student should have been created in data bundle";
 
         try {
-            logic.joinCourse(instructorList.get(0).getRegKey(), authContext.account());
+            logic.joinCourse(createdInstructor.getRegKey(), authContext.account());
+            logic.joinCourse(createdStudent.getRegKey(), getCurrentAccount());
         } catch (EntityDoesNotExistException | EntityAlreadyExistsException e) {
             // EntityDoesNotExistException should not be thrown as all entities should exist in demo course.
             // EntityAlreadyExistsException should not be thrown as updated entities should not have
@@ -126,8 +129,8 @@ public class CreateAccountAction extends Action {
      *
      * @return the ID of demo course
      */
-    private String importDemoData(String instructorEmail, String instructorName, String instructorInstitute, String timezone)
-            throws InvalidParametersException {
+    private DataBundle importDemoData(String instructorEmail, String instructorName,
+            String instructorInstitute, String timezone) throws InvalidParametersException {
 
         String courseId = generateDemoCourseId(instructorEmail);
         Instant now = Instant.now();
@@ -143,7 +146,7 @@ public class CreateAccountAction extends Action {
         // Used for timestamp of comments
         String dateString5 = getDateString(now);
 
-        String instructorEmailAsStudent = instructorEmail.replace("@", "+student@");
+        String instructorEmailAsStudent = getInstructorAsStudentEmail(instructorEmail);
         String dataBundleString = Templates.populateTemplate(Templates.INSTRUCTOR_SAMPLE_DATA,
                 // replace instructor-as-student email
                 "teammates.demo.instructor.student@demo.course", instructorEmailAsStudent,
@@ -170,9 +173,7 @@ public class CreateAccountAction extends Action {
 
         DataBundle dataBundle = DataBundleLogic.deserializeDataBundle(dataBundleString);
 
-        logic.persistDataBundle(dataBundle);
-
-        return courseId;
+        return logic.persistDataBundle(dataBundle);
     }
 
     // Strategy to Generate New Demo Course Id:
@@ -259,6 +260,15 @@ public class CreateAccountAction extends Action {
         int previousDedupSuffix = Integer.parseInt(instructorEmailOrProposedCourseId.substring(lastIndexOfDemo + 5));
 
         return StringHelper.truncateHead(root + "-demo" + (previousDedupSuffix + 1), maximumIdLength);
+    }
+
+    /**
+     * Generate an email for instructor-as-student in demo course, by replacing "@" in instructor email with "+student@".
+     *
+     * <p>This is to make sure the generated email for student does not conflict with the instructor email.
+     */
+    private String getInstructorAsStudentEmail(String instructorEmail) {
+        return instructorEmail.replace("@", "+student@");
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -127,7 +127,7 @@ public class CreateAccountAction extends Action {
     /**
      * Imports demo course for the new instructor.
      *
-     * @return the ID of demo course
+     * @return the DataBundle with the demo course
      */
     private DataBundle importDemoData(String instructorEmail, String instructorName,
             String instructorInstitute, String timezone) throws InvalidParametersException {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13993

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Previously, the wrong email was used when linking instructor account to the created demo student. This failure was handled silently. This PR fixes this issue as well as reduces the number of unnecessary DB calls by retrieving the created student from the data bundle directly.