### PR TITLE
[#9125] Simplify DB queries that get feedback sessions in time range

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosedRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosedRemindersActionIT.java
@@ -67,7 +67,7 @@ public class FeedbackSessionClosedRemindersActionIT extends BaseActionIT<Feedbac
         assertEquals("Successful", response1.getMessage());
         assertTrue(session.isClosedEmailSent());
 
-        verifySpecifiedTasksAdded("send-email-queue", 1);
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
 
         ______TS("Success Case: no sessions to consider (`session` already sent closed email)");
         session.setClosedEmailSent(true);
@@ -92,7 +92,7 @@ public class FeedbackSessionClosedRemindersActionIT extends BaseActionIT<Feedbac
 
         assertEquals("Successful", response3.getMessage());
         assertTrue(session.isClosedEmailSent());
-        verifySpecifiedTasksAdded("send-email-queue", 1);
+        verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
 
         ______TS("Success Case: no sessions to consider (`session` closed outside redundancy window)");
         session.setClosedEmailSent(false);

--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosedRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosedRemindersActionIT.java
@@ -81,7 +81,7 @@ public class FeedbackSessionClosedRemindersActionIT extends BaseActionIT<Feedbac
         assertEquals("Successful", response2.getMessage());
         verifyNoTasksAdded();
 
-        ______TS("Success Case: no sessions to consider (`session` closed more than 1 hour ago)");
+        ______TS("Success Case: email task added (`session` closed more than 1 hour ago but within redundancy window)");
         session.setClosedEmailSent(false);
         session.setEndTime(now.minusSeconds(thirtyMin * 3));
         session.setGracePeriod(noGracePeriod);
@@ -91,6 +91,19 @@ public class FeedbackSessionClosedRemindersActionIT extends BaseActionIT<Feedbac
         MessageOutput response3 = (MessageOutput) actionOutput3.getOutput();
 
         assertEquals("Successful", response3.getMessage());
+        assertTrue(session.isClosedEmailSent());
+        verifySpecifiedTasksAdded("send-email-queue", 1);
+
+        ______TS("Success Case: no sessions to consider (`session` closed outside redundancy window)");
+        session.setClosedEmailSent(false);
+        session.setEndTime(now.minusSeconds(thirtyMin * 5));
+        session.setGracePeriod(noGracePeriod);
+
+        FeedbackSessionClosedRemindersAction action4 = getAction(params);
+        JsonResult actionOutput4 = getJsonResult(action4);
+        MessageOutput response4 = (MessageOutput) actionOutput4.getOutput();
+
+        assertEquals("Successful", response4.getMessage());
         verifyNoTasksAdded();
     }
 

--- a/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingSoonRemindersActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/FeedbackSessionClosingSoonRemindersActionIT.java
@@ -279,4 +279,30 @@ public class FeedbackSessionClosingSoonRemindersActionIT extends BaseActionIT<Fe
         // Only 1 email task should be added for the deadline extension
         verifySpecifiedTasksAdded(Const.TaskQueue.SEND_EMAIL_QUEUE_NAME, 1);
     }
