### PR TITLE
[#13969] Reduce abstractions in action tests

### DIFF
--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -494,24 +494,6 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         verifyWithoutLoginCannotAccess(params);
     }
 
-    void verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-            Course thisCourse, String privilege, String... submissionParams) {
-        verifyAccessibleWithCorrectSameCoursePrivilege(thisCourse, privilege, submissionParams);
-        verifyInaccessibleWithoutCorrectSameCoursePrivilege(thisCourse, privilege, submissionParams);
-        verifyStudentsCannotAccess(submissionParams);
-        verifyUnregisteredCannotAccess(submissionParams);
-        verifyWithoutLoginCannotAccess(submissionParams);
-    }
-
-    void verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-            Course thisCourse, InstructorPrivileges privilege, String... submissionParams) {
-        verifyAccessibleWithCorrectSameCoursePrivilege(thisCourse, privilege, submissionParams);
-        verifyInaccessibleWithoutCorrectSameCoursePrivilege(thisCourse, privilege, submissionParams);
-        verifyStudentsCannotAccess(submissionParams);
-        verifyUnregisteredCannotAccess(submissionParams);
-        verifyWithoutLoginCannotAccess(submissionParams);
-    }
-
     // Students
     void verifyOnlyStudentsCanAccess(String... params) {
         verifyStudentsCanAccess(params);

--- a/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
@@ -88,6 +88,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         assertEquals(newInstructor.getName(), response.getName());
         assertEquals(newInstructor.getEmail(), response.getEmail());
+        logoutUser();
     }
 
     @Test
@@ -110,6 +111,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         InvalidOperationException ioe = verifyInvalidOperation(requestBody, params);
+
         assertEquals("An instructor with the same email address already exists in the course.",
                 ioe.getMessage());
 
@@ -117,6 +119,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).createInstructor(any(Instructor.class));
+        logoutUser();
     }
 
     @Test
@@ -144,6 +147,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).createInstructor(any(Instructor.class));
+        logoutUser();
     }
 
     @Test
@@ -186,6 +190,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
 
         assertEquals(newInstructor.getName(), response.getName());
         assertEquals(newInstructor.getEmail(), response.getEmail());
+        logoutUser();
     }
 
     @Test
@@ -195,6 +200,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCanAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+        logoutUser();
     }
 
     @Test
@@ -207,6 +213,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+        logoutUser();
     }
 
     @Test
@@ -217,18 +224,21 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+        logoutUser();
     }
 
     @Test
     void testAccessControl_student_cannotAccess() {
         loginAsStudent("student-googleId");
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+        logoutUser();
     }
 
     @Test
     void testAccessControl_unregistered_cannotAccess() {
         loginAsUnregistered("unregistered-googleId");
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+        logoutUser();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
@@ -189,12 +189,51 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
     }
 
     @Test
-    void testAccessControl() {
-        String[] params = new String[] {
-                Const.ParamsNames.COURSE_ID, typicalCourse.getId(),
-        };
+    void testAccessControl_sameCourseInstructorWithModifyInstructorPrivilege_canAccess() {
+        typicalInstructor.setCourse(typicalCourse);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCanAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+    }
 
-        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-                typicalCourse, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, params);
+    @Test
+    void testAccessControl_sameCourseInstructorWithoutModifyInstructorPrivilege_cannotAccess() {
+        typicalInstructor.setCourse(typicalCourse);
+        InstructorPrivileges privileges = new InstructorPrivileges();
+        privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
+        typicalInstructor.setPrivileges(privileges);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+    }
+
+    @Test
+    void testAccessControl_differentCourseInstructor_cannotAccess() {
+        Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
+        typicalInstructor.setCourse(otherCourse);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+    }
+
+    @Test
+    void testAccessControl_student_cannotAccess() {
+        loginAsStudent("student-googleId");
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+    }
+
+    @Test
+    void testAccessControl_unregistered_cannotAccess() {
+        loginAsUnregistered("unregistered-googleId");
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
+    }
+
+    @Test
+    void testAccessControl_loggedOut_cannotAccess() {
+        logoutUser();
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, typicalCourse.getId());
     }
 }

--- a/src/test/java/teammates/ui/webapi/GetDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetDeadlineExtensionsActionTest.java
@@ -67,6 +67,7 @@ public class GetDeadlineExtensionsActionTest
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCanAccess(getTypicalParams());
+        logoutUser();
     }
 
     @Test
@@ -80,6 +81,7 @@ public class GetDeadlineExtensionsActionTest
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCannotAccess(getTypicalParams());
+        logoutUser();
     }
 
     @Test
@@ -91,18 +93,21 @@ public class GetDeadlineExtensionsActionTest
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(typicalInstructor.getId().toString());
         verifyCannotAccess(getTypicalParams());
