### PR TITLE
[#13975] fix: update JoinCourseAction to use RegKeyRequest body instead of query param

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/JoinCourseActionIT.java
@@ -13,6 +13,7 @@ import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidOperationException;
+import teammates.ui.request.RegKeyRequest;
 import teammates.ui.webapi.JoinCourseAction;
 
 /**
@@ -57,12 +58,10 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
 
         loginAsUnregistered(loggedInGoogleIdStu);
 
-        String[] submissionParams = new String[] {
-                Const.ParamsNames.REGKEY, student1RegKey,
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
-        };
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey(student1RegKey);
 
-        JoinCourseAction joinCourseAction = getAction(submissionParams);
+        JoinCourseAction joinCourseAction = getAction(regKeyRequest);
         getJsonResult(joinCourseAction);
 
         verifyNumberOfEmailsSent(1);
@@ -73,12 +72,9 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
 
         ______TS("failure: student is already registered");
 
-        submissionParams = new String[] {
-                Const.ParamsNames.REGKEY, student1RegKey,
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
-        };
+        regKeyRequest.setKey(student1RegKey);
 
-        InvalidOperationException ioe = verifyInvalidOperation(submissionParams);
+        InvalidOperationException ioe = verifyInvalidOperation(regKeyRequest);
         assertEquals("User has already joined course", ioe.getMessage());
 
         verifyNoEmailsSent();
@@ -87,12 +83,9 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
 
         loginAsUnregistered(loggedInGoogleIdInst);
 
-        submissionParams = new String[] {
-                Const.ParamsNames.REGKEY, instructor1RegKey,
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
-        };
+        regKeyRequest.setKey(instructor1RegKey);
 
-        joinCourseAction = getAction(submissionParams);
+        joinCourseAction = getAction(regKeyRequest);
         getJsonResult(joinCourseAction);
 
         verifyNumberOfEmailsSent(1);
@@ -103,24 +96,18 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
 
         ______TS("failure: instructor is already registered");
 
-        submissionParams = new String[] {
-                Const.ParamsNames.REGKEY, instructor1RegKey,
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
-        };
+        regKeyRequest.setKey(instructor1RegKey);
 
-        ioe = verifyInvalidOperation(submissionParams);
+        ioe = verifyInvalidOperation(regKeyRequest);
         assertEquals("User has already joined course", ioe.getMessage());
 
         verifyNoEmailsSent();
 
         ______TS("failure: invalid regkey");
 
-        submissionParams = new String[] {
-                Const.ParamsNames.REGKEY, "ANXKJZNZXNJCZXKJDNKSDA",
-                Const.ParamsNames.ENTITY_TYPE, Const.EntityType.STUDENT,
-        };
+        regKeyRequest.setKey("ANXKJZNZXNJCZXKJDNKSDA");
 
-        verifyEntityNotFound(submissionParams);
+        verifyEntityNotFound(regKeyRequest);
 
         verifyNoEmailsSent();
     }

--- a/src/main/java/teammates/ui/request/RegKeyRequest.java
+++ b/src/main/java/teammates/ui/request/RegKeyRequest.java
@@ -1,0 +1,21 @@
+package teammates.ui.request;
+
+/**
+ * The request that contain RegKey.
+ */
+public class RegKeyRequest extends BasicRequest {
+    private String key;
+
+    @Override
+    public void validate() throws InvalidHttpRequestBodyException {
+        assertTrue(key != null, "RegKey can not be null");
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/src/main/java/teammates/ui/request/RegKeyRequest.java
+++ b/src/main/java/teammates/ui/request/RegKeyRequest.java
@@ -1,14 +1,14 @@
 package teammates.ui.request;
 
 /**
- * The request that contain RegKey.
+ * The request that contains a registration key.
  */
 public class RegKeyRequest extends BasicRequest {
     private String key;
 
     @Override
     public void validate() throws InvalidHttpRequestBodyException {
-        assertTrue(key != null, "RegKey can not be null");
+        assertTrue(key != null, "Registration key cannot be null");
     }
 
     public String getKey() {

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -2,13 +2,14 @@ package teammates.ui.webapi;
 
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
+import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.request.RegKeyRequest;
 
 /**
  * Action: joins a course for a student/instructor.
@@ -26,9 +27,9 @@ public class JoinCourseAction extends Action {
     }
 
     @Override
-    public JsonResult execute() throws InvalidOperationException {
-        String regKey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
-        return joinCourse(regKey);
+    public JsonResult execute() throws InvalidOperationException, InvalidHttpRequestBodyException {
+        RegKeyRequest requestBody = getAndValidateRequestBody(RegKeyRequest.class);
+        return joinCourse(requestBody.getKey());
     }
 
     private JsonResult joinCourse(String regKey) throws InvalidOperationException {

--- a/src/test/java/teammates/ui/webapi/JoinCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/JoinCourseActionTest.java
@@ -19,6 +19,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.MessageOutput;
+import teammates.ui.request.RegKeyRequest;
 
 /**
  * SUT: {@link JoinCourseAction}.
@@ -52,8 +53,8 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
 
     @Test
     void testExecute_invalidParams_throwsInvalidHttpParameterException() {
-        String [] params1 = {};
-        verifyHttpParameterFailure(params1);
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        verifyHttpRequestBodyFailure(regKeyRequest);
     }
 
     @Test
@@ -66,10 +67,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getCourse(stubStudent.getCourseId())).thenReturn(stubCourse);
         when(mockEmailGenerator.generateUserCourseRegisteredEmail(stubStudent.getName(), stubStudent.getEmail(),
                 "unreg-student", false, stubCourse)).thenReturn(stubEmailWrapper);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "registered-key-student",
-        };
-        JoinCourseAction action = getAction(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("registered-key-student");
+
+        JoinCourseAction action = getAction(regKeyRequest);
         JsonResult jsonResult = getJsonResult(action);
         MessageOutput messageOutput = (MessageOutput) jsonResult.getOutput();
         assertEquals("User successfully joined course", messageOutput.getMessage());
@@ -84,10 +86,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getStudentByRegistrationKey("registered-key-student")).thenReturn(stubStudent);
         when(mockLogic.joinCourse(eq("registered-key-student"), any()))
                 .thenThrow(EntityAlreadyExistsException.class);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "registered-key-student",
-        };
-        JoinCourseAction action = getAction(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("registered-key-student");
+
+        JoinCourseAction action = getAction(regKeyRequest);
         assertThrows(InvalidOperationException.class, action::execute);
         verifyNoEmailsSent();
     }
@@ -100,10 +103,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getStudentByRegistrationKey("invalid-reg-key")).thenReturn(stubStudent);
         when(mockLogic.joinCourse(eq("invalid-reg-key"), any()))
                 .thenThrow(EntityDoesNotExistException.class);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "invalid-reg-key",
-        };
-        verifyEntityNotFound(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("invalid-reg-key");
+
+        verifyEntityNotFound(regKeyRequest);
         verifyNoEmailsSent();
     }
 
@@ -118,10 +122,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getCourse(stubInstructor.getCourseId())).thenReturn(stubCourse);
         when(mockEmailGenerator.generateUserCourseRegisteredEmail(stubInstructor.getName(), stubInstructor.getEmail(),
                 "unreg-instructor", true, stubCourse)).thenReturn(stubEmailWrapper);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "registered-key-instructor",
-        };
-        JoinCourseAction action = getAction(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("registered-key-instructor");
+
+        JoinCourseAction action = getAction(regKeyRequest);
         JsonResult jsonResult = getJsonResult(action);
         MessageOutput messageOutput = (MessageOutput) jsonResult.getOutput();
         assertEquals("User successfully joined course", messageOutput.getMessage());
@@ -136,10 +141,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getInstructorByRegistrationKey("registered-key-instructor")).thenReturn(stubInstructor);
         when(mockLogic.joinCourse(eq("registered-key-instructor"), any()))
                 .thenThrow(EntityAlreadyExistsException.class);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "registered-key-instructor",
-        };
-        JoinCourseAction action = getAction(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("registered-key-instructor");
+
+        JoinCourseAction action = getAction(regKeyRequest);
         assertThrows(InvalidOperationException.class, action::execute);
         verifyNoEmailsSent();
     }
@@ -152,10 +158,11 @@ public class JoinCourseActionTest extends BaseActionTest<JoinCourseAction> {
         when(mockLogic.getInstructorByRegistrationKey("invalid-reg-key")).thenReturn(stubInstructor);
         when(mockLogic.joinCourse(eq("invalid-reg-key"), any()))
                 .thenThrow(EntityDoesNotExistException.class);
-        String[] params = {
-                Const.ParamsNames.REGKEY, "invalid-reg-key",
-        };
-        verifyEntityNotFound(params);
+
+        RegKeyRequest regKeyRequest = new RegKeyRequest();
+        regKeyRequest.setKey("invalid-reg-key");
+
+        verifyEntityNotFound(regKeyRequest);
         verifyNoEmailsSent();
     }
 

--- a/src/web/app/user-join-page.component.spec.ts
+++ b/src/web/app/user-join-page.component.spec.ts
@@ -145,12 +145,13 @@ describe('UserJoinPageComponent', () => {
   });
 
   it('should join course when join course button is clicked on', () => {
-    const params: string[] = ['key'];
+    const key = 'key';
+    const entityType = 'student';
     component.isLoading = false;
     component.hasJoined = false;
     component.userId = 'user';
-    component.key = params[0];
-    component.entityType = params[1];
+    component.key = key;
+    component.entityType = entityType;
     component.validUrl = true;
 
     const courseSpy = vi.spyOn(courseService, 'joinCourse').mockReturnValue(of({}));
@@ -162,9 +163,9 @@ describe('UserJoinPageComponent', () => {
     btn.click();
 
     expect(courseSpy).toHaveBeenCalledTimes(1);
-    expect(courseSpy).toHaveBeenLastCalledWith(...params);
+    expect(courseSpy).toHaveBeenLastCalledWith({ key });
     expect(navSpy).toHaveBeenCalledTimes(1);
-    expect(navSpy).toHaveBeenLastCalledWith(`/web/${params[1]}`);
+    expect(navSpy).toHaveBeenLastCalledWith(`/web/${entityType}`);
   });
 
   it('should redirect user to home page if user is logged in and join URL has been used', () => {

--- a/src/web/app/user-join-page.component.ts
+++ b/src/web/app/user-join-page.component.ts
@@ -93,7 +93,7 @@ export class UserJoinPageComponent implements OnInit {
    * Joins the course.
    */
   joinCourse(): void {
-    this.courseService.joinCourse(this.key).subscribe({
+    this.courseService.joinCourse({ key: this.key }).subscribe({
       next: () => {
         this.navigationService.navigateByURL(`/web/${this.entityType}`);
       },

--- a/src/web/services/course.service.spec.ts
+++ b/src/web/services/course.service.spec.ts
@@ -5,7 +5,7 @@ import { CourseService } from './course.service';
 import { HttpRequestService } from './http-request.service';
 import createSpyFromClass from '../test-helpers/create-spy-from-class';
 import { ResourceEndpoints } from '../types/api-const';
-import { CourseCreateRequest, CourseUpdateRequest } from '../types/api-request';
+import { CourseCreateRequest, CourseUpdateRequest, RegKeyRequest } from '../types/api-request';
 
 describe('CourseService', () => {
   let spyHttpRequestService: any;
@@ -133,11 +133,11 @@ describe('CourseService', () => {
   });
 
   it('should execute PUT when joining course', () => {
-    const paramMap: Record<string, string> = {
+    const regKeyRequest: RegKeyRequest = {
       key: '123',
     };
-    service.joinCourse(paramMap['key']);
-    expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.JOIN, paramMap);
+    service.joinCourse(regKeyRequest);
+    expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.JOIN, {}, regKeyRequest);
   });
 
   it('should execute POST to remind unregistered students of a course', () => {

--- a/src/web/services/course.service.ts
+++ b/src/web/services/course.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { HttpRequestService } from './http-request.service';
 import { ResourceEndpoints } from '../types/api-const';
 import { Course, Courses, JoinStatus, MessageOutput, Student } from '../types/api-output';
-import { CourseCreateRequest, CourseUpdateRequest } from '../types/api-request';
+import { CourseCreateRequest, CourseUpdateRequest, RegKeyRequest } from '../types/api-request';
 
 /**
  * The statistics of a course
@@ -142,11 +142,8 @@ export class CourseService {
   /**
    * Join a course by calling API.
    */
-  joinCourse(regKey: string): Observable<any> {
-    const paramMap: Record<string, string> = {
-      key: regKey,
-    };
-    return this.httpRequestService.put(ResourceEndpoints.JOIN, paramMap);
+  joinCourse(regKeyRequest: RegKeyRequest): Observable<any> {
+    return this.httpRequestService.put(ResourceEndpoints.JOIN, {}, regKeyRequest);
   }
 
   /**

--- a/src/web/types/api-request.ts
+++ b/src/web/types/api-request.ts
@@ -229,6 +229,10 @@ export interface NotificationCreateRequest extends NotificationBasicRequest {
 export interface NotificationUpdateRequest extends NotificationBasicRequest {
 }
 
+export interface RegKeyRequest extends BasicRequest {
+  key: string;
+}
+
 export interface SendEmailRequest extends BasicRequest {
   email: EmailWrapper;
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13975 

**Outline of Solution**
Pass RegKeyRequest as the PUT request body in CourseService.joinCourse,                                                                                                                                                            and fix related tests in course.service.spec.ts and                                                                                                                                                                                 
user-join-page.component.spec.ts to match the correct call signature.  

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->