### PR TITLE
[#13942] Remove Jersey configuration

### DIFF
--- a/src/main/resources/jersey-multipart-config.properties
+++ b/src/main/resources/jersey-multipart-config.properties
@@ -1,5 +1,0 @@
-# Jersey library may cause problem in Google App Engine environment when trying to upload big files.
-# This file contains the properties needed to rectify the problem.
-# See http://stackoverflow.com/questions/6301973/multipart-file-upload-on-google-appengine-using-jersey-1-7
-bufferThreshold = -1
-jersey.config.multipart.bufferThreshold = -1


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13942

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Jersey library was removed in https://github.com/TEAMMATES/teammates/pull/13943. The configuration file can now be removed as well.