+
+    @Test
+    public void textExecute_typicalSuccess7() {
+        ______TS("Typical Success Case 7: No tasks queued -- session is shorter than the closing-soon lead time");
+        long oneHour = 60 * 60;
+        Instant now = Instant.now();
+        Duration noGracePeriod = Duration.between(now, now);
+
+        FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
+        session.setClosingSoonEmailSent(false);
+        session.setStartTime(now.minusSeconds(oneHour / 2));
+        session.setEndTime(now.plusSeconds(oneHour * 23));
+        session.setGracePeriod(noGracePeriod);
+        session.getDeadlineExtensions().forEach(de -> de.setClosingSoonEmailSent(true));
+
+        String[] params = {};
+
+        FeedbackSessionClosingSoonRemindersAction action1 = getAction(params);
+        JsonResult actionOutput1 = getJsonResult(action1);
+        MessageOutput response1 = (MessageOutput) actionOutput1.getOutput();
+
+        assertEquals("Successful", response1.getMessage());
+        assertFalse(session.isClosingSoonEmailSent());
+
+        verifyNoTasksAdded();
+    }
 }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -33,6 +33,8 @@ public final class Const {
     public static final Charset ENCODING = StandardCharsets.UTF_8;
 
     public static final Duration FEEDBACK_SESSIONS_SEARCH_WINDOW = Duration.ofDays(30);
+    public static final Duration FEEDBACK_SESSION_REMINDER_EMAIL_REDUNDANCY_WINDOW = Duration.ofHours(2);
+    public static final Duration FEEDBACK_SESSION_EVENT_EMAIL_LOOKBACK_WINDOW = Duration.ofDays(2);
     public static final Duration LOGS_RETENTION_PERIOD = Duration.ofDays(30);
     public static final Duration STUDENT_ACTIVITY_LOGS_RETENTION_PERIOD = Duration.ofDays(90);
     public static final Duration COOKIE_VALIDITY_PERIOD = Duration.ofDays(7);

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1487,10 +1487,10 @@ public class Logic {
     }
 
     /**
-     * Returns a list of sessions that were closed within past hour.
+     * Returns a list of sessions that were closed recently.
      */
-    public List<FeedbackSession> getFeedbackSessionsClosedWithinThePastHour() {
-        return feedbackSessionsLogic.getFeedbackSessionsClosedWithinThePastHour();
+    public List<FeedbackSession> getFeedbackSessionsClosedRecently() {
+        return feedbackSessionsLogic.getFeedbackSessionsClosedRecently();
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -469,7 +469,7 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Returns a list of sessions that are going to close within the next 24 hours.
+     * Returns sessions in the reminder window before the closing time.
      */
     public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingSoonEmail();
@@ -478,7 +478,7 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Returns a list of sessions that are going to open in 24 hours.
+     * Returns sessions in the reminder window before the opening time.
      */
     public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpeningSoonEmail();
@@ -505,7 +505,7 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Gets a list of undeleted feedback sessions which start within the last 2 hours
+     * Gets a list of undeleted feedback sessions which opened recently
      * and need an open email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsWhichNeedOpenedEmailsToBeSent() {

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -17,7 +17,6 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.Logger;
 import teammates.common.util.SanitizationHelper;
-import teammates.common.util.TimeHelper;
 import teammates.storage.api.FeedbackSessionsDb;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
@@ -38,6 +37,7 @@ public final class FeedbackSessionsLogic {
 
     private static final int NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT = 24;
     private static final int NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT = 24;
+    private static final int NUMBER_OF_HOURS_FOR_EMAIL_REDUNDANCY = 2;
 
     private static final FeedbackSessionsLogic instance = new FeedbackSessionsLogic();
 
@@ -463,65 +463,31 @@ public final class FeedbackSessionsLogic {
      *         sent as they are published
      */
     public List<FeedbackSession> getFeedbackSessionsWhichNeedAutomatedPublishedEmailsToBeSent() {
-        List<FeedbackSession> sessionsToSendEmailsFor = new ArrayList<>();
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingPublishedEmail();
-        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
-
-        for (FeedbackSession session : sessions) {
-            // automated emails are required only for custom publish times
-            if (session.isPublished()
-                    && !TimeHelper.isSpecialTime(session.getResultsVisibleFromTime())
-                    && session.getCourse().getDeletedAt() == null) {
-                sessionsToSendEmailsFor.add(session);
-            }
-        }
-        log.info(String.format("Number of sessions under consideration after filtering: %d",
-                sessionsToSendEmailsFor.size()));
-        return sessionsToSendEmailsFor;
+        log.info(String.format("Number of sessions to send published emails for: %d", sessions.size()));
+        return sessions;
     }
 
     /**
      * Returns a list of sessions that are going to close within the next 24 hours.
      */
     public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
-        List<FeedbackSession> requiredSessions = new ArrayList<>();
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingSoonEmail();
-        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
-
-        for (FeedbackSession session : sessions) {
-            if (session.isClosingWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)
-                    && session.getCourse().getDeletedAt() == null) {
-                requiredSessions.add(session);
-            }
-        }
-
-        log.info(String.format("Number of sessions under consideration after filtering: %d",
-                requiredSessions.size()));
-        return requiredSessions;
+        log.info(String.format("Number of sessions to send closing soon emails for: %d", sessions.size()));
+        return sessions;
     }
 
     /**
      * Returns a list of sessions that are going to open in 24 hours.
      */
     public List<FeedbackSession> getFeedbackSessionsOpeningWithinTimeLimit() {
-        List<FeedbackSession> requiredSessions = new ArrayList<>();
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpeningSoonEmail();
-        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
-
-        for (FeedbackSession session : sessions) {
-            if (session.isOpeningWithinTimeLimit(NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT)
-                    && session.getCourse().getDeletedAt() == null) {
-                requiredSessions.add(session);
-            }
-        }
-
-        log.info(String.format("Number of sessions under consideration after filtering: %d",
-                requiredSessions.size()));
-        return requiredSessions;
+        log.info(String.format("Number of sessions to send opening soon emails for: %d", sessions.size()));
+        return sessions;
     }
 
     /**
-     * Returns a list of sessions that were closed within past hour.
+     * Returns a list of sessions that were closed recently.
      */
     public List<FeedbackSession> getFeedbackSessionsClosedWithinThePastHour() {
         List<FeedbackSession> requiredSessions = new ArrayList<>();
@@ -529,9 +495,7 @@ public final class FeedbackSessionsLogic {
         log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
 
         for (FeedbackSession session : sessions) {
-            // is session closed in the past 1 hour
-            if (session.isClosedWithinPastHour()
-                    && session.getCourse().getDeletedAt() == null) {
+            if (session.isClosedWithinPastHours(NUMBER_OF_HOURS_FOR_EMAIL_REDUNDANCY)) {
                 requiredSessions.add(session);
             }
         }
@@ -545,19 +509,9 @@ public final class FeedbackSessionsLogic {
      * and need an open email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsWhichNeedOpenedEmailsToBeSent() {
-        List<FeedbackSession> sessionsToSendEmailsFor = new ArrayList<>();
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingOpenedEmail();
-        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
-
-        for (FeedbackSession session : sessions) {
-            if (session.isOpened() && session.getCourse().getDeletedAt() == null) {
-                sessionsToSendEmailsFor.add(session);
-            }
-        }
-
-        log.info(String.format("Number of sessions under consideration after filtering: %d",
-                sessionsToSendEmailsFor.size()));
-        return sessionsToSendEmailsFor;
+        log.info(String.format("Number of sessions to send opened emails for: %d", sessions.size()));
+        return sessions;
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1,5 +1,6 @@
 package teammates.logic.core;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,8 +38,6 @@ public final class FeedbackSessionsLogic {
 
     private static final int NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT = 24;
     private static final int NUMBER_OF_HOURS_BEFORE_OPENING_SOON_ALERT = 24;
-    private static final int NUMBER_OF_HOURS_FOR_EMAIL_REDUNDANCY = 2;
-
     private static final FeedbackSessionsLogic instance = new FeedbackSessionsLogic();
 
     private FeedbackSessionsDb fsDb;
@@ -473,8 +472,19 @@ public final class FeedbackSessionsLogic {
      */
     public List<FeedbackSession> getFeedbackSessionsClosingWithinTimeLimit() {
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosingSoonEmail();
-        log.info(String.format("Number of sessions to send closing soon emails for: %d", sessions.size()));
-        return sessions;
+        log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
+
+        List<FeedbackSession> filteredSessions = new ArrayList<>();
+        for (FeedbackSession session : sessions) {
+            if (Duration.between(session.getStartTime(), session.getEndTime())
+                    .compareTo(Duration.ofHours(NUMBER_OF_HOURS_BEFORE_CLOSING_ALERT)) > 0) {
+                filteredSessions.add(session);
+            }
+        }
+
+        log.info(String.format("Number of sessions under consideration after filtering: %d",
+                filteredSessions.size()));
+        return filteredSessions;
     }
 
     /**
@@ -489,19 +499,19 @@ public final class FeedbackSessionsLogic {
     /**
      * Returns a list of sessions that were closed recently.
      */
-    public List<FeedbackSession> getFeedbackSessionsClosedWithinThePastHour() {
-        List<FeedbackSession> requiredSessions = new ArrayList<>();
+    public List<FeedbackSession> getFeedbackSessionsClosedRecently() {
+        List<FeedbackSession> filteredSessions = new ArrayList<>();
         List<FeedbackSession> sessions = fsDb.getFeedbackSessionsPossiblyNeedingClosedEmail();
         log.info(String.format("Number of sessions under consideration: %d", sessions.size()));
 
         for (FeedbackSession session : sessions) {
-            if (session.isClosedWithinPastHours(NUMBER_OF_HOURS_FOR_EMAIL_REDUNDANCY)) {
-                requiredSessions.add(session);
+            if (session.isClosedWithin(Const.FEEDBACK_SESSION_REMINDER_EMAIL_REDUNDANCY_WINDOW)) {
+                filteredSessions.add(session);
             }
         }
         log.info(String.format("Number of sessions under consideration after filtering: %d",
-                requiredSessions.size()));
-        return requiredSessions;
+                filteredSessions.size()));
+        return filteredSessions;
     }
 
     /**

--- a/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
@@ -12,6 +12,7 @@ import jakarta.persistence.criteria.Root;
 
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.TimeHelper;
+import teammates.storage.entity.Course;
 import teammates.storage.entity.DeadlineExtension;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.User;
@@ -88,11 +89,16 @@ public final class DeadlineExtensionsDb {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<DeadlineExtension> cr = cb.createQuery(DeadlineExtension.class);
         Root<DeadlineExtension> root = cr.from(DeadlineExtension.class);
+        Join<DeadlineExtension, FeedbackSession> feedbackSessionJoin = root.join("feedbackSession");
+        Join<FeedbackSession, Course> courseJoin = feedbackSessionJoin.join("course");
 
         cr.select(root).where(cb.and(
                 cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now()),
                 cb.lessThanOrEqualTo(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(1)),
-                cb.equal(root.get("isClosingSoonEmailSent"), false)
+                cb.isFalse(root.get("isClosingSoonEmailSent")),
+                cb.isTrue(feedbackSessionJoin.get("isClosingSoonEmailEnabled")),
+                cb.isNull(feedbackSessionJoin.get("deletedAt")),
+                cb.isNull(courseJoin.get("deletedAt"))
                 ));
 
         return HibernateUtil.createQuery(cr).getResultList();

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -28,7 +28,8 @@ public final class FeedbackSessionsDb {
     private static final Logger log = Logger.getLogger();
     private static final FeedbackSessionsDb instance = new FeedbackSessionsDb();
 
-    private static final Duration CRON_REDUNDANCY_WINDOW = Duration.ofHours(2);
+    private static final Duration REMINDER_EMAIL_REDUNDANCY_WINDOW = Duration.ofHours(2);
+    private static final Duration EVENT_EMAIL_LOOKBACK_WINDOW = Duration.ofDays(2);
     private static final Duration REMINDER_LEAD_TIME = Duration.ofHours(24);
 
     private FeedbackSessionsDb() {
@@ -211,12 +212,11 @@ public final class FeedbackSessionsDb {
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
         Join<FeedbackSession, Course> courseJoin = root.join("course");
         Instant now = Instant.now();
-        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(CRON_REDUNDANCY_WINDOW);
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(REMINDER_EMAIL_REDUNDANCY_WINDOW);
         Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
                 .where(cb.and(
-                    cb.greaterThan(root.get("startTime"), now),
                     cb.greaterThanOrEqualTo(root.get("startTime"), reminderStart),
                     cb.lessThanOrEqualTo(root.get("startTime"), reminderEnd),
                     cb.isFalse(root.get("isOpeningSoonEmailSent")),
@@ -237,7 +237,7 @@ public final class FeedbackSessionsDb {
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
         Join<FeedbackSession, Course> courseJoin = root.join("course");
         Instant now = Instant.now();
-        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(CRON_REDUNDANCY_WINDOW);
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(REMINDER_EMAIL_REDUNDANCY_WINDOW);
         Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
@@ -298,7 +298,7 @@ public final class FeedbackSessionsDb {
 
         cr.select(root)
                 .where(cb.and(
-                        cb.greaterThanOrEqualTo(root.get("resultsVisibleFromTime"), now.minus(CRON_REDUNDANCY_WINDOW)),
+                        cb.greaterThanOrEqualTo(root.get("resultsVisibleFromTime"), now.minus(EVENT_EMAIL_LOOKBACK_WINDOW)),
                         cb.lessThanOrEqualTo(root.get("resultsVisibleFromTime"), now),
                         nonSpecialResultsVisibleTime,
                         cb.isFalse(root.get("isPublishedEmailSent")),
@@ -323,7 +323,7 @@ public final class FeedbackSessionsDb {
 
         cr.select(root)
                 .where(cb.and(
-                    cb.greaterThanOrEqualTo(root.get("startTime"), now.minus(CRON_REDUNDANCY_WINDOW)),
+                    cb.greaterThanOrEqualTo(root.get("startTime"), now.minus(EVENT_EMAIL_LOOKBACK_WINDOW)),
                     cb.lessThanOrEqualTo(root.get("startTime"), now),
                     cb.greaterThan(root.get("endTime"), now),
                     cb.isFalse(root.get("isOpenedEmailSent")),

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -1,5 +1,6 @@
 package teammates.storage.api;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -7,8 +8,10 @@ import java.util.UUID;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
+import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.Logger;
 import teammates.common.util.TimeHelper;
@@ -24,6 +27,9 @@ public final class FeedbackSessionsDb {
 
     private static final Logger log = Logger.getLogger();
     private static final FeedbackSessionsDb instance = new FeedbackSessionsDb();
+
+    private static final Duration CRON_REDUNDANCY_WINDOW = Duration.ofHours(2);
+    private static final Duration REMINDER_LEAD_TIME = Duration.ofHours(24);
 
     private FeedbackSessionsDb() {
         // prevent initialization
@@ -196,103 +202,133 @@ public final class FeedbackSessionsDb {
     }
 
     /**
-     * Gets a list of undeleted feedback sessions which open in the future
-     * and possibly need a opening soon email to be sent.
+     * Gets a list of undeleted feedback sessions which open soon
+     * and need an opening soon email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingOpeningSoonEmail() {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> courseJoin = root.join("course");
+        Instant now = Instant.now();
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(CRON_REDUNDANCY_WINDOW);
+        Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
                 .where(cb.and(
-                    cb.greaterThan(root.get("startTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
-                    cb.equal(root.get("isOpeningSoonEmailSent"), false),
-                    cb.isNull(root.get("deletedAt"))
+                    cb.greaterThan(root.get("startTime"), now),
+                    cb.greaterThanOrEqualTo(root.get("startTime"), reminderStart),
+                    cb.lessThanOrEqualTo(root.get("startTime"), reminderEnd),
+                    cb.isFalse(root.get("isOpeningSoonEmailSent")),
+                    cb.isNull(root.get("deletedAt")),
+                    cb.isNull(courseJoin.get("deletedAt"))
                 ));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }
 
     /**
-     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
-     * and possibly need a closing soon email to be sent.
+     * Gets a list of undeleted feedback sessions which close soon
+     * and need a closing soon email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingClosingSoonEmail() {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> courseJoin = root.join("course");
+        Instant now = Instant.now();
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(CRON_REDUNDANCY_WINDOW);
+        Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
                 .where(cb.and(
-                        // Retrieve sessions with endTime from 2 days ago onwards
-                        // to prevent issues caused by time zone differences
-                        cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
-                        cb.and(
-                                cb.equal(root.get("isClosingSoonEmailSent"), false),
-                                cb.equal(root.get("isClosingSoonEmailEnabled"), true),
-                                cb.equal(root.get("isClosedEmailSent"), false),
-                                cb.isNull(root.get("deletedAt")))
+                        cb.lessThan(root.get("startTime"), now),
+                        cb.greaterThan(root.get("endTime"), now),
+                        cb.greaterThanOrEqualTo(root.get("endTime"), reminderStart),
+                        cb.lessThanOrEqualTo(root.get("endTime"), reminderEnd),
+                        cb.isFalse(root.get("isClosingSoonEmailSent")),
+                        cb.isTrue(root.get("isClosingSoonEmailEnabled")),
+                        cb.isFalse(root.get("isClosedEmailSent")),
+                        cb.isNull(root.get("deletedAt")),
+                        cb.isNull(courseJoin.get("deletedAt"))
                ));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }
 
     /**
-     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
-     * and possibly need a closed email to be sent.
+     * Gets a list of undeleted feedback sessions which may have closed recently
+     * and need a closed email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingClosedEmail() {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> courseJoin = root.join("course");
+        Instant now = Instant.now();
 
         cr.select(root)
                 .where(cb.and(
+                        cb.lessThanOrEqualTo(root.get("endTime"), now),
                         cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
                         cb.isFalse(root.get("isClosedEmailSent")),
                         cb.isTrue(root.get("isClosingSoonEmailEnabled")),
-                        cb.isNull(root.get("deletedAt"))
+                        cb.isNull(root.get("deletedAt")),
+                        cb.isNull(courseJoin.get("deletedAt"))
                ));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }
 
     /**
-     * Gets a list of undeleted published feedback sessions which possibly need a published email
+     * Gets a list of undeleted published feedback sessions which need a published email
      * to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingPublishedEmail() {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> courseJoin = root.join("course");
+        Instant now = Instant.now();
+        Predicate nonSpecialResultsVisibleTime = root.get("resultsVisibleFromTime").in(
+                Const.TIME_REPRESENTS_FOLLOW_OPENING,
+                Const.TIME_REPRESENTS_FOLLOW_VISIBLE,
+                Const.TIME_REPRESENTS_LATER,
+                Const.TIME_REPRESENTS_NOW).not();
 
         cr.select(root)
                 .where(cb.and(
-                        cb.greaterThan(root.get("resultsVisibleFromTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
-                        cb.and(
-                                cb.equal(root.get("isPublishedEmailSent"), false),
-                                cb.equal(root.get("isPublishedEmailEnabled"), true),
-                                cb.isNull(root.get("deletedAt")))
+                        cb.greaterThanOrEqualTo(root.get("resultsVisibleFromTime"), now.minus(CRON_REDUNDANCY_WINDOW)),
+                        cb.lessThanOrEqualTo(root.get("resultsVisibleFromTime"), now),
+                        nonSpecialResultsVisibleTime,
+                        cb.isFalse(root.get("isPublishedEmailSent")),
+                        cb.isTrue(root.get("isPublishedEmailEnabled")),
+                        cb.isNull(root.get("deletedAt")),
+                        cb.isNull(courseJoin.get("deletedAt"))
                ));
 
         return HibernateUtil.createQuery(cr).getResultList();
     }
 
     /**
-     * Gets a list of undeleted feedback sessions which start within the last 2 days
-     * and possibly need an open email to be sent.
+     * Gets a list of undeleted feedback sessions which opened recently
+     * and need an open email to be sent.
      */
     public List<FeedbackSession> getFeedbackSessionsPossiblyNeedingOpenedEmail() {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
+        Join<FeedbackSession, Course> courseJoin = root.join("course");
+        Instant now = Instant.now();
 
         cr.select(root)
                 .where(cb.and(
-                    cb.greaterThan(root.get("startTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
+                    cb.greaterThanOrEqualTo(root.get("startTime"), now.minus(CRON_REDUNDANCY_WINDOW)),
+                    cb.lessThanOrEqualTo(root.get("startTime"), now),
+                    cb.greaterThan(root.get("endTime"), now),
                     cb.isFalse(root.get("isOpenedEmailSent")),
-                    cb.isNull(root.get("deletedAt"))
+                    cb.isNull(root.get("deletedAt")),
+                    cb.isNull(courseJoin.get("deletedAt"))
                 ));
 
         return HibernateUtil.createQuery(cr).getResultList();

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -14,7 +14,6 @@ import jakarta.persistence.criteria.Root;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.Logger;
-import teammates.common.util.TimeHelper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 
@@ -28,8 +27,6 @@ public final class FeedbackSessionsDb {
     private static final Logger log = Logger.getLogger();
     private static final FeedbackSessionsDb instance = new FeedbackSessionsDb();
 
-    private static final Duration REMINDER_EMAIL_REDUNDANCY_WINDOW = Duration.ofHours(2);
-    private static final Duration EVENT_EMAIL_LOOKBACK_WINDOW = Duration.ofDays(2);
     private static final Duration REMINDER_LEAD_TIME = Duration.ofHours(24);
 
     private FeedbackSessionsDb() {
@@ -212,7 +209,8 @@ public final class FeedbackSessionsDb {
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
         Join<FeedbackSession, Course> courseJoin = root.join("course");
         Instant now = Instant.now();
-        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(REMINDER_EMAIL_REDUNDANCY_WINDOW);
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME)
+                .minus(Const.FEEDBACK_SESSION_REMINDER_EMAIL_REDUNDANCY_WINDOW);
         Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
@@ -237,7 +235,8 @@ public final class FeedbackSessionsDb {
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
         Join<FeedbackSession, Course> courseJoin = root.join("course");
         Instant now = Instant.now();
-        Instant reminderStart = now.plus(REMINDER_LEAD_TIME).minus(REMINDER_EMAIL_REDUNDANCY_WINDOW);
+        Instant reminderStart = now.plus(REMINDER_LEAD_TIME)
+                .minus(Const.FEEDBACK_SESSION_REMINDER_EMAIL_REDUNDANCY_WINDOW);
         Instant reminderEnd = now.plus(REMINDER_LEAD_TIME);
 
         cr.select(root)
@@ -270,7 +269,8 @@ public final class FeedbackSessionsDb {
         cr.select(root)
                 .where(cb.and(
                         cb.lessThanOrEqualTo(root.get("endTime"), now),
-                        cb.greaterThan(root.get("endTime"), TimeHelper.getInstantDaysOffsetFromNow(-2)),
+                        cb.greaterThan(root.get("endTime"),
+                                now.minus(Const.FEEDBACK_SESSION_EVENT_EMAIL_LOOKBACK_WINDOW)),
                         cb.isFalse(root.get("isClosedEmailSent")),
                         cb.isTrue(root.get("isClosingSoonEmailEnabled")),
                         cb.isNull(root.get("deletedAt")),
@@ -298,7 +298,8 @@ public final class FeedbackSessionsDb {
 
         cr.select(root)
                 .where(cb.and(
-                        cb.greaterThanOrEqualTo(root.get("resultsVisibleFromTime"), now.minus(EVENT_EMAIL_LOOKBACK_WINDOW)),
+                        cb.greaterThanOrEqualTo(root.get("resultsVisibleFromTime"),
+                                now.minus(Const.FEEDBACK_SESSION_EVENT_EMAIL_LOOKBACK_WINDOW)),
                         cb.lessThanOrEqualTo(root.get("resultsVisibleFromTime"), now),
                         nonSpecialResultsVisibleTime,
                         cb.isFalse(root.get("isPublishedEmailSent")),
@@ -323,7 +324,8 @@ public final class FeedbackSessionsDb {
 
         cr.select(root)
                 .where(cb.and(
-                    cb.greaterThanOrEqualTo(root.get("startTime"), now.minus(EVENT_EMAIL_LOOKBACK_WINDOW)),
+                    cb.greaterThanOrEqualTo(root.get("startTime"),
+                            now.minus(Const.FEEDBACK_SESSION_EVENT_EMAIL_LOOKBACK_WINDOW)),
                     cb.lessThanOrEqualTo(root.get("startTime"), now),
                     cb.greaterThan(root.get("endTime"), now),
                     cb.isFalse(root.get("isOpenedEmailSent")),

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -570,15 +570,6 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
-     * Checks if the session closed some time in the last one hour from calling this function.
-     *
-     * @return true if the session closed within the past hour; false otherwise.
-     */
-    public boolean isClosedWithinPastHour() {
-        return isClosedWithinPastHours(1);
-    }
-
-    /**
      * Checks if the session closed some time in the last {@code hours} from calling this function.
      *
      * @return true if the session closed within the past {@code hours}; false otherwise.

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -575,8 +575,17 @@ public class FeedbackSession extends BaseEntity {
      * @return true if the session closed within the past hour; false otherwise.
      */
     public boolean isClosedWithinPastHour() {
+        return isClosedWithinPastHours(1);
+    }
+
+    /**
+     * Checks if the session closed some time in the last {@code hours} from calling this function.
+     *
+     * @return true if the session closed within the past {@code hours}; false otherwise.
+     */
+    public boolean isClosedWithinPastHours(long hours) {
         Instant now = Instant.now();
         Instant timeClosed = endTime.plus(gracePeriod);
-        return timeClosed.isBefore(now) && Duration.between(timeClosed, now).compareTo(Duration.ofHours(1)) < 0;
+        return timeClosed.isBefore(now) && Duration.between(timeClosed, now).compareTo(Duration.ofHours(hours)) < 0;
     }
 }

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -544,39 +544,13 @@ public class FeedbackSession extends BaseEntity {
     }
 
     /**
-     * Returns true if the feedback session is closing (almost closed) after the number of specified hours.
-     */
-    public boolean isClosingWithinTimeLimit(long hours) {
-        Instant now = Instant.now();
-        Duration difference = Duration.between(now, endTime);
-        // If now and start are almost similar, it means the feedback session
-        // is open for only 24 hours.
-        // Hence we do not send a reminder e-mail for feedback session.
-        return now.isAfter(startTime)
-                && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
-                && difference.compareTo(Duration.ofHours(hours)) < 0;
-    }
-
-    /**
-     * Returns true if the feedback session opens after the number of specified hours.
-     */
-    public boolean isOpeningWithinTimeLimit(long hours) {
-        Instant now = Instant.now();
-        Duration difference = Duration.between(now, startTime);
-
-        return now.isBefore(startTime)
-                && difference.compareTo(Duration.ofHours(hours - 1)) >= 0
-                && difference.compareTo(Duration.ofHours(hours)) < 0;
-    }
-
-    /**
-     * Checks if the session closed some time in the last {@code hours} from calling this function.
+     * Checks if the session closed some time in the specified duration from calling this function.
      *
-     * @return true if the session closed within the past {@code hours}; false otherwise.
+     * @return true if the session closed within the specified duration; false otherwise.
      */
-    public boolean isClosedWithinPastHours(long hours) {
+    public boolean isClosedWithin(Duration duration) {
         Instant now = Instant.now();
         Instant timeClosed = endTime.plus(gracePeriod);
-        return timeClosed.isBefore(now) && Duration.between(timeClosed, now).compareTo(Duration.ofHours(hours)) < 0;
+        return timeClosed.isBefore(now) && Duration.between(timeClosed, now).compareTo(duration) < 0;
     }
 }

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
@@ -16,7 +16,7 @@ public class FeedbackSessionClosedRemindersAction extends AutomatedServiceAction
 
     @Override
     public JsonResult execute() {
-        List<FeedbackSession> sessions = logic.getFeedbackSessionsClosedWithinThePastHour();
+        List<FeedbackSession> sessions = logic.getFeedbackSessionsClosedRecently();
 
         for (FeedbackSession session : sessions) {
             RequestTracer.checkRemainingTime();

--- a/src/test/java/teammates/ui/webapi/FeedbackSessionClosedRemindersActionTest.java
+++ b/src/test/java/teammates/ui/webapi/FeedbackSessionClosedRemindersActionTest.java
@@ -55,13 +55,13 @@ public class FeedbackSessionClosedRemindersActionTest extends BaseActionTest<Fee
 
     @Test
     void testExecute_allSessionsClosed_emailsSent() {
-        when(mockLogic.getFeedbackSessionsClosedWithinThePastHour()).thenReturn(List.of(session, session2));
+        when(mockLogic.getFeedbackSessionsClosedRecently()).thenReturn(List.of(session, session2));
 
         try (MockedStatic<RequestTracer> mockRequestTracer = mockStatic(RequestTracer.class)) {
             FeedbackSessionClosedRemindersAction action = getAction();
             MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-            verify(mockLogic, times(1)).getFeedbackSessionsClosedWithinThePastHour();
+            verify(mockLogic, times(1)).getFeedbackSessionsClosedRecently();
             mockRequestTracer.verify(RequestTracer::checkRemainingTime, times(2));
             verify(mockEmailGenerator, times(1)).generateFeedbackSessionClosedEmails(session);
             verify(mockEmailGenerator, times(1)).generateFeedbackSessionClosedEmails(session2);
@@ -76,13 +76,13 @@ public class FeedbackSessionClosedRemindersActionTest extends BaseActionTest<Fee
 
     @Test
     void testExecute_oneSessionClosed_emailsSent() {
-        when(mockLogic.getFeedbackSessionsClosedWithinThePastHour()).thenReturn(List.of(session));
+        when(mockLogic.getFeedbackSessionsClosedRecently()).thenReturn(List.of(session));
 
         try (MockedStatic<RequestTracer> mockRequestTracer = mockStatic(RequestTracer.class)) {
             FeedbackSessionClosedRemindersAction action = getAction();
             MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-            verify(mockLogic, times(1)).getFeedbackSessionsClosedWithinThePastHour();
+            verify(mockLogic, times(1)).getFeedbackSessionsClosedRecently();
             mockRequestTracer.verify(RequestTracer::checkRemainingTime, times(1));
             verify(mockEmailGenerator, times(1)).generateFeedbackSessionClosedEmails(session);
             verify(session, times(1)).setClosedEmailSent(true);
@@ -95,13 +95,13 @@ public class FeedbackSessionClosedRemindersActionTest extends BaseActionTest<Fee
 
     @Test
     void testExecute_noSessionsClosed_noEmailsSent() {
-        when(mockLogic.getFeedbackSessionsClosedWithinThePastHour()).thenReturn(List.of());
+        when(mockLogic.getFeedbackSessionsClosedRecently()).thenReturn(List.of());
 
         try (MockedStatic<RequestTracer> mockRequestTracer = mockStatic(RequestTracer.class)) {
             FeedbackSessionClosedRemindersAction action = getAction();
             MessageOutput actionOutput = (MessageOutput) getJsonResult(action).getOutput();
 
-            verify(mockLogic, times(1)).getFeedbackSessionsClosedWithinThePastHour();
+            verify(mockLogic, times(1)).getFeedbackSessionsClosedRecently();
             mockRequestTracer.verify(RequestTracer::checkRemainingTime, never());
 
             verifyNoTasksAdded();


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #9125

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Tightened the feedback-session DB selectors to query eligible sessions directly instead of fetching broad 2 day candidate sets and filtering down from there. The only exception is closed emails, which cannot (or rather is too complicated to) query directly because closed time must take into account grace period as well.
2. Added a buffer/catch up windows. This ensures emails are sent even if the cron job fails or is somehow missed. The existing isSent flags ensure emails are not sent twice.
3. Added missing check to skip sending of closing soon emails for sessions that are less than 24 hours.