+        logoutUser();
     }
 
     @Test
     void testAccessControl_student_cannotAccess() {
         loginAsStudent("student-googleId");
         verifyCannotAccess(getTypicalParams());
+        logoutUser();
     }
 
     @Test
     void testAccessControl_unregistered_cannotAccess() {
         loginAsUnregistered("unregistered-googleId");
         verifyCannotAccess(getTypicalParams());
+        logoutUser();
     }
 
     @Test
@@ -115,6 +120,7 @@ public class GetDeadlineExtensionsActionTest
     void testExecute_noParameters_shouldFail() {
         loginAsInstructor(typicalInstructor.getGoogleId());
         verifyHttpParameterFailure();
+        logoutUser();
     }
 
     @Test
@@ -123,6 +129,7 @@ public class GetDeadlineExtensionsActionTest
         loginAsInstructor(typicalInstructor.getGoogleId());
 
         verifyEntityNotFoundAcl(getTypicalParams());
+        logoutUser();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetDeadlineExtensionsActionTest.java
@@ -1,6 +1,7 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -10,6 +11,7 @@ import java.util.Set;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
@@ -58,14 +60,55 @@ public class GetDeadlineExtensionsActionTest
     }
 
     @Test
-    void testAccessControl_instructorWithModifySessionPrivilege_canAccess() {
-        String[] params = getTypicalParams();
+    void testAccessControl_sameCourseInstructorWithModifySessionPrivilege_canAccess() {
+        Course course = typicalFeedbackSession.getCourse();
+        typicalInstructor.setCourse(course);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCanAccess(getTypicalParams());
+    }
 
-        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-                typicalFeedbackSession.getCourse(),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION,
-                params);
-        verifyInstructorsOfOtherCoursesCannotAccess(params);
+    @Test
+    void testAccessControl_sameCourseInstructorWithoutModifySessionPrivilege_cannotAccess() {
+        Course course = typicalFeedbackSession.getCourse();
+        typicalInstructor.setCourse(course);
+        InstructorPrivileges privileges = new InstructorPrivileges();
+        privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, false);
+        typicalInstructor.setPrivileges(privileges);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCannotAccess(getTypicalParams());
+    }
+
+    @Test
+    void testAccessControl_differentCourseInstructor_cannotAccess() {
+        Course course = typicalFeedbackSession.getCourse();
+        Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
+        typicalInstructor.setCourse(otherCourse);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(typicalInstructor);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        loginAsInstructor(typicalInstructor.getId().toString());
+        verifyCannotAccess(getTypicalParams());
+    }
+
+    @Test
+    void testAccessControl_student_cannotAccess() {
+        loginAsStudent("student-googleId");
+        verifyCannotAccess(getTypicalParams());
+    }
+
+    @Test
+    void testAccessControl_unregistered_cannotAccess() {
+        loginAsUnregistered("unregistered-googleId");
+        verifyCannotAccess(getTypicalParams());
+    }
+
+    @Test
+    void testAccessControl_loggedOut_cannotAccess() {
+        logoutUser();
+        verifyCannotAccess(getTypicalParams());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
@@ -3,11 +3,14 @@ package teammates.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
+
+import teammates.common.datatransfer.InstructorPrivileges;
 
 import java.util.UUID;
 
@@ -344,16 +347,64 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
     }
 
     @Test
-    void testGetStudent_instructorUserIdPathSameCourseWithViewSectionPrivilege_canAccess() {
-        String[] params = {
-                Const.ParamsNames.COURSE_ID, stubCourse.getId(),
-                Const.ParamsNames.USER_ID, stubStudent.getId().toString(),
-        };
+    void testGetStudent_sameCourseInstructorWithViewSectionPrivilege_canAccess() {
+        stubInstructor.setCourse(stubCourse);
         when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
-        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-                stubCourse,
-                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS,
-                params);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCanAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+    }
+
+    @Test
+    void testGetStudent_sameCourseInstructorWithoutViewSectionPrivilege_cannotAccess() {
+        stubInstructor.setCourse(stubCourse);
+        InstructorPrivileges privileges = new InstructorPrivileges();
+        privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
+        stubInstructor.setPrivileges(privileges);
+        when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+    }
+
+    @Test
+    void testGetStudent_differentCourseInstructor_cannotAccess() {
+        Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
+        stubInstructor.setCourse(otherCourse);
+        when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+    }
+
+    @Test
+    void testGetStudent_student_cannotAccess() {
+        when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
+        loginAsStudent("student-googleId");
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+    }
+
+    @Test
+    void testGetStudent_unregistered_cannotAccess() {
+        when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
+        loginAsUnregistered("unregistered-googleId");
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+    }
+
+    @Test
+    void testGetStudent_loggedOut_cannotAccess() {
+        when(mockLogic.getStudent(stubStudent.getId())).thenReturn(stubStudent);
+        logoutUser();
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
+                Const.ParamsNames.USER_ID, stubStudent.getId().toString());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
@@ -355,6 +355,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCanAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -369,6 +370,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -381,6 +383,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -389,6 +392,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         loginAsStudent("student-googleId");
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -397,6 +401,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         loginAsUnregistered("unregistered-googleId");
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId(),
                 Const.ParamsNames.USER_ID, stubStudent.getId().toString());
