### PR TITLE
[#13997] Replace JSON deep clones with structuredClone

### DIFF
--- a/src/web/app/components/comment-box/comment-table/comment-table.component.ts
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.ts
@@ -90,7 +90,7 @@ export class CommentTableComponent {
    * Triggers the change of comment rows for the form.
    */
   triggerCommentRowChange(index: number, data: CommentRowModel): void {
-    const newCommentRows: CommentRowModel[] = JSON.parse(JSON.stringify(this.model.commentRows));
+    const newCommentRows: CommentRowModel[] = structuredClone(this.model.commentRows);
     newCommentRows[index] = data;
     this.triggerModelChange('commentRows', newCommentRows);
   }
@@ -106,7 +106,7 @@ export class CommentTableComponent {
    * Handles the close editing event.
    */
   handleCloseEditingCommentRowEvent(index: number): void {
-    const newRowModel: CommentRowModel = JSON.parse(JSON.stringify(this.model.commentRows[index]));
+    const newRowModel: CommentRowModel = structuredClone(this.model.commentRows[index]);
     const originalComment: FeedbackResponseComment = newRowModel.originalComment!;
     newRowModel.commentEditFormModel = {
       commentText: originalComment.commentText,

--- a/src/web/app/components/course-edit-form/course-edit-form-model.ts
+++ b/src/web/app/components/course-edit-form/course-edit-form-model.ts
@@ -93,8 +93,8 @@ const DefaultCourseEditFormModel: CourseEditFormModel = {
 /**
  * Returns default course form model.
  */
-export const DEFAULT_COURSE_FORM_MODEL = (): CourseEditFormModel => {
-  return structuredClone(DefaultCourseModel) as CourseEditFormModel;
+export const DEFAULT_COURSE_FORM_MODEL = (): CourseFormModel => {
+  return structuredClone(DefaultCourseModel);
 };
 
 /**

--- a/src/web/app/components/course-edit-form/course-edit-form-model.ts
+++ b/src/web/app/components/course-edit-form/course-edit-form-model.ts
@@ -64,13 +64,13 @@ const DefaultCourse: Course = {
 };
 
 const DefaultCourseModel: CourseFormModel = {
-  course: JSON.parse(JSON.stringify(DefaultCourse)),
+  course: structuredClone(DefaultCourse),
   timezones: [],
   isSaving: false,
 };
 
 const DefaultCourseAddFormModel: CourseAddFormModel = {
-  course: JSON.parse(JSON.stringify(DefaultCourse)),
+  course: structuredClone(DefaultCourse),
   timezones: [],
   institutes: [],
   activeCourses: [],
@@ -81,8 +81,8 @@ const DefaultCourseAddFormModel: CourseAddFormModel = {
 };
 
 const DefaultCourseEditFormModel: CourseEditFormModel = {
-  course: JSON.parse(JSON.stringify(DefaultCourse)),
-  originalCourse: JSON.parse(JSON.stringify(DefaultCourse)),
+  course: structuredClone(DefaultCourse),
+  originalCourse: structuredClone(DefaultCourse),
   timezones: [],
 
   isSaving: false,
@@ -94,19 +94,19 @@ const DefaultCourseEditFormModel: CourseEditFormModel = {
  * Returns default course form model.
  */
 export const DEFAULT_COURSE_FORM_MODEL = (): CourseEditFormModel => {
-  return JSON.parse(JSON.stringify(DefaultCourseModel));
+  return structuredClone(DefaultCourseModel) as CourseEditFormModel;
 };
 
 /**
  * Returns default course edit form model.
  */
 export const DEFAULT_COURSE_EDIT_FORM_MODEL = (): CourseEditFormModel => {
-  return JSON.parse(JSON.stringify(DefaultCourseEditFormModel));
+  return structuredClone(DefaultCourseEditFormModel);
 };
 
 /**
  * Returns default course add form model.
  */
 export const DEFAULT_COURSE_ADD_FORM_MODEL = (): CourseAddFormModel => {
-  return JSON.parse(JSON.stringify(DefaultCourseAddFormModel));
+  return structuredClone(DefaultCourseAddFormModel);
 };

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -166,7 +166,7 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
 
     for (const user of Object.keys(this.userExpanded)) {
       for (const question of this.responses) {
-        const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
+        const questionCopy: QuestionOutput = structuredClone(question);
         questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (!this.indicateMissingResponses && response.isMissingResponse) {
             // filter out missing responses
@@ -212,7 +212,7 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
           // Should not display anything for contribution and text questions
           continue;
         }
-        const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
+        const questionCopy: QuestionOutput = structuredClone(question);
         questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (response.isMissingResponse) {
             // Missing response is meaningless for team statistics

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -164,7 +164,7 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
       this.userHasRealResponses[user] = false;
 
       for (const question of this.responses) {
-        const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
+        const questionCopy: QuestionOutput = structuredClone(question);
         questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (!this.indicateMissingResponses && response.isMissingResponse) {
             // filter out missing responses
@@ -196,7 +196,7 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
             return this.isGrq ? response.recipient : response.giver;
           });
           for (const other of others) {
-            const questionCopy2: QuestionOutput = JSON.parse(JSON.stringify(questionCopy));
+            const questionCopy2: QuestionOutput = structuredClone(questionCopy);
             questionCopy2.allResponses = questionCopy2.allResponses.filter((response: ResponseOutput) => {
               return this.isGrq ? response.recipient === other : response.giver === other;
             });

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
@@ -201,6 +201,6 @@ export class CustomPrivilegeSettingPanelComponent {
   }
 
   private deepCopy<T>(obj: T): T {
-    return JSON.parse(JSON.stringify(obj));
+    return structuredClone(obj);
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -399,7 +399,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
    */
   cancelEditingInstructor(index: number): void {
     const panelDetail: InstructorEditPanelDetail = this.instructorDetailPanels[index];
-    panelDetail.editPanel = JSON.parse(JSON.stringify(panelDetail.originalPanel));
+    panelDetail.editPanel = structuredClone(panelDetail.originalPanel);
     panelDetail.editPanel.isSavingInstructorEdit = false;
     panelDetail.editPanel.isEditing = false;
   }
@@ -453,7 +453,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
         },
       });
 
-    panelDetail.originalPanel = JSON.parse(JSON.stringify(panelDetail.editPanel));
+    panelDetail.originalPanel = structuredClone(panelDetail.editPanel);
   }
 
   /**
@@ -558,7 +558,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
             editPanel: this.getInstructorEditPanelModel(resp),
           };
           newDetailPanels.editPanel.permission = this.newInstructorPanel.permission;
-          newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
+          newDetailPanels.originalPanel = structuredClone(newDetailPanels.editPanel);
 
           this.instructorDetailPanels.push(newDetailPanels);
           this.statusMessageService.showSuccessToast(
@@ -678,7 +678,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
             sectionLevel.sessionLevel = [];
           }
         });
-        panel.originalPanel = JSON.parse(JSON.stringify(panel.editPanel));
+        panel.originalPanel = structuredClone(panel.editPanel);
       });
   }
 
@@ -806,7 +806,7 @@ export class InstructorCourseEditPageComponent implements OnInit {
             editPanel: this.getInstructorEditPanelModel(newInstructor),
           };
           newDetailPanels.editPanel.permission = this.newInstructorPanel.permission;
-          newDetailPanels.originalPanel = JSON.parse(JSON.stringify(newDetailPanels.editPanel));
+          newDetailPanels.originalPanel = structuredClone(newDetailPanels.editPanel);
 
           this.instructorDetailPanels.push(newDetailPanels);
         },

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -364,7 +364,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
     this.instructorCoursesSortBy = by;
 
     if (this.courseTabModels.length > 1) {
-      const modelCopy: CourseTabModel[] = JSON.parse(JSON.stringify(this.courseTabModels));
+      const modelCopy: CourseTabModel[] = structuredClone(this.courseTabModels);
       modelCopy.sort(this.sortPanelsBy(by));
       this.courseTabModels = modelCopy;
     }

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -550,8 +550,8 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should cancel edit session', () => {
-    component.feedbackSessionModelBeforeEditing = JSON.parse(JSON.stringify(sessionEditFormModel));
-    const testSessionEditFormModel: SessionEditFormModel = JSON.parse(JSON.stringify(sessionEditFormModel));
+    component.feedbackSessionModelBeforeEditing = structuredClone(sessionEditFormModel);
+    const testSessionEditFormModel: SessionEditFormModel = structuredClone(sessionEditFormModel);
     testSessionEditFormModel.instructions = 'New instructions';
     component.sessionEditFormModel = sessionEditFormModel;
     component.isLoadingFeedbackSession = false;
@@ -561,7 +561,7 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should edit existing session', () => {
-    component.feedbackSessionModelBeforeEditing = JSON.parse(JSON.stringify(sessionEditFormModel));
+    component.feedbackSessionModelBeforeEditing = structuredClone(sessionEditFormModel);
     sessionEditFormModel.instructions = 'New instructions';
     component.sessionEditFormModel = sessionEditFormModel;
     component.isLoadingFeedbackSession = false;
@@ -571,7 +571,7 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should delete current session', () => {
-    component.sessionEditFormModel = JSON.parse(JSON.stringify(sessionEditFormModel));
+    component.sessionEditFormModel = structuredClone(sessionEditFormModel);
     const navSpy = vi.spyOn(navigationService, 'navigateWithSuccessMessage').mockResolvedValue();
     vi.spyOn(feedbackSessionsService, 'moveSessionToRecycleBin').mockReturnValue(of(true));
     component.deleteExistingSessionHandler();
@@ -594,10 +594,10 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should save existing question and move question to new position', () => {
-    const questionEditFormModel: QuestionEditFormModel = JSON.parse(JSON.stringify(testQuestionEditFormModel1));
+    const questionEditFormModel: QuestionEditFormModel = structuredClone(testQuestionEditFormModel1);
     questionEditFormModel.questionDescription = 'new description';
     questionEditFormModel.questionNumber = 2;
-    const updatedFeedbackQuestion: FeedbackQuestion = JSON.parse(JSON.stringify(testFeedbackQuestion1));
+    const updatedFeedbackQuestion: FeedbackQuestion = structuredClone(testFeedbackQuestion1);
     updatedFeedbackQuestion.questionDescription = 'new description';
     updatedFeedbackQuestion.questionNumber = 2;
     const feedbackQuestionSpy = vi
@@ -620,7 +620,7 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should discard the changes made to the existing question', () => {
-    const questionEditFormModel: QuestionEditFormModel = JSON.parse(JSON.stringify(testQuestionEditFormModel1));
+    const questionEditFormModel: QuestionEditFormModel = structuredClone(testQuestionEditFormModel1);
     questionEditFormModel.questionDescription = 'new description';
     component.questionEditFormModels = [questionEditFormModel];
     component.feedbackQuestionModels.set(testFeedbackQuestion1.feedbackQuestionId, testFeedbackQuestion1);
@@ -633,7 +633,7 @@ describe('InstructorSessionEditPageComponent', () => {
   });
 
   it('should duplicate question', () => {
-    const duplicateFeedbackQuestion: FeedbackQuestion = JSON.parse(JSON.stringify(testFeedbackQuestion1));
+    const duplicateFeedbackQuestion: FeedbackQuestion = structuredClone(testFeedbackQuestion1);
     duplicateFeedbackQuestion.questionNumber = 2;
     duplicateFeedbackQuestion.feedbackQuestionId = 'duplicate question id';
     component.questionEditFormModels = [testQuestionEditFormModel1];
@@ -718,7 +718,7 @@ describe('InstructorSessionEditPageComponent', () => {
       },
       promise,
     );
-    const copiedFeedbackSession: FeedbackSession = JSON.parse(JSON.stringify(testFeedbackSession));
+    const copiedFeedbackSession: FeedbackSession = structuredClone(testFeedbackSession);
     copiedFeedbackSession.courseId = 'testId2';
 
     component.feedbackSessionName = testFeedbackSession.feedbackSessionName;

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -104,7 +104,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   userDeadlines: Record<string, number> = {};
 
   // to get the original session model on discard changes
-  feedbackSessionModelBeforeEditing: SessionEditFormModel = JSON.parse(JSON.stringify(this.sessionEditFormModel));
+  feedbackSessionModelBeforeEditing: SessionEditFormModel = structuredClone(this.sessionEditFormModel);
 
   // to get the original question model
   feedbackQuestionModels: Map<string, FeedbackQuestion> = new Map();
@@ -386,7 +386,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
    * Handles editing existing session event.
    */
   editExistingSessionHandler(): void {
-    this.feedbackSessionModelBeforeEditing = JSON.parse(JSON.stringify(this.sessionEditFormModel));
+    this.feedbackSessionModelBeforeEditing = structuredClone(this.sessionEditFormModel);
 
     const submissionStartTime: number = this.timezoneService.resolveLocalDateTime(
       this.sessionEditFormModel.submissionStartDate,
@@ -572,7 +572,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
    * Handles canceling existing session event without saving changes.
    */
   cancelEditingSessionHandler(): void {
-    this.sessionEditFormModel = JSON.parse(JSON.stringify(this.feedbackSessionModelBeforeEditing));
+    this.sessionEditFormModel = structuredClone(this.feedbackSessionModelBeforeEditing);
   }
 
   /**
@@ -1263,7 +1263,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   }
 
   private deepCopy<T>(obj: T): T {
-    return JSON.parse(JSON.stringify(obj));
+    return structuredClone(obj);
   }
 
   private scrollToNewEditForm(): void {

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -240,7 +240,7 @@ export class InstructorStudentListPageComponent implements OnInit {
     this.coursesSortBy = by;
 
     if (this.courseTabList.length > 1) {
-      const coursesCopy: CourseTab[] = JSON.parse(JSON.stringify(this.courseTabList));
+      const coursesCopy: CourseTab[] = structuredClone(this.courseTabList);
       coursesCopy.sort(this.sortCoursesBy(by));
       this.courseTabList = coursesCopy;
     }

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -65,7 +65,7 @@ import {
 import { SimpleModalType } from '../../components/simple-modal/simple-modal-type';
 
 describe('SessionSubmissionPageComponent', () => {
-  const deepCopy: <T>(obj: T) => T = <T>(obj: T) => JSON.parse(JSON.stringify(obj));
+  const deepCopy: <T>(obj: T) => T = <T>(obj: T) => structuredClone(obj);
 
   const testStudent: Student = {
     userId: '00000000-0000-4000-8000-000000000003',

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.ts
@@ -327,7 +327,7 @@ export class StudentHomePageComponent implements OnInit {
     this.sortBy = by;
 
     // make a copy of the courses array and sort it
-    const copy: StudentCourse[] = JSON.parse(JSON.stringify(this.courses));
+    const copy: StudentCourse[] = structuredClone(this.courses);
     copy.sort(this.sortPanelsBy(by));
     this.courses = copy;
 

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -556,7 +556,7 @@ function normalizeRanks(ranks: number[]): number[] {
   const rankMapping: Record<number, number> = {};
   rankMapping[RANK_OPTIONS_ANSWER_NOT_SUBMITTED] = RANK_OPTIONS_ANSWER_NOT_SUBMITTED;
 
-  const rankCopy: number[] = JSON.parse(JSON.stringify(ranks));
+  const rankCopy: number[] = structuredClone(ranks);
   rankCopy.sort((a: number, b: number) => a - b);
 
   let normalizedRank = 1;
@@ -728,8 +728,8 @@ export function calculateRubricQuestionStatistics(
     }
     emptyAnswers.push(subQuestionAnswers);
   }
-  stats.answers = JSON.parse(JSON.stringify(emptyAnswers));
-  stats.answersExcludeSelf = JSON.parse(JSON.stringify(emptyAnswers));
+  stats.answers = structuredClone(emptyAnswers);
+  stats.answersExcludeSelf = structuredClone(emptyAnswers);
 
   for (const response of responses) {
     for (let i = 0; i < response.responseDetails.answer.length; i += 1) {
@@ -764,7 +764,7 @@ export function calculateRubricQuestionStatistics(
       recipientName: response.recipient,
       recipientEmail: response.recipientEmail,
       recipientTeam: response.recipientTeam,
-      answers: JSON.parse(JSON.stringify(emptyAnswers)),
+      answers: structuredClone(emptyAnswers),
       answersSum: [],
       percentages: [],
       percentagesAverage: [],
@@ -855,7 +855,7 @@ function calculateSubQuestionWeightAverage(stats: RubricQuestionStatistics, answ
 
 function calculatePercentages(answers: number[][]): number[][] {
   // Deep-copy the answers
-  const percentages: number[][] = JSON.parse(JSON.stringify(answers));
+  const percentages: number[][] = structuredClone(answers);
 
   // Calculate sums for each row
   const sums: number[] = percentages.map((weightedAnswers: number[]) =>

--- a/src/web/services/session-result-csv.service.ts
+++ b/src/web/services/session-result-csv.service.ts
@@ -65,7 +65,7 @@ export class SessionResultCsvService {
     );
     // filter responses based on settings
     for (const question of result.questions) {
-      const currQuestion: QuestionOutput = JSON.parse(JSON.stringify(question));
+      const currQuestion: QuestionOutput = structuredClone(question);
       currQuestion.allResponses = currQuestion.allResponses.filter((response: ResponseOutput) => {
         if (sectionName && sectionDetail) {
           return this.feedbackResponsesService.isFeedbackResponsesDisplayedOnSection(


### PR DESCRIPTION
Fixes #13997

**Outline of Solution**

Replaced `JSON.parse(JSON.stringify(...))` usages that were being used for deep cloning with `structuredClone(...)` under `src/web`.

Actual JSON string parsing was left unchanged.

No UI changes.

**Testing**

- `rg 'JSON\.parse\(JSON\.stringify\(' src/web`
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run build`
- `gradlew.bat lint --continue`