### PR TITLE
[#13721] Combine feedback comment output DTOs

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
@@ -121,6 +121,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
 
         editPage.editInstructor(2, instructors[0]);
+        editPage.waitForPageToLoad();
         editPage.toggleCustomCourseLevelPrivilege(2, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         editPage.toggleCustomCourseLevelPrivilege(2, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         editPage.toggleCustomSectionLevelPrivilege(2, 1, "Section 2",

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -401,7 +401,7 @@ public class InstructorCourseEditPage extends AppPage {
 
     private void clickSaveInstructorButton(int instrNum) {
         click(getSaveInstructorButton(instrNum));
-        waitForPageToLoad();
+        waitForPageToLoad(true);
     }
 
     private void clickAddSectionPrivilegeLink(int instrNum) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -330,6 +330,7 @@ public class InstructorCourseEditPage extends AppPage {
         clickEditInstructorButton(instrNum);
         click(getCourseLevelPanelCheckBox(instrNum, getCourseLevelPrivilegeIndex(privilege)));
         clickSaveInstructorButton(instrNum);
+        waitForPageToLoad();
     }
 
     public void toggleCustomSectionLevelPrivilege(int instrNum, int panelNum, String section,
@@ -344,6 +345,7 @@ public class InstructorCourseEditPage extends AppPage {
         click(getSectionSelectionCheckBox(instrNum, panelNum, getSectionIndex(instrNum, section)));
         click(getSectionLevelCheckBox(instrNum, panelNum, getSectionLevelPrivilegeIndex(privilege)));
         clickSaveInstructorButton(instrNum);
+        waitForPageToLoad();
     }
 
     public void toggleCustomSessionLevelPrivilege(int instrNum, int panelNum, String section, String session,
@@ -360,6 +362,7 @@ public class InstructorCourseEditPage extends AppPage {
         click(getSessionLevelCheckbox(instrNum, panelNum, getSessionIndex(instrNum, session),
                 getSessionLevelPrivilegeIndex(privilege)));
         clickSaveInstructorButton(instrNum);
+        waitForPageToLoad();
     }
 
     private int getNumInstructors() {

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -12,6 +12,8 @@ import teammates.storage.entity.FeedbackResponseComment;
  * The API output format of {@link FeedbackResponseComment}.
  */
 public class FeedbackResponseCommentData extends ApiOutput {
+    private UUID feedbackResponseCommentId;
+
     @Nullable
     private String commentGiver;
     @Nullable
@@ -21,7 +23,6 @@ public class FeedbackResponseCommentData extends ApiOutput {
     @Nullable
     private String lastEditorName;
 
-    private UUID feedbackResponseCommentId;
     private String commentText;
     private long createdAt;
     private long lastEditedAt;

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -2,7 +2,8 @@ package teammates.ui.output;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
+
+import jakarta.annotation.Nullable;
 
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.storage.entity.FeedbackResponseComment;
@@ -11,9 +12,14 @@ import teammates.storage.entity.FeedbackResponseComment;
  * The API output format of {@link FeedbackResponseComment}.
  */
 public class FeedbackResponseCommentData extends ApiOutput {
-
-    String commentGiver;
-    String lastEditorEmail;
+    @Nullable
+    private String commentGiver;
+    @Nullable
+    private String commentGiverName;
+    @Nullable
+    private String lastEditorEmail;
+    @Nullable
+    private String lastEditorName;
 
     private UUID feedbackResponseCommentId;
     private String commentText;
@@ -29,16 +35,27 @@ public class FeedbackResponseCommentData extends ApiOutput {
     }
 
     public FeedbackResponseCommentData(FeedbackResponseComment frc) {
-        // TODO: combine with CommentOutput to simplify output classes
+        this.commentGiver = frc.getGiver().getIdentifier();
+        this.commentGiverName = frc.getGiver().getDisplayName();
+        this.lastEditorEmail = frc.getLastEditedBy().getIdentifier();
+        this.lastEditorName = frc.getLastEditedBy().getDisplayName();
         this.feedbackResponseCommentId = frc.getId();
         this.commentText = frc.getCommentText();
-        this.commentGiver = frc.getGiver().getIdentifier();
         this.showGiverNameTo = convertToFeedbackVisibilityType(frc.getShowGiverNameTo());
         this.showCommentTo = convertToFeedbackVisibilityType(frc.getShowCommentTo());
         this.createdAt = frc.getCreatedAt().toEpochMilli();
         this.lastEditedAt = frc.getUpdatedAt().toEpochMilli();
-        this.lastEditorEmail = frc.getLastEditedBy().getIdentifier();
         this.isVisibilityFollowingFeedbackQuestion = frc.getIsVisibilityFollowingFeedbackQuestion();
+    }
+
+    public FeedbackResponseCommentData(FeedbackResponseComment frc, boolean isGiverVisible) {
+        this(frc);
+        if (!isGiverVisible) {
+            this.commentGiver = null;
+            this.commentGiverName = null;
+            this.lastEditorEmail = null;
+            this.lastEditorName = null;
+        }
     }
 
     /**
@@ -65,7 +82,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
                 break;
             }
             return null;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     public String getCommentText() {
@@ -78,6 +95,10 @@ public class FeedbackResponseCommentData extends ApiOutput {
 
     public String getCommentGiver() {
         return commentGiver;
+    }
+
+    public String getCommentGiverName() {
+        return commentGiverName;
     }
 
     public List<CommentVisibilityType> getShowGiverNameTo() {
@@ -94,6 +115,10 @@ public class FeedbackResponseCommentData extends ApiOutput {
 
     public String getLastEditorEmail() {
         return lastEditorEmail;
+    }
+
+    public String getLastEditorName() {
+        return lastEditorName;
     }
 
     public long getLastEditedAt() {

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -15,11 +15,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
     private UUID feedbackResponseCommentId;
 
     @Nullable
-    private String commentGiver;
-    @Nullable
     private String commentGiverName;
-    @Nullable
-    private String lastEditorEmail;
     @Nullable
     private String lastEditorName;
 
@@ -36,9 +32,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
     }
 
     public FeedbackResponseCommentData(FeedbackResponseComment frc) {
-        this.commentGiver = frc.getGiver().getIdentifier();
         this.commentGiverName = frc.getGiver().getDisplayName();
-        this.lastEditorEmail = frc.getLastEditedBy().getIdentifier();
         this.lastEditorName = frc.getLastEditedBy().getDisplayName();
         this.feedbackResponseCommentId = frc.getId();
         this.commentText = frc.getCommentText();
@@ -52,9 +46,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
     public FeedbackResponseCommentData(FeedbackResponseComment frc, boolean isGiverVisible) {
         this(frc);
         if (!isGiverVisible) {
-            this.commentGiver = null;
             this.commentGiverName = null;
-            this.lastEditorEmail = null;
             this.lastEditorName = null;
         }
     }
@@ -94,10 +86,6 @@ public class FeedbackResponseCommentData extends ApiOutput {
         return feedbackResponseCommentId;
     }
 
-    public String getCommentGiver() {
-        return commentGiver;
-    }
-
     public String getCommentGiverName() {
         return commentGiverName;
     }
@@ -112,10 +100,6 @@ public class FeedbackResponseCommentData extends ApiOutput {
 
     public long getCreatedAt() {
         return createdAt;
-    }
-
-    public String getLastEditorEmail() {
-        return lastEditorEmail;
     }
 
     public String getLastEditorName() {

--- a/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseCommentData.java
@@ -3,9 +3,8 @@ package teammates.ui.output;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.annotation.Nullable;
-
 import teammates.common.datatransfer.participanttypes.ViewerType;
+import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackResponseComment;
 
 /**
@@ -14,9 +13,7 @@ import teammates.storage.entity.FeedbackResponseComment;
 public class FeedbackResponseCommentData extends ApiOutput {
     private UUID feedbackResponseCommentId;
 
-    @Nullable
     private String commentGiverName;
-    @Nullable
     private String lastEditorName;
 
     private String commentText;
@@ -46,8 +43,8 @@ public class FeedbackResponseCommentData extends ApiOutput {
     public FeedbackResponseCommentData(FeedbackResponseComment frc, boolean isGiverVisible) {
         this(frc);
         if (!isGiverVisible) {
-            this.commentGiverName = null;
-            this.lastEditorName = null;
+            this.commentGiverName = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
+            this.lastEditorName = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
         }
     }
 

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -182,7 +182,7 @@ public class SessionResultsData extends ApiOutput {
         // process comments
         List<FeedbackResponseComment> feedbackResponseComments =
                 bundle.getResponseCommentsMap().getOrDefault(response, Collections.emptyList());
-        Queue<CommentOutput> comments = buildComments(feedbackResponseComments, bundle);
+        Queue<FeedbackResponseCommentData> comments = buildComments(feedbackResponseComments, bundle);
 
         return ResponseOutput.builder()
                 .withResponseId(response.getId().toString())
@@ -254,7 +254,7 @@ public class SessionResultsData extends ApiOutput {
         // process comments
         List<FeedbackResponseComment> feedbackResponseComments =
                 bundle.getResponseCommentsMap().getOrDefault(response, Collections.emptyList());
-        Queue<CommentOutput> comments = buildComments(feedbackResponseComments, bundle);
+        Queue<FeedbackResponseCommentData> comments = buildComments(feedbackResponseComments, bundle);
 
         return ResponseOutput.builder()
                 .withIsMissingResponse(false)
@@ -369,40 +369,17 @@ public class SessionResultsData extends ApiOutput {
         }
     }
 
-    private static Queue<CommentOutput> buildComments(List<FeedbackResponseComment> feedbackResponseComments,
+    private static Queue<FeedbackResponseCommentData> buildComments(List<FeedbackResponseComment> feedbackResponseComments,
                                                       SessionResultsBundle bundle) {
-        LinkedList<CommentOutput> outputs = new LinkedList<>();
+        LinkedList<FeedbackResponseCommentData> outputs = new LinkedList<>();
 
-        CommentOutput participantComment = null;
         for (FeedbackResponseComment comment : feedbackResponseComments) {
             if (comment.getIsCommentFromFeedbackParticipant()) {
-                // participant comment will not need these fields
-                participantComment = CommentOutput.builder(comment)
-                        .withCommentGiver(null)
-                        .withCommentGiverName(null)
-                        .withLastEditorEmail(null)
-                        .withLastEditorName(null)
-                        .build();
+                outputs.addFirst(new FeedbackResponseCommentData(comment));
             } else {
-                String giverEmail = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
-                String giverName = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
-                String lastEditorEmail = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
-                String lastEditorName = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT;
-                if (bundle.isCommentGiverVisible(comment)) {
-                    giverEmail = comment.getGiver().getIdentifier();
-                    giverName = comment.getGiver().getDisplayName();
-                    lastEditorEmail = comment.getLastEditedBy().getIdentifier();
-                    lastEditorName = comment.getLastEditedBy().getDisplayName();
-                }
-                outputs.add(CommentOutput.builder(comment)
-                        .withCommentGiver(giverEmail)
-                        .withCommentGiverName(giverName)
-                        .withLastEditorEmail(lastEditorEmail)
-                        .withLastEditorName(lastEditorName)
-                        .build());
+                outputs.add(new FeedbackResponseCommentData(comment, bundle.isCommentGiverVisible(comment)));
             }
         }
-        outputs.addFirst(participantComment);
 
         return outputs;
     }
@@ -495,8 +472,8 @@ public class SessionResultsData extends ApiOutput {
 
         // comments
         @Nullable
-        private CommentOutput participantComment;
-        private List<CommentOutput> instructorComments;
+        private FeedbackResponseCommentData participantComment;
+        private List<FeedbackResponseCommentData> instructorComments;
 
         private ResponseOutput() {
             // use builder instead
@@ -561,11 +538,11 @@ public class SessionResultsData extends ApiOutput {
         }
 
         @Nullable
-        public CommentOutput getParticipantComment() {
+        public FeedbackResponseCommentData getParticipantComment() {
             return participantComment;
         }
 
-        public List<CommentOutput> getInstructorComments() {
+        public List<FeedbackResponseCommentData> getInstructorComments() {
             return instructorComments;
         }
 
@@ -639,12 +616,12 @@ public class SessionResultsData extends ApiOutput {
                 return this;
             }
 
-            Builder withParticipantComment(@Nullable CommentOutput participantComment) {
+            Builder withParticipantComment(@Nullable FeedbackResponseCommentData participantComment) {
                 responseOutput.participantComment = participantComment;
                 return this;
             }
 
-            Builder withInstructorComments(List<CommentOutput> instructorComments) {
+            Builder withInstructorComments(List<FeedbackResponseCommentData> instructorComments) {
                 responseOutput.instructorComments = instructorComments;
                 return this;
             }
@@ -654,73 +631,4 @@ public class SessionResultsData extends ApiOutput {
             }
         }
     }
-
-    /**
-     * API output format for response comments.
-     */
-    public static final class CommentOutput extends FeedbackResponseCommentData {
-
-        @Nullable
-        private String commentGiverName;
-        @Nullable
-        private String lastEditorName;
-
-        private CommentOutput(FeedbackResponseComment frc) {
-            // use builder instead
-            super(frc);
-        }
-
-        /**
-         * Returns a builder for {@link CommentOutput}.
-         */
-        static Builder builder(FeedbackResponseComment frc) {
-            return new Builder(frc);
-        }
-
-        @Nullable
-        public String getCommentGiverName() {
-            return commentGiverName;
-        }
-
-        @Nullable
-        public String getLastEditorName() {
-            return lastEditorName;
-        }
-
-        /**
-         * Builder class for {@link CommentOutput}.
-         */
-        public static final class Builder {
-            private final CommentOutput commentOutput;
-
-            private Builder(FeedbackResponseComment frc) {
-                commentOutput = new CommentOutput(frc);
-            }
-
-            Builder withCommentGiver(@Nullable String commentGiver) {
-                commentOutput.commentGiver = commentGiver;
-                return this;
-            }
-
-            Builder withCommentGiverName(@Nullable String commentGiverName) {
-                commentOutput.commentGiverName = commentGiverName;
-                return this;
-            }
-
-            Builder withLastEditorEmail(@Nullable String lastEditorEmail) {
-                commentOutput.lastEditorEmail = lastEditorEmail;
-                return this;
-            }
-
-            Builder withLastEditorName(@Nullable String lastEditorName) {
-                commentOutput.lastEditorName = lastEditorName;
-                return this;
-            }
-
-            CommentOutput build() {
-                return commentOutput;
-            }
-        }
-    }
-
 }

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -3,11 +3,9 @@ package teammates.ui.output;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
@@ -182,7 +180,12 @@ public class SessionResultsData extends ApiOutput {
         // process comments
         List<FeedbackResponseComment> feedbackResponseComments =
                 bundle.getResponseCommentsMap().getOrDefault(response, Collections.emptyList());
-        Queue<FeedbackResponseCommentData> comments = buildComments(feedbackResponseComments, bundle);
+        List<FeedbackResponseCommentData> instructorComments = buildInstructorComments(feedbackResponseComments, bundle);
+        FeedbackResponseCommentData participantComment = feedbackResponseComments.stream()
+                .filter(FeedbackResponseComment::getIsCommentFromFeedbackParticipant)
+                .findFirst()
+                .map(FeedbackResponseCommentData::new)
+                .orElse(null);
 
         return ResponseOutput.builder()
                 .withResponseId(response.getId().toString())
@@ -195,8 +198,8 @@ public class SessionResultsData extends ApiOutput {
                 .withRecipientEmail(null)
                 .withRecipientSectionName(recipient.getSectionName())
                 .withResponseDetails(response.getFeedbackResponseDetailsCopy())
-                .withParticipantComment(comments.poll())
-                .withInstructorComments(new ArrayList<>(comments))
+                .withParticipantComment(participantComment)
+                .withInstructorComments(instructorComments)
                 .build();
     }
 
@@ -254,7 +257,12 @@ public class SessionResultsData extends ApiOutput {
         // process comments
         List<FeedbackResponseComment> feedbackResponseComments =
                 bundle.getResponseCommentsMap().getOrDefault(response, Collections.emptyList());
-        Queue<FeedbackResponseCommentData> comments = buildComments(feedbackResponseComments, bundle);
+        List<FeedbackResponseCommentData> instructorComments = buildInstructorComments(feedbackResponseComments, bundle);
+        FeedbackResponseCommentData participantComment = feedbackResponseComments.stream()
+                .filter(FeedbackResponseComment::getIsCommentFromFeedbackParticipant)
+                .findFirst()
+                .map(FeedbackResponseCommentData::new)
+                .orElse(null);
 
         return ResponseOutput.builder()
                 .withIsMissingResponse(false)
@@ -269,8 +277,8 @@ public class SessionResultsData extends ApiOutput {
                 .withRecipientEmail(recipientEmail)
                 .withRecipientSectionName(recipientSectionName)
                 .withResponseDetails(response.getFeedbackResponseDetailsCopy())
-                .withParticipantComment(comments.poll())
-                .withInstructorComments(new ArrayList<>(comments))
+                .withParticipantComment(participantComment)
+                .withInstructorComments(instructorComments)
                 .build();
     }
 
@@ -369,14 +377,12 @@ public class SessionResultsData extends ApiOutput {
         }
     }
 
-    private static Queue<FeedbackResponseCommentData> buildComments(List<FeedbackResponseComment> feedbackResponseComments,
-                                                      SessionResultsBundle bundle) {
-        LinkedList<FeedbackResponseCommentData> outputs = new LinkedList<>();
+    private static List<FeedbackResponseCommentData> buildInstructorComments(
+                List<FeedbackResponseComment> feedbackResponseComments, SessionResultsBundle bundle) {
+        List<FeedbackResponseCommentData> outputs = new ArrayList<>();
 
         for (FeedbackResponseComment comment : feedbackResponseComments) {
-            if (comment.getIsCommentFromFeedbackParticipant()) {
-                outputs.addFirst(new FeedbackResponseCommentData(comment));
-            } else {
+            if (!comment.getIsCommentFromFeedbackParticipant()) {
                 outputs.add(new FeedbackResponseCommentData(comment, bundle.isCommentGiverVisible(comment)));
             }
         }

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -192,7 +192,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseCommentData commentData = (FeedbackResponseCommentData) r.getOutput();
 
         assertEquals("Comment to first response", commentData.getCommentText());
-        assertEquals(typicalInstructor.getEmail(), commentData.getCommentGiver());
     }
 
     @Test
@@ -411,7 +410,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseCommentData commentData = (FeedbackResponseCommentData) r.getOutput();
 
         assertEquals("Comment to first response, published session", commentData.getCommentText());
-        assertEquals(typicalInstructor.getEmail(), commentData.getCommentGiver());
     }
 
     @Test
@@ -442,7 +440,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseCommentData commentData = (FeedbackResponseCommentData) r.getOutput();
 
         assertEquals("Instructor submission comment", commentData.getCommentText());
-        assertEquals(typicalInstructor.getEmail(), commentData.getCommentGiver());
     }
 
     @Test
@@ -472,7 +469,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         FeedbackResponseCommentData commentData = (FeedbackResponseCommentData) r.getOutput();
 
         assertEquals("Student submission comment", commentData.getCommentText());
-        assertEquals(typicalStudent.getEmail(), commentData.getCommentGiver());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -415,9 +415,9 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         FeedbackResponseCommentData actualComment = actual.getGiverComment();
         assert expectedComment != null;
         assert actualComment != null;
-        assertEquals(expectedComment.getCommentGiver(), actualComment.getCommentGiver());
+        assertEquals(expectedComment.getCommentGiverName(), actualComment.getCommentGiverName());
         assertEquals(expectedComment.getCommentText(), actualComment.getCommentText());
-        assertEquals(expectedComment.getLastEditorEmail(), actualComment.getLastEditorEmail());
+        assertEquals(expectedComment.getLastEditorName(), actualComment.getLastEditorName());
     }
 
     @Test

--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.spec.ts
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.spec.ts
@@ -3,9 +3,9 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommentEditFormComponent } from './comment-edit-form.component';
 import {
-  CommentOutput,
   CommentVisibilityType,
   FeedbackQuestionType,
+  FeedbackResponseComment,
   FeedbackResponseDetails,
 } from '../../../../types/api-output';
 import { CommentVisibilityControl } from '../../../../types/comment-visibility-control';
@@ -38,7 +38,7 @@ describe('CommentEditFormComponent', () => {
       const feedbackResponseDetails: FeedbackResponseDetails = {
         questionType: FeedbackQuestionType.CONSTSUM,
       };
-      const commentOutputs: CommentOutput[] = [];
+      const commentOutputs: FeedbackResponseComment[] = [];
       component.response = {
         isMissingResponse: true,
         responseId: 'string',

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -25,9 +25,7 @@
           }
           @if (!isFeedbackParticipantComment) {
             <ng-container class="text-secondary">
-              <span class="comment-giver-name"
-                >{{ model.originalComment.commentGiverName || 'Anonymous' }} commented at
-              </span>
+              <span class="comment-giver-name">{{ model.originalComment.commentGiverName }} commented at </span>
               <span
                 class="ngb-tooltip-class"
                 style="margin-right: 0.25rem"
@@ -45,7 +43,7 @@
                   style="margin-right: 0.25rem"
                   class="ngb-tooltip-class"
                   [ngbTooltip]="model.originalComment.lastEditedAt | formatDateDetail: model.timezone!"
-                  >edited by {{ model.originalComment.lastEditorName || 'Anonymous' }}</span
+                  >edited by {{ model.originalComment.lastEditorName }}</span
                 >
               }
             </ng-container>

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -45,8 +45,7 @@
                   style="margin-right: 0.25rem"
                   class="ngb-tooltip-class"
                   [ngbTooltip]="model.originalComment.lastEditedAt | formatDateDetail: model.timezone!"
-                  >edited by
-                  {{ model.originalComment.lastEditorName || 'Anonymous' }}</span
+                  >edited by {{ model.originalComment.lastEditorName || 'Anonymous' }}</span
                 >
               }
             </ng-container>

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -26,7 +26,7 @@
           @if (!isFeedbackParticipantComment) {
             <ng-container class="text-secondary">
               <span class="comment-giver-name"
-                >{{ model.commentGiverName ? model.commentGiverName : model.originalComment.commentGiver }} commented at
+                >{{ model.originalComment.commentGiverName || 'Anonymous' }} commented at
               </span>
               <span
                 class="ngb-tooltip-class"
@@ -46,7 +46,7 @@
                   class="ngb-tooltip-class"
                   [ngbTooltip]="model.originalComment.lastEditedAt | formatDateDetail: model.timezone!"
                   >edited by
-                  {{ model.lastEditorName ? model.lastEditorName : model.originalComment.lastEditorEmail }}</span
+                  {{ model.originalComment.lastEditorName || 'Anonymous' }}</span
                 >
               }
             </ng-container>

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.spec.ts
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.spec.ts
@@ -39,13 +39,13 @@ describe('CommentRowComponent', () => {
       component.model = {
         originalComment: {
           isVisibilityFollowingFeedbackQuestion: true,
-          commentGiver: 'mockCommentGiver',
-          lastEditorEmail: 'mockEditor@example.com',
+          commentGiverName: 'Mock Giver Name',
+          lastEditorName: 'Mock Editor Name',
           feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
           commentText: 'Mock comment text',
           showCommentTo: [CommentVisibilityType.GIVER, CommentVisibilityType.INSTRUCTORS],
-          createdAt: new Date().getTime(),
-          lastEditedAt: new Date().getTime(),
+          createdAt: Date.now(),
+          lastEditedAt: Date.now(),
           showGiverNameTo: [],
         },
         commentEditFormModel: {
@@ -71,13 +71,13 @@ describe('CommentRowComponent', () => {
       component.model = {
         originalComment: {
           isVisibilityFollowingFeedbackQuestion: true,
-          commentGiver: 'mockCommentGiver',
-          lastEditorEmail: 'mockEditor@example.com',
+          commentGiverName: 'Mock Giver Name',
+          lastEditorName: 'Mock Editor Name',
           feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
           commentText: 'Mock comment text',
           showCommentTo: [],
-          createdAt: new Date().getTime(),
-          lastEditedAt: new Date().getTime(),
+          createdAt: Date.now(),
+          lastEditedAt: Date.now(),
           showGiverNameTo: [],
         },
         commentEditFormModel: {
@@ -123,13 +123,13 @@ describe('CommentRowComponent', () => {
       component.model = {
         originalComment: {
           isVisibilityFollowingFeedbackQuestion: false,
-          commentGiver: 'mockCommentGiver',
-          lastEditorEmail: 'mockEditor@example.com',
+          commentGiverName: 'Mock Giver Name',
+          lastEditorName: 'Mock Editor Name',
           feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
           commentText: 'Mock comment text',
           showCommentTo: [CommentVisibilityType.GIVER, CommentVisibilityType.INSTRUCTORS],
-          createdAt: new Date().getTime(),
-          lastEditedAt: new Date().getTime(),
+          createdAt: Date.now(),
+          lastEditedAt: Date.now(),
           showGiverNameTo: [],
         },
         commentEditFormModel: {

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.ts
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.ts
@@ -23,18 +23,10 @@ import { CommentVisibilityTypesJointNamePipe } from '../comment-visibility-setti
  * Model for a comment row.
  */
 export interface CommentRowModel {
-  // original comment and recipient identifier can be null under ADD mode
+  // original comment, recipient identifier and timezone can be null under ADD mode
   originalComment?: FeedbackResponseComment;
   originalRecipientIdentifier?: string;
-  /**
-   * Timezone of the original comment.
-   */
   timezone?: string;
-  // timezone and originalComment are optional under ADD mode.
-
-  // optional fields that make the display name more readable
-  commentGiverName?: string;
-  lastEditorName?: string;
 
   commentEditFormModel: CommentEditFormModel;
   isEditing: boolean;

--- a/src/web/app/components/comment-box/comment-to-comment-row-model.pipe.ts
+++ b/src/web/app/components/comment-box/comment-to-comment-row-model.pipe.ts
@@ -1,6 +1,6 @@
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
 import { CommentRowModel } from './comment-row/comment-row.component';
-import { CommentOutput } from '../../../types/api-output';
+import { FeedbackResponseComment } from '../../../types/api-output';
 
 /**
  * Transforms comment to comment row model.
@@ -8,12 +8,10 @@ import { CommentOutput } from '../../../types/api-output';
 @Injectable({ providedIn: 'root' })
 @Pipe({ name: 'commentToCommentRowModel' })
 export class CommentToCommentRowModelPipe implements PipeTransform {
-  transform(comment: CommentOutput, timezone?: string): CommentRowModel {
+  transform(comment: FeedbackResponseComment, timezone?: string): CommentRowModel {
     return {
       timezone,
       originalComment: comment,
-      commentGiverName: comment.commentGiverName,
-      lastEditorName: comment.lastEditorName,
       commentEditFormModel: {
         commentText: comment.commentText,
         isUsingCustomVisibilities: !comment.isVisibilityFollowingFeedbackQuestion,

--- a/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.spec.ts
+++ b/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.spec.ts
@@ -1,6 +1,6 @@
+import { FeedbackResponseComment } from '../../../types/api-output';
 import { CommentToCommentRowModelPipe } from './comment-to-comment-row-model.pipe';
 import { CommentsToCommentTableModelPipe } from './comments-to-comment-table-model.pipe';
-import { CommentOutput } from '../../../types/api-output';
 import { TestBed } from '@angular/core/testing';
 
 describe('CommentsToCommentTableModelPipe', () => {
@@ -15,7 +15,7 @@ describe('CommentsToCommentTableModelPipe', () => {
   });
 
   it('converts comments to comment table model correctly', () => {
-    const comments: CommentOutput[] = [
+    const comments: FeedbackResponseComment[] = [
       {
         commentGiverName: 'commentGiverName',
         lastEditorName: 'lastEditorName',
@@ -60,8 +60,6 @@ describe('CommentsToCommentTableModelPipe', () => {
             showGiverNameTo: [],
             showCommentTo: [],
           },
-          commentGiverName: 'commentGiverName',
-          lastEditorName: 'lastEditorName',
           commentEditFormModel: {
             commentText: 'commentText',
             isUsingCustomVisibilities: true,
@@ -85,8 +83,6 @@ describe('CommentsToCommentTableModelPipe', () => {
             showGiverNameTo: [],
             showCommentTo: [],
           },
-          commentGiverName: 'commentGiverName2',
-          lastEditorName: 'lastEditorName2',
           commentEditFormModel: {
             commentText: 'commentText2',
             isUsingCustomVisibilities: false,

--- a/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.spec.ts
+++ b/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.spec.ts
@@ -19,8 +19,6 @@ describe('CommentsToCommentTableModelPipe', () => {
       {
         commentGiverName: 'commentGiverName',
         lastEditorName: 'lastEditorName',
-        commentGiver: 'commentGiver',
-        lastEditorEmail: 'lastEditorEmail',
         feedbackResponseCommentId: '00000000-0000-4000-8000-000000000000',
         commentText: 'commentText',
         createdAt: 0,
@@ -32,8 +30,6 @@ describe('CommentsToCommentTableModelPipe', () => {
       {
         commentGiverName: 'commentGiverName2',
         lastEditorName: 'lastEditorName2',
-        commentGiver: 'commentGiver2',
-        lastEditorEmail: 'lastEditorEmail2',
         feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
         commentText: 'commentText2',
         createdAt: 1,
@@ -50,8 +46,6 @@ describe('CommentsToCommentTableModelPipe', () => {
           originalComment: {
             commentGiverName: 'commentGiverName',
             lastEditorName: 'lastEditorName',
-            commentGiver: 'commentGiver',
-            lastEditorEmail: 'lastEditorEmail',
             feedbackResponseCommentId: '00000000-0000-4000-8000-000000000000',
             commentText: 'commentText',
             createdAt: 0,
@@ -73,8 +67,6 @@ describe('CommentsToCommentTableModelPipe', () => {
           originalComment: {
             commentGiverName: 'commentGiverName2',
             lastEditorName: 'lastEditorName2',
-            commentGiver: 'commentGiver2',
-            lastEditorEmail: 'lastEditorEmail2',
             feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
             commentText: 'commentText2',
             createdAt: 1,

--- a/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.ts
+++ b/src/web/app/components/comment-box/comments-to-comment-table-model.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform, inject } from '@angular/core';
 import { CommentTableModel } from './comment-table/comment-table.model';
 import { CommentToCommentRowModelPipe } from './comment-to-comment-row-model.pipe';
-import { CommentOutput } from '../../../types/api-output';
+import { FeedbackResponseComment } from '../../../types/api-output';
 
 /**
  * Transforms comments to readonly comment table model.
@@ -10,10 +10,10 @@ import { CommentOutput } from '../../../types/api-output';
 export class CommentsToCommentTableModelPipe implements PipeTransform {
   private commentToCommentRowModel = inject(CommentToCommentRowModelPipe);
 
-  transform(comments: CommentOutput[], isReadOnly: boolean, timezone?: string): CommentTableModel {
+  transform(comments: FeedbackResponseComment[], isReadOnly: boolean, timezone?: string): CommentTableModel {
     return {
       isReadOnly,
-      commentRows: comments.map((comment: CommentOutput) => {
+      commentRows: comments.map((comment: FeedbackResponseComment) => {
         return this.commentToCommentRowModel.transform(comment, timezone);
       }),
       newCommentRow: {

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -396,7 +396,7 @@ exports[`QuestionResponsePanelComponent > should snap with feedback session with
                                                 <span
                                                   class="comment-giver-name"
                                                 >
-                                                  comment-giver-1 commented at 
+                                                  comment-giver-name-1 commented at 
                                                 </span>
                                                 <span
                                                   class="ngb-tooltip-class"
@@ -950,7 +950,7 @@ exports[`QuestionResponsePanelComponent > should snap with questions and respons
                                                 <span
                                                   class="comment-giver-name"
                                                 >
-                                                  comment-giver-1 commented at 
+                                                  comment-giver-name-1 commented at 
                                                 </span>
                                                 <span
                                                   class="ngb-tooltip-class"

--- a/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
@@ -332,9 +332,7 @@ describe('QuestionResponsePanelComponent', () => {
             } as FeedbackRubricResponseDetails,
             instructorComments: [
               {
-                commentGiver: 'comment-giver-1',
                 commentGiverName: 'comment-giver-name-1',
-                lastEditorEmail: 'comment@egeg.com',
                 lastEditorName: 'comment-editor-name',
                 feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
                 commentText: 'this is a text',
@@ -547,9 +545,7 @@ describe('QuestionResponsePanelComponent', () => {
             } as FeedbackRubricResponseDetails,
             instructorComments: [
               {
-                commentGiver: 'comment-giver-1',
                 commentGiverName: 'comment-giver-name-1',
-                lastEditorEmail: 'comment@egeg.com',
                 lastEditorName: 'comment-editor-name',
                 feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
                 commentText: 'this is a text',

--- a/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
@@ -333,7 +333,9 @@ describe('QuestionResponsePanelComponent', () => {
             instructorComments: [
               {
                 commentGiver: 'comment-giver-1',
+                commentGiverName: 'comment-giver-name-1',
                 lastEditorEmail: 'comment@egeg.com',
+                lastEditorName: 'comment-editor-name',
                 feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
                 commentText: 'this is a text',
                 createdAt: 1402775804,
@@ -546,7 +548,9 @@ describe('QuestionResponsePanelComponent', () => {
             instructorComments: [
               {
                 commentGiver: 'comment-giver-1',
+                commentGiverName: 'comment-giver-name-1',
                 lastEditorEmail: 'comment@egeg.com',
+                lastEditorName: 'comment-editor-name',
                 feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
                 commentText: 'this is a text',
                 createdAt: 1402775804,

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
@@ -46,8 +46,6 @@ describe('PerQuestionViewResponsesComponent', () => {
   const commentOutput: FeedbackResponseComment = {
     commentGiverName: 'Jennie Kim',
     lastEditorName: 'Jennie Kim',
-    commentGiver: 'Jennie Kim',
-    lastEditorEmail: 'jenniekim@gmail.com',
     feedbackResponseCommentId: '00000000-0000-4000-8000-000000000003',
     commentText: 'commentText',
     createdAt: 0,

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.spec.ts
@@ -2,8 +2,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
-  CommentOutput,
   FeedbackQuestion,
+  FeedbackResponseComment,
   FeedbackTextQuestionDetails,
   FeedbackTextResponseDetails,
   QuestionGiverType,
@@ -43,7 +43,7 @@ describe('PerQuestionViewResponsesComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  const commentOutput: CommentOutput = {
+  const commentOutput: FeedbackResponseComment = {
     commentGiverName: 'Jennie Kim',
     lastEditorName: 'Jennie Kim',
     commentGiver: 'Jennie Kim',

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -157,6 +157,8 @@ describe('QuestionSubmissionFormComponent', () => {
   });
 
   const feedbackResponseCommentBuilder = createBuilder<FeedbackResponseComment>({
+    commentGiverName: 'test-giver-name',
+    lastEditorName: 'test-editor-name',
     commentText: 'comment-text',
     showCommentTo: [],
     showGiverNameTo: [],

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -157,12 +157,10 @@ describe('QuestionSubmissionFormComponent', () => {
   });
 
   const feedbackResponseCommentBuilder = createBuilder<FeedbackResponseComment>({
-    commentGiver: 'comment-giver',
     commentText: 'comment-text',
     showCommentTo: [],
     showGiverNameTo: [],
     lastEditedAt: 0,
-    lastEditorEmail: 'last-editor@gmail.com',
     feedbackResponseCommentId: '00000000-0000-4000-8000-000000000000',
     createdAt: 0,
     isVisibilityFollowingFeedbackQuestion: true,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
@@ -116,8 +116,8 @@ export const EXAMPLE_RESPONSE_WITH_COMMENT: ResponseOutput = {
   } as FeedbackContributionResponseDetails,
   instructorComments: [
     {
-      commentGiver: 'Instructor',
-      lastEditorEmail: '',
+      commentGiverName: 'Instructor',
+      lastEditorName: 'Instructor',
       feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
       commentText: 'Good to know!',
       createdAt: 1,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -117,7 +117,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
   showStatistics = true;
   indicateMissingResponses = true;
 
-  currInstructorName?: string;
   instructorCommentTableModel: Record<string, CommentTableModel> = {};
 
   // below are two models contain similar and duplicate data
@@ -333,16 +332,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
                 this.statusMessageService.showErrorToast(resp.error.message);
               },
             });
-
-          // load current instructor name
-          this.instructorService
-            .getInstructor({
-              courseId: this.courseId,
-              intent: Intent.FULL_DETAIL,
-            })
-            .subscribe((instructor: Instructor) => {
-              this.currInstructorName = instructor.name;
-            });
         },
         error: (resp: ErrorMessageOutput) => {
           this.isFeedbackSessionLoading = false;
@@ -521,7 +510,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
       responseId,
       timezone: this.session.timeZone,
       instructorCommentTableModel: this.instructorCommentTableModel,
-      currInstructorName: this.currInstructorName,
     });
   }
 
@@ -543,7 +531,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
       data,
       timezone: this.session.timeZone,
       instructorCommentTableModel: this.instructorCommentTableModel,
-      currInstructorName: this.currInstructorName,
     });
   }
 

--- a/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-records-page/__snapshots__/instructor-student-records-page.component.spec.ts.snap
@@ -5,11 +5,9 @@ exports[`InstructorStudentRecordsPageComponent > should snap when student result
   commentService={[Function _InstructorCommentService]}
   commentsToCommentTableModel={[Function _CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function _FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
   instructorCommentTableModel={[Function Object]}
-  instructorService={[Function _InstructorService]}
   isStudentResultsLoading={[Function Boolean]}
   route={[Function Object]}
   sessionTabs={[Function Array]}
@@ -60,11 +58,9 @@ exports[`InstructorStudentRecordsPageComponent > should snap with default fields
   commentService={[Function _InstructorCommentService]}
   commentsToCommentTableModel={[Function _CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function _FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
   instructorCommentTableModel={[Function Object]}
-  instructorService={[Function _InstructorService]}
   isStudentResultsLoading={[Function Boolean]}
   route={[Function Object]}
   sessionTabs={[Function Array]}
@@ -115,11 +111,9 @@ exports[`InstructorStudentRecordsPageComponent > should snap with populated fiel
   commentService={[Function _InstructorCommentService]}
   commentsToCommentTableModel={[Function _CommentsToCommentTableModelPipe]}
   courseId={[Function String]}
-  currInstructorName="undefined"
   feedbackSessionsService={[Function _FeedbackSessionsService]}
   hasStudentResultsLoadingFailed="false"
   instructorCommentTableModel={[Function Object]}
-  instructorService={[Function _InstructorService]}
   isStudentResultsLoading="false"
   route={[Function Object]}
   sessionTabs={[Function Array]}

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -5,14 +5,12 @@ import { combineLatest, Observable } from 'rxjs';
 import { finalize, map, mergeMap, tap } from 'rxjs/operators';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorCommentEventData, InstructorCommentService } from '../../../services/instructor-comment.service';
-import { InstructorService } from '../../../services/instructor.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TableComparatorService } from '../../../services/table-comparator.service';
 import {
   FeedbackSession,
   FeedbackSessions,
-  Instructor,
   QuestionOutput,
   ResponseOutput,
   SessionResults,
@@ -55,7 +53,6 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private feedbackSessionsService = inject(FeedbackSessionsService);
   private studentService = inject(StudentService);
-  private instructorService = inject(InstructorService);
   private commentsToCommentTableModel = inject(CommentsToCommentTableModelPipe);
   private tableComparatorService = inject(TableComparatorService);
   private statusMessageService = inject(StatusMessageService);
@@ -71,7 +68,6 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
   isStudentResultsLoading = false;
   hasStudentResultsLoadingFailed = false;
 
-  currInstructorName?: string;
   instructorCommentTableModel: Record<string, CommentTableModel> = {};
 
   ngOnInit(): void {
@@ -80,27 +76,12 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
         this.courseId = queryParams.courseid;
         this.studentId = queryParams.userid;
 
-        this.loadInstructorRecords(this.courseId);
         this.loadStudentResults(this.courseId, this.studentId);
       },
       error: (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorToast(resp.error.message);
       },
     });
-  }
-
-  /**
-   * Loads the instructor's records based on the given course ID.
-   */
-  loadInstructorRecords(courseId: string): void {
-    this.instructorService
-      .getInstructor({
-        courseId,
-        intent: Intent.FULL_DETAIL,
-      })
-      .subscribe((instructor: Instructor) => {
-        this.currInstructorName = instructor.name;
-      });
   }
 
   /**
@@ -247,7 +228,6 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
       responseId,
       timezone,
       instructorCommentTableModel: this.instructorCommentTableModel,
-      currInstructorName: this.currInstructorName,
     });
   }
 
@@ -269,7 +249,6 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
       data,
       timezone,
       instructorCommentTableModel: this.instructorCommentTableModel,
-      currInstructorName: this.currInstructorName,
     });
   }
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -107,8 +107,8 @@ describe('SessionSubmissionPageComponent', () => {
   };
 
   const testComment: FeedbackResponseComment = {
-    commentGiver: 'comment giver',
-    lastEditorEmail: 'last-editor@email.com',
+    commentGiverName: 'Comment Giver',
+    lastEditorName: 'Comment Editor',
     feedbackResponseCommentId: '00000000-0000-4000-8000-000000000001',
     commentText: 'comment text',
     createdAt: 10000000,

--- a/src/web/services/instructor-comment.service.spec.ts
+++ b/src/web/services/instructor-comment.service.spec.ts
@@ -25,6 +25,8 @@ describe('InstructorCommentService', () => {
   const createComment = (overrides: Partial<FeedbackResponseComment> = {}): FeedbackResponseComment => ({
     commentGiver: 'instructor@example.com',
     lastEditorEmail: 'instructor@example.com',
+    commentGiverName: 'Original Instructor',
+    lastEditorName: 'Original Instructor',
     feedbackResponseCommentId: 'comment-id',
     commentText: 'comment text',
     createdAt: 1000,
@@ -38,8 +40,6 @@ describe('InstructorCommentService', () => {
   const createCommentRow = (comment: FeedbackResponseComment = createComment()): CommentRowModel => ({
     timezone,
     originalComment: comment,
-    commentGiverName: 'Original Instructor',
-    lastEditorName: 'Original Instructor',
     commentEditFormModel: {
       commentText: comment.commentText,
       isUsingCustomVisibilities: false,

--- a/src/web/services/instructor-comment.service.spec.ts
+++ b/src/web/services/instructor-comment.service.spec.ts
@@ -23,8 +23,6 @@ describe('InstructorCommentService', () => {
   let service: InstructorCommentService;
 
   const createComment = (overrides: Partial<FeedbackResponseComment> = {}): FeedbackResponseComment => ({
-    commentGiver: 'instructor@example.com',
-    lastEditorEmail: 'instructor@example.com',
     commentGiverName: 'Original Instructor',
     lastEditorName: 'Original Instructor',
     feedbackResponseCommentId: 'comment-id',

--- a/src/web/services/instructor-comment.service.spec.ts
+++ b/src/web/services/instructor-comment.service.spec.ts
@@ -160,7 +160,6 @@ describe('InstructorCommentService', () => {
       data: { responseId: 'response-id', index: 0 },
       timezone,
       instructorCommentTableModel,
-      currInstructorName: 'Current Instructor',
     });
 
     expect(spyFeedbackResponseCommentService.updateComment).toHaveBeenCalledWith(
@@ -173,8 +172,6 @@ describe('InstructorCommentService', () => {
       Intent.INSTRUCTOR_RESULT,
     );
     expect(instructorCommentTableModel['response-id'].commentRows[0].originalComment?.commentText).toBe('updated text');
-    expect(instructorCommentTableModel['response-id'].commentRows[0].commentGiverName).toBe('Original Instructor');
-    expect(instructorCommentTableModel['response-id'].commentRows[0].lastEditorName).toBe('Current Instructor');
     expect(instructorCommentTableModel['response-id'].commentRows[0].timezone).toBe(timezone);
   });
 
@@ -221,7 +218,6 @@ describe('InstructorCommentService', () => {
       responseId: 'response-id',
       timezone,
       instructorCommentTableModel,
-      currInstructorName: 'Current Instructor',
     });
 
     expect(spyFeedbackResponseCommentService.createComment).toHaveBeenCalledWith(
@@ -237,8 +233,6 @@ describe('InstructorCommentService', () => {
     expect(instructorCommentTableModel['response-id'].commentRows[0].originalComment?.feedbackResponseCommentId).toBe(
       'new-comment-id',
     );
-    expect(instructorCommentTableModel['response-id'].commentRows[0].commentGiverName).toBe('Current Instructor');
-    expect(instructorCommentTableModel['response-id'].commentRows[0].lastEditorName).toBe('Current Instructor');
     expect(instructorCommentTableModel['response-id'].newCommentRow.commentEditFormModel.commentText).toBe('');
     expect(instructorCommentTableModel['response-id'].isAddingNewComment).toBe(false);
   });

--- a/src/web/services/instructor-comment.service.ts
+++ b/src/web/services/instructor-comment.service.ts
@@ -19,14 +19,12 @@ export interface InstructorCommentUpdateParams {
   data: InstructorCommentEventData;
   timezone: string;
   instructorCommentTableModel: Record<string, CommentTableModel>;
-  currInstructorName?: string;
 }
 
 export interface InstructorCommentSaveParams {
   responseId: string;
   timezone: string;
   instructorCommentTableModel: Record<string, CommentTableModel>;
-  currInstructorName?: string;
 }
 
 export interface InstructorCommentDeleteParams {
@@ -64,12 +62,7 @@ export class InstructorCommentService {
   /**
    * Updates an instructor comment.
    */
-  updateComment({
-    data,
-    timezone,
-    instructorCommentTableModel,
-    currInstructorName,
-  }: InstructorCommentUpdateParams): void {
+  updateComment({ data, timezone, instructorCommentTableModel }: InstructorCommentUpdateParams): void {
     const commentTableModel: CommentTableModel = instructorCommentTableModel[data.responseId];
     const commentRowToUpdate: CommentRowModel = commentTableModel.commentRows[data.index];
     const commentToUpdate: FeedbackResponseComment = commentRowToUpdate.originalComment!;
@@ -86,15 +79,8 @@ export class InstructorCommentService {
       )
       .subscribe({
         next: (commentResponse: FeedbackResponseComment) => {
-          // Only override lastEditorName when the caller provided a current instructor name.
-          const transformedUpdatedComment = {
-            ...commentResponse,
-            commentGiverName: commentRowToUpdate.commentGiverName,
-            ...(currInstructorName ? { lastEditorName: currInstructorName } : {}),
-          };
-
           commentTableModel.commentRows[data.index] = this.commentToCommentRowModel.transform(
-            transformedUpdatedComment,
+            commentResponse,
             timezone,
           );
           instructorCommentTableModel[data.responseId] = {
@@ -110,12 +96,7 @@ export class InstructorCommentService {
   /**
    * Saves an instructor comment.
    */
-  saveNewComment({
-    responseId,
-    timezone,
-    instructorCommentTableModel,
-    currInstructorName,
-  }: InstructorCommentSaveParams): void {
+  saveNewComment({ responseId, timezone, instructorCommentTableModel }: InstructorCommentSaveParams): void {
     const commentTableModel: CommentTableModel = instructorCommentTableModel[responseId];
     const commentRowToAdd: CommentRowModel = commentTableModel.newCommentRow;
 
@@ -131,18 +112,7 @@ export class InstructorCommentService {
       )
       .subscribe({
         next: (commentResponse: FeedbackResponseComment) => {
-          commentTableModel.commentRows.push(
-            this.commentToCommentRowModel.transform(
-              {
-                ...commentResponse,
-                // the giver and editor name will be the current login instructor
-                ...(currInstructorName
-                  ? { commentGiverName: currInstructorName, lastEditorName: currInstructorName }
-                  : {}),
-              },
-              timezone,
-            ),
-          );
+          commentTableModel.commentRows.push(this.commentToCommentRowModel.transform(commentResponse, timezone));
           this.sortComments(commentTableModel);
           instructorCommentTableModel[responseId] = {
             ...commentTableModel,

--- a/src/web/services/test-data/feedbackSessionResultsAllResults.json
+++ b/src/web/services/test-data/feedbackSessionResultsAllResults.json
@@ -38,8 +38,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000057",
               "commentText": "Instructor 1 comment to instructor 1 self feedback Question 3",
               "createdAt": 1767311940000,
@@ -155,8 +153,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000056",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,
@@ -645,8 +641,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000055",
               "commentText": "Instructor 1 comment to student 1 self feedback",
               "createdAt": 1772409540000,

--- a/src/web/services/test-data/feedbackSessionResultsC1S1.json
+++ b/src/web/services/test-data/feedbackSessionResultsC1S1.json
@@ -38,8 +38,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000057",
               "commentText": "Instructor 1 comment to instructor 1 self feedback Question 3",
               "createdAt": 1767311940000,
@@ -155,8 +153,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000056",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,
@@ -645,8 +641,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000055",
               "commentText": "Instructor 1 comment to student 1 self feedback",
               "createdAt": 1772409540000,

--- a/src/web/services/test-data/feedbackSessionResultsC1S1Q1.json
+++ b/src/web/services/test-data/feedbackSessionResultsC1S1Q1.json
@@ -58,8 +58,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006a",
               "commentText": "Instructor 1 comment to student 1 self feedback",
               "createdAt": 1772409540000,

--- a/src/web/services/test-data/feedbackSessionResultsC1S1S1.json
+++ b/src/web/services/test-data/feedbackSessionResultsC1S1S1.json
@@ -38,8 +38,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000057",
               "commentText": "Instructor 1 comment to instructor 1 self feedback Question 3",
               "createdAt": 1767311940000,
@@ -155,8 +153,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000056",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,
@@ -645,8 +641,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000055",
               "commentText": "Instructor 1 comment to student 1 self feedback",
               "createdAt": 1772409540000,

--- a/src/web/services/test-data/feedbackSessionResultsC1S1S1Q2.json
+++ b/src/web/services/test-data/feedbackSessionResultsC1S1S1Q2.json
@@ -40,8 +40,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006b",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,

--- a/src/web/services/test-data/feedbackSessionResultsMcqResults.json
+++ b/src/web/services/test-data/feedbackSessionResultsMcqResults.json
@@ -86,8 +86,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-000000000043",
               "commentText": "Instructor 1 comment to student 2",
               "createdAt": 1451692740000,

--- a/src/web/services/test-data/feedbackSessionResultsMissingResponsesShown.json
+++ b/src/web/services/test-data/feedbackSessionResultsMissingResponsesShown.json
@@ -40,8 +40,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006b",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,
@@ -457,8 +455,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006a",
               "commentText": "Instructor 1 comment to student 1 self feedback",
               "createdAt": 1772409540000,
@@ -717,8 +713,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006c",
               "commentText": "Instructor 1 comment to instructor 1 self feedback Question 3",
               "createdAt": 1767311940000,

--- a/src/web/services/test-data/feedbackSessionResultsSingleQuestion.json
+++ b/src/web/services/test-data/feedbackSessionResultsSingleQuestion.json
@@ -40,8 +40,6 @@
             {
               "commentGiverName": "Instructor1 Course1",
               "lastEditorName": "Instructor1 Course1",
-              "commentGiver": "instructor1@course1.tmt",
-              "lastEditorEmail": "instructor1@course1.tmt",
               "feedbackResponseCommentId": "00000000-0000-0000-0000-00000000006b",
               "commentText": "Instructor 1 comment to response from student 2 to student 5 in feedback Question 2",
               "createdAt": 1769990340000,

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -247,8 +247,8 @@ export interface FeedbackResponse extends ApiOutput {
 
 export interface FeedbackResponseComment extends ApiOutput {
   feedbackResponseCommentId: string;
-  commentGiverName?: string;
-  lastEditorName?: string;
+  commentGiverName: string;
+  lastEditorName: string;
   commentText: string;
   createdAt: number;
   lastEditedAt: number;

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -44,11 +44,6 @@ export interface Builder {
   queryLogsParams: QueryLogsParams;
 }
 
-export interface CommentOutput extends FeedbackResponseComment {
-  commentGiverName?: string;
-  lastEditorName?: string;
-}
-
 export interface ContributionStatistics {
   results: { [index: string]: ContributionStatisticsEntry };
 }
@@ -251,8 +246,10 @@ export interface FeedbackResponse extends ApiOutput {
 }
 
 export interface FeedbackResponseComment extends ApiOutput {
-  commentGiver: string;
-  lastEditorEmail: string;
+  commentGiver?: string;
+  commentGiverName?: string;
+  lastEditorEmail?: string;
+  lastEditorName?: string;
   feedbackResponseCommentId: string;
   commentText: string;
   createdAt: number;
@@ -558,8 +555,8 @@ export interface ResponseOutput {
   recipientEmail?: string;
   recipientSection: string;
   responseDetails: FeedbackResponseDetails;
-  participantComment?: CommentOutput;
-  instructorComments: CommentOutput[];
+  participantComment?: FeedbackResponseComment;
+  instructorComments: FeedbackResponseComment[];
 }
 
 export interface SessionLinksRecoveryResponse extends ApiOutput {

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -246,11 +246,11 @@ export interface FeedbackResponse extends ApiOutput {
 }
 
 export interface FeedbackResponseComment extends ApiOutput {
+  feedbackResponseCommentId: string;
   commentGiver?: string;
   commentGiverName?: string;
   lastEditorEmail?: string;
   lastEditorName?: string;
-  feedbackResponseCommentId: string;
   commentText: string;
   createdAt: number;
   lastEditedAt: number;

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -247,9 +247,7 @@ export interface FeedbackResponse extends ApiOutput {
 
 export interface FeedbackResponseComment extends ApiOutput {
   feedbackResponseCommentId: string;
-  commentGiver?: string;
   commentGiverName?: string;
-  lastEditorEmail?: string;
   lastEditorName?: string;
   commentText: string;
   createdAt: number;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Combine FeedbackResponseComment and CommentOutput. Since the fields in CommentOutput can now be computed without an extra DB call, they are always included in the combined output unless hidden by visibility settings.

This also means we can now remove the fallback email field from the frontend and further simplify the frontend by removing the parts where lastEditorName and commentGiverName is added to the response output (because it is always present now).