+        logoutUser();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentActionTest.java
@@ -10,13 +10,12 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import teammates.common.datatransfer.InstructorPrivileges;
-
 import java.util.UUID;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.util.Const;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -281,12 +282,25 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     }
 
     @Test
-    void testGetStudents_instructorWithViewSectionPrivilegeSameCourse_canAccess() {
-        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-                stubCourse,
-                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS,
-                Const.ParamsNames.COURSE_ID, stubCourse.getId()
-        );
+    void testGetStudents_sameCourseInstructorWithViewSectionPrivilege_canAccess() {
+        stubInstructorWithAllPrivileges.setCourse(stubCourse);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructorWithAllPrivileges);
+        when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
+        loginAsInstructor(stubInstructorWithAllPrivileges.getId().toString());
+        verifyCanAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId());
+    }
+
+    @Test
+    void testGetStudents_sameCourseInstructorWithoutViewSectionPrivilege_cannotAccess() {
+        Instructor instructor = getTypicalInstructor();
+        instructor.setCourse(stubCourse);
+        InstructorPrivileges privileges = new InstructorPrivileges();
+        privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
+        instructor.setPrivileges(privileges);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(instructor);
+        when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
+        loginAsInstructor(instructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
@@ -288,6 +288,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
         loginAsInstructor(stubInstructorWithAllPrivileges.getId().toString());
         verifyCanAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId());
+        logoutUser();
     }
 
     @Test
@@ -301,6 +302,7 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
         when(mockLogic.getCourse(stubCourse.getId())).thenReturn(stubCourse);
         loginAsInstructor(instructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.COURSE_ID, stubCourse.getId());
+        logoutUser();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
@@ -109,6 +109,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCanAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -123,6 +124,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -134,6 +136,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         when(mockLogic.getCourse(stubFeedbackSession.getCourse().getId())).thenReturn(stubFeedbackSession.getCourse());
         loginAsInstructor(stubInstructor.getId().toString());
         verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -141,6 +144,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
         loginAsStudent("student-googleId");
         verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+        logoutUser();
     }
 
     @Test
@@ -148,6 +152,7 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
         loginAsUnregistered("unregistered-googleId");
         verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+        logoutUser();
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
@@ -4,13 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
-import teammates.common.datatransfer.InstructorPrivileges;
-
 import java.time.Instant;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;

--- a/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RestoreFeedbackSessionActionTest.java
@@ -1,7 +1,10 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
+
+import teammates.common.datatransfer.InstructorPrivileges;
 
 import java.time.Instant;
 
@@ -98,19 +101,59 @@ public class RestoreFeedbackSessionActionTest extends BaseActionTest<RestoreFeed
     }
 
     @Test
-    void testAccessControl() {
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId()))
-                .thenReturn(stubFeedbackSession);
+    void testAccessControl_sameCourseInstructorWithModifySessionPrivilege_canAccess() {
+        Course course = stubFeedbackSession.getCourse();
+        stubInstructor.setCourse(course);
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCanAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+    }
 
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
-        };
+    @Test
+    void testAccessControl_sameCourseInstructorWithoutModifySessionPrivilege_cannotAccess() {
+        Course course = stubFeedbackSession.getCourse();
+        stubInstructor.setCourse(course);
+        InstructorPrivileges privileges = new InstructorPrivileges();
+        privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, false);
+        stubInstructor.setPrivileges(privileges);
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(course.getId())).thenReturn(course);
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+    }
 
-        verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess(
-                stubFeedbackSession.getCourse(),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION,
-                params
-        );
-        verifyInstructorsOfOtherCoursesCannotAccess(params);
+    @Test
+    void testAccessControl_differentCourseInstructor_cannotAccess() {
+        Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
+        stubInstructor.setCourse(otherCourse);
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        when(mockLogic.getInstructorByGoogleId(any(), any())).thenReturn(stubInstructor);
+        when(mockLogic.getCourse(stubFeedbackSession.getCourse().getId())).thenReturn(stubFeedbackSession.getCourse());
+        loginAsInstructor(stubInstructor.getId().toString());
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+    }
+
+    @Test
+    void testAccessControl_student_cannotAccess() {
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        loginAsStudent("student-googleId");
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+    }
+
+    @Test
+    void testAccessControl_unregistered_cannotAccess() {
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        loginAsUnregistered("unregistered-googleId");
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
+    }
+
+    @Test
+    void testAccessControl_loggedOut_cannotAccess() {
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
+        logoutUser();
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString());
     }
 }


### PR DESCRIPTION
Part of #13969 

**Outline of Solution**

- Replace `verifyOnlyInstructorsOfTheSameCourseWithCorrectCoursePrivilegeCanAccess` helper method with individual test cases that replicate the internal helper functions.